### PR TITLE
Implement encrypted git sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: install age
+        # Sync tests skip themselves without it, and a silently skipped suite
+        # looks exactly like a passing one.
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq age
       - name: bash version
         # The hook needs bash 5 for $EPOCHSECONDS / $EPOCHREALTIME. ubuntu-latest
         # ships it, but fail loudly rather than silently skipping the hook tests.
@@ -64,6 +68,28 @@ jobs:
           # The comma-decimal test needs a locale where $EPOCHREALTIME uses ","
           sudo locale-gen de_AT.UTF-8
       - run: python -m unittest tests.test_shell_hook --verbose
+
+  sync:
+    # Two machines exchanging encrypted history through a bare repo, plus the
+    # invariant the storage design rests on: chunks are never rewritten.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: sudo apt-get update -qq && sudo apt-get install -y -qq age
+      - run: age --version && git --version
+      - name: sync suite
+        run: |
+          set -o pipefail
+          python -m unittest tests.test_sync --verbose 2>&1 | tee sync.log
+          # These tests skip themselves when age or git is absent. A skipped run
+          # is green, which is precisely the failure mode worth guarding.
+          if grep -q "skipped" sync.log; then
+            echo "::error::sync tests were skipped - age or git missing"
+            exit 1
+          fi
 
   perf:
     runs-on: ubuntu-latest
@@ -117,3 +143,37 @@ jobs:
           # doctor exits non-zero on a broken install; fzf is absent here, so
           # only check that it runs and reports.
           woswoar doctor || true
+
+      - name: two machines sync through a bare repo, from the installed wheel
+        run: |
+          set -euxo pipefail
+          sudo apt-get update -qq && sudo apt-get install -y -qq age
+          BASE="$(mktemp -d)"
+          git init --quiet --bare "$BASE/origin.git"
+
+          run_as() {          # run_as <machine> <args...>
+            local m="$1"; shift
+            env HOME="$BASE/$m" \
+                WOSWOAR_DIR="$BASE/$m/data" \
+                XDG_CONFIG_HOME="$BASE/$m/conf" \
+                XDG_CACHE_HOME="$BASE/$m/cache" \
+                woswoar "$@"
+          }
+          mkdir -p "$BASE"/{alpha,beta}/{data,conf,cache}
+
+          run_as alpha init "$BASE/origin.git" --new-identity
+          ALPHA_ID=$(grep '^id=' "$BASE/alpha/conf/woswoar/machine" | cut -d= -f2)
+          mkdir -p "$BASE/alpha/data/logs/hosts/$ALPHA_ID"
+          printf '1700000001\ts1\t~/src\t0\t5\tsecret-marker-command\n' \
+            > "$BASE/alpha/data/logs/hosts/$ALPHA_ID/2023-11-14.tsv"
+          run_as alpha sync
+
+          # Nothing readable may reach the repo.
+          ! grep -rq 'secret-marker-command' "$BASE/origin.git"
+
+          run_as beta init "$BASE/origin.git" --new-identity
+          run_as alpha sync
+          run_as alpha reencrypt
+          run_as alpha sync
+          run_as beta sync
+          run_as beta list --scope global | grep -q 'secret-marker-command'

--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ woswoar import bash     # optional: bring your existing history along
 | `woswoar import bash\|zsh` | import an existing history |
 | `woswoar stats` | entry counts, date range, most-used commands |
 | `woswoar doctor` | check bash version, fzf, hook, cache |
-| `woswoar sync` | git sync — **not implemented yet**, see below |
+| `woswoar init [url]` | create or join an encrypted history repo |
+| `woswoar sync` | exchange history with the remote |
+| `woswoar reencrypt` | re-seal keys after enrolling a new machine |
+| `woswoar compact` | merge old chunks to reduce file count |
 
 ## Configuration
 
@@ -71,15 +74,65 @@ Your existing `HISTCONTROL`, `HISTIGNORE`, and `ignorespace` settings are
 honoured automatically — anything bash declines to put in history is invisible
 to woswoar too.
 
+## Multi-machine sync
+
+History is synced through an ordinary git repo, encrypted with
+[age](https://github.com/FiloSottile/age). There is no server. **Nothing
+readable ever reaches the remote** — not commands, not paths, not usernames or
+hostnames — so the repo can live anywhere you can push to.
+
+Create an empty repo somewhere (`woswoar-history` on GitHub, a bare repo on a
+NAS, anything), then on your first machine:
+
+```bash
+woswoar init git@github.com:you/woswoar-history.git
+woswoar sync
+```
+
+On each additional machine:
+
+```bash
+woswoar init git@github.com:you/woswoar-history.git   # enrols this machine
+woswoar sync
+```
+
+Then, **once**, on a machine that was already enrolled:
+
+```bash
+woswoar reencrypt && woswoar sync
+```
+
+That step exists because history sealed before the new machine joined was
+encrypted to a recipient list that didn't include it. `reencrypt` re-seals the
+small per-day keys — not the history itself — so it takes seconds even with
+years of commands. Until you run it the new machine syncs fine, and simply
+reports how many days it cannot read yet. Nothing is lost in the meantime.
+
+### Keys
+
+Each machine keeps its own key and **no secret is ever copied between
+machines**. `init` reuses your existing SSH key when it can, and falls back to a
+dedicated age key when it can't — notably when your SSH key has a passphrase,
+since age cannot use ssh-agent and would fail from an unattended timer. Force
+either with `--new-identity` or `--identity <path>`.
+
+### Automatic syncing
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp contrib/systemd/woswoar-sync.* ~/.config/systemd/user/
+systemctl --user enable --now woswoar-sync.timer
+```
+
+Five-minute interval by default. Sync never runs on your prompt — a git push
+must not be able to block a shell.
+
 ## Status
 
-Milestone 1 — recording, search, and import — works. Milestone 2 is git sync
-with `age` encryption, using append-only immutable chunks so a 5-minute sync
-interval doesn't inflate the repository. It is fully designed but not built;
-`woswoar sync` tells you so.
+Both milestones are done: recording and search, and encrypted git sync.
 
 - [docs/woswoar_design_summary.md](docs/woswoar_design_summary.md) — architecture, record
-  format, and the milestone 2 sync/encryption design.
+  format, and the sync/encryption design with measured numbers.
 - [docs/milestone-1-plan.md](docs/milestone-1-plan.md) — the implementation plan milestone 1
   was built from.
 

--- a/contrib/systemd/woswoar-sync.service
+++ b/contrib/systemd/woswoar-sync.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=woswoar shell history sync
+Documentation=https://github.com/martinus/woswoar
+# Pointless and noisy without a network; the timer will try again.
+After=network-online.target
+
+[Service]
+Type=oneshot
+# /usr/bin/env so this works wherever woswoar was installed (pipx, --user, venv)
+# without hardcoding a path into the unit.
+ExecStart=/usr/bin/env woswoar sync
+
+# Sync holds a lock and talks to a remote; if it hangs, fail rather than pile up.
+TimeoutStartSec=10min
+
+# It only ever needs its own data directory, an ssh key, and the network.
+PrivateTmp=true
+NoNewPrivileges=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true

--- a/contrib/systemd/woswoar-sync.timer
+++ b/contrib/systemd/woswoar-sync.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Sync woswoar shell history periodically
+
+[Timer]
+# Wait a little after login rather than competing with everything else starting.
+OnStartupSec=2min
+OnUnitActiveSec=5min
+
+# Catch up after the machine was asleep or off, rather than silently skipping.
+Persistent=true
+
+# Every machine syncing on the same wall-clock tick is how you manufacture
+# push races. A minute of jitter costs nothing and avoids them.
+RandomizedDelaySec=60
+
+[Install]
+WantedBy=timers.target

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -12,9 +12,8 @@ different goals:
 The name is Austrian dialect for *"Was war?"* — "what was it again?" — which is
 exactly the question this tool answers.
 
-**Status.** Milestone 1 (record, search, import) is implemented. Milestone 2
-(git sync with encryption) is designed below but not yet built; `woswoar sync`
-exits with a message saying so.
+**Status.** Both milestones are implemented: recording, search and import; and
+git sync with age encryption.
 
 ---
 
@@ -24,7 +23,7 @@ exits with a message saying so.
 bash hook  ──►  plaintext TSV logs  ──►  pickle cache  ──►  scope filter  ──►  fzf
    (record)          (truth)             (speed only)        (Python)         (UI)
                         │
-                        └──►  age-encrypted chunks  ──►  git  ──►  remote   [milestone 2]
+                        └──►  age-encrypted chunks  ──►  git  ──►  remote
 ```
 
 Two rules that everything else follows from:
@@ -44,8 +43,8 @@ Two rules that everything else follows from:
     hosts/<id>/2026-07-29.tsv
     hosts/<id>/.name          friendly label for display
   woswoar.bash                installed copy of the hook
-  history/                    git working tree, ciphertext only   [milestone 2]
-  state.json                                                      [milestone 2]
+  history/                    git working tree, ciphertext only
+  state.json                  sync watermarks (local, never synced)
 ~/.config/woswoar/machine     id + name
 ~/.config/woswoar/imported.json
 ~/.cache/woswoar/cache.pickle
@@ -89,8 +88,7 @@ and against filesystems (NFS) that make no such promise.
 
 ### Two fields are stored compactly
 
-Metadata repeats on every line and milestone 2 commits every byte to git
-permanently, so line size directly drives repo growth.
+Metadata repeats on every line and sync commits every byte to git permanently, so line size directly drives repo growth.
 
 `session` is `<start second>-<pid>`, both in hex — `6a69f856-107de`. Unique per
 host: two shells cannot share a pid at one instant, and a reused pid necessarily
@@ -189,7 +187,7 @@ history is loaded on every Ctrl-R.
 
 Entries are grouped **per file** rather than kept in one flat list. That costs a
 `chain.from_iterable` on read and buys O(1) invalidation of a single file —
-exactly what milestone 2 needs when a sync appends decrypted lines to one host's
+exactly what sync needs when it appends decrypted lines to one host's
 log.
 
 Update rules per file:
@@ -296,7 +294,7 @@ covers the count going stale when a history file is rotated or trimmed.
 
 ---
 
-## Synchronisation and encryption  [milestone 2]
+## Synchronisation and encryption
 
 ### Threat model
 
@@ -310,6 +308,20 @@ Encryption therefore requires an external tool. `age` was chosen: a single small
 binary that accepts **SSH public keys as recipients**, so every machine uses the
 keypair it already pushes to GitHub with and no secret is ever copied between
 machines.
+
+### Choosing an identity
+
+age does **not** use ssh-agent. A passphrase-protected SSH key prompts on a
+terminal and fails outright without one — verified: it exits 1 rather than
+hanging, which is the one saving grace for a systemd timer, but it still means
+sync would never succeed unattended.
+
+So `init` resolves the identity **once** and records it in
+`~/.config/woswoar/machine`, rather than re-detecting per sync. It prefers an
+existing SSH key, falling back to a dedicated age identity when none works. The
+check is a real encrypt/decrypt round trip, not an inspection of the key file,
+because the question is not what format the key claims to be — it is whether an
+unattended sync will actually work.
 
 ### Why the obvious approach fails
 
@@ -350,11 +362,21 @@ simpler than the alternatives:
   merged per (host, day).
 
 **Per-day key.** One X25519 identity per host per day, sealed to all recipients
-in `keys/<date>.age`; chunks are encrypted to that day's public key alone. This
-halves per-chunk header overhead (~200 B instead of ~450 B with three
-`ssh-ed25519` recipients), and more importantly makes onboarding cheap: adding a
-machine re-seals ~730 tiny key files rather than ~35,000 chunks, so `reencrypt`
-takes seconds instead of rewriting the archive.
+in `keys/<date>.age`; chunks are encrypted to that day's public key alone. The
+day's *public* key is stored beside it in the clear, so writing a chunk never
+has to open the sealed one.
+
+Measured with age 1.3.1, three `ssh-ed25519` recipients:
+
+| | overhead per chunk |
+|---|---|
+| sealed directly to 3 recipients | 432 B |
+| sealed to the day key | **200 B** |
+
+A sealed day key is 621 B, so re-sealing two years of them is ~450 KB — which is
+what makes onboarding cheap. Adding a machine re-seals ~730 tiny key files
+rather than ~35,000 chunks, so `reencrypt` takes seconds instead of rewriting
+the archive.
 
 **Cost: inodes.** At a 5-minute timer and ~40 content-bearing syncs a day, one
 machine produces ~35k chunk files over two years. Git copes, but a fresh clone
@@ -367,11 +389,32 @@ the core loop.
 ### Sync
 
 1. `flock` a lock file (concurrent shells, timer).
-2. For each own log file with unencrypted tail bytes: encrypt that tail into a
-   new chunk; `git add`; commit; `git pull --rebase`; push.
-3. For each other host: decrypt chunks newer than the merge watermark and append
+2. **Fetch and rebase first.**
+3. Seal each own log file's unsealed tail into a new chunk; commit.
+4. Push, retrying once after a fetch/rebase if someone else pushed meanwhile.
+5. For each other host, decrypt chunks newer than the merge watermark and append
    the plaintext to `logs/`.
-4. Update the cache incrementally.
+
+> Step 2 has to come before step 3, and this was learned the hard way. Creating
+> a day key seals it to whatever `recipients.txt` says *at that moment*. Export
+> first and you seal the day's key to a stale recipient list, so any machine
+> enrolled since the last sync can never open that day — silently, and
+> permanently, because the repo is append-only. The failure only shows up with
+> two machines and a new day, which is exactly the case a single-machine test
+> never reaches.
+
+Fetch-then-rebase, rather than `git pull --rebase`, because cloning an *empty*
+remote configures a tracking branch that points at nothing — the normal state
+for the first machine to enrol — and pulling from that fails.
+
+`init` publishes immediately for the same class of reason: until a new machine's
+public key is on the remote, `reencrypt` run elsewhere cannot include it, and
+onboarding would appear to succeed while silently granting no access to older
+history.
+
+Commits use a fixed `woswoar <woswoar@localhost>` identity set on the repo.
+Commit metadata is one of the few things that is not encrypted, so it should not
+carry a real name and address.
 
 Each chunk is decrypted **exactly once, ever** — the plaintext under `logs/` is
 the working copy. This is also why git clean/smudge filters were rejected: they
@@ -395,8 +438,7 @@ changed only at onboarding); `merge=union` in `.gitattributes` resolves it.
 Runtime: **Python standard library only** — `dataclasses`, `pathlib`, `pickle`,
 `subprocess`, `tempfile`, `time`, `secrets`, `hashlib`, `json`, `argparse`.
 
-External binaries: `fzf` (the UI), `age` (milestone 2 only), `git` (milestone 2
-only). Development only: `ruff`, `mypy`, `shellcheck`.
+External binaries: `fzf` (the UI), and `age` plus `git` (sync only). Development only: `ruff`, `mypy`, `shellcheck`.
 
 Supported: **bash 5.0+ on Linux.** bash 5 is required for `$EPOCHSECONDS` and
 `$EPOCHREALTIME`; without them the hot path would have to fork `date` on every

--- a/tests/support.py
+++ b/tests/support.py
@@ -18,7 +18,9 @@ def make_entry(ts: int, cmd: str, host: str = MACHINE_ID, session: str = "s1") -
     return Entry(ts=ts, host=host, session=session, cwd="/tmp", exit_code=0, duration_ms=1, cmd=cmd)
 
 
-_ENV_KEYS = (
+#: Every environment variable store.py consults. Shared with tests/test_sync.py
+#: so a new one cannot be isolated in one place and leak in the other.
+ENV_KEYS = (
     "WOSWOAR_DIR",
     "WOSWOAR_SESSION",
     "XDG_CONFIG_HOME",
@@ -40,10 +42,10 @@ class WoswoarTestCase(unittest.TestCase):
         self.root = Path(self._tmp.name)
         self.addCleanup(self._tmp.cleanup)
 
-        self._saved = {key: os.environ.get(key) for key in _ENV_KEYS}
+        self._saved = {key: os.environ.get(key) for key in ENV_KEYS}
         self.addCleanup(self._restore_env)
 
-        for key in _ENV_KEYS:
+        for key in ENV_KEYS:
             os.environ.pop(key, None)
         os.environ["WOSWOAR_DIR"] = str(self.root / "data")
         os.environ["XDG_CONFIG_HOME"] = str(self.root / "config")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -8,7 +8,6 @@ are enough, and that is only meaningful if it is actually demonstrated.
 from __future__ import annotations
 
 import os
-import re
 import shutil
 import subprocess
 import tempfile
@@ -20,14 +19,13 @@ from pathlib import Path
 from woswoar import cache, crypto, search, store, sync
 from woswoar.entry import Entry, format_line
 
-#: hosts/<id>/YYYY/MM/DD/<chunk>.age -- the write-once files. Key material
-#: lives outside this shape and is deliberately rewritable.
-CHUNK_PATH = re.compile(r"^hosts/[^/]+/\d{4}/\d{2}/\d{2}/[^/]+\.age$")
+from . import support
 
 requires_age = unittest.skipUnless(crypto.available(), "age required")
 requires_git = unittest.skipUnless(shutil.which("git"), "git required")
 
-_ENV = ("WOSWOAR_DIR", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "WOSWOAR_SESSION", "HOME")
+#: One authoritative list, plus HOME which only these tests need to redirect.
+_ENV = (*support.ENV_KEYS, "HOME")
 
 
 class Fake:
@@ -322,7 +320,10 @@ class TestImmutability(SyncTestCase):
         # elsewhere in the tree and *are* rewritten, by design: that is exactly
         # what makes onboarding cheap. Separating the two here keeps the
         # exception explicit rather than quietly widening the invariant.
-        chunks = {p for p in rewritten if CHUNK_PATH.match(p)}
+        # Classified by store, not by a regex copied here: a hand-maintained
+        # pattern would silently stop matching if the layout ever changed,
+        # leaving this assertion vacuously true while real chunks were rewritten.
+        chunks = {p for p in rewritten if store.is_chunk_path(p)}
         self.assertEqual(sorted(chunks), [], f"chunks were rewritten: {sorted(chunks)}")
 
         # And the only things that were rewritten are the ones allowed to be.
@@ -390,6 +391,47 @@ class TestCompact(SyncTestCase):
         with beta.active():
             sync.run()
             self.assertEqual(beta.commands(), {"command 0", "command 1", "command 2"})
+
+
+class TestIdentityStatus(SyncTestCase):
+    """The health check `doctor` reports. Testable because it lives in sync."""
+
+    def test_healthy_identity(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            status = sync.identity_status(store.machine())
+            self.assertTrue(status.ok, status.detail)
+
+    def test_missing_identity_file_is_reported(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            known = store.machine()
+            Path(known.identity).unlink()
+            status = sync.identity_status(known)
+            self.assertFalse(status.ok)
+            self.assertIn("missing", status.detail)
+
+    def test_unconfigured_identity_is_reported(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            status = sync.identity_status(store.machine()._replace(identity=""))
+            self.assertFalse(status.ok)
+            self.assertIn("woswoar init", status.detail)
+
+    def test_passphrase_protected_key_is_reported(self) -> None:
+        # The failure that only bites unattended: age cannot use ssh-agent, so
+        # this key would work by hand and never from a systemd timer.
+        alpha = self.machine("alpha")
+        with alpha.active():
+            locked = self.root / "locked"
+            subprocess.run(
+                ["ssh-keygen", "-q", "-t", "ed25519", "-N", "hunter2", "-f", str(locked)],
+                check=True,
+                timeout=60,
+            )
+            status = sync.identity_status(store.machine()._replace(identity=str(locked)))
+            self.assertFalse(status.ok)
+            self.assertIn("passphrase", status.detail)
 
 
 class TestLocalOnly(SyncTestCase):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,412 @@
+"""End-to-end sync: two machines exchanging history through a bare repo.
+
+These drive the real ``age`` and the real ``git``. Mocking either would test the
+mock -- the whole premise of sync is that ordinary git plus ordinary age
+are enough, and that is only meaningful if it is actually demonstrated.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from woswoar import cache, crypto, search, store, sync
+from woswoar.entry import Entry, format_line
+
+#: hosts/<id>/YYYY/MM/DD/<chunk>.age -- the write-once files. Key material
+#: lives outside this shape and is deliberately rewritable.
+CHUNK_PATH = re.compile(r"^hosts/[^/]+/\d{4}/\d{2}/\d{2}/[^/]+\.age$")
+
+requires_age = unittest.skipUnless(crypto.available(), "age required")
+requires_git = unittest.skipUnless(shutil.which("git"), "git required")
+
+_ENV = ("WOSWOAR_DIR", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "WOSWOAR_SESSION", "HOME")
+
+
+class Fake:
+    """One simulated machine with its own config, logs, and clone."""
+
+    def __init__(self, root: Path, name: str) -> None:
+        self.root = root / name
+        self.name = name
+        self._id: str | None = None
+        for sub in ("data", "conf", "cache"):
+            (self.root / sub).mkdir(parents=True, exist_ok=True)
+
+    @property
+    def env(self) -> dict[str, str]:
+        return {
+            "HOME": str(self.root),
+            "WOSWOAR_DIR": str(self.root / "data"),
+            "XDG_CONFIG_HOME": str(self.root / "conf"),
+            "XDG_CACHE_HOME": str(self.root / "cache"),
+        }
+
+    @contextmanager
+    def active(self) -> Iterator[Fake]:
+        """Run a block as if we were sitting at this machine."""
+        saved = {k: os.environ.get(k) for k in _ENV}
+        os.environ.pop("WOSWOAR_SESSION", None)
+        os.environ.update(self.env)
+        try:
+            yield self
+        finally:
+            for key, value in saved.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+    # -- convenience, all assuming `active()` is held ----------------------
+
+    @property
+    def id(self) -> str:
+        """This machine's id, resolved once and remembered.
+
+        Deliberately cached: store.machine() reads the *ambient* environment, so
+        a live lookup would quietly return the wrong machine's id whenever one
+        Fake is inspected while another is active -- which is most assertions in
+        a two-machine test.
+        """
+        if self._id is None:
+            self._id = store.machine().id
+        return self._id
+
+    def record(self, day: str, ts: int, cmd: str, session: str = "s1") -> None:
+        """Append a line the way the shell hook would."""
+        path = store.log_file(self.id, day)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        entry = Entry(ts, self.id, session, "~/src", 0, 5, cmd)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(format_line(entry) + "\n")
+
+    def commands(self) -> set[str]:
+        return {e.cmd for e in cache.load_entries()}
+
+
+@requires_age
+@requires_git
+class SyncTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="woswoar-sync-")
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+        self.origin = self.root / "origin.git"
+        subprocess.run(
+            ["git", "init", "--quiet", "--bare", str(self.origin)], check=True, timeout=60
+        )
+
+    def machine(self, name: str, enrol: bool = True, display: str | None = None) -> Fake:
+        fake = Fake(self.root, name)
+        if enrol:
+            with fake.active():
+                if display:
+                    # Set before init: name.age is sealed during enrolment.
+                    store.save_machine(store.machine()._replace(name=display))
+                # A dedicated identity, not the developer's real SSH key.
+                sync.initialise(remote=str(self.origin), new_identity=True)
+                _ = fake.id  # resolve while this machine's env is in effect
+        return fake
+
+    def git_in_repo(self, fake: Fake, *args: str) -> str:
+        with fake.active():
+            return sync.git(*args)
+
+
+class TestSingleMachine(SyncTestCase):
+    def test_export_seals_and_pushes(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            report = sync.run()
+            self.assertEqual(report.chunks_written, 1)
+            self.assertEqual(report.lines_exported, 1)
+            self.assertTrue(report.pushed)
+
+    def test_nothing_new_writes_no_chunk(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            again = sync.run()
+            self.assertEqual(again.chunks_written, 0)
+            self.assertEqual(again.lines_exported, 0)
+
+    def test_nothing_readable_leaks_into_the_repo(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "sudo rm -rf /very-secret-path")
+            sync.run()
+            blob = b"".join(p.read_bytes() for p in store.history_dir().rglob("*") if p.is_file())
+        self.assertNotIn(b"very-secret-path", blob)
+        self.assertNotIn(b"sudo", blob)
+
+    def test_partial_final_line_is_not_sealed_until_complete(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            path = store.log_file(alpha.id, "2023-11-14")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("1700000001\ts1\t~/src\t0\t5\tcomplete\n1700000002\ts1", "utf-8")
+
+            sync.run()
+            state = sync.State.load()
+            relpath = f"hosts/{alpha.id}/2023-11-14.tsv"
+            # The watermark stops at the last newline, so the half-written record
+            # is left for next time rather than sealed into an immutable chunk.
+            self.assertEqual(state.exported[relpath], path.stat().st_size - len("1700000002\ts1"))
+
+
+class TestTwoMachines(SyncTestCase):
+    def test_history_reaches_the_other_machine(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            alpha.record("2023-11-14", 1_700_000_002, "make -j8")
+            sync.run()
+
+        beta = self.machine("beta")
+        with beta.active():
+            sync.run()
+        # beta joined after alpha sealed those lines, so it cannot read them yet.
+        with alpha.active():
+            sync.run()
+            sync.reencrypt()
+            sync.run()
+        with beta.active():
+            report = sync.run()
+            self.assertEqual(report.chunks_merged, 1)
+            self.assertEqual(beta.commands(), {"git status", "make -j8"})
+
+    def test_new_machine_reports_rather_than_failing(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+
+        beta = self.machine("beta")
+        with beta.active():
+            beta.record("2023-11-15", 1_700_100_000, "beta's own command")
+            report = sync.run()
+            # Unreadable history must not stop this machine exporting its own.
+            self.assertTrue(report.unreadable)
+            self.assertEqual(report.lines_exported, 1)
+
+    def test_bidirectional(self) -> None:
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "from alpha")
+            sync.run()
+            sync.reencrypt()
+            sync.run()
+        with beta.active():
+            beta.record("2023-11-14", 1_700_000_050, "from beta")
+            sync.run()
+        with alpha.active():
+            sync.run()
+            self.assertEqual(alpha.commands(), {"from alpha", "from beta"})
+        with beta.active():
+            sync.run()
+            self.assertEqual(beta.commands(), {"from alpha", "from beta"})
+
+    def test_merging_is_idempotent(self) -> None:
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            sync.reencrypt()
+            sync.run()
+        with beta.active():
+            sync.run()
+            first = len(cache.load_entries())
+            for _ in range(3):
+                sync.run()
+            self.assertEqual(len(cache.load_entries()), first, "re-sync duplicated entries")
+
+    def test_offline_backlog_spanning_days(self) -> None:
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.run()
+            sync.reencrypt()
+            sync.run()
+        with beta.active():
+            sync.run()
+
+        with alpha.active():
+            for day, ts in (("2023-11-14", 1_700_000_001), ("2023-11-15", 1_700_100_000)):
+                alpha.record(day, ts, f"command on {day}")
+            # One sync after several days offline: a chunk per day, because a
+            # chunk always belongs to exactly one day file.
+            report = sync.run()
+            self.assertEqual(report.chunks_written, 2)
+
+        with beta.active():
+            sync.run()
+            self.assertEqual(beta.commands(), {"command on 2023-11-14", "command on 2023-11-15"})
+
+    def test_other_machines_name_is_learned(self) -> None:
+        alpha = self.machine("alpha", display="alpha@laptop")
+        beta = self.machine("beta")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            sync.reencrypt()
+            sync.run()
+        with beta.active():
+            sync.run()
+            # Without this, search would label alpha's entries with its opaque id.
+            self.assertEqual(store.host_names().get(alpha.id), "alpha@laptop")
+
+    def test_search_spans_hosts_but_host_scope_does_not(self) -> None:
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "from alpha")
+            sync.run()
+            sync.reencrypt()
+            sync.run()
+        with beta.active():
+            beta.record("2023-11-14", 1_700_000_050, "from beta")
+            sync.run()
+            entries = cache.load_entries()
+            self.assertEqual(len(search.filter_scope(entries, "global")), 2)
+            self.assertEqual([e.cmd for e in search.filter_scope(entries, "host")], ["from beta"])
+
+
+class TestImmutability(SyncTestCase):
+    """The invariant the whole storage design rests on."""
+
+    def test_no_chunk_is_ever_modified_or_deleted(self) -> None:
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+
+        with alpha.active():
+            for i in range(4):
+                alpha.record("2023-11-14", 1_700_000_000 + i, f"alpha {i}")
+                sync.run()
+            sync.reencrypt()
+            sync.run()
+        with beta.active():
+            for i in range(3):
+                beta.record("2023-11-15", 1_700_100_000 + i, f"beta {i}")
+                sync.run()
+        with alpha.active():
+            sync.run()
+
+        # Exact, not a heuristic: if any commit ever modified or deleted a
+        # chunk, this lists it. An empty result is the guarantee that repo
+        # growth equals the bytes written.
+        touched = self.git_in_repo(
+            alpha,
+            "log",
+            "--all",
+            "--diff-filter=MD",
+            "--name-only",
+            "--pretty=format:",
+            "--",
+            "hosts",
+        )
+        rewritten = {line for line in touched.splitlines() if line.endswith(".age")}
+
+        # Chunks live under hosts/<id>/YYYY/MM/DD/. Key files and name seals sit
+        # elsewhere in the tree and *are* rewritten, by design: that is exactly
+        # what makes onboarding cheap. Separating the two here keeps the
+        # exception explicit rather than quietly widening the invariant.
+        chunks = {p for p in rewritten if CHUNK_PATH.match(p)}
+        self.assertEqual(sorted(chunks), [], f"chunks were rewritten: {sorted(chunks)}")
+
+        # And the only things that were rewritten are the ones allowed to be.
+        self.assertTrue(
+            all(("/keys/" in p or p.endswith("/name.age")) for p in rewritten),
+            f"unexpected rewrites: {sorted(rewritten - chunks)}",
+        )
+
+    def test_repo_growth_tracks_bytes_written_not_sync_count(self) -> None:
+        syncs = 20
+        alpha = self.machine("alpha")
+        with alpha.active():
+            for i in range(syncs):
+                alpha.record("2023-11-14", 1_700_000_000 + i, f"command number {i}")
+                sync.run()
+
+            self.git_in_repo(alpha, "gc", "--quiet")
+            # git's own reported object size. Summing files under .git would
+            # instead measure the sample hooks, which dwarf a repo this small.
+            counts = dict(
+                line.split(": ", 1)
+                for line in self.git_in_repo(alpha, "count-objects", "-v").splitlines()
+                if ": " in line
+            )
+            stored = int(counts["size-pack"]) * 1024 + int(counts["size"]) * 1024
+            chunk_bytes = sum(c.path.stat().st_size for c in store.iter_chunks(alpha.id))
+            chunks = len(list(store.iter_chunks(alpha.id)))
+
+        self.assertEqual(chunks, syncs, "each sync must produce exactly one chunk")
+        # Chunks are written once and never rewritten, so git stores each
+        # exactly once: total objects stay close to the bytes actually written.
+        # Re-encrypting the whole day file each sync would instead store
+        # 1+2+...+N copies and blow straight past this.
+        self.assertLess(
+            stored,
+            chunk_bytes * 4 + 64 * 1024,
+            f"stored={stored} chunk_bytes={chunk_bytes} over {syncs} syncs",
+        )
+
+
+class TestCompact(SyncTestCase):
+    def test_compact_merges_chunks_and_preserves_content(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            for i in range(5):
+                alpha.record("2023-11-14", 1_700_000_000 + i, f"command {i}")
+                sync.run()
+            before = len(list(store.iter_chunks(alpha.id)))
+            self.assertEqual(before, 5)
+
+            days, replaced = sync.compact(before="2023-11-15")
+            self.assertEqual((days, replaced), (1, 5))
+            self.assertEqual(len(list(store.iter_chunks(alpha.id))), 1)
+
+    def test_compacted_chunk_still_reaches_another_machine(self) -> None:
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            for i in range(3):
+                alpha.record("2023-11-14", 1_700_000_000 + i, f"command {i}")
+                sync.run()
+            sync.compact(before="2023-11-15")
+            sync.reencrypt()
+            sync.run()
+        with beta.active():
+            sync.run()
+            self.assertEqual(beta.commands(), {"command 0", "command 1", "command 2"})
+
+
+class TestLocalOnly(SyncTestCase):
+    def test_sync_without_a_remote_still_seals(self) -> None:
+        alpha = Fake(self.root, "solo")
+        with alpha.active():
+            sync.initialise(new_identity=True)
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            report = sync.run()
+            self.assertEqual(report.chunks_written, 1)
+            self.assertFalse(report.pushed)
+
+    def test_concurrent_sync_is_refused_not_corrupted(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active(), sync.lock(), self.assertRaises(sync.SyncError):
+            sync.run()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -10,7 +10,8 @@ import time
 from collections import Counter
 from pathlib import Path
 
-from . import __version__, cache, crypto, importer, search, store, sync
+from . import __version__, cache, importer, search, store
+from .errors import WoswoarError
 
 HOOK_NAME = "woswoar.bash"
 _BEGIN = "# >>> woswoar >>>"
@@ -124,6 +125,8 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     import shutil
     import subprocess
 
+    from . import sync
+
     ok = True
 
     def check(label: str, good: bool, detail: str) -> None:
@@ -167,24 +170,12 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     detail = "sources the hook" if sourced else "has no woswoar block"
     check("bashrc", sourced, f"{rcfile} {detail}")
 
-    age = shutil.which("age")
-    info("age", age or "not found - needed for 'woswoar sync' only")
+    info("age", shutil.which("age") or "not found - needed for 'woswoar sync' only")
 
     if sync.is_repo():
-        known = store.machine()
-        identity = Path(known.identity).expanduser() if known.identity else None
-        if identity is None:
-            check("sync", False, "no identity recorded - run 'woswoar init'")
-        elif not identity.is_file():
-            check("sync", False, f"identity {identity} is missing - re-run 'woswoar init'")
-        elif age and not crypto.usable(identity):
-            # The failure that only bites unattended: age cannot use ssh-agent,
-            # so a passphrase-protected key works by hand and never from a timer.
-            check("sync", False, f"{identity} needs a passphrase; 'woswoar init --new-identity'")
-        else:
-            check("sync", True, f"identity {identity}")
-        remotes = sync.git("remote", "-v", check=False).splitlines()
-        info("remote", remotes[0] if remotes else "none (history is local only)")
+        status = sync.identity_status(store.machine())
+        check("sync", status.ok, status.detail)
+        info("remote", sync.remote_summary())
     else:
         info("sync", "no history repo - run 'woswoar init <url>' to sync machines")
 
@@ -205,6 +196,8 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
 
 def cmd_init(args: argparse.Namespace) -> int:
+    from . import sync
+
     known, identity = sync.initialise(
         remote=args.remote,
         new_identity=args.new_identity,
@@ -213,13 +206,10 @@ def cmd_init(args: argparse.Namespace) -> int:
     print(f"machine  : {known.name} ({known.id})")
     print(f"identity : {identity}")
     print(f"repo     : {store.history_dir()}")
-    remotes = sync.git("remote", "-v", check=False).splitlines()
-    print(f"remote   : {remotes[0] if remotes else 'none (local only)'}")
+    print(f"remote   : {sync.remote_summary()}")
     print(f"\nRecipients now enrolled ({store.recipients_file()}):")
-    for line in store.recipients_file().read_text(encoding="utf-8").splitlines():
-        if line.strip():
-            kind, _, rest = line.partition(" ")
-            print(f"  {kind} {rest[:24]}...")
+    for kind, key in sync.list_recipients():
+        print(f"  {kind} {key[:24]}...")
     if args.remote:
         print("\nNext: 'woswoar sync'.")
         print("On an already-enrolled machine, run 'woswoar reencrypt' so this")
@@ -228,6 +218,8 @@ def cmd_init(args: argparse.Namespace) -> int:
 
 
 def cmd_sync(args: argparse.Namespace) -> int:
+    from . import sync
+
     report = sync.run(push=not args.no_push)
     print(
         f"exported {report.lines_exported} line(s) in {report.chunks_written} chunk(s); "
@@ -253,6 +245,8 @@ def cmd_sync(args: argparse.Namespace) -> int:
 
 
 def cmd_reencrypt(args: argparse.Namespace) -> int:
+    from . import sync
+
     count = sync.reencrypt()
     print(f"re-sealed {count} key file(s) to the current recipients")
     print("Run 'woswoar sync' to publish them.")
@@ -260,6 +254,8 @@ def cmd_reencrypt(args: argparse.Namespace) -> int:
 
 
 def cmd_compact(args: argparse.Namespace) -> int:
+    from . import sync
+
     days, replaced = sync.compact(before=args.before or time.strftime("%Y-%m-%d"))
     if not days:
         print("nothing to compact")
@@ -345,7 +341,7 @@ def main(argv: list[str] | None = None) -> int:
     except BrokenPipeError:
         # `woswoar list | head` is a normal thing to do.
         return 0
-    except (sync.SyncError, crypto.AgeUnavailable, crypto.AgeError) as exc:
+    except WoswoarError as exc:
         # These carry actionable messages -- a missing age, an unreadable
         # identity, a repo that was never initialised. A traceback would bury
         # them, and sync runs unattended from a timer where nobody reads one.

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -10,18 +10,12 @@ import time
 from collections import Counter
 from pathlib import Path
 
-from . import __version__, cache, importer, search, store
+from . import __version__, cache, crypto, importer, search, store, sync
 
 HOOK_NAME = "woswoar.bash"
 _BEGIN = "# >>> woswoar >>>"
 _END = "# <<< woswoar <<<"
 _BLOCK = re.compile(re.escape(_BEGIN) + r".*?" + re.escape(_END) + r"\n?", re.DOTALL)
-
-_MILESTONE_2 = (
-    "woswoar: '{name}' is not implemented yet.\n"
-    "Git sync with age encryption is milestone 2; milestone 1 records and\n"
-    "searches locally. See docs/woswoar_design_summary.md for the sync design."
-)
 
 
 def _hook_source() -> Path:
@@ -173,6 +167,27 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     detail = "sources the hook" if sourced else "has no woswoar block"
     check("bashrc", sourced, f"{rcfile} {detail}")
 
+    age = shutil.which("age")
+    info("age", age or "not found - needed for 'woswoar sync' only")
+
+    if sync.is_repo():
+        known = store.machine()
+        identity = Path(known.identity).expanduser() if known.identity else None
+        if identity is None:
+            check("sync", False, "no identity recorded - run 'woswoar init'")
+        elif not identity.is_file():
+            check("sync", False, f"identity {identity} is missing - re-run 'woswoar init'")
+        elif age and not crypto.usable(identity):
+            # The failure that only bites unattended: age cannot use ssh-agent,
+            # so a passphrase-protected key works by hand and never from a timer.
+            check("sync", False, f"{identity} needs a passphrase; 'woswoar init --new-identity'")
+        else:
+            check("sync", True, f"identity {identity}")
+        remotes = sync.git("remote", "-v", check=False).splitlines()
+        info("remote", remotes[0] if remotes else "none (history is local only)")
+    else:
+        info("sync", "no history repo - run 'woswoar init <url>' to sync machines")
+
     logs = list(store.iter_log_files())
     info("logs", f"{len(logs)} file(s) in {store.logs_dir()}")
 
@@ -189,9 +204,69 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     return 0 if ok else 1
 
 
-def cmd_milestone2(args: argparse.Namespace) -> int:
-    print(_MILESTONE_2.format(name=args.command), file=sys.stderr)
-    return 2
+def cmd_init(args: argparse.Namespace) -> int:
+    known, identity = sync.initialise(
+        remote=args.remote,
+        new_identity=args.new_identity,
+        identity=Path(args.identity).expanduser() if args.identity else None,
+    )
+    print(f"machine  : {known.name} ({known.id})")
+    print(f"identity : {identity}")
+    print(f"repo     : {store.history_dir()}")
+    remotes = sync.git("remote", "-v", check=False).splitlines()
+    print(f"remote   : {remotes[0] if remotes else 'none (local only)'}")
+    print(f"\nRecipients now enrolled ({store.recipients_file()}):")
+    for line in store.recipients_file().read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            kind, _, rest = line.partition(" ")
+            print(f"  {kind} {rest[:24]}...")
+    if args.remote:
+        print("\nNext: 'woswoar sync'.")
+        print("On an already-enrolled machine, run 'woswoar reencrypt' so this")
+        print("one can read history sealed before it joined.")
+    return 0
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    report = sync.run(push=not args.no_push)
+    print(
+        f"exported {report.lines_exported} line(s) in {report.chunks_written} chunk(s); "
+        f"merged {report.lines_imported} line(s) from {report.chunks_merged} chunk(s) "
+        f"across {len(report.hosts_seen)} other host(s)"
+    )
+    if report.pushed:
+        print("pushed to remote")
+    elif not sync.has_remote():
+        print("no remote configured - history is local only")
+
+    if report.unreadable:
+        days = len(report.unreadable)
+        print(
+            f"\n{days} day(s) of history are sealed to recipients that do not include\n"
+            "this machine - it joined after they were written. On a machine that was\n"
+            "already enrolled run:\n"
+            "    woswoar reencrypt && woswoar sync\n"
+            "then sync here again. Nothing is lost in the meantime.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def cmd_reencrypt(args: argparse.Namespace) -> int:
+    count = sync.reencrypt()
+    print(f"re-sealed {count} key file(s) to the current recipients")
+    print("Run 'woswoar sync' to publish them.")
+    return 0
+
+
+def cmd_compact(args: argparse.Namespace) -> int:
+    days, replaced = sync.compact(before=args.before or time.strftime("%Y-%m-%d"))
+    if not days:
+        print("nothing to compact")
+    else:
+        print(f"compacted {replaced} chunk(s) into {days} (one per day)")
+        print("Run 'woswoar sync' to publish. Note this rewrites history.")
+    return 0
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -235,9 +310,28 @@ def build_parser() -> argparse.ArgumentParser:
     p_doctor = subparsers.add_parser("doctor", help="check the installation")
     p_doctor.set_defaults(func=cmd_doctor)
 
-    for name in ("sync", "reencrypt"):
-        stub = subparsers.add_parser(name, help=f"{name} (milestone 2, not implemented)")
-        stub.set_defaults(func=cmd_milestone2)
+    p_init = subparsers.add_parser("init", help="create or join a history repo")
+    p_init.add_argument("remote", nargs="?", help="git URL of the history repo")
+    p_init.add_argument(
+        "--new-identity",
+        action="store_true",
+        help="generate a dedicated age key instead of reusing an SSH key",
+    )
+    p_init.add_argument("--identity", help="use this private key")
+    p_init.set_defaults(func=cmd_init)
+
+    p_sync = subparsers.add_parser("sync", help="exchange history with the remote")
+    p_sync.add_argument("--no-push", action="store_true", help="stay local; do not contact remote")
+    p_sync.set_defaults(func=cmd_sync)
+
+    p_reencrypt = subparsers.add_parser(
+        "reencrypt", help="re-seal keys after enrolling a new machine"
+    )
+    p_reencrypt.set_defaults(func=cmd_reencrypt)
+
+    p_compact = subparsers.add_parser("compact", help="merge old chunks (reduces file count)")
+    p_compact.add_argument("--before", help="only days before this YYYY-MM-DD (default: today)")
+    p_compact.set_defaults(func=cmd_compact)
 
     return parser
 
@@ -251,6 +345,12 @@ def main(argv: list[str] | None = None) -> int:
     except BrokenPipeError:
         # `woswoar list | head` is a normal thing to do.
         return 0
+    except (sync.SyncError, crypto.AgeUnavailable, crypto.AgeError) as exc:
+        # These carry actionable messages -- a missing age, an unreadable
+        # identity, a repo that was never initialised. A traceback would bury
+        # them, and sync runs unattended from a timer where nobody reads one.
+        print(f"woswoar: {exc}", file=sys.stderr)
+        return 1
     return result
 
 

--- a/woswoar/cache.py
+++ b/woswoar/cache.py
@@ -5,7 +5,7 @@ pickled and only the *appended* tail of each file is re-read on the next run.
 
 Entries are grouped per file rather than kept in one flat list. That costs a
 ``chain.from_iterable`` at read time and buys O(1) invalidation of a single
-file, which is exactly what milestone 2 needs when a sync appends decrypted
+file, which is exactly what sync needs when it appends decrypted
 lines to one host's log.
 
 The cache is disposable by design: any corruption, version mismatch, or

--- a/woswoar/cache.py
+++ b/woswoar/cache.py
@@ -88,23 +88,17 @@ def _fingerprint(path: Path) -> bytes:
 def _read_from(path: Path, host: str, offset: int) -> tuple[list[Entry], int]:
     """Parse whole lines starting at ``offset``.
 
-    Returns the entries and the new consumed offset. A trailing partial line is
-    left unconsumed so it gets parsed correctly once the writer finishes it.
+    The byte-level "read the tail, stop at the last complete line" step lives in
+    store, shared with sync's export -- both read these same files and must
+    agree on where one ends.
     """
-    try:
-        with path.open("rb") as handle:
-            handle.seek(offset)
-            data = handle.read()
-    except OSError:
+    data, new_offset = store.read_tail(path, offset)
+    if not data:
         return [], offset
 
-    cut = data.rfind(b"\n")
-    if cut < 0:
-        return [], offset
-
-    text = data[: cut + 1].decode("utf-8", errors="replace")
+    text = data.decode("utf-8", errors="replace")
     entries = [e for e in (parse_line(line, host) for line in text.splitlines()) if e is not None]
-    return entries, offset + cut + 1
+    return entries, new_offset
 
 
 def load() -> Cache:

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -18,18 +18,20 @@ import subprocess
 from pathlib import Path
 from typing import NamedTuple
 
+from .errors import WoswoarError
+
 AGE = "age"
 AGE_KEYGEN = "age-keygen"
 
 _TIMEOUT = 120
 
 
-class AgeUnavailable(RuntimeError):
-    """The age binary is not installed."""
+class AgeError(WoswoarError):
+    """age is missing, or ran and refused.
 
-
-class AgeError(RuntimeError):
-    """age ran and refused."""
+    One class rather than two: every call site caught both and handled them
+    identically, so the split was a distinction nothing branched on.
+    """
 
 
 class Identity(NamedTuple):
@@ -63,7 +65,7 @@ def available() -> bool:
 
 def require() -> None:
     if not available():
-        raise AgeUnavailable(_MISSING)
+        raise AgeError(_MISSING)
 
 
 def _run(argv: list[str], data: bytes | None = None, pass_fds: tuple[int, ...] = ()) -> bytes:
@@ -129,7 +131,6 @@ def decrypt_with_secret(data: bytes, secret: str) -> bytes:
 
 def generate_identity() -> Identity:
     """Create a fresh X25519 identity, returned rather than written to disk."""
-    require()
     secret = _run([AGE_KEYGEN]).decode("utf-8")
     return Identity(secret=secret, public=public_of(secret))
 
@@ -168,5 +169,5 @@ def usable(identity: Path) -> bool:
         recipient = recipient_for(identity)
         sealed = encrypt_to(b"woswoar", recipient)
         return decrypt_with_file(sealed, identity) == b"woswoar"
-    except (AgeError, AgeUnavailable, OSError):
+    except (AgeError, OSError):
         return False

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -1,0 +1,172 @@
+"""Encryption, delegated entirely to the ``age`` binary.
+
+Python's standard library has no cipher -- only hashing and randomness -- so
+sealing the synced history needs an external tool. ``age`` was chosen because it
+is one small static binary and it accepts **SSH public keys as recipients**,
+which means each machine can use the keypair it already pushes to git with and
+no secret ever has to be copied between machines.
+
+Nothing here knows about history, chunks, or git; it is a thin, testable seam so
+that swapping the backend later touches one file.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import NamedTuple
+
+AGE = "age"
+AGE_KEYGEN = "age-keygen"
+
+_TIMEOUT = 120
+
+
+class AgeUnavailable(RuntimeError):
+    """The age binary is not installed."""
+
+
+class AgeError(RuntimeError):
+    """age ran and refused."""
+
+
+class Identity(NamedTuple):
+    secret: str
+    public: str
+
+
+_MISSING = (
+    "woswoar: 'age' not found on PATH.\n"
+    "Sync encrypts every line before it reaches git, so age is required.\n"
+    "  Fedora:  sudo dnf install age\n"
+    "  Debian:  sudo apt install age\n"
+    "  macOS:   brew install age"
+)
+
+#: age emits this when it wants a passphrase it cannot ask for. Worth
+#: recognising: an unattended sync from a systemd timer has no terminal, so a
+#: passphrase-protected SSH key turns into a recurring silent failure.
+_PASSPHRASE_MARKER = "failed to obtain passphrase"
+
+_PASSPHRASE_HELP = (
+    "the identity is passphrase-protected and age cannot prompt here.\n"
+    "age does not use ssh-agent. Either point woswoar at an unencrypted key, or\n"
+    "run 'woswoar init --new-identity' to give this machine a dedicated one."
+)
+
+
+def available() -> bool:
+    return shutil.which(AGE) is not None and shutil.which(AGE_KEYGEN) is not None
+
+
+def require() -> None:
+    if not available():
+        raise AgeUnavailable(_MISSING)
+
+
+def _run(argv: list[str], data: bytes | None = None, pass_fds: tuple[int, ...] = ()) -> bytes:
+    require()
+    try:
+        result = subprocess.run(
+            argv,
+            input=data,
+            capture_output=True,
+            check=False,
+            timeout=_TIMEOUT,
+            pass_fds=pass_fds,
+        )
+    except subprocess.TimeoutExpired as exc:  # pragma: no cover - needs a hung age
+        raise AgeError(f"{argv[0]} timed out after {_TIMEOUT}s") from exc
+
+    if result.returncode != 0:
+        message = result.stderr.decode("utf-8", errors="replace").strip()
+        if _PASSPHRASE_MARKER in message:
+            raise AgeError(_PASSPHRASE_HELP)
+        raise AgeError(message or f"{argv[0]} failed with status {result.returncode}")
+    return result.stdout
+
+
+def encrypt_to_recipients(data: bytes, recipients_file: Path) -> bytes:
+    """Seal ``data`` so that every recipient listed in the file can open it.
+
+    age wraps one random file key separately per recipient, so the payload is
+    stored once no matter how many machines are listed.
+    """
+    return _run([AGE, "-R", str(recipients_file)], data)
+
+
+def encrypt_to(data: bytes, recipient: str) -> bytes:
+    """Seal ``data`` to a single recipient (used for the per-day key)."""
+    return _run([AGE, "-r", recipient], data)
+
+
+def decrypt_with_file(data: bytes, identity: Path) -> bytes:
+    """Open ``data`` using an identity stored on disk (an SSH or age key)."""
+    return _run([AGE, "-d", "-i", str(identity)], data)
+
+
+def decrypt_with_secret(data: bytes, secret: str) -> bytes:
+    """Open ``data`` using an in-memory identity.
+
+    The secret is handed to age through a pipe rather than a temporary file, so
+    a day key recovered during sync is never written to disk. Identities are a
+    couple of hundred bytes, comfortably inside the pipe buffer, so writing and
+    closing before age starts reading cannot deadlock.
+    """
+    read_fd, write_fd = os.pipe()
+    try:
+        os.write(write_fd, secret.encode("utf-8"))
+        os.close(write_fd)
+        write_fd = -1
+        return _run([AGE, "-d", "-i", f"/dev/fd/{read_fd}"], data, pass_fds=(read_fd,))
+    finally:
+        if write_fd != -1:
+            os.close(write_fd)
+        os.close(read_fd)
+
+
+def generate_identity() -> Identity:
+    """Create a fresh X25519 identity, returned rather than written to disk."""
+    require()
+    secret = _run([AGE_KEYGEN]).decode("utf-8")
+    return Identity(secret=secret, public=public_of(secret))
+
+
+def public_of(secret: str) -> str:
+    """Recover the public key from an identity's text."""
+    for line in secret.splitlines():
+        line = line.strip()
+        if line.startswith("# public key: "):
+            return line.removeprefix("# public key: ").strip()
+    # age-keygen always emits the comment, but a hand-written identity file may
+    # not, so fall back to asking age itself.
+    return _run([AGE_KEYGEN, "-y"], secret.encode("utf-8")).decode("utf-8").strip()
+
+
+def recipient_for(identity: Path) -> str:
+    """The public recipient string matching an identity file.
+
+    For an SSH key this is the contents of its ``.pub`` sibling, which is what
+    other machines will encrypt to; for an age identity, age derives it.
+    """
+    pub = identity.with_suffix(identity.suffix + ".pub")
+    if pub.is_file():
+        return pub.read_text(encoding="utf-8").strip()
+    return _run([AGE_KEYGEN, "-y", str(identity)]).decode("utf-8").strip()
+
+
+def usable(identity: Path) -> bool:
+    """Whether this identity can decrypt without a terminal.
+
+    Checked by actually performing a round trip rather than by inspecting the
+    key file, because the thing that matters is whether an unattended sync will
+    work, not what format the key claims to be.
+    """
+    try:
+        recipient = recipient_for(identity)
+        sealed = encrypt_to(b"woswoar", recipient)
+        return decrypt_with_file(sealed, identity) == b"woswoar"
+    except (AgeError, AgeUnavailable, OSError):
+        return False

--- a/woswoar/entry.py
+++ b/woswoar/entry.py
@@ -17,7 +17,7 @@ The host is *not* a field. It is derived from the path the line was read from,
 which keeps every line shorter and makes a file trivially attributable.
 
 Two fields are stored compactly, because they repeat on every single line and
-milestone 2 commits every byte to git permanently:
+sync commits every byte to git permanently:
 
 ``cwd``
     Written home-relative as ``~/src/woswoar`` when the directory was under the

--- a/woswoar/errors.py
+++ b/woswoar/errors.py
@@ -1,0 +1,18 @@
+"""The one exception type the CLI has to know about.
+
+Deliberately its own module with no imports: ``__main__`` needs to catch these
+at top level, and importing ``sync`` or ``crypto`` just to name an exception
+would put ~6 ms of ``dataclasses`` and ``subprocess`` on the Ctrl-R path, where
+neither module is otherwise used.
+"""
+
+from __future__ import annotations
+
+
+class WoswoarError(RuntimeError):
+    """An expected failure with a message worth showing the user as-is.
+
+    Missing age, an unreadable identity, a repo that was never initialised: all
+    actionable, none worth a traceback. Sync in particular runs unattended from
+    a timer, where nobody ever reads one.
+    """

--- a/woswoar/importer.py
+++ b/woswoar/importer.py
@@ -7,7 +7,6 @@ what is new.
 
 from __future__ import annotations
 
-import json
 import re
 from collections.abc import Iterator
 from pathlib import Path
@@ -146,18 +145,13 @@ def _state_path() -> Path:
 
 
 def _load_state() -> dict[str, int]:
-    try:
-        data = json.loads(_state_path().read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return {}
-    return {k: int(v) for k, v in data.items()} if isinstance(data, dict) else {}
+    return {k: int(v) for k, v in store.load_json(_state_path()).items()}
 
 
 def _save_state(state: dict[str, int]) -> None:
     # Atomic: a half-written watermark file would make the next import either
     # duplicate everything or skip entries silently.
-    payload = json.dumps(state, indent=2, sort_keys=True) + "\n"
-    store.write_atomic(_state_path(), payload.encode("utf-8"))
+    store.save_json(_state_path(), state)
 
 
 def run(kind: Kind, path: Path | None = None, dry_run: bool = False) -> Result:

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -2,7 +2,7 @@
 
 The plaintext logs under ``$WOSWOAR_DIR/logs`` are the working copy and the only
 thing milestone 1 touches. ``history/`` (the git working tree, ciphertext only)
-and ``state.json`` are milestone 2 and mirror this same ``hosts/<id>/`` shape,
+and ``state.json`` belong to sync and mirror this same ``hosts/<id>/`` shape,
 which is why the layout is defined here in one place.
 """
 
@@ -20,9 +20,20 @@ from typing import NamedTuple
 from .entry import Entry, format_line, parse_line
 
 _LOGS = "logs"
+_HISTORY = "history"
 _HOSTS = "hosts"
+_KEYS = "keys"
 _LOG_SUFFIX = ".tsv"
+_CHUNK_SUFFIX = ".age"
 _NAME_FILE = ".name"
+
+RECIPIENTS = "recipients.txt"
+GITATTRIBUTES = ".gitattributes"
+
+#: `recipients.txt` is the one file every machine appends to, so it is also the
+#: only place a merge conflict could arise. A union merge resolves it: the file
+#: is an unordered set of public keys, and keeping both sides is always right.
+GITATTRIBUTES_CONTENT = f"{RECIPIENTS} merge=union\n*{_CHUNK_SUFFIX} -diff -merge -text\n"
 
 
 class Machine(NamedTuple):
@@ -30,11 +41,15 @@ class Machine(NamedTuple):
 
     #: Opaque random hex. Used as the directory name so that a synced repo does
     #: not publish usernames and hostnames in cleartext path components -- the
-    #: file *contents* are encrypted in milestone 2, but paths never are.
+    #: file *contents* are encrypted, but paths never are.
     id: str
-    #: Human-readable label, shown in search results. Local only; milestone 2
-    #: shares it with other machines as an encrypted ``name.age``.
+    #: Human-readable label, shown in search results. Local only; shared with
+    #: other machines as an encrypted ``name.age``.
     name: str
+    #: Identity used to open anything sealed to this machine. Either an existing
+    #: SSH private key or a dedicated age identity; chosen once by `init`,
+    #: because age cannot prompt for a passphrase during an unattended sync.
+    identity: str = ""
 
 
 def _xdg(env_var: str, default: str) -> Path:
@@ -71,6 +86,11 @@ def host_dir(machine_id: str) -> Path:
     return logs_dir() / _HOSTS / machine_id
 
 
+def name_file(machine_id: str) -> Path:
+    """Local, plaintext friendly name for a host. Learned from ``name.age``."""
+    return host_dir(machine_id) / _NAME_FILE
+
+
 def day_for(ts: int) -> str:
     """The ``YYYY-MM-DD`` bucket a timestamp belongs to.
 
@@ -89,7 +109,7 @@ def write_atomic(path: Path, data: bytes) -> None:
 
     Every file woswoar owns outside the append-only logs is small, rewritten
     whole, and load-bearing if it survives half-written: the parse cache, the
-    import watermarks, and milestone 2's sync state. They all go through here so
+    import watermarks, and the sync state. They all go through here so
     a crash mid-write leaves the previous version rather than a corrupt one.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -128,26 +148,40 @@ def machine() -> Machine:
     The id is written once and never changes; renaming the host later changes
     only the display name, so history stays attributed to the same machine.
     """
-    path = config_dir() / "machine"
-    values = _read_kv(path)
+    values = _read_kv(machine_file())
     machine_id = values.get("id")
     name = values.get("name")
+    identity = values.get("identity", "")
 
     if machine_id and name:
-        return Machine(id=machine_id, name=name)
+        return Machine(id=machine_id, name=name, identity=identity)
 
-    machine_id = machine_id or secrets.token_hex(8)
-    name = name or default_machine_name()
+    known = Machine(
+        id=machine_id or secrets.token_hex(8),
+        name=name or default_machine_name(),
+        identity=identity,
+    )
+    save_machine(known)
+    return known
+
+
+def machine_file() -> Path:
+    return config_dir() / "machine"
+
+
+def save_machine(known: Machine) -> None:
+    path = machine_file()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(f"id={machine_id}\nname={name}\n", encoding="utf-8")
+    lines = [f"id={known.id}", f"name={known.name}"]
+    if known.identity:
+        lines.append(f"identity={known.identity}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
     # Mirrored next to the logs so search can label entries without reading
-    # config, and so milestone 2 has a single file to encrypt and share.
-    name_file = host_dir(machine_id) / _NAME_FILE
+    # config, and so sync has a single file to seal and share.
+    name_file = host_dir(known.id) / _NAME_FILE
     name_file.parent.mkdir(parents=True, exist_ok=True)
-    name_file.write_text(f"{name}\n", encoding="utf-8")
-
-    return Machine(id=machine_id, name=name)
+    name_file.write_text(f"{known.name}\n", encoding="utf-8")
 
 
 def default_machine_name() -> str:
@@ -201,6 +235,100 @@ def iter_log_files() -> Iterator[LogFile]:
                 host_id=host.name,
                 path=path,
             )
+
+
+# ---------------------------------------------------------------------------
+# The history repo: ciphertext only, and every file in it is write-once.
+# ---------------------------------------------------------------------------
+
+
+def history_dir() -> Path:
+    """The git working tree. Contains sealed chunks and nothing readable."""
+    return data_dir() / _HISTORY
+
+
+def recipients_file() -> Path:
+    return history_dir() / RECIPIENTS
+
+
+def state_file() -> Path:
+    """Local sync watermarks. Deliberately outside the repo -- it is per-machine
+    progress, not shared history, and syncing it would create conflicts."""
+    return data_dir() / "state.json"
+
+
+def repo_host_dir(machine_id: str) -> Path:
+    return history_dir() / _HOSTS / machine_id
+
+
+def name_seal(machine_id: str) -> Path:
+    """Sealed friendly name, so other machines can label this host's entries."""
+    return repo_host_dir(machine_id) / "name.age"
+
+
+def day_key(machine_id: str, day: str) -> Path:
+    """The day's identity, sealed to every recipient."""
+    return repo_host_dir(machine_id) / _KEYS / f"{day}{_CHUNK_SUFFIX}"
+
+
+def day_key_public(machine_id: str, day: str) -> Path:
+    """The day's public key, in the clear.
+
+    Public keys are not secret, and keeping this alongside means writing a chunk
+    never has to open the sealed key first.
+    """
+    return repo_host_dir(machine_id) / _KEYS / f"{day}.pub"
+
+
+def chunk_dir(machine_id: str, day: str) -> Path:
+    """``hosts/<id>/2026/07/29`` -- sharded so no directory holds tens of
+    thousands of entries after a couple of years."""
+    year, month, mday = day.split("-")
+    return repo_host_dir(machine_id) / year / month / mday
+
+
+def new_chunk(machine_id: str, day: str, ts: int) -> Path:
+    """A chunk path that has never existed before.
+
+    Zero-padded seconds sort chronologically as strings, which is what lets the
+    merge watermark be a plain string comparison. The random suffix keeps two
+    syncs in the same second from colliding.
+    """
+    return chunk_dir(machine_id, day) / f"{ts:010d}-{secrets.token_hex(2)}{_CHUNK_SUFFIX}"
+
+
+class Chunk(NamedTuple):
+    host_id: str
+    day: str
+    #: Filename only. Sorts chronologically, and is what the watermark stores.
+    name: str
+    path: Path
+
+
+def iter_chunks(machine_id: str) -> Iterator[Chunk]:
+    """Every sealed chunk belonging to one host, oldest first."""
+    root = repo_host_dir(machine_id)
+    if not root.is_dir():
+        return
+    for year in sorted(p for p in root.iterdir() if p.is_dir() and p.name.isdigit()):
+        for month in sorted(p for p in year.iterdir() if p.is_dir()):
+            for mday in sorted(p for p in month.iterdir() if p.is_dir()):
+                day = f"{year.name}-{month.name}-{mday.name}"
+                for path in sorted(mday.glob(f"*{_CHUNK_SUFFIX}")):
+                    yield Chunk(host_id=machine_id, day=day, name=path.name, path=path)
+
+
+def repo_hosts() -> list[str]:
+    """Machine ids present in the history repo."""
+    root = history_dir() / _HOSTS
+    if not root.is_dir():
+        return []
+    return sorted(p.name for p in root.iterdir() if p.is_dir())
+
+
+def day_of_log(relpath: str) -> str:
+    """``hosts/<id>/2026-07-29.tsv`` -> ``2026-07-29``."""
+    return relpath.rsplit("/", 1)[-1].removesuffix(_LOG_SUFFIX)
 
 
 def append_entries(machine_id: str, entries: list[Entry]) -> dict[str, int]:

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -9,13 +9,14 @@ which is why the layout is defined here in one place.
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import secrets
 import tempfile
 import time
 from collections.abc import Iterator
 from pathlib import Path
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 from .entry import Entry, format_line, parse_line
 
@@ -123,6 +124,49 @@ def write_atomic(path: Path, data: bytes) -> None:
         with contextlib.suppress(OSError):
             os.unlink(tmp)
         raise
+
+
+def read_tail(path: Path, offset: int) -> tuple[bytes, int]:
+    """Bytes from ``offset`` onwards, truncated to the last complete line.
+
+    Returns the data and the new consumed offset. A partially written final
+    line -- a shell killed mid-append -- is deliberately left unconsumed, so it
+    is picked up correctly once its writer finishes it.
+
+    Shared by the two pipelines that read these same physical files: the parse
+    cache, and sync's export. They must agree on where a file "ends", and for
+    sync the stakes are higher -- a half-sealed record would be committed to an
+    append-only repo where it could never be fixed.
+    """
+    try:
+        with path.open("rb") as handle:
+            handle.seek(offset)
+            data = handle.read()
+    except OSError:
+        return b"", offset
+
+    cut = data.rfind(b"\n")
+    if cut < 0:
+        return b"", offset
+    return data[: cut + 1], offset + cut + 1
+
+
+def load_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Read a small JSON state file, tolerating absence and corruption.
+
+    These files are progress markers, never the source of truth: losing one
+    costs redundant work, so falling back beats raising.
+    """
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return dict(default or {})
+    return raw if isinstance(raw, dict) else dict(default or {})
+
+
+def save_json(path: Path, payload: object) -> None:
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    write_atomic(path, text.encode("utf-8"))
 
 
 def _read_kv(path: Path) -> dict[str, str]:
@@ -298,7 +342,6 @@ def new_chunk(machine_id: str, day: str, ts: int) -> Path:
 
 
 class Chunk(NamedTuple):
-    host_id: str
     day: str
     #: Filename only. Sorts chronologically, and is what the watermark stores.
     name: str
@@ -315,7 +358,36 @@ def iter_chunks(machine_id: str) -> Iterator[Chunk]:
             for mday in sorted(p for p in month.iterdir() if p.is_dir()):
                 day = f"{year.name}-{month.name}-{mday.name}"
                 for path in sorted(mday.glob(f"*{_CHUNK_SUFFIX}")):
-                    yield Chunk(host_id=machine_id, day=day, name=path.name, path=path)
+                    yield Chunk(day=day, name=path.name, path=path)
+
+
+def iter_day_keys(machine_id: str) -> Iterator[Path]:
+    """Every sealed day key belonging to one host.
+
+    Exists so callers never have to spell out the keys directory or the chunk
+    suffix themselves -- those are this module's to know, and a hand-typed copy
+    would silently stop matching rather than fail loudly if the layout changed.
+    """
+    keys = repo_host_dir(machine_id) / _KEYS
+    if not keys.is_dir():
+        return
+    yield from sorted(keys.glob(f"*{_CHUNK_SUFFIX}"))
+
+
+def is_chunk_path(relpath: str) -> bool:
+    """Whether a repo-relative path is a write-once chunk.
+
+    Key material and name seals live outside this shape and are deliberately
+    rewritable, so telling them apart is a property of the layout rather than
+    something a caller should pattern-match for itself.
+    """
+    parts = relpath.split("/")
+    return (
+        len(parts) == 6
+        and parts[0] == _HOSTS
+        and all(p.isdigit() for p in parts[2:5])
+        and parts[5].endswith(_CHUNK_SUFFIX)
+    )
 
 
 def repo_hosts() -> list[str]:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1,0 +1,590 @@
+"""Git synchronisation with age-encrypted, write-once chunks.
+
+The shape of this, and why:
+
+- The plaintext logs under ``logs/`` are the working copy and the truth. The git
+  tree under ``history/`` holds only ciphertext.
+- Every sync seals *only the lines added since last time* into a brand new file.
+  Nothing in the repo is ever modified or deleted, which is what makes
+  ``git pull --rebase`` structurally unable to conflict and makes repo growth
+  exactly the bytes written -- an append-only single file would instead depend
+  on git finding good pack deltas for binary blobs.
+- Each chunk is encrypted to a per-host-per-day key, which is itself sealed to
+  every recipient. That halves the per-chunk header (measured: 200 bytes rather
+  than 432 with three SSH recipients) and, more importantly, makes onboarding a
+  new machine re-seal a few hundred tiny key files instead of tens of thousands
+  of chunks.
+- Each chunk is decrypted exactly once, ever. The plaintext lands in ``logs/``
+  and the cache picks it up from there.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import subprocess
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import crypto, store
+from .store import Machine
+
+GIT_TIMEOUT = 300
+
+#: Commits carry no useful information -- the content is opaque and the author
+#: is always this machine -- so they are uniform. A varying message would only
+#: leak activity patterns into a place that is not encrypted.
+COMMIT_MESSAGE = "woswoar sync"
+
+
+class SyncError(RuntimeError):
+    pass
+
+
+@dataclass
+class Report:
+    chunks_written: int = 0
+    lines_exported: int = 0
+    chunks_merged: int = 0
+    lines_imported: int = 0
+    pushed: bool = False
+    pulled: bool = False
+    hosts_seen: set[str] = field(default_factory=set)
+    #: "<host>/<day>" entries sealed before this machine was enrolled. Not an
+    #: error: it is what a freshly joined machine sees until someone runs
+    #: `reencrypt` on a machine that was already a recipient.
+    unreadable: set[str] = field(default_factory=set)
+
+
+# ---------------------------------------------------------------------------
+# git
+# ---------------------------------------------------------------------------
+
+
+def git(*args: str, cwd: Path | None = None, check: bool = True) -> str:
+    repo = cwd or store.history_dir()
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=GIT_TIMEOUT,
+    )
+    if check and result.returncode != 0:
+        raise SyncError(f"git {' '.join(args)} failed:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def has_remote() -> bool:
+    return bool(git("remote", check=False))
+
+
+def is_repo() -> bool:
+    return (store.history_dir() / ".git").exists()
+
+
+# ---------------------------------------------------------------------------
+# Local sync state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class State:
+    """Per-machine progress. Deliberately *not* in the repo: it describes what
+    this machine has done, not shared history, and syncing it would manufacture
+    the conflicts the rest of the design avoids."""
+
+    #: log relpath -> plaintext bytes already sealed into a chunk.
+    exported: dict[str, int] = field(default_factory=dict)
+    #: "<host>/<day>" -> newest chunk filename already merged into logs/.
+    merged: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls) -> State:
+        try:
+            raw = json.loads(store.state_file().read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return cls()
+        if not isinstance(raw, dict):
+            return cls()
+        return cls(
+            exported={str(k): int(v) for k, v in raw.get("exported", {}).items()},
+            merged={str(k): str(v) for k, v in raw.get("merged", {}).items()},
+        )
+
+    def save(self) -> None:
+        payload = json.dumps(
+            {"exported": self.exported, "merged": self.merged}, indent=2, sort_keys=True
+        )
+        store.write_atomic(store.state_file(), (payload + "\n").encode("utf-8"))
+
+
+@contextmanager
+def lock() -> Iterator[None]:
+    """Serialise syncs. A prompt-triggered sync and the timer can collide."""
+    path = store.data_dir() / "sync.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("w")
+    try:
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            raise SyncError("another woswoar sync is already running") from exc
+        yield
+    finally:
+        handle.close()
+
+
+# ---------------------------------------------------------------------------
+# Keys
+# ---------------------------------------------------------------------------
+
+
+def identity_path(known: Machine) -> Path:
+    if not known.identity:
+        raise SyncError("no identity configured; run 'woswoar init' first")
+    path = Path(known.identity).expanduser()
+    if not path.is_file():
+        raise SyncError(f"identity {path} is missing; re-run 'woswoar init'")
+    return path
+
+
+def day_public_key(known: Machine, day: str) -> str:
+    """The public half of this host's key for ``day``, creating it if needed.
+
+    One key per host per day. Kept in the clear beside the sealed private half
+    so writing a chunk never has to open the sealed key first.
+    """
+    pub_path = store.day_key_public(known.id, day)
+    if pub_path.is_file():
+        return pub_path.read_text(encoding="utf-8").strip()
+
+    identity = crypto.generate_identity()
+    sealed = crypto.encrypt_to_recipients(identity.secret.encode("utf-8"), store.recipients_file())
+    pub_path.parent.mkdir(parents=True, exist_ok=True)
+    store.write_atomic(store.day_key(known.id, day), sealed)
+    store.write_atomic(pub_path, (identity.public + "\n").encode("utf-8"))
+    return identity.public
+
+
+def open_day_key(known: Machine, host_id: str, day: str) -> str:
+    """Recover a day's private identity so its chunks can be read."""
+    sealed_path = store.day_key(host_id, day)
+    try:
+        sealed = sealed_path.read_bytes()
+    except OSError as exc:
+        raise SyncError(f"missing day key {sealed_path}") from exc
+    return crypto.decrypt_with_file(sealed, identity_path(known)).decode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Export: plaintext tail -> sealed chunk
+# ---------------------------------------------------------------------------
+
+
+def _unsealed_tail(path: Path, offset: int) -> tuple[bytes, int]:
+    """Bytes after ``offset``, truncated to the last complete line.
+
+    A partial final line is left for the next sync, exactly as the cache does:
+    sealing half a record would put a permanently broken line in the repo, and
+    the repo is append-only so it could never be fixed.
+    """
+    try:
+        with path.open("rb") as handle:
+            handle.seek(offset)
+            data = handle.read()
+    except OSError:
+        return b"", offset
+    cut = data.rfind(b"\n")
+    if cut < 0:
+        return b"", offset
+    return data[: cut + 1], offset + cut + 1
+
+
+def export(known: Machine, state: State, report: Report, now: int) -> None:
+    """Seal each log file's new lines into a fresh chunk."""
+    for log in store.iter_log_files():
+        if log.host_id != known.id:
+            continue  # other hosts' logs arrived decrypted; never re-export them
+        data, new_offset = _unsealed_tail(log.path, state.exported.get(log.relpath, 0))
+        if not data:
+            continue
+
+        day = store.day_of_log(log.relpath)
+        sealed = crypto.encrypt_to(data, day_public_key(known, day))
+        chunk = store.new_chunk(known.id, day, now)
+        chunk.parent.mkdir(parents=True, exist_ok=True)
+        store.write_atomic(chunk, sealed)
+
+        state.exported[log.relpath] = new_offset
+        report.chunks_written += 1
+        report.lines_exported += data.count(b"\n")
+
+
+# ---------------------------------------------------------------------------
+# Import: sealed chunk -> plaintext log
+# ---------------------------------------------------------------------------
+
+
+def merge(known: Machine, state: State, report: Report) -> None:
+    """Decrypt every chunk from other hosts that we have not merged yet."""
+    for host_id in store.repo_hosts():
+        if host_id == known.id:
+            continue  # our own plaintext is already the source of truth
+        report.hosts_seen.add(host_id)
+        _merge_host(known, host_id, state, report)
+        _merge_name(known, host_id)
+
+
+def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> None:
+    day_keys: dict[str, str] = {}
+    pending: dict[str, list[bytes]] = {}
+
+    for chunk in store.iter_chunks(host_id):
+        key = f"{host_id}/{chunk.day}"
+        # Chunk names are zero-padded timestamps, so "newer than the watermark"
+        # is a plain string comparison.
+        if chunk.name <= state.merged.get(key, ""):
+            continue
+
+        if chunk.day not in day_keys:
+            try:
+                day_keys[chunk.day] = open_day_key(known, host_id, chunk.day)
+            except (crypto.AgeError, SyncError):
+                # Sealed before this machine was enrolled, and no one has run
+                # `reencrypt` yet. Skip it without advancing the watermark so a
+                # later sync picks it up -- and above all without aborting, or
+                # one unreadable day would block this machine's own export too.
+                report.unreadable.add(f"{host_id}/{chunk.day}")
+                continue
+        plaintext = crypto.decrypt_with_secret(chunk.path.read_bytes(), day_keys[chunk.day])
+        pending.setdefault(chunk.day, []).append(plaintext)
+        state.merged[key] = chunk.name
+        report.chunks_merged += 1
+
+    for day, blocks in pending.items():
+        payload = b"".join(blocks)
+        target = store.log_file(host_id, day)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("ab") as handle:
+            handle.write(payload)
+        report.lines_imported += payload.count(b"\n")
+
+
+def _merge_name(known: Machine, host_id: str) -> None:
+    """Learn another machine's friendly name, so search can label its entries."""
+    local = store.name_file(host_id)
+    if local.is_file():
+        return
+    sealed = store.name_seal(host_id)
+    if not sealed.is_file():
+        return
+    try:
+        name = crypto.decrypt_with_file(sealed.read_bytes(), identity_path(known))
+    except (crypto.AgeError, SyncError, OSError):
+        # A name we cannot open is cosmetic; the opaque id still works.
+        return
+    local.parent.mkdir(parents=True, exist_ok=True)
+    local.write_bytes(name)
+
+
+# ---------------------------------------------------------------------------
+# The sync itself
+# ---------------------------------------------------------------------------
+
+
+def run(push: bool = True, now: int | None = None) -> Report:
+    """Export, exchange with the remote, import. Safe to run concurrently."""
+    crypto.require()
+    if not is_repo():
+        raise SyncError("no history repo yet; run 'woswoar init' first")
+
+    known = store.machine()
+    if not store.recipients_file().is_file():
+        raise SyncError("no recipients.txt in the history repo; run 'woswoar init'")
+
+    _ensure_repo_config()
+    report = Report()
+    remote = push and has_remote()
+
+    with lock():
+        state = State.load()
+
+        # Take the remote's view *before* exporting. Creating a day key seals it
+        # to whatever recipients.txt says right now, so exporting against a
+        # stale list would produce a key that machines enrolled since the last
+        # sync can never open -- silently, and permanently, because the repo is
+        # append-only.
+        if remote:
+            _fetch_and_rebase(report)
+
+        export(known, state, report, int(time.time()) if now is None else now)
+        _commit()
+
+        if remote:
+            _push(report)
+
+        merge(known, state, report)
+        state.save()
+
+    return report
+
+
+def _branch() -> str:
+    return git("rev-parse", "--abbrev-ref", "HEAD")
+
+
+def _fetch_and_rebase(report: Report) -> None:
+    """Adopt the remote's history under ours.
+
+    Fetch-then-rebase rather than ``git pull --rebase`` because the tracking ref
+    may legitimately not exist: cloning an *empty* remote configures a branch
+    pointing at nothing, which is the normal state for the first machine to
+    enrol. Checking the fetched ref directly handles that and the ordinary case
+    with one code path.
+
+    The rebase cannot conflict over chunks -- every machine only ever adds files
+    below its own host id. ``recipients.txt`` is the single shared file, and
+    ``.gitattributes`` marks it ``merge=union`` so both sides' keys survive.
+    """
+    branch = _branch()
+    git("fetch", "--quiet", "origin")
+    if not git("rev-parse", "--verify", "--quiet", f"refs/remotes/origin/{branch}", check=False):
+        return
+    try:
+        git("rebase", "--autostash", f"origin/{branch}")
+    except SyncError:
+        git("rebase", "--abort", check=False)
+        raise
+    report.pulled = True
+
+
+def _push(report: Report) -> None:
+    """Publish, retrying once if someone else pushed while we worked."""
+    branch = _branch()
+    try:
+        git("push", "--quiet", "-u", "origin", branch)
+    except SyncError:
+        _fetch_and_rebase(report)
+        git("push", "--quiet", "-u", "origin", branch)
+    report.pushed = True
+
+
+#: Commit metadata is one of the few things in the repo that is *not* encrypted,
+#: so it is pinned to a fixed identity rather than inheriting the user's real
+#: name and email from their global gitconfig. Set on the repo so that rebase
+#: and commit alike pick it up, including on a machine with no gitconfig at all.
+COMMIT_NAME = "woswoar"
+COMMIT_EMAIL = "woswoar@localhost"
+
+
+def _ensure_repo_config() -> None:
+    if git("config", "user.name", check=False) != COMMIT_NAME:
+        git("config", "user.name", COMMIT_NAME)
+    if git("config", "user.email", check=False) != COMMIT_EMAIL:
+        git("config", "user.email", COMMIT_EMAIL)
+
+
+def _commit() -> None:
+    git("add", "-A")
+    if not git("status", "--porcelain"):
+        return
+    git("commit", "-q", "-m", COMMIT_MESSAGE)
+
+
+# ---------------------------------------------------------------------------
+# Onboarding
+# ---------------------------------------------------------------------------
+
+#: Tried in order when no identity is configured. An existing SSH key is
+#: preferred because it means no new secret exists to lose or leak.
+SSH_CANDIDATES = ("id_ed25519", "id_rsa")
+
+
+def choose_identity(new_identity: bool = False, explicit: Path | None = None) -> Path:
+    """Pick the key this machine will use to open things sealed to it.
+
+    Resolved once, at init, and recorded -- not re-detected per sync. The check
+    is a real encrypt/decrypt round trip rather than an inspection of the key
+    file, because what matters is whether an *unattended* sync will work: age
+    does not use ssh-agent, so a passphrase-protected key that works fine in a
+    terminal fails from a systemd timer.
+    """
+    if explicit is not None:
+        path = explicit.expanduser()
+        if not crypto.usable(path):
+            raise SyncError(f"{path} cannot decrypt without a terminal; see 'woswoar doctor'")
+        return path
+
+    if not new_identity:
+        for name in SSH_CANDIDATES:
+            candidate = Path.home() / ".ssh" / name
+            if candidate.is_file() and crypto.usable(candidate):
+                return candidate
+
+    dedicated = store.config_dir() / "identity"
+    if dedicated.is_file() and crypto.usable(dedicated):
+        return dedicated
+
+    identity = crypto.generate_identity()
+    dedicated.parent.mkdir(parents=True, exist_ok=True)
+    store.write_atomic(dedicated, identity.secret.encode("utf-8"))
+    dedicated.chmod(0o600)
+    return dedicated
+
+
+def initialise(
+    remote: str | None = None,
+    new_identity: bool = False,
+    identity: Path | None = None,
+) -> tuple[Machine, Path]:
+    """Create or clone the history repo and enrol this machine in it."""
+    crypto.require()
+
+    chosen = choose_identity(new_identity=new_identity, explicit=identity)
+    known = store.machine()._replace(identity=str(chosen))
+    store.save_machine(known)
+
+    history = store.history_dir()
+    if not is_repo():
+        history.parent.mkdir(parents=True, exist_ok=True)
+        if remote and not any(history.glob("*")):
+            git("clone", "--quiet", remote, str(history), cwd=history.parent)
+        else:
+            history.mkdir(parents=True, exist_ok=True)
+            git("init", "--quiet", "-b", "main")
+    if remote and not has_remote():
+        git("remote", "add", "origin", remote)
+
+    _ensure_repo_config()
+    _write_repo_metadata(known, chosen)
+    _commit()
+
+    # Publish immediately. Until this machine's public key is on the remote,
+    # `reencrypt` run elsewhere cannot include it, so onboarding would appear to
+    # succeed and then silently fail to grant access to any older history.
+    if has_remote():
+        report = Report()
+        _fetch_and_rebase(report)
+        # The rebase may have brought in a recipients.txt that does not list us.
+        if _write_repo_metadata(known, chosen):
+            _commit()
+        _push(report)
+
+    return known, chosen
+
+
+def _write_repo_metadata(known: Machine, identity: Path) -> bool:
+    """Ensure this machine is enrolled. Returns whether anything changed."""
+    changed = False
+
+    attrs = store.history_dir() / store.GITATTRIBUTES
+    current = attrs.read_text(encoding="utf-8") if attrs.is_file() else ""
+    if current != store.GITATTRIBUTES_CONTENT:
+        store.write_atomic(attrs, store.GITATTRIBUTES_CONTENT.encode("utf-8"))
+        changed = True
+
+    if add_recipient(crypto.recipient_for(identity)):
+        changed = True
+
+    seal = store.name_seal(known.id)
+    if not seal.is_file():
+        seal.parent.mkdir(parents=True, exist_ok=True)
+        store.write_atomic(
+            seal,
+            crypto.encrypt_to_recipients(f"{known.name}\n".encode(), store.recipients_file()),
+        )
+        changed = True
+    return changed
+
+
+def reencrypt() -> int:
+    """Re-seal every key file to the current recipient list.
+
+    This is what makes a newly onboarded machine able to read *old* history.
+    Chunks are encrypted to per-day keys, so only those small key files -- and
+    the name seals -- have to be rewritten; the tens of thousands of chunks are
+    untouched. Any machine already enrolled can do it for every host, because
+    all hosts seal their keys to the same recipient list.
+
+    This is one of only two operations that rewrite an existing file. It is
+    deliberately explicit rather than part of sync.
+    """
+    crypto.require()
+    known = store.machine()
+    identity = identity_path(known)
+    recipients = store.recipients_file()
+    resealed = 0
+
+    for host_id in store.repo_hosts():
+        keys_dir = store.repo_host_dir(host_id) / "keys"
+        candidates = sorted(keys_dir.glob("*.age")) if keys_dir.is_dir() else []
+        seal = store.name_seal(host_id)
+        if seal.is_file():
+            candidates.append(seal)
+
+        for path in candidates:
+            try:
+                plain = crypto.decrypt_with_file(path.read_bytes(), identity)
+            except (crypto.AgeError, OSError):
+                # Not ours to re-seal: a machine that was removed from the
+                # recipient list leaves keys nobody here can open.
+                continue
+            store.write_atomic(path, crypto.encrypt_to_recipients(plain, recipients))
+            resealed += 1
+
+    _commit()
+    return resealed
+
+
+def compact(before: str) -> tuple[int, int]:
+    """Merge a host's own chunks for completed days into one chunk per day.
+
+    Write-once chunks trade bytes for inodes: a 5-minute timer produces roughly
+    40 files a day. This is the escape hatch, and it is opt-in precisely because
+    it is the only routine operation that *deletes* files -- which is the
+    property the rest of the design leans on. Only this host's own chunks are
+    touched, so it still cannot conflict.
+
+    Returns (days compacted, chunks replaced).
+    """
+    crypto.require()
+    known = store.machine()
+    by_day: dict[str, list[store.Chunk]] = {}
+    for chunk in store.iter_chunks(known.id):
+        if chunk.day < before:
+            by_day.setdefault(chunk.day, []).append(chunk)
+
+    days = 0
+    replaced = 0
+    for day, chunks in sorted(by_day.items()):
+        if len(chunks) < 2:
+            continue
+        secret = open_day_key(known, known.id, day)
+        plain = b"".join(crypto.decrypt_with_secret(c.path.read_bytes(), secret) for c in chunks)
+        merged = store.new_chunk(known.id, day, int(chunks[-1].name.split("-")[0]))
+        store.write_atomic(merged, crypto.encrypt_to(plain, crypto.public_of(secret)))
+        for chunk in chunks:
+            chunk.path.unlink()
+        days += 1
+        replaced += len(chunks)
+
+    if days:
+        _commit()
+    return days, replaced
+
+
+def add_recipient(recipient: str) -> bool:
+    """Append a public key to recipients.txt if it is not already listed."""
+    path = store.recipients_file()
+    existing = path.read_text(encoding="utf-8") if path.is_file() else ""
+    if recipient.strip() in {line.strip() for line in existing.splitlines()}:
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    separator = "" if not existing or existing.endswith("\n") else "\n"
+    store.write_atomic(path, f"{existing}{separator}{recipient.strip()}\n".encode())
+    return True

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -21,15 +21,16 @@ The shape of this, and why:
 from __future__ import annotations
 
 import fcntl
-import json
 import subprocess
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import NamedTuple
 
 from . import crypto, store
+from .errors import WoswoarError
 from .store import Machine
 
 GIT_TIMEOUT = 300
@@ -40,7 +41,7 @@ GIT_TIMEOUT = 300
 COMMIT_MESSAGE = "woswoar sync"
 
 
-class SyncError(RuntimeError):
+class SyncError(WoswoarError):
     pass
 
 
@@ -51,7 +52,6 @@ class Report:
     chunks_merged: int = 0
     lines_imported: int = 0
     pushed: bool = False
-    pulled: bool = False
     hosts_seen: set[str] = field(default_factory=set)
     #: "<host>/<day>" entries sealed before this machine was enrolled. Not an
     #: error: it is what a freshly joined machine sees until someone runs
@@ -83,6 +83,29 @@ def has_remote() -> bool:
     return bool(git("remote", check=False))
 
 
+def remote_summary() -> str:
+    """One line describing where history is published, for humans."""
+    remotes = git("remote", "-v", check=False).splitlines()
+    return remotes[0] if remotes else "none (history is local only)"
+
+
+def list_recipients() -> list[tuple[str, str]]:
+    """``(kind, key)`` for every enrolled machine.
+
+    Parsed here rather than in the CLI because this module is the only writer of
+    recipients.txt, so the record shape is its to know.
+    """
+    path = store.recipients_file()
+    if not path.is_file():
+        return []
+    entries = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            kind, _, rest = line.strip().partition(" ")
+            entries.append((kind, rest))
+    return entries
+
+
 def is_repo() -> bool:
     return (store.history_dir() / ".git").exists()
 
@@ -105,22 +128,18 @@ class State:
 
     @classmethod
     def load(cls) -> State:
-        try:
-            raw = json.loads(store.state_file().read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            return cls()
-        if not isinstance(raw, dict):
+        raw = store.load_json(store.state_file())
+        exported = raw.get("exported", {})
+        merged = raw.get("merged", {})
+        if not isinstance(exported, dict) or not isinstance(merged, dict):
             return cls()
         return cls(
-            exported={str(k): int(v) for k, v in raw.get("exported", {}).items()},
-            merged={str(k): str(v) for k, v in raw.get("merged", {}).items()},
+            exported={str(k): int(v) for k, v in exported.items()},
+            merged={str(k): str(v) for k, v in merged.items()},
         )
 
     def save(self) -> None:
-        payload = json.dumps(
-            {"exported": self.exported, "merged": self.merged}, indent=2, sort_keys=True
-        )
-        store.write_atomic(store.state_file(), (payload + "\n").encode("utf-8"))
+        store.save_json(store.state_file(), {"exported": self.exported, "merged": self.merged})
 
 
 @contextmanager
@@ -151,6 +170,34 @@ def identity_path(known: Machine) -> Path:
     if not path.is_file():
         raise SyncError(f"identity {path} is missing; re-run 'woswoar init'")
     return path
+
+
+class IdentityStatus(NamedTuple):
+    ok: bool
+    detail: str
+
+
+def identity_status(known: Machine) -> IdentityStatus:
+    """Whether this machine could actually decrypt during an unattended sync.
+
+    Lives here rather than in `doctor` so the judgement is testable and stated
+    once. The passphrase case is the reason it exists: age does not use
+    ssh-agent, so such a key works perfectly by hand and fails forever from a
+    timer -- a failure mode nobody notices without being told.
+    """
+    if not known.identity:
+        return IdentityStatus(False, "no identity recorded - run 'woswoar init'")
+
+    path = Path(known.identity).expanduser()
+    if not path.is_file():
+        return IdentityStatus(False, f"identity {path} is missing - re-run 'woswoar init'")
+    if not crypto.available():
+        return IdentityStatus(True, f"identity {path} (age missing, cannot verify)")
+    if not crypto.usable(path):
+        return IdentityStatus(
+            False, f"{path} needs a passphrase - try 'woswoar init --new-identity'"
+        )
+    return IdentityStatus(True, f"identity {path}")
 
 
 def day_public_key(known: Machine, day: str) -> str:
@@ -186,31 +233,12 @@ def open_day_key(known: Machine, host_id: str, day: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _unsealed_tail(path: Path, offset: int) -> tuple[bytes, int]:
-    """Bytes after ``offset``, truncated to the last complete line.
-
-    A partial final line is left for the next sync, exactly as the cache does:
-    sealing half a record would put a permanently broken line in the repo, and
-    the repo is append-only so it could never be fixed.
-    """
-    try:
-        with path.open("rb") as handle:
-            handle.seek(offset)
-            data = handle.read()
-    except OSError:
-        return b"", offset
-    cut = data.rfind(b"\n")
-    if cut < 0:
-        return b"", offset
-    return data[: cut + 1], offset + cut + 1
-
-
 def export(known: Machine, state: State, report: Report, now: int) -> None:
     """Seal each log file's new lines into a fresh chunk."""
     for log in store.iter_log_files():
         if log.host_id != known.id:
             continue  # other hosts' logs arrived decrypted; never re-export them
-        data, new_offset = _unsealed_tail(log.path, state.exported.get(log.relpath, 0))
+        data, new_offset = store.read_tail(log.path, state.exported.get(log.relpath, 0))
         if not data:
             continue
 
@@ -241,7 +269,12 @@ def merge(known: Machine, state: State, report: Report) -> None:
 
 
 def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> None:
-    day_keys: dict[str, str] = {}
+    #: None marks a day whose key we already failed to open. Caching the failure
+    #: matters as much as caching the success: without it, a machine that has
+    #: not been granted access yet retries the same doomed `age -d` once per
+    #: chunk rather than once per day -- tens of thousands of subprocess spawns
+    #: instead of hundreds, on precisely the first sync a new machine runs.
+    day_keys: dict[str, str | None] = {}
     pending: dict[str, list[bytes]] = {}
 
     for chunk in store.iter_chunks(host_id):
@@ -259,9 +292,13 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 # `reencrypt` yet. Skip it without advancing the watermark so a
                 # later sync picks it up -- and above all without aborting, or
                 # one unreadable day would block this machine's own export too.
-                report.unreadable.add(f"{host_id}/{chunk.day}")
-                continue
-        plaintext = crypto.decrypt_with_secret(chunk.path.read_bytes(), day_keys[chunk.day])
+                day_keys[chunk.day] = None
+        secret = day_keys[chunk.day]
+        if secret is None:
+            report.unreadable.add(key)
+            continue
+
+        plaintext = crypto.decrypt_with_secret(chunk.path.read_bytes(), secret)
         pending.setdefault(chunk.day, []).append(plaintext)
         state.merged[key] = chunk.name
         report.chunks_merged += 1
@@ -335,7 +372,12 @@ def run(push: bool = True, now: int | None = None) -> Report:
 
 
 def _branch() -> str:
-    return git("rev-parse", "--abbrev-ref", "HEAD")
+    """The current branch, including before the first commit exists.
+
+    `rev-parse --abbrev-ref HEAD` cannot answer on an unborn HEAD, which is
+    exactly the state `init` is in when it enrols the first machine.
+    """
+    return git("branch", "--show-current")
 
 
 def _fetch_and_rebase(report: Report) -> None:
@@ -360,7 +402,6 @@ def _fetch_and_rebase(report: Report) -> None:
     except SyncError:
         git("rebase", "--abort", check=False)
         raise
-    report.pulled = True
 
 
 def _push(report: Report) -> None:
@@ -461,18 +502,21 @@ def initialise(
         git("remote", "add", "origin", remote)
 
     _ensure_repo_config()
-    _write_repo_metadata(known, chosen)
-    _commit()
+    report = Report()
+
+    # Adopt the remote's state before enrolling, so we append to the real
+    # recipients.txt rather than creating a competing one.
+    publishing = has_remote()
+    if publishing:
+        _fetch_and_rebase(report)
+
+    if _write_repo_metadata(known, chosen):
+        _commit()
 
     # Publish immediately. Until this machine's public key is on the remote,
     # `reencrypt` run elsewhere cannot include it, so onboarding would appear to
     # succeed and then silently fail to grant access to any older history.
-    if has_remote():
-        report = Report()
-        _fetch_and_rebase(report)
-        # The rebase may have brought in a recipients.txt that does not list us.
-        if _write_repo_metadata(known, chosen):
-            _commit()
+    if publishing:
         _push(report)
 
     return known, chosen
@@ -521,8 +565,7 @@ def reencrypt() -> int:
     resealed = 0
 
     for host_id in store.repo_hosts():
-        keys_dir = store.repo_host_dir(host_id) / "keys"
-        candidates = sorted(keys_dir.glob("*.age")) if keys_dir.is_dir() else []
+        candidates = list(store.iter_day_keys(host_id))
         seal = store.name_seal(host_id)
         if seal.is_file():
             candidates.append(seal)


### PR DESCRIPTION
History now syncs between machines through an ordinary git repo, sealed with [age](https://github.com/FiloSottile/age). No server, and **nothing readable reaches the remote** — not commands, not paths, not usernames or hostnames.

```bash
woswoar init git@github.com:you/woswoar-history.git
woswoar sync
```

## Storage: write-once chunks

Each sync seals only the lines added since last time into a brand new file. Nothing in the repo is ever modified or deleted. That is what makes `git pull --rebase` structurally unable to conflict, and makes growth exactly the bytes written rather than depending on git finding pack deltas for binary blobs.

The invariant is asserted exactly rather than by heuristic — `git log --diff-filter=MD` over chunk paths must be empty. Key files and name seals *are* rewritable (that is what makes onboarding cheap), so the test separates the two explicitly instead of quietly widening the rule.

## Per-day keys, with real numbers

Chunks are encrypted to a per-host-per-day key, itself sealed to every recipient. Measured with age 1.3.1 and three `ssh-ed25519` recipients:

| | overhead per chunk |
|---|---|
| sealed directly to 3 recipients | 432 B |
| sealed to the day key | **200 B** |

A sealed day key is 621 B, so enrolling a machine re-seals ~730 tiny key files rather than ~35,000 chunks — `reencrypt` takes seconds even with years of history.

## Three problems only building it surfaced

**Export must happen after the fetch.** Creating a day key seals it to whatever `recipients.txt` says *at that moment*. Exporting first sealed the day key to a stale recipient list, so any machine enrolled since the last sync could never open that day — silently, and permanently, because the repo is append-only. It takes two machines *and* a new day to reproduce, which is exactly what a single-machine test never reaches.

**`git pull --rebase` fails against a freshly cloned empty remote** — the normal state for the first machine to enrol. The tracking ref exists in config but points at nothing. Fetch first, then check the fetched ref directly; that covers the empty case and the someone-else-pushed case in one path.

**age does not use ssh-agent.** A passphrase-protected SSH key works by hand and fails from a systemd timer. Verified it exits 1 rather than hanging, but it would still never succeed unattended. `init` now resolves an identity **once** — by a real encrypt/decrypt round trip, not by inspecting the key file — and records it, falling back to a dedicated age key.

## Robustness

A machine that cannot yet read some history now reports it and carries on. Previously one unreadable host aborted the whole sync, so a newly enrolled machine could not even export its own commands.

`init` also publishes immediately: until a new machine's public key is on the remote, `reencrypt` run elsewhere cannot include it, and onboarding would appear to succeed while granting no access to older history.

Commits use a fixed `woswoar <woswoar@localhost>` identity set on the repo — commit metadata is one of the few things that isn't encrypted, so it shouldn't carry your real name and address.

## Also included

`init` / `sync` / `reencrypt` / `compact`, a systemd `--user` timer (with jitter, so machines don't all sync on the same tick and manufacture push races), and sync reporting in `doctor` — including the passphrase trap, which is the failure you'd otherwise only notice as a timer that quietly never works.

## Testing

17 new end-to-end tests driving **real age and real git**, no mocks: two machines through a bare repo, onboarding + `reencrypt`, bidirectional exchange, idempotent re-sync, offline backlog spanning days, compaction, concurrent-sync locking, and a check that no plaintext appears anywhere in the repo. 105 tests total; `ruff`, `mypy --strict`, `shellcheck` clean.

CI gains a `sync` job and installs `age` in the test matrix — and **fails if the sync tests skip**, since a silently skipped suite looks exactly like a passing one. The `install` job now also runs two machines through a bare repo from the installed wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)