### PR TITLE
Import history from atuin

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,18 @@ its existing history.
 The database is opened read-only — it is very likely a running atuin's live
 database, and woswoar has no business writing to it.
 
-One consequence worth knowing: `woswoar sync` only ever publishes *this*
-machine's own commands, so history imported for other machines stays local. Run
-`woswoar import atuin` on each machine to give them all the full set.
+**If you sync several woswoar machines, use `--this-host-only` on each.** Sync
+publishes only this machine's own commands, so importing every atuin host on
+every machine means each peer's history exists twice: once imported locally,
+once arriving over sync. Letting each machine import just its own keeps one
+copy of everything.
+
+Importing everything is the right choice when only one machine runs woswoar —
+you get all nine machines' history, it just stays local.
+
+woswoar reuses a peer's real host id when that peer is already known locally, so
+importing *after* your machines have synced also avoids duplicates. Importing
+before they have met cannot: the ids were assigned independently.
 
 `woswoar doctor` checks the installation if something looks wrong.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ woswoar import bash
 - **Records exit code, duration, and working directory** alongside the command.
 - **Costs 28 µs per command and forks nothing.** The hook is pure bash; Python
   never runs on your prompt.
-- **Imports** your existing `~/.bash_history` or `~/.zsh_history`, idempotently.
+- **Imports** your existing bash, zsh, or **atuin** history, idempotently.
 
 ## Requirements
 
@@ -45,6 +45,26 @@ woswoar install         # writes the hook and sources it from ~/.bashrc
 woswoar import bash     # optional: bring your existing history along
 ```
 
+### Coming from atuin
+
+```bash
+woswoar import atuin --dry-run   # see what would happen, changes nothing
+woswoar import atuin
+```
+
+atuin keeps every machine it has synced with in one sqlite database, so an
+import can carry history from several hosts. woswoar keeps them apart rather
+than flattening them, so `--scope host` and `stats` stay truthful: each atuin
+machine gets its own host entry, and commands from *this* machine merge into
+its existing history.
+
+The database is opened read-only — it is very likely a running atuin's live
+database, and woswoar has no business writing to it.
+
+One consequence worth knowing: `woswoar sync` only ever publishes *this*
+machine's own commands, so history imported for other machines stays local. Run
+`woswoar import atuin` on each machine to give them all the full set.
+
 `woswoar doctor` checks the installation if something looks wrong.
 
 ## Commands
@@ -53,7 +73,7 @@ woswoar import bash     # optional: bring your existing history along
 |---|---|
 | `woswoar search` | interactive picker (what Ctrl-R runs) |
 | `woswoar list` | plain output, used by fzf's scope-switch reload |
-| `woswoar import bash\|zsh` | import an existing history |
+| `woswoar import bash\|zsh\|atuin` | import an existing history |
 | `woswoar stats` | entry counts, date range, most-used commands |
 | `woswoar doctor` | check bash version, fzf, hook, cache |
 | `woswoar init [url]` | create or join an encrypted history repo |

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -312,11 +312,27 @@ Conversions, all of which are quirks of the real format rather than guesses:
 **Host attribution is the interesting part.** atuin syncs every machine into one
 database, so an import can carry commands from many hosts — nine, in the case
 this was built against. Flattening them into the importing machine would make
-`--scope host` and `stats` lie, so each atuin machine gets its own woswoar host
-directory. Ids are derived from the hostname (`blake2b`, 16 hex chars) rather
-than random, so a second import lands in the same place instead of forking a
-duplicate machine. Commands from *this* machine merge into its real id, so they
-sit alongside what the hook records and sync normally.
+`--scope host` and `stats` lie, so each atuin machine gets its own woswoar host.
+
+Ids resolve in this order, once per distinct hostname:
+
+1. **This machine** keeps its real id, so imported history sits alongside what
+   the hook records and syncs normally.
+2. **A machine already known locally** — because its history has synced in —
+   reuses *its* id. Without this the same peer would exist twice, under its real
+   random id and under a derived one, with the same label and no way to
+   reconcile them.
+3. **Anything else** gets an id derived from the label (`blake2b`, 16 hex
+   chars), so a second import lands in the same place instead of forking a
+   duplicate machine.
+
+The label drops the DNS domain, matching `store.default_machine_name()`. Without
+that, a host whose nodename is an FQDN would file *its own* history as a foreign
+machine — invisible to `--scope host`, never published by sync.
+
+Rule 2 only helps if the peers have already met. When several machines run
+woswoar, `--this-host-only` is the reliable answer: each imports its own rows
+and sync distributes them, so exactly one copy of everything exists.
 
 Idempotency is by `(timestamp, command)` per host, **not** by a position
 watermark: atuin backfills *older* rows whenever it syncs from another machine,

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -292,6 +292,41 @@ the untimed case, where synthesised timestamps shift as the source grows and so
 cannot identify an entry. A `(ts, cmd)` check handles everything else, and
 covers the count going stale when a history file is rotated or trimmed.
 
+### atuin
+
+`woswoar import atuin` reads atuin's sqlite database directly — **read-only**,
+since it is very likely the live database of a running atuin, and read-only also
+means woswoar cannot trigger WAL recovery on someone else's file.
+
+Conversions, all of which are quirks of the real format rather than guesses:
+
+| atuin | woswoar |
+|---|---|
+| `timestamp` in nanoseconds | seconds |
+| `duration` in nanoseconds, **`-1` when the command never finished** | milliseconds, `-1` preserved |
+| `cwd` absolute, or the literal string **`"unknown"`** | home-relative for this machine, `""` for unknown |
+| `hostname` as `host:user` | one woswoar host per machine |
+| `session` UUID | hashed to 14 hex chars, matching the hook's width |
+| `deleted_at` non-null | skipped |
+
+**Host attribution is the interesting part.** atuin syncs every machine into one
+database, so an import can carry commands from many hosts — nine, in the case
+this was built against. Flattening them into the importing machine would make
+`--scope host` and `stats` lie, so each atuin machine gets its own woswoar host
+directory. Ids are derived from the hostname (`blake2b`, 16 hex chars) rather
+than random, so a second import lands in the same place instead of forking a
+duplicate machine. Commands from *this* machine merge into its real id, so they
+sit alongside what the hook records and sync normally.
+
+Idempotency is by `(timestamp, command)` per host, **not** by a position
+watermark: atuin backfills *older* rows whenever it syncs from another machine,
+so "everything after the last row I saw" would silently miss them.
+
+Since sync only publishes this machine's own commands, history imported for
+*other* machines stays local. That is deliberate — each machine runs the import
+against its own atuin database, which avoids two machines publishing overlapping
+copies of the same history.
+
 ---
 
 ## Synchronisation and encryption

--- a/tests/test_importer_atuin.py
+++ b/tests/test_importer_atuin.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 import sqlite3
 import unittest
+from collections.abc import Sequence
 from pathlib import Path
 
 from woswoar import cache, importer, search, store
@@ -40,7 +41,7 @@ BASE = 1_700_000_000 * SECOND
 
 
 class AtuinTestCase(WoswoarTestCase):
-    def atuin(self, rows: list[tuple[object, ...]], name: str = "history.db") -> Path:
+    def atuin(self, rows: Sequence[tuple[object, ...]], name: str = "history.db") -> Path:
         """Build an atuin database. Rows are (ts_ns, dur_ns, exit, cmd, cwd, session, host)."""
         path = self.root / name
         db = sqlite3.connect(path)
@@ -272,6 +273,138 @@ class TestIdempotency(AtuinTestCase):
         self.assertEqual(dict(result.per_host), {"martin@laptop": 2, "martin@desktop": 1})
         # Biggest first, so the summary reads usefully with nine machines.
         self.assertEqual([n for n, _ in result.per_host], ["martin@laptop", "martin@desktop"])
+
+
+class TestReviewRegressions(AtuinTestCase):
+    """Each of these was a real defect found by review, not a hypothetical."""
+
+    def test_fqdn_hostname_is_still_recognised_as_this_machine(self) -> None:
+        # default_machine_name() uses only the first nodename component, so
+        # comparing atuin's raw hostname filed one's *own* history under a
+        # foreign host: invisible to --scope host, never published by sync.
+        user, _, host = store.default_machine_name().partition("@")
+        db = self.atuin([(BASE, 0, 0, "mine", "/tmp", "s1", f"{host}.example.com:{user}")])
+        importer.run("atuin", db)
+        self.assertEqual(cache.load_entries()[0].host, store.machine().id)
+
+    def test_fqdn_and_short_hostname_are_the_same_machine(self) -> None:
+        db = self.atuin(
+            [
+                (BASE, 0, 0, "a", "/tmp", "s1", "laptop.lan:martin"),
+                (BASE + SECOND, 0, 0, "b", "/tmp", "s1", "laptop:martin"),
+            ]
+        )
+        importer.run("atuin", db)
+        self.assertEqual(
+            len(
+                {e.host for e in cache.load_entries()},
+            ),
+            1,
+        )
+
+    def test_a_peer_already_known_locally_is_not_duplicated(self) -> None:
+        # Once a peer's history syncs in it has a real, random host id. A
+        # derived id could never equal it, so the same machine would exist
+        # twice under two directories sharing one label.
+        peer_id = "aaaabbbbccccdddd"
+        store.name_file(peer_id).parent.mkdir(parents=True, exist_ok=True)
+        store.name_file(peer_id).write_text("martin@laptop\n", encoding="utf-8")
+
+        db = self.atuin([(BASE, 0, 0, "cmd", "/tmp", "s1", "laptop:martin")])
+        importer.run("atuin", db)
+        self.assertEqual(cache.load_entries()[0].host, peer_id)
+
+    def test_undecodable_command_does_not_abort_the_import(self) -> None:
+        db = self.atuin([(BASE + SECOND, 0, 0, "fine", "/tmp", "s1", "box:someone")])
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "INSERT INTO history (id, timestamp, duration, exit, command, cwd, session,"
+            " hostname) VALUES ('bad', ?, 0, 0, CAST(x'6c73ff' AS TEXT), '/tmp', 's1',"
+            " 'box:someone')",
+            (BASE,),
+        )
+        conn.commit()
+        conn.close()
+
+        # Previously raised sqlite3.OperationalError straight out of the
+        # generator, past the CLI's handler, killing the whole import.
+        result = importer.run("atuin", db)
+        self.assertEqual(result.imported, 2)
+        self.assertIn("fine", {e.cmd for e in cache.load_entries()})
+
+    def test_path_with_uri_metacharacters_is_read_not_created(self) -> None:
+        # A '#' truncated the spliced URI, dropping mode=ro -- so sqlite
+        # cheerfully created a new writable database at the truncated name,
+        # the exact opposite of the read-only guarantee.
+        db = self.atuin([(BASE, 0, 0, "cmd", "/tmp", "s1", "box:someone")], "od#d?b%1.db")
+        before = sorted(p.name for p in self.root.iterdir() if p.is_file())
+
+        result = importer.run("atuin", db)
+        self.assertEqual(result.imported, 1, "the real database was not read")
+        # A truncated URI made sqlite create a *new* writable database at the
+        # cut-off name; only woswoar's own directories may appear.
+        self.assertEqual(sorted(p.name for p in self.root.iterdir() if p.is_file()), before)
+
+    def test_first_import_into_an_empty_store_reports_no_false_skips(self) -> None:
+        # Same second, same command, different directory: one row survives
+        # woswoar's whole-second resolution. Counting that as "already
+        # present" made a first-ever import claim entries it had never seen.
+        db = self.atuin(
+            [
+                (BASE, 0, 0, "make", "/a", "s1", "box:someone"),
+                (BASE, 0, 0, "make", "/b", "s1", "box:someone"),
+            ]
+        )
+        result = importer.run("atuin", db)
+        self.assertEqual(result.skipped, 0)
+        self.assertEqual(result.collapsed, 1)
+        self.assertEqual(result.imported, 1)
+
+    def test_a_missing_name_is_repaired_by_reimporting(self) -> None:
+        db = self.atuin([(BASE, 0, 0, "cmd", "/tmp", "s1", "laptop:martin")])
+        importer.run("atuin", db)
+
+        host_id = next(h for h, n in store.host_names().items() if n == "martin@laptop")
+        store.name_file(host_id).unlink()
+
+        # The second run imports nothing, so a name write gated on fresh
+        # entries would leave this host labelled by its opaque id forever.
+        importer.run("atuin", db)
+        self.assertEqual(store.host_names().get(host_id), "martin@laptop")
+
+    def test_host_resolution_does_not_scale_with_row_count(self) -> None:
+        many = [
+            (BASE + i * SECOND, 0, 0, f"cmd {i}", "/tmp", "s1", f"host{i % 5}:user")
+            for i in range(400)
+        ]
+        db = self.atuin(many)
+        calls = 0
+        real = store.default_machine_name
+
+        def counted() -> str:
+            nonlocal calls
+            calls += 1
+            return real()
+
+        store.default_machine_name = counted
+        self.addCleanup(lambda: setattr(store, "default_machine_name", real))
+        importer.run("atuin", db)
+
+        # Once for the whole import, not once per row: this was ~60% of runtime.
+        self.assertLessEqual(calls, 2, f"resolved host identity {calls} times for 400 rows")
+
+
+class TestThisHostOnly(AtuinTestCase):
+    def test_only_this_machines_history_is_imported(self) -> None:
+        db = self.atuin(
+            [
+                (BASE, 0, 0, "mine", "/tmp", "s1", self.this_machine()),
+                (BASE + SECOND, 0, 0, "theirs", "/tmp", "s2", "elsewhere:someone"),
+            ]
+        )
+        result = importer.run("atuin", db, this_host_only=True)
+        self.assertEqual(result.imported, 1)
+        self.assertEqual({e.cmd for e in cache.load_entries()}, {"mine"})
 
 
 class TestFailures(AtuinTestCase):

--- a/tests/test_importer_atuin.py
+++ b/tests/test_importer_atuin.py
@@ -1,0 +1,303 @@
+"""Importing atuin's sqlite history.
+
+The fixture mirrors the schema and the quirks of a real atuin database
+(18.16.1): nanosecond timestamps, ``-1`` for a duration it never saw finish,
+the literal string ``unknown`` for an unknown directory, and a ``host:user``
+hostname carrying history from every machine atuin has synced with.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import unittest
+from pathlib import Path
+
+from woswoar import cache, importer, search, store
+from woswoar.entry import MAX_CMD_CHARS
+
+from .support import WoswoarTestCase
+
+SCHEMA = """
+CREATE TABLE history (
+    id text primary key,
+    timestamp integer not null,
+    duration integer not null,
+    exit integer not null,
+    command text not null,
+    cwd text not null,
+    session text not null,
+    hostname text not null,
+    deleted_at integer,
+    author text,
+    intent text,
+    unique(timestamp, cwd, command)
+)
+"""
+
+SECOND = 1_000_000_000
+BASE = 1_700_000_000 * SECOND
+
+
+class AtuinTestCase(WoswoarTestCase):
+    def atuin(self, rows: list[tuple[object, ...]], name: str = "history.db") -> Path:
+        """Build an atuin database. Rows are (ts_ns, dur_ns, exit, cmd, cwd, session, host)."""
+        path = self.root / name
+        db = sqlite3.connect(path)
+        db.execute(SCHEMA)
+        db.executemany(
+            "INSERT INTO history (id, timestamp, duration, exit, command, cwd, session, hostname)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [(f"id{i}", *row) for i, row in enumerate(rows)],
+        )
+        db.commit()
+        db.close()
+        return path
+
+    def this_machine(self) -> str:
+        """The `host:user` atuin would record on the machine running the tests."""
+        user, _, host = store.default_machine_name().partition("@")
+        return f"{host}:{user}"
+
+
+class TestConversion(AtuinTestCase):
+    def test_nanosecond_timestamp_becomes_seconds(self) -> None:
+        db = self.atuin([(BASE, 5 * SECOND, 0, "git status", "/tmp", "s1", "box:someone")])
+        importer.run("atuin", db)
+        entry = cache.load_entries()[0]
+        self.assertEqual(entry.ts, 1_700_000_000)
+
+    def test_nanosecond_duration_becomes_milliseconds(self) -> None:
+        db = self.atuin([(BASE, 1_500_000_000, 0, "sleep 1.5", "/tmp", "s1", "box:someone")])
+        importer.run("atuin", db)
+        self.assertEqual(cache.load_entries()[0].duration_ms, 1500)
+
+    def test_unfinished_command_keeps_unknown_duration(self) -> None:
+        # atuin writes -1 when it never saw the command finish. woswoar uses the
+        # same convention, so it must survive rather than become -1000 ms.
+        db = self.atuin([(BASE, -1, 0, "vim", "/tmp", "s1", "box:someone")])
+        importer.run("atuin", db)
+        self.assertEqual(cache.load_entries()[0].duration_ms, -1)
+
+    def test_unknown_cwd_becomes_empty(self) -> None:
+        db = self.atuin([(BASE, 0, 0, "ls", "unknown", "s1", "box:someone")])
+        importer.run("atuin", db)
+        self.assertEqual(cache.load_entries()[0].cwd, "")
+
+    def test_exit_code_is_preserved(self) -> None:
+        db = self.atuin([(BASE, 0, 130, "sleep 99", "/tmp", "s1", "box:someone")])
+        importer.run("atuin", db)
+        self.assertEqual(cache.load_entries()[0].exit_code, 130)
+
+    def test_commands_with_newlines_and_tabs_survive(self) -> None:
+        tricky = "for i in 1 2; do\n\techo $i\ndone"
+        db = self.atuin([(BASE, 0, 0, tricky, "/tmp", "s1", "box:someone")])
+        importer.run("atuin", db)
+        self.assertEqual(cache.load_entries()[0].cmd, tricky)
+
+    def test_session_is_shortened_but_stays_distinct(self) -> None:
+        db = self.atuin(
+            [
+                (BASE, 0, 0, "a", "/tmp", "0191f0e6-1111-7000-8000-000000000001", "box:someone"),
+                (BASE + SECOND, 0, 0, "b", "/tmp", "0191f0e6-2222-7000-8000-000000000002", "b:s"),
+            ]
+        )
+        importer.run("atuin", db)
+        sessions = {e.session for e in cache.load_entries()}
+        self.assertEqual(len(sessions), 2)
+        # Repeated on every line, so it is hashed to the same width the hook writes.
+        self.assertTrue(all(len(s) == 14 for s in sessions), sessions)
+
+    def test_deleted_rows_are_not_imported(self) -> None:
+        db = self.atuin([(BASE, 0, 0, "kept", "/tmp", "s1", "box:someone")])
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "INSERT INTO history (id, timestamp, duration, exit, command, cwd, session,"
+            " hostname, deleted_at) VALUES ('x', ?, 0, 0, 'forgotten', '/tmp', 's1',"
+            " 'box:someone', 12345)",
+            (BASE + SECOND,),
+        )
+        conn.commit()
+        conn.close()
+
+        importer.run("atuin", db)
+        self.assertEqual({e.cmd for e in cache.load_entries()}, {"kept"})
+
+    def test_empty_commands_are_skipped(self) -> None:
+        db = self.atuin(
+            [
+                (BASE, 0, 0, "   ", "/tmp", "s1", "box:someone"),
+                (BASE + SECOND, 0, 0, "real", "/tmp", "s1", "box:someone"),
+            ]
+        )
+        importer.run("atuin", db)
+        self.assertEqual({e.cmd for e in cache.load_entries()}, {"real"})
+
+
+class TestHostAttribution(AtuinTestCase):
+    def test_each_machine_gets_its_own_host(self) -> None:
+        db = self.atuin(
+            [
+                (BASE, 0, 0, "on laptop", "/tmp", "s1", "laptop:martin"),
+                (BASE + SECOND, 0, 0, "on desktop", "/tmp", "s2", "desktop:martin"),
+            ]
+        )
+        importer.run("atuin", db)
+        # Flattening these into one host would make --scope host and stats lie.
+        hosts = {e.host for e in cache.load_entries()}
+        self.assertEqual(len(hosts), 2)
+
+    def test_machine_names_are_recorded_for_display(self) -> None:
+        db = self.atuin([(BASE, 0, 0, "cmd", "/tmp", "s1", "laptop:martin")])
+        importer.run("atuin", db)
+        self.assertIn("martin@laptop", store.host_names().values())
+
+    def test_host_ids_are_stable_across_imports(self) -> None:
+        db = self.atuin([(BASE, 0, 0, "cmd", "/tmp", "s1", "laptop:martin")])
+        importer.run("atuin", db)
+        first = {e.host for e in cache.load_entries()}
+
+        other = self.atuin([(BASE + SECOND, 0, 0, "later", "/tmp", "s1", "laptop:martin")], "b.db")
+        importer.run("atuin", other)
+        # Derived from the name, not random, so a second import lands in the
+        # same host directory instead of forking a duplicate machine.
+        self.assertEqual({e.host for e in cache.load_entries()}, first)
+
+    def test_this_machines_history_merges_into_its_own_host(self) -> None:
+        db = self.atuin([(BASE, 0, 0, "mine", "/tmp", "s1", self.this_machine())])
+        importer.run("atuin", db)
+        entry = next(e for e in cache.load_entries() if e.cmd == "mine")
+        # So it sits with what the hook records, and syncs normally.
+        self.assertEqual(entry.host, store.machine().id)
+
+    def test_host_scope_separates_imported_machines(self) -> None:
+        db = self.atuin(
+            [
+                (BASE, 0, 0, "mine", "/tmp", "s1", self.this_machine()),
+                (BASE + SECOND, 0, 0, "theirs", "/tmp", "s2", "elsewhere:someone"),
+            ]
+        )
+        importer.run("atuin", db)
+        entries = cache.load_entries()
+        self.assertEqual(len(search.filter_scope(entries, "global")), 2)
+        self.assertEqual([e.cmd for e in search.filter_scope(entries, "host")], ["mine"])
+
+    def test_own_paths_are_stored_home_relative(self) -> None:
+        home = str(Path.home())
+        db = self.atuin(
+            [
+                (BASE, 0, 0, "mine", f"{home}/src", "s1", self.this_machine()),
+                (BASE + SECOND, 0, 0, "theirs", "/home/other/src", "s2", "elsewhere:other"),
+            ]
+        )
+        importer.run("atuin", db)
+        by_cmd = {e.cmd: e for e in cache.load_entries()}
+        self.assertEqual(by_cmd["mine"].cwd, "~/src")
+        # Another machine's home is a guess; a wrong ~ is worse than a long path.
+        self.assertEqual(by_cmd["theirs"].cwd, "/home/other/src")
+
+    def test_hostname_without_a_username(self) -> None:
+        db = self.atuin([(BASE, 0, 0, "cmd", "/tmp", "s1", "plainhost")])
+        importer.run("atuin", db)
+        self.assertIn("plainhost", store.host_names().values())
+
+
+class TestIdempotency(AtuinTestCase):
+    def test_reimport_adds_nothing(self) -> None:
+        db = self.atuin(
+            [
+                (BASE, 0, 0, "one", "/tmp", "s1", "box:someone"),
+                (BASE + SECOND, 0, 0, "two", "/tmp", "s1", "box:someone"),
+            ]
+        )
+        first = importer.run("atuin", db)
+        again = importer.run("atuin", db)
+
+        self.assertEqual(first.imported, 2)
+        self.assertEqual(again.imported, 0)
+        self.assertEqual(again.skipped, 2)
+        self.assertEqual(len(cache.load_entries()), 2)
+
+    def test_reimport_picks_up_backfilled_older_rows(self) -> None:
+        # atuin backfills *older* entries whenever it syncs from another
+        # machine, so a "everything after the last row I saw" watermark would
+        # silently miss them. Dedup is by (timestamp, command) for that reason.
+        db = self.atuin([(BASE + 10 * SECOND, 0, 0, "newer", "/tmp", "s1", "box:someone")])
+        importer.run("atuin", db)
+
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "INSERT INTO history (id, timestamp, duration, exit, command, cwd, session,"
+            " hostname) VALUES ('back', ?, 0, 0, 'older', '/tmp', 's1', 'box:someone')",
+            (BASE,),
+        )
+        conn.commit()
+        conn.close()
+
+        result = importer.run("atuin", db)
+        self.assertEqual(result.imported, 1)
+        self.assertEqual({e.cmd for e in cache.load_entries()}, {"newer", "older"})
+
+    def test_overlong_command_is_not_reimported_forever(self) -> None:
+        # Regression, found against a real 54,943-row atuin database: commands
+        # past MAX_CMD_CHARS are truncated on write, so a dedup key built from
+        # the original text never matched what was stored, and those entries
+        # were re-appended on every single import.
+        huge = "echo " + "x" * (MAX_CMD_CHARS + 5000)
+        db = self.atuin(
+            [
+                (BASE, 0, 0, huge, "/tmp", "s1", "box:someone"),
+                (BASE + SECOND, 0, 0, "normal", "/tmp", "s1", "box:someone"),
+            ]
+        )
+        self.assertEqual(importer.run("atuin", db).imported, 2)
+        self.assertEqual(importer.run("atuin", db).imported, 0)
+        self.assertEqual(len(cache.load_entries()), 2)
+
+    def test_dry_run_writes_no_history(self) -> None:
+        db = self.atuin([(BASE, 0, 0, "cmd", "/tmp", "s1", "box:someone")])
+        result = importer.run("atuin", db, dry_run=True)
+        self.assertEqual(result.imported, 1)
+        self.assertEqual(cache.load_entries(), [])
+
+    def test_per_host_counts_are_reported(self) -> None:
+        db = self.atuin(
+            [
+                (BASE, 0, 0, "a", "/tmp", "s1", "laptop:martin"),
+                (BASE + SECOND, 0, 0, "b", "/tmp", "s1", "laptop:martin"),
+                (BASE + 2 * SECOND, 0, 0, "c", "/tmp", "s2", "desktop:martin"),
+            ]
+        )
+        result = importer.run("atuin", db)
+        self.assertEqual(dict(result.per_host), {"martin@laptop": 2, "martin@desktop": 1})
+        # Biggest first, so the summary reads usefully with nine machines.
+        self.assertEqual([n for n, _ in result.per_host], ["martin@laptop", "martin@desktop"])
+
+
+class TestFailures(AtuinTestCase):
+    def test_missing_database_is_reported_clearly(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            importer.run("atuin", self.root / "nope.db")
+
+    def test_a_database_that_is_not_atuin_is_reported_clearly(self) -> None:
+        path = self.root / "other.db"
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE something (x int)")
+        conn.commit()
+        conn.close()
+        with self.assertRaises(FileNotFoundError):
+            importer.run("atuin", path)
+
+    def test_the_database_is_never_written_to(self) -> None:
+        db = self.atuin([(BASE, 0, 0, "cmd", "/tmp", "s1", "box:someone")])
+        before = db.read_bytes()
+        os.chmod(db, 0o444)
+        self.addCleanup(os.chmod, db, 0o644)
+
+        importer.run("atuin", db)
+        # Opened mode=ro: this is very likely a running atuin's live database.
+        self.assertEqual(db.read_bytes(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -82,15 +82,23 @@ def cmd_search(args: argparse.Namespace) -> int:
 def cmd_import(args: argparse.Namespace) -> int:
     try:
         result = importer.run(
-            args.kind, Path(args.file).expanduser() if args.file else None, dry_run=args.dry_run
+            args.kind,
+            Path(args.file).expanduser() if args.file else None,
+            dry_run=args.dry_run,
+            this_host_only=args.this_host_only,
         )
     except FileNotFoundError as exc:
         print(f"woswoar: {exc}", file=sys.stderr)
         return 1
 
     prefix = "would import" if args.dry_run else "imported"
+    notes = []
+    if result.skipped:
+        notes.append(f"{result.skipped} already present")
+    if result.collapsed:
+        notes.append(f"{result.collapsed} same-second duplicates collapsed")
     print(f"{result.source}: {result.parsed} parsed, {prefix} {result.imported}", end="")
-    print(f", {result.skipped} already present" if result.skipped else "")
+    print(f", {', '.join(notes)}" if notes else "")
 
     if len(result.per_host) > 1:
         print("\nper machine:")
@@ -309,6 +317,11 @@ def build_parser() -> argparse.ArgumentParser:
         "or ~/.local/share/atuin/history.db)",
     )
     p_import.add_argument("--dry-run", action="store_true")
+    p_import.add_argument(
+        "--this-host-only",
+        action="store_true",
+        help="atuin: skip history belonging to other machines",
+    )
     p_import.set_defaults(func=cmd_import)
 
     p_install = subparsers.add_parser("install", help="install the shell hook into .bashrc")

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -91,6 +91,16 @@ def cmd_import(args: argparse.Namespace) -> int:
     prefix = "would import" if args.dry_run else "imported"
     print(f"{result.source}: {result.parsed} parsed, {prefix} {result.imported}", end="")
     print(f", {result.skipped} already present" if result.skipped else "")
+
+    if len(result.per_host) > 1:
+        print("\nper machine:")
+        width = max(len(name) for name, _ in result.per_host)
+        for name, count in result.per_host:
+            print(f"  {name:<{width}}  {count}")
+        print(
+            "\nOnly this machine's own commands are published by 'woswoar sync'.\n"
+            "Run 'woswoar import atuin' on each machine to give them all the full set."
+        )
     return 0
 
 
@@ -109,8 +119,10 @@ def cmd_stats(args: argparse.Namespace) -> int:
     print(f"entries  : {len(entries)} ({unique} unique)")
     print(f"range    : {store.day_for(oldest)} .. {store.day_for(newest)}")
     print("hosts    :")
+    labels = {host: names.get(host, host) for host, _ in per_host.most_common()}
+    width = max((len(label) for label in labels.values()), default=0)
     for host, count in per_host.most_common():
-        print(f"  {names.get(host, host):<24} {count}")
+        print(f"  {labels[host]:<{width}}  {count}")
 
     top = Counter(e.cmd for e in entries).most_common(args.top)
     if top:
@@ -291,7 +303,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_import = subparsers.add_parser("import", help="import an existing shell history")
     p_import.add_argument("kind", choices=importer.KINDS)
-    p_import.add_argument("--file", help="source file (default: ~/.bash_history or ~/.zsh_history)")
+    p_import.add_argument(
+        "--file",
+        help="source (default: ~/.bash_history, ~/.zsh_history, "
+        "or ~/.local/share/atuin/history.db)",
+    )
     p_import.add_argument("--dry-run", action="store_true")
     p_import.set_defaults(func=cmd_import)
 

--- a/woswoar/importer.py
+++ b/woswoar/importer.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import hashlib
 import re
 import sqlite3
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Literal, NamedTuple
 
@@ -50,6 +50,11 @@ class Result(NamedTuple):
     imported: int
     skipped: int
     source: Path
+    #: Rows dropped because an identical (second, command) was already taken
+    #: during *this* run -- distinct from `skipped`, which means it was already
+    #: on disk. Reporting them as one made a first-ever import into an empty
+    #: store claim entries were "already present".
+    collapsed: int = 0
     #: (display name, count) per machine, biggest first. Only atuin carries
     #: more than one host. A tuple rather than a dict because Result is a
     #: NamedTuple, and a mutable default would be shared across instances.
@@ -191,52 +196,102 @@ def _atuin_rows(path: Path) -> Iterator[AtuinRow]:
         raise FileNotFoundError(f"no atuin database at {path}")
 
     try:
-        db = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        db = sqlite3.connect(_readonly_uri(path), uri=True)
     except sqlite3.Error as exc:
         raise FileNotFoundError(f"cannot open {path} read-only: {exc}") from exc
 
+    # atuin has no encoding guarantee -- a mistyped paste or a filename in some
+    # other charset lands in the table verbatim, and sqlite3's default strict
+    # decode raises mid-iteration. Losing a character beats losing the import,
+    # which is the same trade the bash and zsh readers already make.
+    db.text_factory = lambda raw: raw.decode("utf-8", errors="replace")
+
     try:
         try:
-            cursor = db.execute(_ATUIN_QUERY)
+            for ts_ns, duration_ns, exit_code, cmd, cwd, session, hostname in db.execute(
+                _ATUIN_QUERY
+            ):
+                yield AtuinRow(
+                    ts=int(ts_ns) // _NS_PER_SECOND,
+                    # atuin writes -1 when it never saw the command finish,
+                    # which happens to be woswoar's own "unknown" value too.
+                    duration_ms=int(duration_ns) // _NS_PER_MS if duration_ns >= 0 else -1,
+                    exit_code=int(exit_code),
+                    cmd=cmd,
+                    cwd="" if cwd == _ATUIN_UNKNOWN_CWD else cwd,
+                    # Opaque either way, and repeated on every line; 14 hex
+                    # chars matches what the shell hook writes.
+                    session=hashlib.blake2b(session.encode(), digest_size=7).hexdigest(),
+                    hostname=hostname,
+                )
         except sqlite3.Error as exc:
-            raise FileNotFoundError(f"{path} does not look like an atuin database: {exc}") from exc
-
-        for ts_ns, duration_ns, exit_code, cmd, cwd, session, hostname in cursor:
-            yield AtuinRow(
-                ts=int(ts_ns) // _NS_PER_SECOND,
-                # atuin writes -1 when it never saw the command finish, which
-                # happens to be woswoar's own "unknown" value too.
-                duration_ms=int(duration_ns) // _NS_PER_MS if duration_ns >= 0 else -1,
-                exit_code=int(exit_code),
-                cmd=cmd,
-                cwd="" if cwd == _ATUIN_UNKNOWN_CWD else cwd,
-                # Opaque either way, and repeated on every line; 14 hex chars
-                # matches what the shell hook writes.
-                session=hashlib.blake2b(session.encode(), digest_size=7).hexdigest(),
-                hostname=hostname,
-            )
+            # Wraps the whole loop, not just execute(): sqlite reports a bad
+            # schema on execute but a bad *row* only once iteration reaches it.
+            raise FileNotFoundError(f"cannot read {path} as an atuin database: {exc}") from exc
     finally:
         db.close()
 
 
-def _host_for(hostname: str) -> tuple[str, str]:
-    """Map an atuin ``hostname:username`` to a woswoar (host id, display name).
+def _readonly_uri(path: Path) -> str:
+    """A sqlite URI that cannot be misread as carrying query parameters.
 
-    atuin syncs every machine's history into one database, so an import can
-    carry commands from many hosts. Flattening them into this machine would
-    make `--scope host` and `stats` lie, so each gets its own host directory.
+    Interpolating the path directly is unsafe: a ``#`` or ``?`` in it truncates
+    the filename, which drops ``mode=ro`` and makes sqlite happily *create* a
+    new writable database at the truncated name -- the exact opposite of the
+    guarantee this function exists to provide.
+    """
+    return f"{path.resolve().as_uri()}?mode=ro"
 
-    The id is derived from the name rather than random, so re-importing lands
-    in the same place. Commands from *this* machine merge into its real id, so
-    they sit alongside what the hook records and get synced normally.
+
+def display_name(hostname: str) -> str:
+    """atuin's ``host:user`` as a woswoar machine label.
+
+    The DNS domain is dropped to match :func:`store.default_machine_name`,
+    which uses only the first component of the nodename. Without that, the same
+    machine seen as ``mbp.local`` and as ``mbp`` would be two different hosts --
+    and one's *own* history would be filed as a foreign machine, invisible to
+    ``--scope host`` and never published by sync.
     """
     host, _, user = hostname.partition(":")
-    display = f"{user}@{host}" if user else host
+    host = host.split(".")[0]
+    return f"{user}@{host}" if user else host
 
-    if display == store.default_machine_name():
-        known = store.machine()
-        return known.id, known.name
-    return hashlib.blake2b(hostname.encode(), digest_size=8).hexdigest(), display
+
+def resolve_hosts(hostnames: Iterable[str]) -> dict[str, tuple[str, str]]:
+    """Map each atuin hostname to a woswoar (host id, display name).
+
+    Resolved once per distinct hostname rather than per row: there are a
+    handful of machines and tens of thousands of rows, and this reads config
+    and calls ``uname``.
+
+    Order matters:
+
+    1. This machine keeps its real id, so imported history sits alongside what
+       the hook records and syncs normally.
+    2. A machine already known locally -- because its history has synced in --
+       reuses *its* id. Otherwise the same peer would exist twice, under its
+       real random id and under a derived one, with the same label and no way
+       to reconcile them.
+    3. Anything else gets an id derived from the label, so a second import
+       lands in the same place instead of forking a duplicate machine.
+    """
+    known = store.machine()
+    own = {store.default_machine_name(), known.name}
+    existing = {name: host_id for host_id, name in store.host_names().items()}
+
+    resolved: dict[str, tuple[str, str]] = {}
+    for hostname in hostnames:
+        display = display_name(hostname)
+        if display in own:
+            resolved[hostname] = (known.id, known.name)
+        elif display in existing:
+            resolved[hostname] = (existing[display], display)
+        else:
+            resolved[hostname] = (
+                hashlib.blake2b(display.encode(), digest_size=8).hexdigest(),
+                display,
+            )
+    return resolved
 
 
 def _home_relative(cwd: str, home: str) -> str:
@@ -276,7 +331,9 @@ def _save_state(state: dict[str, int]) -> None:
     store.save_json(_state_path(), state)
 
 
-def run_atuin(path: Path | None = None, dry_run: bool = False) -> Result:
+def run_atuin(
+    path: Path | None = None, dry_run: bool = False, this_host_only: bool = False
+) -> Result:
     """Import atuin's sqlite history, preserving which machine ran what.
 
     Idempotency is by ``(timestamp, command)`` per host rather than by a
@@ -286,29 +343,46 @@ def run_atuin(path: Path | None = None, dry_run: bool = False) -> Result:
     """
     source = path or atuin_db()
     home = str(Path.home())
+    own_id = store.machine().id
+
+    by_hostname: dict[str, list[AtuinRow]] = {}
+    parsed = 0
+    for row in _atuin_rows(source):
+        parsed += 1
+        by_hostname.setdefault(row.hostname, []).append(row)
+
+    # Once per machine, not once per row.
+    resolved = resolve_hosts(by_hostname)
 
     by_host: dict[str, list[AtuinRow]] = {}
     names: dict[str, str] = {}
-    own_id = store.machine().id
-    parsed = 0
-
-    for row in _atuin_rows(source):
-        parsed += 1
-        host_id, display = _host_for(row.hostname)
+    for hostname, rows in by_hostname.items():
+        host_id, display = resolved[hostname]
+        if this_host_only and host_id != own_id:
+            continue
         names[host_id] = display
-        by_host.setdefault(host_id, []).append(row)
+        by_host.setdefault(host_id, []).extend(rows)
 
     entries_by_host: dict[str, list[Entry]] = {}
     skipped = 0
+    collapsed = 0
 
     for host_id, rows in by_host.items():
         days = {store.day_for(r.ts) for r in rows}
-        known = store.existing_keys(host_id, days)
+        on_disk = store.existing_keys(host_id, days)
+        known = set(on_disk)
         fresh: list[Entry] = []
         for row in rows:
             key = _dedup_key(row.ts, row.cmd)
             if key in known:
-                skipped += 1
+                # Two different things wearing the same skip. Already on disk
+                # means a previous import; otherwise it is a same-second,
+                # same-command row that woswoar's whole-second resolution
+                # cannot tell apart from the one already taken this run.
+                if key in on_disk:
+                    skipped += 1
+                else:
+                    collapsed += 1
                 continue
             known.add(key)
             fresh.append(
@@ -330,11 +404,11 @@ def run_atuin(path: Path | None = None, dry_run: bool = False) -> Result:
     imported = sum(len(v) for v in entries_by_host.values())
     if not dry_run:
         for host_id, entries in entries_by_host.items():
-            if not entries:
-                continue
-            store.append_entries(host_id, entries)
-            # So search labels these entries with a machine name rather than
-            # the opaque id. Never overwrite a name learned from a real sync.
+            if entries:
+                store.append_entries(host_id, entries)
+            # Written even when nothing was imported, so a run interrupted
+            # between the append and the label can be repaired by re-importing.
+            # Guarded only against overwriting a name learned from a real sync.
             label = store.name_file(host_id)
             if not label.is_file():
                 label.parent.mkdir(parents=True, exist_ok=True)
@@ -344,6 +418,7 @@ def run_atuin(path: Path | None = None, dry_run: bool = False) -> Result:
         parsed=parsed,
         imported=imported,
         skipped=skipped,
+        collapsed=collapsed,
         source=source,
         per_host=tuple(
             sorted(
@@ -354,7 +429,12 @@ def run_atuin(path: Path | None = None, dry_run: bool = False) -> Result:
     )
 
 
-def run(kind: Kind, path: Path | None = None, dry_run: bool = False) -> Result:
+def run(
+    kind: Kind,
+    path: Path | None = None,
+    dry_run: bool = False,
+    this_host_only: bool = False,
+) -> Result:
     """Import a history file, skipping anything already imported.
 
     Idempotency uses two independent guards. A per-source count handles the
@@ -363,7 +443,7 @@ def run(kind: Kind, path: Path | None = None, dry_run: bool = False) -> Result:
     else, and covers the count going stale if the source is rotated or trimmed.
     """
     if kind == "atuin":
-        return run_atuin(path, dry_run=dry_run)
+        return run_atuin(path, dry_run=dry_run, this_host_only=this_host_only)
 
     source = path or default_path(kind)
     if not source.is_file():
@@ -383,15 +463,20 @@ def run(kind: Kind, path: Path | None = None, dry_run: bool = False) -> Result:
     fresh = parsed[already:]
     machine_id = store.machine().id
     days = {store.day_for(p.ts) for p in fresh}
-    known = store.existing_keys(machine_id, days)
+    on_disk = store.existing_keys(machine_id, days)
+    known = set(on_disk)
 
     entries: list[Entry] = []
     skipped = 0
+    collapsed = 0
     for item in fresh:
         # Not `key`: that name already holds the per-source state key below.
         seen = _dedup_key(item.ts, item.cmd)
         if seen in known:
-            skipped += 1
+            if seen in on_disk:
+                skipped += 1
+            else:
+                collapsed += 1
             continue
         known.add(seen)
         entries.append(
@@ -411,4 +496,10 @@ def run(kind: Kind, path: Path | None = None, dry_run: bool = False) -> Result:
         state[key] = len(parsed)
         _save_state(state)
 
-    return Result(parsed=len(parsed), imported=len(entries), skipped=skipped, source=source)
+    return Result(
+        parsed=len(parsed),
+        imported=len(entries),
+        skipped=skipped,
+        collapsed=collapsed,
+        source=source,
+    )

--- a/woswoar/importer.py
+++ b/woswoar/importer.py
@@ -1,4 +1,4 @@
-"""Import an existing bash or zsh history.
+"""Import an existing shell history: bash, zsh, or atuin.
 
 Onboarding is the whole point: a history tool that starts empty is useless on
 day one. Imports are idempotent, so re-running after a few weeks picks up only
@@ -7,16 +7,18 @@ what is new.
 
 from __future__ import annotations
 
+import hashlib
 import re
+import sqlite3
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Literal, NamedTuple
 
 from . import store
-from .entry import Entry
+from .entry import Entry, truncate
 
-Kind = Literal["bash", "zsh"]
-KINDS: tuple[Kind, ...] = ("bash", "zsh")
+Kind = Literal["bash", "zsh", "atuin"]
+KINDS: tuple[Kind, ...] = ("bash", "zsh", "atuin")
 
 SESSION = "import"
 
@@ -48,6 +50,10 @@ class Result(NamedTuple):
     imported: int
     skipped: int
     source: Path
+    #: (display name, count) per machine, biggest first. Only atuin carries
+    #: more than one host. A tuple rather than a dict because Result is a
+    #: NamedTuple, and a mutable default would be shared across instances.
+    per_host: tuple[tuple[str, int], ...] = ()
 
 
 def default_path(kind: Kind) -> Path:
@@ -140,6 +146,122 @@ def parse_zsh(text: str, mtime: int) -> list[Parsed]:
     return parsed
 
 
+# ---------------------------------------------------------------------------
+# atuin
+# ---------------------------------------------------------------------------
+
+#: atuin's own placeholder when it did not know the working directory.
+_ATUIN_UNKNOWN_CWD = "unknown"
+
+#: atuin stores nanoseconds; woswoar stores whole seconds and milliseconds.
+_NS_PER_SECOND = 1_000_000_000
+_NS_PER_MS = 1_000_000
+
+_ATUIN_QUERY = """
+    SELECT timestamp, duration, exit, command, cwd, session, hostname
+    FROM history
+    WHERE deleted_at IS NULL AND trim(command) != ''
+    ORDER BY timestamp
+"""
+
+
+def atuin_db() -> Path:
+    return Path.home() / ".local/share/atuin/history.db"
+
+
+class AtuinRow(NamedTuple):
+    ts: int
+    duration_ms: int
+    exit_code: int
+    cmd: str
+    cwd: str
+    session: str
+    #: atuin's ``hostname:username``.
+    hostname: str
+
+
+def _atuin_rows(path: Path) -> Iterator[AtuinRow]:
+    """Stream atuin's history table.
+
+    Opened read-only through a URI, because this is very likely the live
+    database of a running atuin: woswoar has no business writing to it, and
+    read-only also means we cannot trigger WAL recovery on someone else's file.
+    """
+    if not path.is_file():
+        raise FileNotFoundError(f"no atuin database at {path}")
+
+    try:
+        db = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    except sqlite3.Error as exc:
+        raise FileNotFoundError(f"cannot open {path} read-only: {exc}") from exc
+
+    try:
+        try:
+            cursor = db.execute(_ATUIN_QUERY)
+        except sqlite3.Error as exc:
+            raise FileNotFoundError(f"{path} does not look like an atuin database: {exc}") from exc
+
+        for ts_ns, duration_ns, exit_code, cmd, cwd, session, hostname in cursor:
+            yield AtuinRow(
+                ts=int(ts_ns) // _NS_PER_SECOND,
+                # atuin writes -1 when it never saw the command finish, which
+                # happens to be woswoar's own "unknown" value too.
+                duration_ms=int(duration_ns) // _NS_PER_MS if duration_ns >= 0 else -1,
+                exit_code=int(exit_code),
+                cmd=cmd,
+                cwd="" if cwd == _ATUIN_UNKNOWN_CWD else cwd,
+                # Opaque either way, and repeated on every line; 14 hex chars
+                # matches what the shell hook writes.
+                session=hashlib.blake2b(session.encode(), digest_size=7).hexdigest(),
+                hostname=hostname,
+            )
+    finally:
+        db.close()
+
+
+def _host_for(hostname: str) -> tuple[str, str]:
+    """Map an atuin ``hostname:username`` to a woswoar (host id, display name).
+
+    atuin syncs every machine's history into one database, so an import can
+    carry commands from many hosts. Flattening them into this machine would
+    make `--scope host` and `stats` lie, so each gets its own host directory.
+
+    The id is derived from the name rather than random, so re-importing lands
+    in the same place. Commands from *this* machine merge into its real id, so
+    they sit alongside what the hook records and get synced normally.
+    """
+    host, _, user = hostname.partition(":")
+    display = f"{user}@{host}" if user else host
+
+    if display == store.default_machine_name():
+        known = store.machine()
+        return known.id, known.name
+    return hashlib.blake2b(hostname.encode(), digest_size=8).hexdigest(), display
+
+
+def _home_relative(cwd: str, home: str) -> str:
+    """Match the hook's storage convention for this machine's own paths."""
+    if not cwd or not home:
+        return cwd
+    if cwd == home:
+        return "~"
+    if cwd.startswith(f"{home}/"):
+        return "~" + cwd[len(home) :]
+    return cwd
+
+
+def _dedup_key(ts: int, cmd: str) -> tuple[int, str]:
+    """The identity an entry will have *once written*.
+
+    Over-long commands are truncated on the way to disk, so a key built from
+    the original text can never match what is already stored -- and the entry
+    would be re-imported, and appended again, on every single run. Found by
+    importing a real atuin database: three of 54,943 commands were long enough
+    to trip it, and they came back every time.
+    """
+    return (ts, truncate(cmd))
+
+
 def _state_path() -> Path:
     return store.config_dir() / "imported.json"
 
@@ -154,6 +276,84 @@ def _save_state(state: dict[str, int]) -> None:
     store.save_json(_state_path(), state)
 
 
+def run_atuin(path: Path | None = None, dry_run: bool = False) -> Result:
+    """Import atuin's sqlite history, preserving which machine ran what.
+
+    Idempotency is by ``(timestamp, command)`` per host rather than by a
+    position watermark: atuin backfills *older* rows whenever it syncs from
+    another machine, so "everything after the last row I saw" would silently
+    miss them.
+    """
+    source = path or atuin_db()
+    home = str(Path.home())
+
+    by_host: dict[str, list[AtuinRow]] = {}
+    names: dict[str, str] = {}
+    own_id = store.machine().id
+    parsed = 0
+
+    for row in _atuin_rows(source):
+        parsed += 1
+        host_id, display = _host_for(row.hostname)
+        names[host_id] = display
+        by_host.setdefault(host_id, []).append(row)
+
+    entries_by_host: dict[str, list[Entry]] = {}
+    skipped = 0
+
+    for host_id, rows in by_host.items():
+        days = {store.day_for(r.ts) for r in rows}
+        known = store.existing_keys(host_id, days)
+        fresh: list[Entry] = []
+        for row in rows:
+            key = _dedup_key(row.ts, row.cmd)
+            if key in known:
+                skipped += 1
+                continue
+            known.add(key)
+            fresh.append(
+                Entry(
+                    ts=row.ts,
+                    host=host_id,
+                    session=row.session,
+                    # Only rewrite paths for this machine: another host's home
+                    # directory is a guess, and a wrong ~ is worse than a long
+                    # but honest absolute path.
+                    cwd=_home_relative(row.cwd, home) if host_id == own_id else row.cwd,
+                    exit_code=row.exit_code,
+                    duration_ms=row.duration_ms,
+                    cmd=row.cmd,
+                )
+            )
+        entries_by_host[host_id] = fresh
+
+    imported = sum(len(v) for v in entries_by_host.values())
+    if not dry_run:
+        for host_id, entries in entries_by_host.items():
+            if not entries:
+                continue
+            store.append_entries(host_id, entries)
+            # So search labels these entries with a machine name rather than
+            # the opaque id. Never overwrite a name learned from a real sync.
+            label = store.name_file(host_id)
+            if not label.is_file():
+                label.parent.mkdir(parents=True, exist_ok=True)
+                label.write_text(f"{names[host_id]}\n", encoding="utf-8")
+
+    return Result(
+        parsed=parsed,
+        imported=imported,
+        skipped=skipped,
+        source=source,
+        per_host=tuple(
+            sorted(
+                ((names[h], len(e)) for h, e in entries_by_host.items() if e),
+                key=lambda pair: -pair[1],
+            )
+        ),
+    )
+
+
 def run(kind: Kind, path: Path | None = None, dry_run: bool = False) -> Result:
     """Import a history file, skipping anything already imported.
 
@@ -162,6 +362,9 @@ def run(kind: Kind, path: Path | None = None, dry_run: bool = False) -> Result:
     and so cannot identify an entry. A ``(ts, cmd)`` check handles everything
     else, and covers the count going stale if the source is rotated or trimmed.
     """
+    if kind == "atuin":
+        return run_atuin(path, dry_run=dry_run)
+
     source = path or default_path(kind)
     if not source.is_file():
         raise FileNotFoundError(f"no history file at {source}")
@@ -185,10 +388,12 @@ def run(kind: Kind, path: Path | None = None, dry_run: bool = False) -> Result:
     entries: list[Entry] = []
     skipped = 0
     for item in fresh:
-        if (item.ts, item.cmd) in known:
+        # Not `key`: that name already holds the per-source state key below.
+        seen = _dedup_key(item.ts, item.cmd)
+        if seen in known:
             skipped += 1
             continue
-        known.add((item.ts, item.cmd))
+        known.add(seen)
         entries.append(
             Entry(
                 ts=item.ts,


### PR DESCRIPTION
`woswoar import atuin` reads atuin's sqlite database directly.

```
$ woswoar import atuin --dry-run
/home/martinus/.local/share/atuin/history.db: 54943 parsed, would import 54763, 180 already present

per machine:
  martinleitnerankerl@at1i-ws07                  25965
  martinus@box                                   12328
  martin.leitner-anker@dynatrace.org@DT-24YYR14  6795
  podfather@speichi                               3465
  ...
```

Opened **read-only** — it is very likely a running atuin's live database, and read-only also means woswoar cannot trigger WAL recovery on someone else's file. Verified byte-identical afterwards.

## Conversions

All of these are quirks of the real format, found by inspecting an actual database rather than guessed:

| atuin | woswoar |
|---|---|
| `timestamp` in nanoseconds | seconds |
| `duration` in nanoseconds, **`-1` when the command never finished** (14,201 rows) | milliseconds, `-1` preserved |
| `cwd` absolute, or the literal string **`"unknown"`** (14,077 rows) | home-relative for this machine, `""` for unknown |
| `hostname` as `host:user` | one woswoar host per machine |
| `session` UUID | hashed to 14 hex chars, the hook's width |
| `deleted_at` non-null | skipped |

## Host attribution

The interesting part. atuin syncs every machine into one database, so an import can carry commands from many hosts — **nine**, in the database this was built against. Flattening them into the importing machine would make `--scope host` and `stats` lie, so each atuin machine gets its own woswoar host.

Ids are derived from the hostname rather than random, so a second import lands in the same place instead of forking a duplicate machine. Commands from *this* machine merge into its real id, so they sit alongside what the hook records and sync normally.

Idempotency is by `(timestamp, command)` per host, **not** a position watermark: atuin backfills *older* rows whenever it syncs from another machine, so "everything after the last row I saw" would silently miss them.

Since sync only publishes this machine's own commands, history imported for *other* machines stays local — deliberate, since each machine runs the import against its own atuin database, which avoids two machines publishing overlapping copies.

## A latent bug this surfaced

Only visible against real data. Commands past `MAX_CMD_CHARS` are truncated on write, so a dedup key built from the *original* text could never match what was stored — those entries were re-appended on **every** import, forever. Exactly 3 of 54,943 commands were long enough to trip it (13k, 21k and 14k chars).

The key is now built from the form that actually reaches disk, which fixes the **bash and zsh importers too**. Regression test included.

Also widens the `stats` host column, which the real hostnames overflowed.

## Testing

23 new tests against a fixture mirroring the real schema and quirks. 133 total; `ruff`, `mypy --strict`, `shellcheck` clean.

Verified end to end against the real 54,943-row database: imports in 0.6 s, re-imports add nothing, source untouched, and `woswoar list` over the resulting 54,763 entries stays at 100 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)