### PR TITLE
Make reencrypt fetch before re-sealing

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,18 +183,25 @@ woswoar sync
 
 ```bash
 # then once, on a machine that was already enrolled
-woswoar reencrypt && woswoar sync
+woswoar reencrypt
 ```
 
 <details>
-<summary>Why that last step exists</summary>
+<summary>Why that last step exists — and why the new machine can't do it itself</summary>
 
 History sealed *before* the new machine joined was encrypted to a recipient list
 that did not include it. `reencrypt` re-seals the small per-day keys — not the
-history itself — so it takes seconds even with years of commands.
+history itself — so it takes seconds even with years of commands. It fetches and
+publishes on its own, so it is one command, not a sync sandwich.
 
-Until you run it, the new machine syncs fine and simply reports how many days it
-cannot read yet. Nothing is lost in the meantime.
+**Only a machine that is already a recipient can do this**, and that is the
+point rather than a limitation: re-sealing a key means *opening* it first. If a
+machine nobody had granted access to could re-seal old keys for itself, the
+encryption would not be worth anything. Run it on the new machine and it will
+tell you it could not open those keys.
+
+Until someone runs it, the new machine syncs fine and simply reports how many
+days it cannot read yet. Nothing is lost in the meantime.
 
 </details>
 

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -463,6 +463,29 @@ public key is on the remote, `reencrypt` run elsewhere cannot include it, and
 onboarding would appear to succeed while silently granting no access to older
 history.
 
+### `reencrypt`
+
+Re-sealing every day key to the current recipient list is what lets a newly
+enrolled machine read *old* history. It is deliberately a separate command — it
+is one of only two operations that rewrite an existing file — but it is a
+*complete* one: it fetches, re-seals, commits and pushes under the same lock
+`sync` takes.
+
+> The fetch is the part that is easy to get wrong, and it is the same trap as
+> exporting before fetching. The recipient list is a **file in the working
+> tree**, and the entire purpose of the operation is that a machine enrolled
+> since the last sync appears in it. Re-sealing against a stale checkout
+> rewrites every key back to the *old* recipients, prints `re-sealed 730 key
+> file(s)`, and grants exactly nothing. It looks like success from both
+> machines: the old one reports a full re-seal, the new one keeps reporting
+> unreadable days.
+
+**Only a machine that is already a recipient can do it**, because re-sealing a
+key means opening it first. That is the property the design rests on, not a
+missing feature — a machine nobody granted access to must not be able to grant
+itself access. Running it on the new machine re-seals only what that machine
+owns and reports the rest as skipped, rather than reporting a successful no-op.
+
 Commits use a fixed `woswoar <woswoar@localhost>` identity set on the repo.
 Commit metadata is one of the few things that is not encrypted, so it should not
 carry a real name and address.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -174,14 +174,60 @@ class TestTwoMachines(SyncTestCase):
         with beta.active():
             sync.run()
         # beta joined after alpha sealed those lines, so it cannot read them yet.
+        # One command on an already-enrolled machine is the whole fix, exactly
+        # as documented -- no surrounding sync to fetch beta's key or publish.
         with alpha.active():
-            sync.run()
             sync.reencrypt()
-            sync.run()
         with beta.active():
             report = sync.run()
             self.assertEqual(report.chunks_merged, 1)
             self.assertEqual(beta.commands(), {"git status", "make -j8"})
+
+    def test_reencrypt_alone_grants_access_without_a_surrounding_sync(self) -> None:
+        """The recipient list is a file in the working tree.
+
+        Re-sealing against a checkout taken before the new machine enrolled
+        rewrites every key to the *old* recipients and reports full success,
+        while granting nothing. So `reencrypt` has to fetch first, and this
+        pins that it does -- alpha never syncs after beta joins.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+
+        beta = self.machine("beta")  # init publishes beta's public key
+        with alpha.active():
+            report = sync.reencrypt()
+            self.assertTrue(report.pushed)
+            self.assertEqual(report.skipped, 0)
+            self.assertGreater(report.resealed, 0)
+
+        with beta.active():
+            sync.run()
+            self.assertEqual(beta.commands(), {"git status"})
+
+    def test_a_new_machine_cannot_reencrypt_for_itself(self) -> None:
+        """Re-sealing means opening the key first, which beta cannot do.
+
+        This is the property the encryption rests on, not a missing feature:
+        a machine nobody granted access to must not be able to grant itself
+        access. It must say so rather than report a successful no-op.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+
+        beta = self.machine("beta")
+        with beta.active():
+            sync.run()
+            report = sync.reencrypt()
+            # It re-seals what it owns -- its own name seal -- and skips
+            # alpha's day key, so it still cannot read alpha's history.
+            self.assertGreater(report.skipped, 0)
+            self.assertEqual(sync.run().unreadable, {f"{alpha.id}/2023-11-14"})
+            self.assertEqual(beta.commands(), set())
 
     def test_new_machine_reports_rather_than_failing(self) -> None:
         alpha = self.machine("alpha")
@@ -204,7 +250,6 @@ class TestTwoMachines(SyncTestCase):
             alpha.record("2023-11-14", 1_700_000_001, "from alpha")
             sync.run()
             sync.reencrypt()
-            sync.run()
         with beta.active():
             beta.record("2023-11-14", 1_700_000_050, "from beta")
             sync.run()
@@ -222,7 +267,6 @@ class TestTwoMachines(SyncTestCase):
             alpha.record("2023-11-14", 1_700_000_001, "git status")
             sync.run()
             sync.reencrypt()
-            sync.run()
         with beta.active():
             sync.run()
             first = len(cache.load_entries())
@@ -236,7 +280,6 @@ class TestTwoMachines(SyncTestCase):
         with alpha.active():
             sync.run()
             sync.reencrypt()
-            sync.run()
         with beta.active():
             sync.run()
 
@@ -259,7 +302,6 @@ class TestTwoMachines(SyncTestCase):
             alpha.record("2023-11-14", 1_700_000_001, "git status")
             sync.run()
             sync.reencrypt()
-            sync.run()
         with beta.active():
             sync.run()
             # Without this, search would label alpha's entries with its opaque id.
@@ -272,7 +314,6 @@ class TestTwoMachines(SyncTestCase):
             alpha.record("2023-11-14", 1_700_000_001, "from alpha")
             sync.run()
             sync.reencrypt()
-            sync.run()
         with beta.active():
             beta.record("2023-11-14", 1_700_000_050, "from beta")
             sync.run()
@@ -293,7 +334,6 @@ class TestImmutability(SyncTestCase):
                 alpha.record("2023-11-14", 1_700_000_000 + i, f"alpha {i}")
                 sync.run()
             sync.reencrypt()
-            sync.run()
         with beta.active():
             for i in range(3):
                 beta.record("2023-11-15", 1_700_100_000 + i, f"beta {i}")
@@ -387,7 +427,6 @@ class TestCompact(SyncTestCase):
                 sync.run()
             sync.compact(before="2023-11-15")
             sync.reencrypt()
-            sync.run()
         with beta.active():
             sync.run()
             self.assertEqual(beta.commands(), {"command 0", "command 1", "command 2"})

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -257,7 +257,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
             f"\n{days} day(s) of history are sealed to recipients that do not include\n"
             "this machine - it joined after they were written. On a machine that was\n"
             "already enrolled run:\n"
-            "    woswoar reencrypt && woswoar sync\n"
+            "    woswoar reencrypt\n"
             "then sync here again. Nothing is lost in the meantime.",
             file=sys.stderr,
         )
@@ -267,9 +267,22 @@ def cmd_sync(args: argparse.Namespace) -> int:
 def cmd_reencrypt(args: argparse.Namespace) -> int:
     from . import sync
 
-    count = sync.reencrypt()
-    print(f"re-sealed {count} key file(s) to the current recipients")
-    print("Run 'woswoar sync' to publish them.")
+    report = sync.reencrypt()
+    print(f"re-sealed {report.resealed} key file(s) to the current recipients")
+    if report.pushed:
+        print("pushed to remote")
+    else:
+        print("no remote configured; nothing published")
+    if report.skipped:
+        # Almost always means this machine is the new one. Saying so beats
+        # letting "re-sealed 0 key files" read as success.
+        print(
+            f"\n{report.skipped} key file(s) could not be opened by this machine, so\n"
+            "they were left alone. Re-sealing a key means opening it first, which\n"
+            "only a machine that was already a recipient can do. Run this on one of\n"
+            "those instead.",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -546,8 +546,15 @@ def _write_repo_metadata(known: Machine, identity: Path) -> bool:
     return changed
 
 
-def reencrypt() -> int:
-    """Re-seal every key file to the current recipient list.
+class ReencryptReport(NamedTuple):
+    resealed: int
+    #: Keys this machine cannot open, so cannot re-seal for anyone else.
+    skipped: int
+    pushed: bool
+
+
+def reencrypt() -> ReencryptReport:
+    """Re-seal every key file to the current recipient list, and publish it.
 
     This is what makes a newly onboarded machine able to read *old* history.
     Chunks are encrypted to per-day keys, so only those small key files -- and
@@ -555,33 +562,61 @@ def reencrypt() -> int:
     untouched. Any machine already enrolled can do it for every host, because
     all hosts seal their keys to the same recipient list.
 
+    Only a machine that is *already* a recipient can do this: re-sealing means
+    opening the existing key first. That is the point rather than a limitation
+    -- if a machine nobody had granted access to could re-seal old keys, the
+    encryption would not be worth anything. So the new machine cannot onboard
+    itself, and one that cannot open a key skips it silently.
+
+    Fetching first is not optional, for the same reason `run` exports after
+    fetching: the recipient list this re-seals to is a *file in the working
+    tree*, and the whole purpose of the operation is that a machine enrolled
+    since the last sync appears in it. Re-sealing against a stale checkout
+    reports full success and grants exactly nothing.
+
     This is one of only two operations that rewrite an existing file. It is
     deliberately explicit rather than part of sync.
     """
     crypto.require()
+    if not is_repo():
+        raise SyncError("no history repo yet; run 'woswoar init' first")
+
     known = store.machine()
     identity = identity_path(known)
     recipients = store.recipients_file()
-    resealed = 0
+    _ensure_repo_config()
+    git_report = Report()
+    remote = has_remote()
+    resealed = skipped = 0
 
-    for host_id in store.repo_hosts():
-        candidates = list(store.iter_day_keys(host_id))
-        seal = store.name_seal(host_id)
-        if seal.is_file():
-            candidates.append(seal)
+    # The same lock sync takes: this rewrites files in the working tree, and a
+    # timer-driven sync must not be reading them halfway through.
+    with lock():
+        if remote:
+            _fetch_and_rebase(git_report)
 
-        for path in candidates:
-            try:
-                plain = crypto.decrypt_with_file(path.read_bytes(), identity)
-            except (crypto.AgeError, OSError):
-                # Not ours to re-seal: a machine that was removed from the
-                # recipient list leaves keys nobody here can open.
-                continue
-            store.write_atomic(path, crypto.encrypt_to_recipients(plain, recipients))
-            resealed += 1
+        for host_id in store.repo_hosts():
+            candidates = list(store.iter_day_keys(host_id))
+            seal = store.name_seal(host_id)
+            if seal.is_file():
+                candidates.append(seal)
 
-    _commit()
-    return resealed
+            for path in candidates:
+                try:
+                    plain = crypto.decrypt_with_file(path.read_bytes(), identity)
+                except (crypto.AgeError, OSError):
+                    # Not ours to re-seal: keys sealed before this machine
+                    # joined, or left behind by one since removed.
+                    skipped += 1
+                    continue
+                store.write_atomic(path, crypto.encrypt_to_recipients(plain, recipients))
+                resealed += 1
+
+        _commit()
+        if remote:
+            _push(git_report)
+
+    return ReencryptReport(resealed, skipped, git_report.pushed)
 
 
 def compact(before: str) -> tuple[int, int]:


### PR DESCRIPTION
Answering "does `reencrypt` push, and can't the new machine do it?" turned up a real bug.

### Both parts of the answer

**It did not push** — it committed locally, which is why the docs said `woswoar reencrypt && woswoar sync`.

**The new machine cannot do it, structurally.** Re-sealing a key means *opening* it first, and the new machine is not a recipient of the old day keys. That is the property the encryption rests on, not a missing feature — a machine nobody granted access to must not be able to grant itself access.

### The bug

Re-sealing seals to `recipients.txt` **as it stands in the working tree**, and the entire purpose of the operation is that a machine enrolled since the last sync appears in that file. Without a fetch it re-seals every key back to the *old* recipient list, prints `re-sealed N key file(s)`, and grants nothing.

It looks like success from both sides: the old machine reports a full re-seal, the new one keeps reporting unreadable days. Same trap as exporting before fetching, which `sync` already avoids for exactly this reason.

The documented `woswoar reencrypt && woswoar sync` hit it precisely — `reencrypt` ran against the stale checkout, and the `sync` that would have fetched came after. Reproduced before fixing:

```
alpha re-sealed 2 key file(s)
alpha's recipients at that moment:
age1alw0r65ysr9avc7ahuxuzcqnwplz2k35f7kn2kxrrkuu07vhegls52str0   <- beta missing

beta: merged=0 unreadable={'3d1d046872d71f22/2023-11-14'}
beta sees: set()
```

The existing tests missed it because every single one happened to `sync.run()` first.

### Changes

- `reencrypt` fetches, re-seals, commits and pushes — one self-contained command. Docs drop the trailing `sync`.
- It takes the **sync lock**, which it never did. It rewrites files in the working tree that a timer-driven sync could be reading.
- Returns a `ReencryptReport(resealed, skipped, pushed)` and reports keys it could not open, instead of counting only successes. That is what a new machine sees if it tries to reencrypt for itself — without the count it reads as a successful no-op.

### Tests

Two new ones, plus the existing eight now exercise the documented single command rather than sandwiching it between syncs:

- `test_reencrypt_alone_grants_access_without_a_surrounding_sync` — alpha never syncs after beta joins. Fails on `main`.
- `test_a_new_machine_cannot_reencrypt_for_itself` — pins that beta re-seals only what it owns and still cannot read alpha's history.

144 tests pass; ruff and mypy --strict clean.