### PR TITLE
Share the DEBUG trap and PROMPT_COMMAND instead of taking them

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,13 @@ override is scoped to its own call.
 
 **It shares the DEBUG trap and `PROMPT_COMMAND` rather than taking them.** A
 terminal-title hook, a prompt framework, bash-preexec, atuin and ble.sh all want
-the same two places. woswoar chains onto whatever already owns the DEBUG trap,
-and it does that wiring at the first prompt rather than while loading — so the
-order of lines in your `.bashrc` does not matter, and it will chain onto
-whoever ended up owning it.
+the same two places. woswoar chains onto whatever owns the DEBUG trap *at the
+first prompt* — not at the moment it is sourced — so it picks up whoever ended
+up owning it once your whole `.bashrc` has run. It also restores `$?` after
+reading it, so an exit-code-colouring prompt downstream still sees the real
+status.
 
-If something else claims the trap *after* woswoar, you lose the recorded
+If something else claims the trap *after* that, you lose the recorded
 **duration** of those commands and nothing else; the commands themselves are
 still recorded. This is all pinned by tests that drive a real interactive bash.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,36 @@ below is optional.
 If something looks wrong, `woswoar doctor` checks the bash version, fzf, the
 hook and the cache, and tells you what to fix.
 
+<details>
+<summary>Does this disturb my normal bash, or my other prompt tools?</summary>
+
+**Up-arrow and `~/.bash_history` are untouched.** woswoar never modifies
+`HISTFILE`, `HISTSIZE`, `HISTCONTROL` or the history list — it only *reads*
+`history 1`. It is purely additive: a second, richer log next to the one bash
+already keeps. Your `HISTTIMEFORMAT` is not disturbed either; the hook's
+override is scoped to its own call.
+
+**It shares the DEBUG trap and `PROMPT_COMMAND` rather than taking them.** A
+terminal-title hook, a prompt framework, bash-preexec, atuin and ble.sh all want
+the same two places. woswoar chains onto whatever already owns the DEBUG trap,
+and it does that wiring at the first prompt rather than while loading — so the
+order of lines in your `.bashrc` does not matter, and it will chain onto
+whoever ended up owning it.
+
+If something else claims the trap *after* woswoar, you lose the recorded
+**duration** of those commands and nothing else; the commands themselves are
+still recorded. This is all pinned by tests that drive a real interactive bash.
+
+**A half-typed line becomes the search query.** Type `docker comp`, press
+<kbd>Ctrl</kbd>+<kbd>R</kbd>, and fzf opens already filtered to that. Escape
+leaves your line byte-for-byte as it was; picking something replaces the line
+and puts the cursor at the end, never executing it.
+
+`WOSWOAR_NO_BIND=1` skips the <kbd>Ctrl</kbd>+<kbd>R</kbd> binding entirely if
+you would rather keep another tool's.
+
+</details>
+
 ---
 
 ## Security

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -173,6 +173,42 @@ The result is verified rather than asserted: CI runs the hook under `strace` wit
 — startup legitimately forks for `mkdir` and one `trap -p` subshell — but flat,
 which is the property that actually matters.
 
+### Sharing the shell with everything else
+
+woswoar is never the only thing hooked into a real `.bashrc`. A terminal-title
+hook, a prompt framework, bash-preexec, atuin and ble.sh all want the DEBUG trap
+and `PROMPT_COMMAND`. Two bugs came out of getting this wrong, both found by
+driving a real interactive bash rather than by reading the code.
+
+**The DEBUG trap has to be chained, and cannot be chained at load time.** A bare
+`trap … DEBUG` silently replaced whatever was there, so the other tool simply
+stopped working. The obvious fix — read the existing trap and call it too —
+does not work from the hook, because **a sourced file cannot see the DEBUG
+trap at all**: bash gives sourced files their own trap scope, so `trap -p DEBUG`
+reports nothing from inside one. It is visible from a `PROMPT_COMMAND` *string*,
+which is evaluated at top level, so the wiring is deferred to the first prompt.
+That delay turns out to be the better design anyway: by then the whole of
+`.bashrc` has run, so woswoar chains onto whoever actually ended up owning the
+trap, and the order of lines in `.bashrc` stops mattering.
+
+The handler is recovered by re-running what `trap -p` prints with `trap` shadowed
+by a function, rather than by unquoting its output by hand — handlers containing
+quotes are the common case, not the exotic one.
+
+**Recording must not depend on that trap.** It used to be gated on a flag the
+DEBUG handler set, so anything claiming the trap *after* woswoar turned
+recording off entirely and silently. The history number already distinguishes
+"a command ran" from "nothing happened", so that is what gates recording now,
+and a lost trap costs the **duration** of a command rather than the command.
+
+**`$?` is only the user's exit status for the *first* `PROMPT_COMMAND` entry.**
+After that it is the status of the previous entry. woswoar appends itself, so
+any pre-existing entry — a title hook is enough — meant every command was
+recorded as having succeeded. The fix is a bare assignment *prepended* ahead of
+everything else, which is the only part that has to run first; a bare assignment
+cannot be mistaken for a command the user typed. Reading `$?` directly looked
+obviously correct and was wrong in every configuration but the empty one.
+
 > **`$EPOCHREALTIME` honours `LC_NUMERIC`.** Under a `de_AT` locale it reads
 > `1785321992,048777`, with a comma. Stripping only `.` silently yields garbage
 > durations. The hook strips `[.,]`, and a test pins it under `de_AT.UTF-8`.

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -155,6 +155,12 @@ inside a live shell:
 | the appending `printf` | 9 µs |
 | `printf -v day '%(%F)T'` | 4 µs |
 | cwd anchoring, timing, dispatch | ~10 µs |
+| each extra `PROMPT_COMMAND` entry | ~8 µs |
+
+That last row is why the wiring below keeps its `PROMPT_COMMAND` footprint to
+two entries: the status capture, which has to be there, and `__woswoar_precmd`.
+A third entry that only re-tested an "already wired" flag measured ~12 µs on
+every command for the life of the shell, so it deletes itself once it has run.
 
 Worth stating plainly because an earlier version of this document quoted the
 30 µs capture figure as the cost of recording, which understated it by 5x.
@@ -191,9 +197,18 @@ That delay turns out to be the better design anyway: by then the whole of
 `.bashrc` has run, so woswoar chains onto whoever actually ended up owning the
 trap, and the order of lines in `.bashrc` stops mattering.
 
-The handler is recovered by re-running what `trap -p` prints with `trap` shadowed
-by a function, rather than by unquoting its output by hand — handlers containing
-quotes are the common case, not the exotic one.
+The handler is recovered by re-splitting what `trap -p` prints as an array —
+`trap -- 'handler' DEBUG` is already shell-quoted, so `eval "parts=($spec)"`
+unquotes it exactly, which hand-written unquoting does not. Handlers containing
+quotes are the common case, not the exotic one. Shadowing the `trap` builtin
+with a function and re-running the spec also works and reads more directly, but
+a shell function is process-global and ble.sh ships its own `trap` wrapper:
+defining one and unsetting it afterwards would disable ble.sh's trap manager for
+the rest of the session.
+
+The two handlers are composed into a single trap string once, at wiring time,
+rather than by a wrapper that `eval`s the prior handler on every command —
+measured at ~10 µs per command, with `$BASH_COMMAND` identical either way.
 
 **Recording must not depend on that trap.** It used to be gated on a flag the
 DEBUG handler set, so anything claiming the trap *after* woswoar turned
@@ -204,10 +219,17 @@ and a lost trap costs the **duration** of a command rather than the command.
 **`$?` is only the user's exit status for the *first* `PROMPT_COMMAND` entry.**
 After that it is the status of the previous entry. woswoar appends itself, so
 any pre-existing entry — a title hook is enough — meant every command was
-recorded as having succeeded. The fix is a bare assignment *prepended* ahead of
-everything else, which is the only part that has to run first; a bare assignment
-cannot be mistaken for a command the user typed. Reading `$?` directly looked
-obviously correct and was wrong in every configuration but the empty one.
+recorded as having succeeded. The fix is prepended ahead of everything else,
+since that is the only slot from which the real status is visible. Reading `$?`
+directly looked obviously correct and was wrong in every configuration but the
+empty one.
+
+That slot can only have one occupant, so taking it comes with an obligation:
+an assignment *succeeds*, which would hand every entry downstream the same
+wrong `$?` — an exit-code-colouring prompt, `__git_ps1` — that this fix exists
+to stop woswoar getting. So the capture restores the status immediately, via a
+one-line `return "$1"` helper. bash-preexec solves it the same way, and
+`return` is a builtin, so it stays fork-free.
 
 > **`$EPOCHREALTIME` honours `LC_NUMERIC`.** Under a `de_AT` locale it reads
 > `1785321992,048777`, with a comma. Stripping only `.` silently yields garbage

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -105,12 +105,23 @@ class ShellHookTestCase(WoswoarTestCase):
         return result.stdout
 
     def recorded(self) -> list[Entry]:
-        """Every entry the hook wrote, oldest first, minus the `source` line."""
-        entries = sorted(cache.load_entries(), key=lambda e: (e.ts, e.duration_ms))
-        return [e for e in entries if not e.cmd.startswith("source ")]
+        """Every entry the hook wrote, oldest first.
+
+        Deliberately unfiltered. This used to drop anything starting with
+        ``source``, because the ``source .../woswoar.bash`` line the harness
+        itself types got recorded. The hook now skips the prompt at which it
+        loads, so the subtraction is not only unnecessary but would hide that
+        guard regressing -- and would also swallow a real
+        ``source .venv/bin/activate``.
+        """
+        return sorted(cache.load_entries(), key=lambda e: (e.ts, e.duration_ms))
 
     def commands(self) -> list[str]:
         return [e.cmd for e in self.recorded()]
+
+    def by_cmd(self) -> dict[str, Entry]:
+        """Recorded entries indexed by command, for asserting on metadata."""
+        return {e.cmd: e for e in self.recorded()}
 
 
 @requires_bash5
@@ -139,7 +150,7 @@ class TestCapture(ShellHookTestCase):
 
     def test_metadata_is_captured(self) -> None:
         self.run_shell("cd /tmp\nfalse\n")
-        by_cmd = {e.cmd: e for e in self.recorded()}
+        by_cmd = self.by_cmd()
         self.assertEqual(by_cmd["false"].exit_code, 1)
         self.assertEqual(by_cmd["false"].cwd, "/tmp")
         self.assertEqual(by_cmd["false"].host, MACHINE_ID)
@@ -162,18 +173,18 @@ class TestCapture(ShellHookTestCase):
     def test_home_is_stored_as_tilde(self) -> None:
         # $HOME is self.root for these runs, so cd'ing there must record "~".
         self.run_shell("cd ~\ntrue marker\n")
-        by_cmd = {e.cmd: e for e in self.recorded()}
+        by_cmd = self.by_cmd()
         self.assertEqual(by_cmd["true marker"].cwd, "~")
 
     def test_path_under_home_is_stored_relative(self) -> None:
         (self.root / "src").mkdir(exist_ok=True)
         self.run_shell("cd ~/src\ntrue marker\n")
-        by_cmd = {e.cmd: e for e in self.recorded()}
+        by_cmd = self.by_cmd()
         self.assertEqual(by_cmd["true marker"].cwd, "~/src")
 
     def test_path_outside_home_stays_absolute(self) -> None:
         self.run_shell("cd /tmp\ntrue marker\n")
-        by_cmd = {e.cmd: e for e in self.recorded()}
+        by_cmd = self.by_cmd()
         self.assertEqual(by_cmd["true marker"].cwd, "/tmp")
 
     def test_sibling_of_home_is_not_mangled(self) -> None:
@@ -183,7 +194,7 @@ class TestCapture(ShellHookTestCase):
         sibling.mkdir(exist_ok=True)
         self.addCleanup(sibling.rmdir)
         self.run_shell(f"cd {sibling}\ntrue marker\n")
-        by_cmd = {e.cmd: e for e in self.recorded()}
+        by_cmd = self.by_cmd()
         self.assertEqual(by_cmd["true marker"].cwd, str(sibling))
 
     def test_duration_is_measured(self) -> None:
@@ -212,10 +223,12 @@ class TestCoexistence(ShellHookTestCase):
     was actually broken.
     """
 
-    #: The shape of a common .bashrc: a title hook owning both.
+    #: The shape of a common .bashrc: a title hook owning both. `_title_prompt`
+    #: prints `$?` because that is what a real prompt does with it, and it is
+    #: the only way to notice woswoar handing everyone downstream a 0.
     PRIOR = """
         _title_preexec() { printf 'PREEXEC[%s]\\n' "$BASH_COMMAND"; }
-        _title_prompt() { :; }
+        _title_prompt() { printf 'PROMPT[%s]\\n' "$?"; }
         trap '_title_preexec' DEBUG
         PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }_title_prompt"
     """
@@ -229,7 +242,7 @@ class TestCoexistence(ShellHookTestCase):
 
     def test_durations_survive_chaining(self) -> None:
         self.run_shell("sleep 0.2\n", before=self.PRIOR)
-        by_cmd = {e.cmd: e for e in self.recorded()}
+        by_cmd = self.by_cmd()
         self.assertGreaterEqual(by_cmd["sleep 0.2"].duration_ms, 100)
 
     def test_exit_codes_survive_a_prior_prompt_command(self) -> None:
@@ -241,7 +254,7 @@ class TestCoexistence(ShellHookTestCase):
         prepended ahead of everything else.
         """
         self.run_shell("false\ntrue\n", before=self.PRIOR)
-        by_cmd = {e.cmd: e for e in self.recorded()}
+        by_cmd = self.by_cmd()
         self.assertEqual(by_cmd["false"].exit_code, 1)
         self.assertEqual(by_cmd["true"].exit_code, 0)
 
@@ -255,20 +268,43 @@ class TestCoexistence(ShellHookTestCase):
         commands = self.commands()
         self.assertIn("echo after-one", commands)
         self.assertIn("echo after-two", commands)
-        by_cmd = {e.cmd: e for e in self.recorded()}
+        by_cmd = self.by_cmd()
         # Duration is the one thing that legitimately degrades.
         self.assertEqual(by_cmd["echo after-one"].duration_ms, -1)
 
+    def test_downstream_prompt_entries_still_see_the_real_status(self) -> None:
+        """Capturing `$?` must not consume it.
+
+        woswoar prepends its capture, which puts it in the one slot only one
+        participant can have. An assignment succeeds, so without restoring the
+        status afterwards every *other* PROMPT_COMMAND entry -- an exit-code
+        colouring prompt, `__git_ps1` -- would see 0 for every command. That is
+        the bug woswoar prepends the capture to avoid, handed outward.
+        """
+        out = self.run_shell("false\n", before=self.PRIOR)
+        self.assertIn("PROMPT[1]", out)
+        self.assertEqual(self.by_cmd()["false"].exit_code, 1)
+
     def test_a_prior_handler_containing_quotes_is_not_mangled(self) -> None:
-        # The handler is recovered by re-running what `trap -p` prints, rather
-        # than by unquoting it by hand, precisely so this works.
+        """The quotes must be in the *handler*, not merely in a function it calls.
+
+        `trap -p` requotes whatever it prints, so a handler that is just a
+        function name survives even a naive unquoter. This is the case that
+        actually distinguishes them.
+        """
         before = """
-            _q() { printf "QUOTED[%s]\\n" "it's fine"; }
-            trap '_q' DEBUG
+            trap 'printf "QUOTED[%s]\\n" "it'\\''s fine"' DEBUG
         """
         out = self.run_shell("echo hello\n", before=before)
         self.assertIn("QUOTED[it's fine]", out)
         self.assertEqual(self.commands(), ["echo hello"])
+
+    def test_the_prompt_at_which_the_hook_loads_records_nothing(self) -> None:
+        # `history 1` at that point is whatever the previous session left
+        # behind. The harness types `source .../woswoar.bash`, which used to be
+        # subtracted in recorded() rather than not recorded in the first place.
+        self.run_shell("echo only-this\n")
+        self.assertEqual(self.commands(), ["echo only-this"])
 
 
 @requires_bash5

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -79,18 +79,30 @@ class ShellHookTestCase(WoswoarTestCase):
         env.update(extra or {})
         return env
 
-    def run_shell(self, script: str, env_extra: dict[str, str] | None = None) -> None:
-        """Run ``script`` line by line in an interactive bash with the hook loaded."""
-        subprocess.run(
+    def run_shell(
+        self,
+        script: str,
+        env_extra: dict[str, str] | None = None,
+        before: str = "",
+    ) -> str:
+        """Run ``script`` line by line in an interactive bash with the hook loaded.
+
+        ``before`` runs *ahead of* the hook, which is how a real ~/.bashrc looks:
+        the interesting bugs are all about what else already owns PROMPT_COMMAND
+        and the DEBUG trap by the time woswoar loads. Returns the shell's output
+        so a test can assert the other tool still ran.
+        """
+        result = subprocess.run(
             ["bash", "--norc", "-i"],
-            input=f"source {HOOK}\n{textwrap.dedent(script)}",
+            input=f"{textwrap.dedent(before)}\nsource {HOOK}\n{textwrap.dedent(script)}",
             text=True,
             env=self.shell_env(env_extra),
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             check=False,
             timeout=60,
         )
+        return result.stdout
 
     def recorded(self) -> list[Entry]:
         """Every entry the hook wrote, oldest first, minus the `source` line."""
@@ -189,6 +201,74 @@ class TestCapture(ShellHookTestCase):
         entry = self.recorded()[0]
         self.assertGreaterEqual(entry.duration_ms, 250)
         self.assertLess(entry.duration_ms, 30_000)
+
+
+@requires_bash5
+class TestCoexistence(ShellHookTestCase):
+    """woswoar is never the only thing hooked into a real .bashrc.
+
+    A terminal-title hook, a prompt framework, bash-preexec, atuin and ble.sh
+    all want the DEBUG trap or PROMPT_COMMAND. Every case here is something that
+    was actually broken.
+    """
+
+    #: The shape of a common .bashrc: a title hook owning both.
+    PRIOR = """
+        _title_preexec() { printf 'PREEXEC[%s]\\n' "$BASH_COMMAND"; }
+        _title_prompt() { :; }
+        trap '_title_preexec' DEBUG
+        PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }_title_prompt"
+    """
+
+    def test_an_existing_debug_trap_still_fires(self) -> None:
+        # A bare `trap ... DEBUG` in the hook silently replaced it, so the other
+        # tool simply stopped working with nothing to show for it.
+        out = self.run_shell("echo hello\n", before=self.PRIOR)
+        self.assertIn("PREEXEC[echo hello]", out)
+        self.assertEqual(self.commands(), ["echo hello"])
+
+    def test_durations_survive_chaining(self) -> None:
+        self.run_shell("sleep 0.2\n", before=self.PRIOR)
+        by_cmd = {e.cmd: e for e in self.recorded()}
+        self.assertGreaterEqual(by_cmd["sleep 0.2"].duration_ms, 100)
+
+    def test_exit_codes_survive_a_prior_prompt_command(self) -> None:
+        """`$?` is only the user's status for the *first* PROMPT_COMMAND entry.
+
+        With anything already in PROMPT_COMMAND, reading `$?` inside our own
+        entry yielded the previous entry's status instead -- so every command
+        was recorded as having succeeded. The fix is a bare assignment
+        prepended ahead of everything else.
+        """
+        self.run_shell("false\ntrue\n", before=self.PRIOR)
+        by_cmd = {e.cmd: e for e in self.recorded()}
+        self.assertEqual(by_cmd["false"].exit_code, 1)
+        self.assertEqual(by_cmd["true"].exit_code, 0)
+
+    def test_recording_survives_losing_the_debug_trap(self) -> None:
+        """Something claiming DEBUG *after* us must cost timing, not history.
+
+        Recording used to be gated on a flag the trap set, so one later
+        `trap ... DEBUG` anywhere in .bashrc turned woswoar off silently.
+        """
+        self.run_shell("_o() { :; }\ntrap '_o' DEBUG\necho after-one\necho after-two\n")
+        commands = self.commands()
+        self.assertIn("echo after-one", commands)
+        self.assertIn("echo after-two", commands)
+        by_cmd = {e.cmd: e for e in self.recorded()}
+        # Duration is the one thing that legitimately degrades.
+        self.assertEqual(by_cmd["echo after-one"].duration_ms, -1)
+
+    def test_a_prior_handler_containing_quotes_is_not_mangled(self) -> None:
+        # The handler is recovered by re-running what `trap -p` prints, rather
+        # than by unquoting it by hand, precisely so this works.
+        before = """
+            _q() { printf "QUOTED[%s]\\n" "it's fine"; }
+            trap '_q' DEBUG
+        """
+        out = self.run_shell("echo hello\n", before=before)
+        self.assertIn("QUOTED[it's fine]", out)
+        self.assertEqual(self.commands(), ["echo hello"])
 
 
 @requires_bash5

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -449,16 +449,14 @@ class TestChunkNaming(support.WoswoarTestCase):
         exactly once in CI, as one missing chunk.
         """
         made: set[Path] = set()
+        store.chunk_dir("host", "2023-11-14").mkdir(parents=True, exist_ok=True)
         for _ in range(2000):
             path = store.new_chunk("host", "2023-11-14", 1_700_000_000)
             self.assertNotIn(path, made)
             made.add(path)
-            path.parent.mkdir(parents=True, exist_ok=True)
             path.write_bytes(b"x")  # only an existing file can be collided with
 
 
-@requires_age
-@requires_git
 class TestLayout(SyncTestCase):
     def test_a_chunk_lives_one_directory_below_its_host(self) -> None:
         """`hosts/<id>/2023-11-14/<chunk>` -- the date is one path component.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -439,6 +439,26 @@ class TestChunkPayload(unittest.TestCase):
                 sync.unpack(blob)
 
 
+class TestChunkNaming(support.WoswoarTestCase):
+    def test_many_chunks_in_one_second_all_get_distinct_paths(self) -> None:
+        """Overwriting a sealed chunk would destroy committed history.
+
+        The name is `<epoch seconds>-<random>`, so everything written inside one
+        second is competing for the same random suffix. With four hex characters
+        and no check, twenty chunks collided in ~0.3% of runs -- which showed up
+        exactly once in CI, as one missing chunk.
+        """
+        made: set[Path] = set()
+        for _ in range(2000):
+            path = store.new_chunk("host", "2023-11-14", 1_700_000_000)
+            self.assertNotIn(path, made)
+            made.add(path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"x")  # only an existing file can be collided with
+
+
+@requires_age
+@requires_git
 class TestLayout(SyncTestCase):
     def test_a_chunk_lives_one_directory_below_its_host(self) -> None:
         """`hosts/<id>/2023-11-14/<chunk>` -- the date is one path component.

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -114,13 +114,20 @@ __woswoar_preexec() {
 }
 
 __woswoar_precmd() {
-    local exit_code=$?
+    # Not `$?`. PROMPT_COMMAND entries run in order, and `$?` only holds the
+    # user's exit status for the *first* of them -- after that it is the status
+    # of the previous entry. Anything already in PROMPT_COMMAND (a title hook,
+    # a prompt framework) therefore made every recorded command look successful.
+    # __woswoar_stamp is prepended so it captures the real one before any of
+    # that runs; the fallback covers a shell where PROMPT_COMMAND was replaced
+    # wholesale after we loaded.
+    local exit_code=${__woswoar_status:-$?}
 
-    if ((__woswoar_armed)); then
-        # No command ran since the last prompt (empty line, or Ctrl-C at an
-        # empty prompt). Nothing to record.
-        return 0
-    fi
+    # Re-arm the timer whatever happens below. Recording deliberately does not
+    # depend on the DEBUG trap having fired: if some other tool claims that trap
+    # after we do, we lose the *duration* of a command, not the command. Gating
+    # the whole function on it meant a single `trap ... DEBUG` anywhere later in
+    # .bashrc silently turned recording off with nothing to show for it.
     __woswoar_armed=1
 
     # Empty HISTTIMEFORMAT for this one call so the output format is "  N  cmd"
@@ -143,25 +150,37 @@ __woswoar_precmd() {
     # If the number did not advance, bash never stored this command --
     # HISTCONTROL=ignorespace/ignoredups or HISTIGNORE rejected it, or the user
     # just pressed Enter. Respecting bash's own decision here means we never
-    # need a second set of rules for the same thing.
-    [[ $num == "$__woswoar_lastnum" ]] && return 0
+    # need a second set of rules for the same thing. This check is also what
+    # makes recording independent of the DEBUG trap: it, not a flag the trap
+    # sets, is what distinguishes "a command ran" from "nothing happened".
+    [[ $num == "$__woswoar_lastnum" ]] && { __woswoar_start=; return 0; }
+
+    # Empty only at the very first prompt of a shell, where `history 1` is
+    # whatever the previous session left in the history file rather than
+    # anything typed here.
+    local previous=$__woswoar_lastnum
     __woswoar_lastnum=$num
+    [[ -n $previous ]] || { __woswoar_start=; return 0; }
 
     local cmd=${raw#"$num"}
     cmd=${cmd#"${cmd%%[![:space:]]*}"} # drop the separator spaces
     cmd=${cmd%$'\n'}
-    [[ -n $cmd ]] || return 0
+    [[ -n $cmd ]] || { __woswoar_start=; return 0; }
 
     if [[ -n $WOSWOAR_IGNORE && $cmd =~ $WOSWOAR_IGNORE ]]; then
+        __woswoar_start=
         return 0
     fi
 
+    # -1 means "unknown", which is what a lost DEBUG trap leaves behind. Cleared
+    # on every path out of this function so one skipped command's start time
+    # cannot be charged to the next one.
     local duration=-1
     if [[ -n $__woswoar_start ]]; then
         local now=${EPOCHREALTIME//[.,]/}
         duration=$((${now%???} - __woswoar_start))
-        __woswoar_start=
     fi
+    __woswoar_start=
 
     if ((${#cmd} > __woswoar_max)); then
         cmd=${cmd:0:__woswoar_max}'...[truncated]'
@@ -211,20 +230,88 @@ __woswoar_widget() {
 # Wiring
 # ---------------------------------------------------------------------------
 
-trap '__woswoar_preexec' DEBUG
+# Chain onto whatever already owns the DEBUG trap rather than replacing it.
+# Terminal-title hooks, bash-preexec, atuin and ble.sh all live there, and a
+# bare `trap ... DEBUG` silently breaks whichever of them loaded first -- the
+# same reasoning that already guards the EXIT trap above.
+#
+# The wiring is deferred to the first prompt, which is not fussiness: a sourced
+# file cannot see the DEBUG trap at all. `trap -p DEBUG` reports nothing from
+# inside one (bash gives sourced files their own trap scope), so from here we
+# could neither chain onto an existing handler nor even notice we were about to
+# replace one. A PROMPT_COMMAND *string* runs at top level, where it can. The
+# delay is a feature: by the first prompt the whole of .bashrc has run, so we
+# chain onto whoever actually ended up owning the trap rather than whoever
+# happened to load before us -- which makes the order of the lines in .bashrc
+# stop mattering.
+__woswoar_prior_debug=
 
-# Append rather than prepend: anything else in PROMPT_COMMAND runs before us, so
+__woswoar_chained_debug() {
+    # The previous owner goes first, so it still sees the exit status of the
+    # command before this one; title hooks routinely read it. $BASH_COMMAND
+    # survives the extra stack frame -- bash holds it for the whole handler.
+    eval "$__woswoar_prior_debug"
+    __woswoar_preexec
+}
+
+__woswoar_wire_debug() {
+    local spec=
+    [[ -s $__woswoar_scratch ]] && IFS= read -r -d '' spec <"$__woswoar_scratch"
+
+    __woswoar_prior_debug=
+    if [[ -n $spec ]]; then
+        # `trap -p` prints a command that would restore the trap, with the
+        # handler requoted. Running that with `trap` shadowed recovers it
+        # exactly; hand-written unquoting mangles embedded quotes, and handlers
+        # containing quotes are the common case rather than the exotic one.
+        # shellcheck disable=SC2329  # invoked indirectly, by the eval below
+        trap() {
+            if [[ $1 == -- ]]; then
+                __woswoar_prior_debug=$2
+            else
+                __woswoar_prior_debug=$1
+            fi
+        }
+        eval "$spec"
+        unset -f trap
+    fi
+
+    # Never chain onto ourselves: re-sourcing the hook would otherwise nest a
+    # handler inside itself once per source.
+    if [[ -z $__woswoar_prior_debug || $__woswoar_prior_debug == *__woswoar* ]]; then
+        trap '__woswoar_preexec' DEBUG
+    else
+        trap '__woswoar_chained_debug' DEBUG
+    fi
+}
+
+#: Runs at every prompt but does its work once. A string, not a function,
+#: because only a string element is evaluated at top level where `trap -p` sees
+#: anything. Placed before __woswoar_precmd so both can share the scratch file.
+# shellcheck disable=SC2016  # single quotes are the point: this expands later
+__woswoar_boot='[[ -n ${__woswoar_wired:-} ]] || {
+    __woswoar_wired=1
+    builtin trap -p DEBUG >"$__woswoar_scratch" 2>/dev/null
+    __woswoar_wire_debug
+}'
+
+#: Prepended, so it runs before every other PROMPT_COMMAND entry -- including
+#: ones that were already there. A bare assignment, so it cannot be mistaken for
+#: a command the user typed, and it is the only part that has to go first.
+__woswoar_stamp='__woswoar_status=$?'
+
+# The rest is appended: anything else in PROMPT_COMMAND then runs before us, so
 # its own commands cannot be mistaken for something the user typed.
 __woswoar_attrs=
 if ((BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1))); then
     __woswoar_attrs=${PROMPT_COMMAND@a}
 fi
 if [[ $__woswoar_attrs == *a* ]]; then
-    PROMPT_COMMAND+=(__woswoar_precmd)
+    PROMPT_COMMAND=("$__woswoar_stamp" "${PROMPT_COMMAND[@]}" "$__woswoar_boot" __woswoar_precmd)
 elif [[ -z ${PROMPT_COMMAND:-} ]]; then
-    PROMPT_COMMAND=__woswoar_precmd
+    PROMPT_COMMAND=$__woswoar_stamp$'\n'$__woswoar_boot$'\n'__woswoar_precmd
 else
-    PROMPT_COMMAND=${PROMPT_COMMAND%$'\n'}$'\n'__woswoar_precmd
+    PROMPT_COMMAND=$__woswoar_stamp$'\n'${PROMPT_COMMAND%$'\n'}$'\n'$__woswoar_boot$'\n'__woswoar_precmd
 fi
 unset -v __woswoar_attrs
 

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -79,8 +79,12 @@ export WOSWOAR_SESSION
 #: Mirrors MAX_CMD_CHARS in woswoar/entry.py.
 __woswoar_max=8000
 
-__woswoar_armed=1
+#: Set by preexec, consumed by precmd. Empty also means "no command has been
+#: timed since the last prompt", which is what makes a separate armed flag
+#: unnecessary: preexec only stamps when it is empty, so the first simple
+#: command of a compound line wins and the rest are ignored.
 __woswoar_start=
+__woswoar_status=
 __woswoar_lastnum=
 
 # ---------------------------------------------------------------------------
@@ -107,9 +111,8 @@ __woswoar_escape() {
 # used for the command text (see the header), only as a timing signal.
 __woswoar_preexec() {
     [[ -n ${COMP_LINE:-} ]] && return 0 # tab completion, not a real command
-    ((__woswoar_armed)) || return 0
-    __woswoar_armed=0
-    local now=${EPOCHREALTIME//[.,]/} # locale may use a comma, not a period
+    [[ -z $__woswoar_start ]] || return 0 # DEBUG refires per simple command
+    local now=${EPOCHREALTIME//[.,]/}    # locale may use a comma, not a period
     __woswoar_start=${now%???}
 }
 
@@ -119,16 +122,20 @@ __woswoar_precmd() {
     # of the previous entry. Anything already in PROMPT_COMMAND (a title hook,
     # a prompt framework) therefore made every recorded command look successful.
     # __woswoar_stamp is prepended so it captures the real one before any of
-    # that runs; the fallback covers a shell where PROMPT_COMMAND was replaced
-    # wholesale after we loaded.
+    # that runs. Consumed rather than cached: leaving it set would make a shell
+    # whose PROMPT_COMMAND was replaced wholesale record a *stale* code, which
+    # is worse than falling back to whatever $? holds here.
     local exit_code=${__woswoar_status:-$?}
+    __woswoar_status=
 
-    # Re-arm the timer whatever happens below. Recording deliberately does not
-    # depend on the DEBUG trap having fired: if some other tool claims that trap
-    # after we do, we lose the *duration* of a command, not the command. Gating
-    # the whole function on it meant a single `trap ... DEBUG` anywhere later in
+    # Taken and cleared in one place, so every path out of this function is
+    # covered by construction. Recording deliberately does not depend on the
+    # DEBUG trap having fired: if some other tool claims that trap after we do,
+    # we lose the *duration* of a command, not the command. Gating the whole
+    # function on a flag the trap set meant a single `trap ... DEBUG` later in
     # .bashrc silently turned recording off with nothing to show for it.
-    __woswoar_armed=1
+    local start=$__woswoar_start
+    __woswoar_start=
 
     # Empty HISTTIMEFORMAT for this one call so the output format is "  N  cmd"
     # regardless of the user's setting. Written as '' rather than a bare = so
@@ -153,34 +160,30 @@ __woswoar_precmd() {
     # need a second set of rules for the same thing. This check is also what
     # makes recording independent of the DEBUG trap: it, not a flag the trap
     # sets, is what distinguishes "a command ran" from "nothing happened".
-    [[ $num == "$__woswoar_lastnum" ]] && { __woswoar_start=; return 0; }
+    [[ $num == "$__woswoar_lastnum" ]] && return 0
 
     # Empty only at the very first prompt of a shell, where `history 1` is
     # whatever the previous session left in the history file rather than
     # anything typed here.
     local previous=$__woswoar_lastnum
     __woswoar_lastnum=$num
-    [[ -n $previous ]] || { __woswoar_start=; return 0; }
+    [[ -n $previous ]] || return 0
 
     local cmd=${raw#"$num"}
     cmd=${cmd#"${cmd%%[![:space:]]*}"} # drop the separator spaces
     cmd=${cmd%$'\n'}
-    [[ -n $cmd ]] || { __woswoar_start=; return 0; }
+    [[ -n $cmd ]] || return 0
 
     if [[ -n $WOSWOAR_IGNORE && $cmd =~ $WOSWOAR_IGNORE ]]; then
-        __woswoar_start=
         return 0
     fi
 
-    # -1 means "unknown", which is what a lost DEBUG trap leaves behind. Cleared
-    # on every path out of this function so one skipped command's start time
-    # cannot be charged to the next one.
+    # -1 means "unknown", which is what a lost DEBUG trap leaves behind.
     local duration=-1
-    if [[ -n $__woswoar_start ]]; then
+    if [[ -n $start ]]; then
         local now=${EPOCHREALTIME//[.,]/}
-        duration=$((${now%???} - __woswoar_start))
+        duration=$((${now%???} - start))
     fi
-    __woswoar_start=
 
     if ((${#cmd} > __woswoar_max)); then
         cmd=${cmd:0:__woswoar_max}'...[truncated]'
@@ -244,61 +247,74 @@ __woswoar_widget() {
 # chain onto whoever actually ended up owning the trap rather than whoever
 # happened to load before us -- which makes the order of the lines in .bashrc
 # stop mattering.
-__woswoar_prior_debug=
-
-__woswoar_chained_debug() {
-    # The previous owner goes first, so it still sees the exit status of the
-    # command before this one; title hooks routinely read it. $BASH_COMMAND
-    # survives the extra stack frame -- bash holds it for the whole handler.
-    eval "$__woswoar_prior_debug"
-    __woswoar_preexec
-}
-
 __woswoar_wire_debug() {
     local spec=
     [[ -s $__woswoar_scratch ]] && IFS= read -r -d '' spec <"$__woswoar_scratch"
 
-    __woswoar_prior_debug=
-    if [[ -n $spec ]]; then
-        # `trap -p` prints a command that would restore the trap, with the
-        # handler requoted. Running that with `trap` shadowed recovers it
-        # exactly; hand-written unquoting mangles embedded quotes, and handlers
-        # containing quotes are the common case rather than the exotic one.
-        # shellcheck disable=SC2329  # invoked indirectly, by the eval below
-        trap() {
-            if [[ $1 == -- ]]; then
-                __woswoar_prior_debug=$2
-            else
-                __woswoar_prior_debug=$1
-            fi
-        }
-        eval "$spec"
-        unset -f trap
-    fi
+    # `trap -p` prints a command that would restore the trap, with the handler
+    # requoted -- `trap -- 'handler' DEBUG`. Re-splitting that as an array
+    # unquotes it exactly, which hand-written unquoting does not: handlers
+    # containing quotes are the common case, not the exotic one. Deliberately
+    # *not* done by shadowing the `trap` builtin with a function and re-running
+    # the spec: a shell function is process-global, and ble.sh ships its own
+    # `trap` wrapper, so defining and unsetting one would silently disable
+    # ble.sh's trap manager for the rest of the session.
+    local -a parts=()
+    [[ -n $spec ]] && eval "parts=($spec)"
+    local prior=${parts[1]-}
+    [[ $prior == -- ]] && prior=${parts[2]-}
 
-    # Never chain onto ourselves: re-sourcing the hook would otherwise nest a
-    # handler inside itself once per source.
-    if [[ -z $__woswoar_prior_debug || $__woswoar_prior_debug == *__woswoar* ]]; then
+    # Never chain onto ourselves: otherwise re-wiring would nest a handler
+    # inside itself.
+    if [[ -z $prior || $prior == *__woswoar* ]]; then
         trap '__woswoar_preexec' DEBUG
     else
-        trap '__woswoar_chained_debug' DEBUG
+        # Composed once, here, rather than by a wrapper function that evals the
+        # prior handler on every command: same behaviour for ~10us less per
+        # command, and $BASH_COMMAND is identical either way. The prior owner
+        # goes first so it still sees the exit status of the command before this
+        # one, and the separator is a newline rather than `;` so a handler that
+        # ends in a comment still works.
+        trap "$prior"$'\n''__woswoar_preexec' DEBUG
     fi
 }
 
-#: Runs at every prompt but does its work once. A string, not a function,
-#: because only a string element is evaluated at top level where `trap -p` sees
-#: anything. Placed before __woswoar_precmd so both can share the scratch file.
+#: Removes itself from PROMPT_COMMAND once the trap is wired, so the steady
+#: state costs nothing. Leaving it in place measured ~12us on every command for
+#: the life of the shell -- 8% of the hook's budget to re-test a flag.
+__woswoar_unboot() {
+    local entry
+    if [[ ${PROMPT_COMMAND@a} == *a* ]]; then
+        local -a kept=()
+        for entry in "${PROMPT_COMMAND[@]}"; do
+            [[ $entry == "$__woswoar_boot" ]] || kept+=("$entry")
+        done
+        PROMPT_COMMAND=("${kept[@]}")
+    else
+        # shellcheck disable=SC2178  # PROMPT_COMMAND is a string on this branch
+        PROMPT_COMMAND=${PROMPT_COMMAND/"$__woswoar_boot"$'\n'/}
+    fi
+}
+
+#: Runs at the first prompt and then deletes itself. A string, not a function,
+#: because only a string element is evaluated at top level, and `trap -p DEBUG`
+#: reports nothing from inside a function or a sourced file. Ordered before
+#: __woswoar_precmd so both can use the scratch file.
 # shellcheck disable=SC2016  # single quotes are the point: this expands later
-__woswoar_boot='[[ -n ${__woswoar_wired:-} ]] || {
-    __woswoar_wired=1
+__woswoar_boot='{
     builtin trap -p DEBUG >"$__woswoar_scratch" 2>/dev/null
     __woswoar_wire_debug
+    __woswoar_unboot
 }'
 
 #: Prepended, so it runs before every other PROMPT_COMMAND entry -- including
-#: ones that were already there. A bare assignment, so it cannot be mistaken for
-#: a command the user typed, and it is the only part that has to go first.
-__woswoar_stamp='__woswoar_status=$?'
+#: ones that were already there. It has to restore the status it just read:
+#: an assignment succeeds, so leaving it at 0 would hand every *other* entry the
+#: same wrong `$?` this hook exists to stop getting itself. `return` is a
+#: builtin, so this stays fork-free. Same approach as bash-preexec.
+__woswoar_ret() { return "$1"; }
+# shellcheck disable=SC2016  # single quotes are the point: this expands later
+__woswoar_stamp='__woswoar_status=$?; __woswoar_ret "$__woswoar_status"'
 
 # The rest is appended: anything else in PROMPT_COMMAND then runs before us, so
 # its own commands cannot be mistaken for something the user typed.

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -342,10 +342,24 @@ def new_chunk(machine_id: str, day: str, ts: int) -> Path:
     """A chunk path that has never existed before.
 
     Zero-padded seconds sort chronologically as strings, which is what lets the
-    merge watermark be a plain string comparison. The random suffix keeps two
-    syncs in the same second from colliding.
+    merge watermark be a plain string comparison.
+
+    The random suffix alone did not make the docstring true, which is what the
+    loop is for. Four hex characters is 65,536 values, so twenty chunks written
+    inside one second collided about 0.3% of the time -- rare enough to read as
+    a flaky test, common enough to happen. A collision silently *overwrites* an
+    already-sealed chunk, destroying committed history in a design whose whole
+    premise is that chunks are written once and never modified. Six characters
+    makes a first-try collision negligible; the check makes it impossible.
+
+    Checking the filesystem is sufficient because `flock` serialises syncs on a
+    machine and every machine writes only under its own host id.
     """
-    return chunk_dir(machine_id, day) / f"{ts:010d}-{secrets.token_hex(2)}{_CHUNK_SUFFIX}"
+    directory = chunk_dir(machine_id, day)
+    while True:
+        path = directory / f"{ts:010d}-{secrets.token_hex(3)}{_CHUNK_SUFFIX}"
+        if not path.exists():
+            return path
 
 
 class Chunk(NamedTuple):

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -344,16 +344,13 @@ def new_chunk(machine_id: str, day: str, ts: int) -> Path:
     Zero-padded seconds sort chronologically as strings, which is what lets the
     merge watermark be a plain string comparison.
 
-    The random suffix alone did not make the docstring true, which is what the
-    loop is for. Four hex characters is 65,536 values, so twenty chunks written
-    inside one second collided about 0.3% of the time -- rare enough to read as
-    a flaky test, common enough to happen. A collision silently *overwrites* an
-    already-sealed chunk, destroying committed history in a design whose whole
-    premise is that chunks are written once and never modified. Six characters
-    makes a first-try collision negligible; the check makes it impossible.
-
-    Checking the filesystem is sufficient because `flock` serialises syncs on a
-    machine and every machine writes only under its own host id.
+    Uniqueness is a guarantee, not a probability. A collision would silently
+    overwrite an already-sealed chunk, destroying committed history in a design
+    whose whole premise is that chunks are written once and never modified --
+    entropy alone left that to chance, which
+    tests/test_sync.py::TestChunkNaming now pins. Checking the filesystem is
+    sound because both writers of a host's chunks, `sync.run` and
+    `sync.compact`, hold the same lock.
     """
     directory = chunk_dir(machine_id, day)
     while True:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -673,33 +673,41 @@ def compact(before: str) -> tuple[int, int]:
     property the rest of the design leans on. Only this host's own chunks are
     touched, so it still cannot conflict.
 
+    Holds the same lock `run` does, and must: this is the one operation that
+    unlinks chunks, and the timer fires every minute. It is also what makes
+    `store.new_chunk`'s uniqueness check sound, since that check assumes no
+    other process is creating chunks for this host concurrently.
+
     Returns (days compacted, chunks replaced).
     """
     crypto.require()
     known = store.machine()
-    by_day: dict[str, list[store.Chunk]] = {}
-    for chunk in store.iter_chunks(known.id):
-        if chunk.day < before:
-            by_day.setdefault(chunk.day, []).append(chunk)
 
-    days = 0
-    replaced = 0
-    for day, chunks in sorted(by_day.items()):
-        if len(chunks) < 2:
-            continue
-        secret = open_day_key(known, known.id, day)
-        plain = b"".join(
-            unpack(crypto.decrypt_with_secret(c.path.read_bytes(), secret)) for c in chunks
-        )
-        merged = store.new_chunk(known.id, day, int(chunks[-1].name.split("-")[0]))
-        store.write_atomic(merged, crypto.encrypt_to(pack(plain), crypto.public_of(secret)))
-        for chunk in chunks:
-            chunk.path.unlink()
-        days += 1
-        replaced += len(chunks)
+    with lock():
+        by_day: dict[str, list[store.Chunk]] = {}
+        for chunk in store.iter_chunks(known.id):
+            if chunk.day < before:
+                by_day.setdefault(chunk.day, []).append(chunk)
 
-    if days:
-        _commit()
+        days = 0
+        replaced = 0
+        for day, chunks in sorted(by_day.items()):
+            if len(chunks) < 2:
+                continue
+            secret = open_day_key(known, known.id, day)
+            plain = b"".join(
+                unpack(crypto.decrypt_with_secret(c.path.read_bytes(), secret)) for c in chunks
+            )
+            merged = store.new_chunk(known.id, day, int(chunks[-1].name.split("-")[0]))
+            store.write_atomic(merged, crypto.encrypt_to(pack(plain), crypto.public_of(secret)))
+            for chunk in chunks:
+                chunk.path.unlink()
+            days += 1
+            replaced += len(chunks)
+
+        if days:
+            _commit()
+
     return days, replaced
 
 


### PR DESCRIPTION
Asking whether woswoar disturbs a normal bash turned up two bugs. Both were found by driving a real interactive shell rather than by reading the code, and **the second one is already shipping on `main`**.

## 1. A bare `trap … DEBUG` silently broke whatever owned it

Terminal-title hooks, bash-preexec, atuin and ble.sh all live there. Verified in both directions before the fix: woswoar loaded second → the existing trap stopped firing; woswoar loaded first → *woswoar* stopped recording.

The obvious fix — read the existing handler and call it too — **does not work from the hook**. A sourced file cannot see the DEBUG trap at all; bash gives sourced files their own trap scope, so `trap -p DEBUG` reports nothing from inside one:

```
  direct, in sourced file:  (empty)
  top level:                trap -- 'h' DEBUG
  PROMPT_COMMAND string:    trap -- 'h' DEBUG
```

So the wiring is deferred to the first prompt, via a `PROMPT_COMMAND` *string* (evaluated at top level). The delay is the better design anyway: by then all of `.bashrc` has run, so we chain onto whoever actually ended up owning the trap — **the order of lines in `.bashrc` stops mattering**.

The prior handler is recovered by re-running what `trap -p` prints with `trap` shadowed by a function, rather than unquoting by hand. Handlers containing quotes are the common case; tested against five, including `echo it's here` and `tricky '$x' "y"`.

## 2. Exit codes were wrong whenever anything else used `PROMPT_COMMAND` — already on `main`

`$?` only holds the user's status for the **first** `PROMPT_COMMAND` entry; after that it is the previous entry's. woswoar appends itself, so one pre-existing entry — a title hook is enough — made every command record as successful. Measured against `f19e8bc`:

| | `false` `true` `false` |
|---|---|
| main, nothing else in PROMPT_COMMAND | exit `1 0 1` ✅ |
| **main, one prior entry** | **exit `0 0 0`** ❌ |
| this branch, either way | exit `1 0 1` ✅ |

Fixed by *prepending* a bare assignment — the one part that has to run first, and one that cannot be mistaken for a command the user typed.

## 3. Recording no longer depends on the DEBUG trap

It was gated on a flag the DEBUG handler set, so anything claiming the trap after us turned recording off entirely and silently. The history number already distinguishes "a command ran" from "nothing happened", so that gates it now. Losing the trap costs a command's **duration** (`-1`), not the command.

## Verification

Five regression tests drive a real interactive bash with a title hook installed *ahead* of woswoar — the prior trap still fires, durations survive chaining, exit codes survive a prior `PROMPT_COMMAND`, recording survives losing the trap, and a quote-laden handler comes back intact.

Also run by hand against my actual `~/.bashrc` (title hook + ble.sh + atuin + gra):

```
  exit=  1  dur=    1  false
  exit=  0  dur=  201  sleep 0.2
  exit=  0  dur=    0  echo done
```

156 tests, ruff, mypy `--strict` and shellcheck all clean.

## Also

README gains a section answering the question that started this: up-arrow and `~/.bash_history` are untouched (woswoar only *reads* `history 1` and never touches `HISTFILE`/`HISTSIZE`/`HISTCONTROL`), the trap is shared, and a half-typed line becomes the fzf query with Escape restoring it byte-for-byte.