### PR TITLE
Hand age the key bytes, never the path

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ at all — only hashing — so instead of reaching for a third-party library and
 composing primitives by hand, woswoar shells out to
 [age](https://github.com/FiloSottile/age): a small, audited, widely deployed
 tool with one job. woswoar's crypto module is a
-[173-line subprocess wrapper](woswoar/crypto.py). There is no key derivation, no
+[small subprocess wrapper](woswoar/crypto.py). There is no key derivation, no
 nonce management and no mode selection to get wrong, because none of it lives
 here.
 

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -500,6 +500,44 @@ check is a real encrypt/decrypt round trip, not an inspection of the key file,
 because the question is not what format the key claims to be — it is whether an
 unattended sync will actually work.
 
+### age never gets a path
+
+**woswoar reads key material itself and hands `age` the bytes. No age
+invocation names a file in `$HOME`.**
+
+The rule came from a machine where `woswoar init` failed with
+
+```
+age-keygen: error: failed to open input file ".../woswoar/identity":
+  open .../woswoar/identity: permission denied
+```
+
+on a file that was mode 600 and owned by the user running the command. age was
+sandboxed and denied the hidden directories under `$HOME`; whether *the user*
+can read a file is simply a different question from whether *age* can, and
+passing a path asks the second one.
+
+Two things made it worse than a confusing error. The round-trip check above
+runs through the same decrypt, so the machine's perfectly good unencrypted
+`~/.ssh/id_ed25519` failed it and was silently rejected — and the only failure
+the code modelled was a passphrase, so it told the user their unencrypted key
+needed one and pointed at `--new-identity`, which cannot help. The passphrase
+case is now classified where the evidence is, in `_run`, from age's own stderr,
+rather than inferred from which step happened to fail.
+
+One path remains: `decrypt_with_secret` passes `/dev/fd/N`. That is a kernel
+object holding an inherited pipe rather than a file in `$HOME`, and it is the
+assumption the whole arrangement rests on — worth knowing if a sandbox is ever
+found that blocks it too.
+
+The rule is asserted at the seam every age call passes through, not per
+function, because per-function tests only cover what someone remembered to
+write one for. That is not hypothetical: the first version of this fix
+converted the two identity calls and left `encrypt_to_recipients` passing
+`-R recipients.txt`, so the reported machine would still have failed one step
+later, at sealing the name file during `init`. The seam test catches it; a
+third per-function test would not have existed.
+
 ### Why the obvious approach fails
 
 Re-encrypting a whole day file on every sync writes a fresh random blob each

--- a/tests/support.py
+++ b/tests/support.py
@@ -3,14 +3,22 @@
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 import unittest
 from pathlib import Path
 
-from woswoar import store
+from woswoar import crypto, store
 from woswoar.entry import Entry
 
 MACHINE_ID = "0123456789abcdef"
+
+#: External tools some suites need. Defined once so that a check which has to
+#: grow later -- an age version floor, say -- cannot be updated in one file and
+#: forgotten in the other.
+requires_age = unittest.skipUnless(crypto.available(), "age required")
+requires_git = unittest.skipUnless(shutil.which("git"), "git required")
+requires_ssh_keygen = unittest.skipUnless(shutil.which("ssh-keygen"), "ssh-keygen required")
 
 
 def make_entry(ts: int, cmd: str, host: str = MACHINE_ID, session: str = "s1") -> Entry:

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,106 @@
+"""How identities reach `age`.
+
+The rule these pin: woswoar reads key files itself and hands `age` the bytes.
+Passing a path instead makes every operation depend on age being able to open
+that path, which is a different question from whether the user can -- a
+sandboxed age (snap, flatpak, anything confined) is refused access to
+``~/.config`` and ``~/.ssh`` and reports "permission denied" for a file its
+owner can plainly read.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from woswoar import crypto
+
+requires_age = unittest.skipUnless(crypto.available(), "age required")
+requires_ssh_keygen = unittest.skipUnless(shutil.which("ssh-keygen"), "ssh-keygen required")
+
+
+class ArgvSpy:
+    """Records every argv crypto hands to a subprocess."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+        self._real = crypto._run
+
+    def __enter__(self) -> ArgvSpy:
+        def spy(
+            argv: list[str],
+            data: bytes | None = None,
+            pass_fds: tuple[int, ...] = (),
+        ) -> bytes:
+            self.calls.append(list(argv))
+            return self._real(argv, data, pass_fds)
+
+        crypto._run = spy
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        crypto._run = self._real
+
+    def mentions(self, needle: str) -> bool:
+        return any(needle in arg for call in self.calls for arg in call)
+
+
+@requires_age
+class TestIdentitiesAreNeverPassedAsPaths(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="woswoar-crypto-")
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def age_identity(self) -> Path:
+        path = self.root / "identity"
+        identity = crypto.generate_identity()
+        path.write_text(identity.secret, encoding="utf-8")
+        return path
+
+    def test_decrypt_with_file_does_not_name_the_identity(self) -> None:
+        path = self.age_identity()
+        sealed = crypto.encrypt_to(b"payload", crypto.recipient_for(path))
+        with ArgvSpy() as spy:
+            self.assertEqual(crypto.decrypt_with_file(sealed, path), b"payload")
+        self.assertFalse(spy.mentions(str(path)), f"identity path leaked into argv: {spy.calls}")
+
+    def test_recipient_for_does_not_name_the_identity(self) -> None:
+        path = self.age_identity()
+        with ArgvSpy() as spy:
+            self.assertTrue(crypto.recipient_for(path).startswith("age1"))
+        self.assertFalse(spy.mentions(str(path)), f"identity path leaked into argv: {spy.calls}")
+
+    @requires_ssh_keygen
+    def test_an_unencrypted_ssh_key_is_usable(self) -> None:
+        """The case that sent this investigation the wrong way.
+
+        `usable()` reported an unencrypted ed25519 key as needing a passphrase,
+        because age could not open it and the only failure the code knew about
+        was a passphrase.
+        """
+        key = self.root / "id_ed25519"
+        subprocess.run(
+            ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", str(key), "-q", "-C", "woswoar-test"],
+            check=True,
+            timeout=60,
+        )
+        self.assertEqual(crypto.why_unusable(key), "")
+
+        sealed = crypto.encrypt_to(b"payload", crypto.recipient_for(key))
+        with ArgvSpy() as spy:
+            self.assertEqual(crypto.decrypt_with_file(sealed, key), b"payload")
+        self.assertFalse(spy.mentions(str(key)), f"ssh key path leaked into argv: {spy.calls}")
+
+    def test_an_unreadable_identity_is_reported_as_unreadable(self) -> None:
+        # Not as "needs a passphrase", which is what it used to say and which
+        # points at a fix that cannot work.
+        missing = self.root / "gone"
+        self.assertIn("cannot be read", crypto.why_unusable(missing))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,105 +1,121 @@
-"""How identities reach `age`.
+"""How key material reaches `age`.
 
-The rule these pin: woswoar reads key files itself and hands `age` the bytes.
-Passing a path instead makes every operation depend on age being able to open
-that path, which is a different question from whether the user can -- a
-sandboxed age (snap, flatpak, anything confined) is refused access to
-``~/.config`` and ``~/.ssh`` and reports "permission denied" for a file its
-owner can plainly read.
+The rule: woswoar reads key files itself and hands `age` the bytes. See
+:func:`woswoar.crypto.decrypt_with_file` for why, and the design document for
+the incident that established it.
 """
 
 from __future__ import annotations
 
-import shutil
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from woswoar import crypto
 
-requires_age = unittest.skipUnless(crypto.available(), "age required")
-requires_ssh_keygen = unittest.skipUnless(shutil.which("ssh-keygen"), "ssh-keygen required")
+from .support import requires_age, requires_ssh_keygen
 
-
-class ArgvSpy:
-    """Records every argv crypto hands to a subprocess."""
-
-    def __init__(self) -> None:
-        self.calls: list[list[str]] = []
-        self._real = crypto._run
-
-    def __enter__(self) -> ArgvSpy:
-        def spy(
-            argv: list[str],
-            data: bytes | None = None,
-            pass_fds: tuple[int, ...] = (),
-        ) -> bytes:
-            self.calls.append(list(argv))
-            return self._real(argv, data, pass_fds)
-
-        crypto._run = spy
-        return self
-
-    def __exit__(self, *exc: object) -> None:
-        crypto._run = self._real
-
-    def mentions(self, needle: str) -> bool:
-        return any(needle in arg for call in self.calls for arg in call)
+#: The one path age is still given. It is a kernel object holding an inherited
+#: pipe, not a file in $HOME, which is what the rule is actually about.
+_ALLOWED_PATH_PREFIX = "/dev/fd/"
 
 
 @requires_age
-class TestIdentitiesAreNeverPassedAsPaths(unittest.TestCase):
+class TestNoAgeCallNamesAFile(unittest.TestCase):
+    """Asserted at the seam every age invocation passes through.
+
+    Per-function tests would only cover the functions someone remembered to
+    write one for -- and that is not hypothetical: the first version of this
+    fix left ``encrypt_to_recipients`` passing ``-R recipients.txt``, so the
+    reported machine would still have failed, one step later.
+    """
+
     def setUp(self) -> None:
-        self._tmp = tempfile.TemporaryDirectory(prefix="woswoar-crypto-")
-        self.addCleanup(self._tmp.cleanup)
-        self.root = Path(self._tmp.name)
+        tmp = tempfile.TemporaryDirectory(prefix="woswoar-crypto-")
+        self.addCleanup(tmp.cleanup)
+        self.tmp = Path(tmp.name)
 
     def age_identity(self) -> Path:
-        path = self.root / "identity"
-        identity = crypto.generate_identity()
-        path.write_text(identity.secret, encoding="utf-8")
+        path = self.tmp / "identity"
+        path.write_text(crypto.generate_identity().secret, encoding="utf-8")
         return path
 
-    def test_decrypt_with_file_does_not_name_the_identity(self) -> None:
-        path = self.age_identity()
-        sealed = crypto.encrypt_to(b"payload", crypto.recipient_for(path))
-        with ArgvSpy() as spy:
-            self.assertEqual(crypto.decrypt_with_file(sealed, path), b"payload")
-        self.assertFalse(spy.mentions(str(path)), f"identity path leaked into argv: {spy.calls}")
-
-    def test_recipient_for_does_not_name_the_identity(self) -> None:
-        path = self.age_identity()
-        with ArgvSpy() as spy:
-            self.assertTrue(crypto.recipient_for(path).startswith("age1"))
-        self.assertFalse(spy.mentions(str(path)), f"identity path leaked into argv: {spy.calls}")
-
-    @requires_ssh_keygen
-    def test_an_unencrypted_ssh_key_is_usable(self) -> None:
-        """The case that sent this investigation the wrong way.
-
-        `usable()` reported an unencrypted ed25519 key as needing a passphrase,
-        because age could not open it and the only failure the code knew about
-        was a passphrase.
-        """
-        key = self.root / "id_ed25519"
+    def ssh_identity(self) -> Path:
+        key = self.tmp / "id_ed25519"
         subprocess.run(
             ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", str(key), "-q", "-C", "woswoar-test"],
             check=True,
             timeout=60,
         )
-        self.assertEqual(crypto.why_unusable(key), "")
+        return key
 
-        sealed = crypto.encrypt_to(b"payload", crypto.recipient_for(key))
-        with ArgvSpy() as spy:
-            self.assertEqual(crypto.decrypt_with_file(sealed, key), b"payload")
-        self.assertFalse(spy.mentions(str(key)), f"ssh key path leaked into argv: {spy.calls}")
+    def assert_named_no_file(self, spy: mock.Mock) -> None:
+        for call in spy.call_args_list:
+            for arg in call.args[0]:
+                if arg.startswith(_ALLOWED_PATH_PREFIX):
+                    continue
+                self.assertFalse(
+                    Path(arg).exists(),
+                    f"age was given a real path: {arg!r} in {call.args[0]!r}",
+                )
 
-    def test_an_unreadable_identity_is_reported_as_unreadable(self) -> None:
-        # Not as "needs a passphrase", which is what it used to say and which
-        # points at a fix that cannot work.
-        missing = self.root / "gone"
-        self.assertIn("cannot be read", crypto.why_unusable(missing))
+    def exercise(self, identity: Path) -> None:
+        """Every entry point that touches key material, once."""
+        recipient = crypto.recipient_for(identity)
+        sealed = crypto.encrypt_to(b"payload", recipient)
+        self.assertEqual(crypto.decrypt_with_file(sealed, identity), b"payload")
+
+        to_many = crypto.encrypt_to_recipients(b"payload", [recipient])
+        self.assertEqual(crypto.decrypt_with_file(to_many, identity), b"payload")
+
+        self.assertEqual(crypto.why_unusable(identity), "")
+
+    def test_age_identity(self) -> None:
+        identity = self.age_identity()
+        with mock.patch.object(crypto, "_run", wraps=crypto._run) as spy:
+            self.exercise(identity)
+        self.assert_named_no_file(spy)
+
+    @requires_ssh_keygen
+    def test_ssh_identity(self) -> None:
+        """The case that sent the investigation the wrong way.
+
+        `why_unusable` reported an unencrypted ed25519 key as needing a
+        passphrase, because age could not open it and a passphrase was the only
+        failure the code modelled.
+        """
+        identity = self.ssh_identity()
+        with mock.patch.object(crypto, "_run", wraps=crypto._run) as spy:
+            self.exercise(identity)
+        self.assert_named_no_file(spy)
+
+    def test_sealing_to_several_recipients_reaches_all_of_them(self) -> None:
+        # `-R <file>` became repeated `-r <key>`; this is what that has to keep
+        # doing.
+        first, second = self.age_identity(), self.tmp / "second"
+        second.write_text(crypto.generate_identity().secret, encoding="utf-8")
+        sealed = crypto.encrypt_to_recipients(
+            b"payload", [crypto.recipient_for(first), crypto.recipient_for(second)]
+        )
+        self.assertEqual(crypto.decrypt_with_file(sealed, first), b"payload")
+        self.assertEqual(crypto.decrypt_with_file(sealed, second), b"payload")
+
+    def test_sealing_to_nobody_says_so(self) -> None:
+        with self.assertRaises(crypto.AgeError) as caught:
+            crypto.encrypt_to_recipients(b"payload", [])
+        self.assertIn("no recipients", str(caught.exception))
+
+
+@requires_age
+class TestWhyUnusable(unittest.TestCase):
+    def test_an_unreadable_identity_is_not_reported_as_a_passphrase(self) -> None:
+        # "needs a passphrase" points at --new-identity, which cannot help when
+        # the real problem is that the file could not be opened at all.
+        reason = crypto.why_unusable(Path("/nonexistent/woswoar/identity"))
+        self.assertIn("cannot be read", reason)
+        self.assertNotIn("passphrase", reason)
 
 
 if __name__ == "__main__":

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -8,7 +8,6 @@ are enough, and that is only meaningful if it is actually demonstrated.
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 import tempfile
 import unittest
@@ -17,13 +16,11 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
-from woswoar import cache, crypto, search, store, sync
+from woswoar import cache, search, store, sync
 from woswoar.entry import Entry, format_line
 
 from . import support
-
-requires_age = unittest.skipUnless(crypto.available(), "age required")
-requires_git = unittest.skipUnless(shutil.which("git"), "git required")
+from .support import requires_age, requires_git
 
 #: One authoritative list, plus HOME which only these tests need to redirect.
 _ENV = (*support.ENV_KEYS, "HOME")

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+from collections.abc import Iterable
 from pathlib import Path
 from typing import NamedTuple
 
@@ -90,13 +91,24 @@ def _run(argv: list[str], data: bytes | None = None, pass_fds: tuple[int, ...] =
     return result.stdout
 
 
-def encrypt_to_recipients(data: bytes, recipients_file: Path) -> bytes:
-    """Seal ``data`` so that every recipient listed in the file can open it.
+def encrypt_to_recipients(data: bytes, recipients: Iterable[str]) -> bytes:
+    """Seal ``data`` so that every one of ``recipients`` can open it.
 
     age wraps one random file key separately per recipient, so the payload is
     stored once no matter how many machines are listed.
+
+    Takes the keys, not the path to the file holding them, for the same reason
+    the identity functions do: no age invocation may name a file in ``$HOME``.
+    Passing ``-R recipients.txt`` reintroduced exactly the failure this module
+    exists to avoid, one step later in `init`.
     """
-    return _run([AGE, "-R", str(recipients_file)], data)
+    keys = list(recipients)
+    if not keys:
+        raise AgeError("no recipients to seal to; run 'woswoar init' first")
+    argv = [AGE]
+    for key in keys:
+        argv += ["-r", key]
+    return _run(argv, data)
 
 
 def encrypt_to(data: bytes, recipient: str) -> bytes:
@@ -163,8 +175,10 @@ def recipient_for(identity: Path) -> str:
     pub = identity.with_suffix(identity.suffix + ".pub")
     if pub.is_file():
         return pub.read_text(encoding="utf-8").strip()
-    # On stdin, not as a path argument -- see decrypt_with_file.
-    return _run([AGE_KEYGEN, "-y"], identity.read_bytes()).decode("utf-8").strip()
+    # Reading the file ourselves, then reusing public_of, which already knows
+    # both how to skip the subprocess when the identity carries its own
+    # `# public key:` comment and how to feed age on stdin when it does not.
+    return public_of(identity.read_text(encoding="utf-8"))
 
 
 def why_unusable(identity: Path) -> str:
@@ -174,11 +188,14 @@ def why_unusable(identity: Path) -> str:
     key file, because the thing that matters is whether an unattended sync will
     work, not what format the key claims to be.
 
-    The reason is returned rather than a bare bool because the two failures
-    need different advice and used to be reported as the same one: a key that
-    needs a passphrase wants ``--new-identity``, whereas a key this process
-    cannot even read wants the *file* looked at, and telling someone their
-    unencrypted key needs a passphrase sends them the wrong way entirely.
+    The reason is returned rather than a bare bool because the failures need
+    different advice and used to be reported as the same one: a key that needs
+    a passphrase wants ``--new-identity``, whereas a key this process cannot
+    even read wants the *file* looked at, and telling someone their unencrypted
+    key needs a passphrase sends them the wrong way entirely. The wording comes
+    from `_run`, which already classifies the passphrase case from age's own
+    stderr -- inferring it from which step failed is how the misdiagnosis
+    happened in the first place.
     """
     try:
         identity.read_bytes()
@@ -194,8 +211,8 @@ def why_unusable(identity: Path) -> str:
     try:
         if decrypt_with_file(sealed, identity) != b"woswoar":
             return "age round trip did not return the original"
-    except (AgeError, OSError):
-        return "needs a passphrase, so an unattended sync could never use it"
+    except (AgeError, OSError) as exc:
+        return f"cannot decrypt: {exc}"
     return ""
 
 

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -105,8 +105,16 @@ def encrypt_to(data: bytes, recipient: str) -> bytes:
 
 
 def decrypt_with_file(data: bytes, identity: Path) -> bytes:
-    """Open ``data`` using an identity stored on disk (an SSH or age key)."""
-    return _run([AGE, "-d", "-i", str(identity)], data)
+    """Open ``data`` using an identity stored on disk (an SSH or age key).
+
+    Python reads the file and hands age the *bytes*, never the path. Passing
+    a path makes the operation depend on age being able to open it, which is
+    not the same question as whether the user can: a sandboxed age -- snap,
+    flatpak, or anything else confined -- is refused access to ``~/.config``
+    and ``~/.ssh`` and fails with a bare "permission denied" on a file the
+    owner can plainly read.
+    """
+    return decrypt_with_secret(data, identity.read_text(encoding="utf-8"))
 
 
 def decrypt_with_secret(data: bytes, secret: str) -> bytes:
@@ -155,19 +163,41 @@ def recipient_for(identity: Path) -> str:
     pub = identity.with_suffix(identity.suffix + ".pub")
     if pub.is_file():
         return pub.read_text(encoding="utf-8").strip()
-    return _run([AGE_KEYGEN, "-y", str(identity)]).decode("utf-8").strip()
+    # On stdin, not as a path argument -- see decrypt_with_file.
+    return _run([AGE_KEYGEN, "-y"], identity.read_bytes()).decode("utf-8").strip()
 
 
-def usable(identity: Path) -> bool:
-    """Whether this identity can decrypt without a terminal.
+def why_unusable(identity: Path) -> str:
+    """``""`` if this identity can decrypt unattended, else why not.
 
     Checked by actually performing a round trip rather than by inspecting the
     key file, because the thing that matters is whether an unattended sync will
     work, not what format the key claims to be.
+
+    The reason is returned rather than a bare bool because the two failures
+    need different advice and used to be reported as the same one: a key that
+    needs a passphrase wants ``--new-identity``, whereas a key this process
+    cannot even read wants the *file* looked at, and telling someone their
+    unencrypted key needs a passphrase sends them the wrong way entirely.
     """
+    try:
+        identity.read_bytes()
+    except OSError as exc:
+        return f"cannot be read: {exc.strerror}"
+
     try:
         recipient = recipient_for(identity)
         sealed = encrypt_to(b"woswoar", recipient)
-        return decrypt_with_file(sealed, identity) == b"woswoar"
+    except (AgeError, OSError) as exc:
+        return f"no usable public key: {exc}"
+
+    try:
+        if decrypt_with_file(sealed, identity) != b"woswoar":
+            return "age round trip did not return the original"
     except (AgeError, OSError):
-        return False
+        return "needs a passphrase, so an unattended sync could never use it"
+    return ""
+
+
+def usable(identity: Path) -> bool:
+    return not why_unusable(identity)

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -194,10 +194,10 @@ def identity_status(known: Machine) -> IdentityStatus:
         return IdentityStatus(False, f"identity {path} is missing - re-run 'woswoar init'")
     if not crypto.available():
         return IdentityStatus(True, f"identity {path} (age missing, cannot verify)")
-    if not crypto.usable(path):
-        return IdentityStatus(
-            False, f"{path} needs a passphrase - try 'woswoar init --new-identity'"
-        )
+    reason = crypto.why_unusable(path)
+    if reason:
+        hint = " - try 'woswoar init --new-identity'" if "passphrase" in reason else ""
+        return IdentityStatus(False, f"{path} {reason}{hint}")
     return IdentityStatus(True, f"identity {path}")
 
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -90,21 +90,25 @@ def remote_summary() -> str:
     return remotes[0] if remotes else "none (history is local only)"
 
 
+def recipients() -> list[str]:
+    """Every enrolled machine's public key, in the form age wants on `-r`.
+
+    Read here rather than handed to age as a path: `crypto` never names a file
+    in $HOME, because a sandboxed age cannot open one.
+    """
+    path = store.recipients_file()
+    if not path.is_file():
+        return []
+    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
 def list_recipients() -> list[tuple[str, str]]:
     """``(kind, key)`` for every enrolled machine.
 
     Parsed here rather than in the CLI because this module is the only writer of
     recipients.txt, so the record shape is its to know.
     """
-    path = store.recipients_file()
-    if not path.is_file():
-        return []
-    entries = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if line.strip():
-            kind, _, rest = line.strip().partition(" ")
-            entries.append((kind, rest))
-    return entries
+    return [(kind, rest) for kind, _, rest in (line.partition(" ") for line in recipients())]
 
 
 def is_repo() -> bool:
@@ -196,8 +200,10 @@ def identity_status(known: Machine) -> IdentityStatus:
         return IdentityStatus(True, f"identity {path} (age missing, cannot verify)")
     reason = crypto.why_unusable(path)
     if reason:
-        hint = " - try 'woswoar init --new-identity'" if "passphrase" in reason else ""
-        return IdentityStatus(False, f"{path} {reason}{hint}")
+        # No hint appended here: crypto already puts the right advice in the
+        # reason, and picking it by grepping this string for "passphrase" made
+        # sync depend on crypto's exact wording.
+        return IdentityStatus(False, f"identity {path} {reason}")
     return IdentityStatus(True, f"identity {path}")
 
 
@@ -212,7 +218,7 @@ def day_public_key(known: Machine, day: str) -> str:
         return pub_path.read_text(encoding="utf-8").strip()
 
     identity = crypto.generate_identity()
-    sealed = crypto.encrypt_to_recipients(identity.secret.encode("utf-8"), store.recipients_file())
+    sealed = crypto.encrypt_to_recipients(identity.secret.encode("utf-8"), recipients())
     pub_path.parent.mkdir(parents=True, exist_ok=True)
     store.write_atomic(store.day_key(known.id, day), sealed)
     store.write_atomic(pub_path, (identity.public + "\n").encode("utf-8"))
@@ -504,8 +510,12 @@ def choose_identity(new_identity: bool = False, explicit: Path | None = None) ->
     """
     if explicit is not None:
         path = explicit.expanduser()
-        if not crypto.usable(path):
-            raise SyncError(f"{path} cannot decrypt without a terminal; see 'woswoar doctor'")
+        reason = crypto.why_unusable(path)
+        if reason:
+            # The reason, not a guess at it. Reporting every failure as
+            # "cannot decrypt without a terminal" is what sent someone with a
+            # perfectly good unencrypted key looking for a passphrase problem.
+            raise SyncError(f"{path} {reason}")
         return path
 
     if not new_identity:
@@ -586,7 +596,7 @@ def _write_repo_metadata(known: Machine, identity: Path) -> bool:
         seal.parent.mkdir(parents=True, exist_ok=True)
         store.write_atomic(
             seal,
-            crypto.encrypt_to_recipients(f"{known.name}\n".encode(), store.recipients_file()),
+            crypto.encrypt_to_recipients(f"{known.name}\n".encode(), recipients()),
         )
         changed = True
     return changed
@@ -629,7 +639,6 @@ def reencrypt() -> ReencryptReport:
 
     known = store.machine()
     identity = identity_path(known)
-    recipients = store.recipients_file()
     _ensure_repo_config()
     remote = has_remote()
     resealed = skipped = 0
@@ -639,6 +648,13 @@ def reencrypt() -> ReencryptReport:
     with lock():
         if remote:
             _fetch_and_rebase()
+
+        # Read *after* the fetch, never before. The whole point of this command
+        # is to seal to a machine that enrolled since the last sync, so taking
+        # the list from a pre-fetch checkout would re-seal everything to the old
+        # recipients and report full success. Reading it once here also saves
+        # re-parsing the file for every one of a few thousand key files.
+        keys = recipients()
 
         for host_id in store.repo_hosts():
             candidates = list(store.iter_day_keys(host_id))
@@ -654,7 +670,7 @@ def reencrypt() -> ReencryptReport:
                     # joined, or left behind by one since removed.
                     skipped += 1
                     continue
-                store.write_atomic(path, crypto.encrypt_to_recipients(plain, recipients))
+                store.write_atomic(path, crypto.encrypt_to_recipients(plain, keys))
                 resealed += 1
 
         _commit()


### PR DESCRIPTION
Reported from a work machine:

```
$ woswoar init git@github.com:martinus/woswoar-history.git
woswoar: age-keygen: error: failed to open input file
  "/home/martinus/.config/woswoar/identity": permission denied

$ l /home/martinus/.config/woswoar/identity
.rw------- 189 martinus 30 Jul 07:54 .../identity
```

The file is readable by its owner. It is **age** that cannot open it.

## One bug, two symptoms

`recipient_for()` ran `age-keygen -y <path>` and `decrypt_with_file()` ran `age -d -i <path>`. Both made the operation depend on *age* being able to open the file — a different question from whether the user can. A confined age (snap, flatpak, any sandbox not granting `~/.config` and `~/.ssh`) is refused and reports a bare "permission denied".

The second symptom, reported separately: **an unencrypted `~/.ssh/id_ed25519` was not used.** Same cause. `usable()` round-trips through `decrypt_with_file`, so a key age couldn't open failed the check, `choose_identity()` fell back to generating a dedicated identity, and *that* then failed at the same step. And the only failure the code modelled was a passphrase, so it told the user their unencrypted key "needs a passphrase" and pointed at `--new-identity` — advice that cannot work.

## The fix was already the module's own pattern

`public_of()` pipes the key on stdin; `decrypt_with_secret()` passes it through `os.pipe()` + `/dev/fd` so a day key never touches disk. These two calls were simply inconsistent with that. Python now reads the file and hands over the bytes, so access is decided by the permissions **woswoar** has, not age's sandbox.

Verified equivalent locally for both key types:

```
age-keygen -y by path : age1m66v2es84v5...
age-keygen -y by stdin: age1m66v2es84v5...      identical
age -d, ssh key by path : hello
age -d, ssh key via pipe: hello
```

`why_unusable()` replaces the bool and distinguishes *cannot read* from *needs a passphrase*, offering `--new-identity` only for the latter.

## Tests

`tests/test_crypto.py` pins the invariant directly, by spying on the argv handed to age: neither call may mention the identity path. Plus an unencrypted ed25519 key must report usable, and a missing identity must say "cannot be read" rather than "needs a passphrase".

All four fail on the previous commit. 163 tests, ruff, mypy `--strict` clean.