### PR TITLE
Write the .bashrc line with $HOME, and give onboarding one recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ woswoar import bash     # optional: bring your existing history along
 ```
 
 Open a new shell and press <kbd>Ctrl</kbd>+<kbd>R</kbd>. That's it — everything
-below is optional.
+below is optional. To add more machines, see
+[Sync across machines](#sync-across-machines).
 
 If something looks wrong, `woswoar doctor` checks the bash version, fzf, the
 hook and the cache, and tells you what to fix.
@@ -195,30 +196,43 @@ Being straight about the limits is part of the security story:
 
 ---
 
-## Multi-machine sync
+## Sync across machines
 
-Create an empty repository anywhere you can push to — `woswoar-history` on
-GitHub, a bare repo on a NAS, a folder on a USB stick. Then:
+First, create an empty repository anywhere you can push to — `woswoar-history`
+on GitHub, a bare repo on a NAS, a folder on a USB stick. You only do this once,
+ever.
+
+### Then, on each machine
+
+The same four lines everywhere — first machine or fifth, it makes no difference:
 
 ```bash
-# on your first machine
-woswoar init git@github.com:you/woswoar-history.git
-woswoar sync
+pipx install .
+woswoar install                                       # hook it into bash
+woswoar import atuin --this-host-only                 # optional: this machine's past
+woswoar init git@github.com:you/woswoar-history.git   # join the repo
 ```
 
-```bash
-# on every additional machine
-woswoar init git@github.com:you/woswoar-history.git   # enrols this machine
-woswoar sync
-```
+Open a new shell. That machine is now recording and syncing.
+
+### One extra step, from the second machine onwards
+
+On a machine you set up **earlier**, run:
 
 ```bash
-# then once, on a machine that was already enrolled
 woswoar reencrypt
 ```
 
+That is what lets the newcomer read history from before it existed. There is no
+rush: until you run it, the new machine syncs its own commands normally and just
+reports how many older days it cannot read yet.
+
+> [!TIP]
+> `.bashrc` is written with `$HOME`, not your username, so the same one works on
+> every machine — handy if you keep your dotfiles in a repo.
+
 <details>
-<summary>Why that last step exists — and why the new machine can't do it itself</summary>
+<summary>Why that extra step exists — and why the new machine can't do it itself</summary>
 
 History sealed *before* the new machine joined was encrypted to a recipient list
 that did not include it. `reencrypt` re-seals the small per-day keys — not the

--- a/tests/support.py
+++ b/tests/support.py
@@ -19,6 +19,7 @@ MACHINE_ID = "0123456789abcdef"
 requires_age = unittest.skipUnless(crypto.available(), "age required")
 requires_git = unittest.skipUnless(shutil.which("git"), "git required")
 requires_ssh_keygen = unittest.skipUnless(shutil.which("ssh-keygen"), "ssh-keygen required")
+requires_bash = unittest.skipUnless(shutil.which("bash"), "bash required")
 
 
 def make_entry(ts: int, cmd: str, host: str = MACHINE_ID, session: str = "s1") -> Entry:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,110 @@
+"""What `woswoar install` writes into .bashrc.
+
+One .bashrc is routinely shared across machines through a dotfiles repo, so the
+line has to be identical on all of them. It was not: it named the absolute path,
+which differs the moment two machines disagree about the username.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+from woswoar.__main__ import main, portable_hook_path
+
+from .support import WoswoarTestCase, requires_bash
+
+
+class TestPortableHookPath(unittest.TestCase):
+    def test_a_path_under_home_becomes_a_variable(self) -> None:
+        home = Path.home()
+        self.assertEqual(
+            portable_hook_path(home / ".local/share/woswoar/woswoar.bash"),
+            "$HOME/.local/share/woswoar/woswoar.bash",
+        )
+
+    def test_a_path_outside_home_stays_absolute(self) -> None:
+        # Nothing portable to say about it, and guessing beats being explicit
+        # in exactly no situation.
+        self.assertEqual(
+            portable_hook_path(Path("/opt/woswoar/woswoar.bash")), "/opt/woswoar/woswoar.bash"
+        )
+
+
+class TestInstall(WoswoarTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self._home_before = os.environ.get("HOME")
+        os.environ["HOME"] = str(self.home)
+        self.addCleanup(self._restore_home)
+        self.rcfile = self.home / ".bashrc"
+
+    def _restore_home(self) -> None:
+        if self._home_before is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._home_before
+
+    def install(self) -> str:
+        self.assertEqual(main(["install", "--rcfile", str(self.rcfile)]), 0)
+        return self.rcfile.read_text(encoding="utf-8")
+
+    def test_the_sourced_line_names_no_username(self) -> None:
+        os.environ["WOSWOAR_DIR"] = str(self.home / ".local/share/woswoar")
+        text = self.install()
+        self.assertIn('source "$HOME/.local/share/woswoar/woswoar.bash"', text)
+        self.assertNotIn(str(self.home), text)
+
+    def test_reinstalling_rewrites_an_older_absolute_block(self) -> None:
+        """The upgrade path. Both of the reporting machines have one of these."""
+        os.environ["WOSWOAR_DIR"] = str(self.home / ".local/share/woswoar")
+        stale = (
+            "# >>> woswoar >>>\n"
+            f'source "{self.home}/.local/share/woswoar/woswoar.bash"\n'
+            "# <<< woswoar <<<\n"
+        )
+        self.rcfile.write_text(f"# my settings\n\n{stale}", encoding="utf-8")
+
+        text = self.install()
+        self.assertIn('source "$HOME/.local/share/woswoar/woswoar.bash"', text)
+        self.assertNotIn(str(self.home), text)
+        self.assertEqual(text.count("# >>> woswoar >>>"), 1, "block was duplicated")
+        self.assertIn("# my settings", text, "the rest of the file must survive")
+
+    def test_a_directory_outside_home_is_still_written_absolute(self) -> None:
+        outside = self.root / "elsewhere"
+        os.environ["WOSWOAR_DIR"] = str(outside)
+        text = self.install()
+        self.assertIn(f'source "{outside}/woswoar.bash"', text)
+
+    @requires_bash
+    def test_bash_resolves_the_line_to_the_installed_hook(self) -> None:
+        """The point of the whole thing: the line has to still work.
+
+        Asserting on the string only proves it looks portable. This proves a
+        real bash expands it to the file install just wrote.
+        """
+        os.environ["WOSWOAR_DIR"] = str(self.home / ".local/share/woswoar")
+        self.install()
+        line = next(
+            ln
+            for ln in self.rcfile.read_text(encoding="utf-8").splitlines()
+            if ln.startswith("source ")
+        )
+        resolved = subprocess.run(
+            ["bash", "-c", f'printf "%s" {line.removeprefix("source ")}'],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+            env={"HOME": str(self.home), "PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        ).stdout
+        self.assertTrue(Path(resolved).is_file(), f"{resolved} was not written by install")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -29,6 +29,25 @@ def _hook_source() -> Path:
         return Path(str(path))
 
 
+def portable_hook_path(target: Path) -> str:
+    """The hook's location written so one ``.bashrc`` can serve every machine.
+
+    A literal ``/home/martinus/...`` in the sourced line means the same shared
+    ``.bashrc`` has to differ per machine as soon as two of them disagree about
+    the username -- which is exactly what a dotfiles repo exists to avoid. The
+    part before ``$HOME`` is the only part that varies, so that is the part
+    that becomes a variable.
+
+    Anything outside ``$HOME`` is written absolute: there is nothing portable
+    to say about it, and guessing would be worse than being explicit.
+    """
+    home = Path.home()
+    try:
+        return f"$HOME/{target.relative_to(home).as_posix()}"
+    except ValueError:
+        return str(target)
+
+
 def cmd_install(args: argparse.Namespace) -> int:
     """Set up machine identity, install the hook, and wire up .bashrc."""
     import shutil
@@ -43,7 +62,7 @@ def cmd_install(args: argparse.Namespace) -> int:
     print(f"hook    : {target}")
 
     rcfile = Path(args.rcfile).expanduser() if args.rcfile else Path.home() / ".bashrc"
-    block = f'{_BEGIN}\nsource "{target}"\n{_END}\n'
+    block = f'{_BEGIN}\nsource "{portable_hook_path(target)}"\n{_END}\n'
 
     existing = rcfile.read_text(encoding="utf-8") if rcfile.is_file() else ""
     if _BLOCK.search(existing):


### PR DESCRIPTION
Two things reported from setting up a second machine.

## 1. One `.bashrc` could not serve both machines

`install` wrote the absolute path, so a shared dotfiles `.bashrc` needed two different lines:

```bash
source "/home/martinleitnerankerl/.local/share/woswoar/woswoar.bash"
source "/home/martinus/.local/share/woswoar/woswoar.bash"
```

The username is the only part that varies, so that is the part that becomes a variable:

```bash
source "$HOME/.local/share/woswoar/woswoar.bash"
```

A hook installed outside `$HOME` is still written absolute — nothing portable to say about it, and guessing would be worse than being explicit. **Re-running `woswoar install` rewrites an existing block in place**, so both machines converge by running it again.

### tests/test_install.py is new

There was no coverage of what `install` writes at all, which is how this shipped. It pins:

- the `$HOME` form, and that the username appears nowhere
- the outside-`$HOME` absolute fallback
- that re-installing rewrites an older absolute block **without** duplicating it or eating the rest of the file — the upgrade path both reporting machines need
- that a real `bash` expands the emitted line back to the file `install` just wrote

That last one is the point. Asserting on the string only proves it *looks* portable.

## 2. Onboarding a machine was spread over two sections

Setting up machine number two meant reading **Install**, then **Multi-machine sync** a hundred lines later, and noticing the `reencrypt` caveat sandwiched between them.

Now it is one recipe — create the repo once, then the same four commands on every machine, first or fifth:

```bash
pipx install .
woswoar install                                       # hook it into bash
woswoar import atuin --this-host-only                 # optional: this machine's past
woswoar init git@github.com:you/woswoar-history.git   # join the repo
```

…and one `woswoar reencrypt` on a machine set up earlier, with the explanation moved into a `<details>` rather than sitting in the path.

170 tests, ruff, mypy `--strict` clean.