### PR TITLE
Record under ble.sh, which needs blehook rather than the DEBUG trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,17 @@ already keeps. Your `HISTTIMEFORMAT` is not disturbed either; the hook's
 override is scoped to its own call.
 
 **It shares the DEBUG trap and `PROMPT_COMMAND` rather than taking them.** A
-terminal-title hook, a prompt framework, bash-preexec, atuin and ble.sh all want
-the same two places. woswoar chains onto whatever owns the DEBUG trap *at the
-first prompt* — not at the moment it is sourced — so it picks up whoever ended
-up owning it once your whole `.bashrc` has run. It also restores `$?` after
-reading it, so an exit-code-colouring prompt downstream still sees the real
-status.
+terminal-title hook, a prompt framework, bash-preexec and atuin all want the same
+two places. woswoar chains onto whatever owns the DEBUG trap *at the first
+prompt* — not at the moment it is sourced — so it picks up whoever ended up
+owning it once your whole `.bashrc` has run. It also restores `$?` after reading
+it, so an exit-code-colouring prompt downstream still sees the real status.
+
+**[ble.sh](https://github.com/akinomyoga/ble.sh) is handled separately**, because
+it replaces bash's prompt machinery rather than hooking into it — neither
+`PROMPT_COMMAND` nor the DEBUG trap sees your commands there. woswoar registers
+with `blehook PREEXEC`/`PRECMD` when it finds ble.sh loaded. Nothing to
+configure; it works in either load order, and alongside atuin.
 
 If something else claims the trap *after* that, you lose the recorded
 **duration** of those commands and nothing else; the commands themselves are

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -186,6 +186,26 @@ hook, a prompt framework, bash-preexec, atuin and ble.sh all want the DEBUG trap
 and `PROMPT_COMMAND`. Two bugs came out of getting this wrong, both found by
 driving a real interactive bash rather than by reading the code.
 
+**ble.sh needs a different mechanism entirely, and says nothing when it does not
+get one.** It replaces bash's prompt machinery rather than hooking into it:
+`PROMPT_COMMAND` runs once, at the prompt where `.bashrc` finishes, and never
+again, while the DEBUG trap fires only on ble.sh's own internals. Measured with
+a probe independent of woswoar — a plain `PROMPT_COMMAND` entry and a plain
+DEBUG trap, three commands typed — plain bash fired the entry 4 times and ble.sh
+fired it **once**, while the trap fired 71 times, none of them a user command.
+So every part of the normal wiring looks installed and records nothing.
+
+ble.sh offers `blehook PREEXEC` and `blehook PRECMD` instead, and they are a
+better fit than what they replace: PREEXEC is handed the command line as `$1`,
+and PRECMD sees the real `$?`. The hook registers with those when `$BLE_VERSION`
+is set and falls back to trap-and-`PROMPT_COMMAND` otherwise.
+
+This one is worth remembering as a *testing* lesson rather than a shell one. It
+was originally reported as working, because the check piped its input — and
+ble.sh only activates on a tty, so it silently never loaded. Everything about
+that verification looked right except that it was not testing the thing it named.
+Anything involving ble.sh has to run under a real pty.
+
 **The DEBUG trap has to be chained, and cannot be chained at load time.** A bare
 `trap … DEBUG` silently replaced whatever was there, so the other tool simply
 stopped working. The obvious fix — read the existing trap and call it too —

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -299,6 +299,46 @@ class TestCoexistence(ShellHookTestCase):
         self.assertIn("QUOTED[it's fine]", out)
         self.assertEqual(self.commands(), ["echo hello"])
 
+    #: The two things ble.sh gives a consumer, and the only two the hook uses.
+    #: Enough to pin *our* branch; the real thing was verified by hand against
+    #: ble.sh 0.4 in a pty, which CI has no way to install.
+    BLESH_STUB = """
+        BLE_VERSION=0.4.0-stub
+        blehook() { printf '%s\\n' "$1" >> "$BLEHOOK_LOG"; }
+    """
+
+    def blehook_registrations(self, log: Path) -> list[str]:
+        return log.read_text(encoding="utf-8").splitlines() if log.is_file() else []
+
+    def test_under_blesh_we_register_with_blehook(self) -> None:
+        """ble.sh does not run PROMPT_COMMAND or fire DEBUG on user commands.
+
+        It replaces bash's prompt machinery outright, so the hook's normal
+        wiring records nothing at all -- silently, because every part of it
+        still looks installed. Recording was completely dead on any machine
+        that loads ble.sh, which is the usual way to run atuin on bash.
+        """
+        log = self.root / "blehook.log"
+        self.run_shell(
+            "true\n",
+            env_extra={"BLEHOOK_LOG": str(log)},
+            before=self.BLESH_STUB,
+        )
+        registered = self.blehook_registrations(log)
+        self.assertIn("PREEXEC+=__woswoar_preexec", registered)
+        self.assertIn("PRECMD+=__woswoar_precmd", registered)
+
+    def test_without_blesh_we_do_not_call_blehook(self) -> None:
+        # The branch has to be a branch, not a belt-and-braces both.
+        log = self.root / "blehook.log"
+        self.run_shell(
+            "true\n",
+            env_extra={"BLEHOOK_LOG": str(log)},
+            before='blehook() { printf "%s\\n" "$1" >> "$BLEHOOK_LOG"; }',
+        )
+        self.assertEqual(self.blehook_registrations(log), [])
+        self.assertEqual(self.commands(), ["true"])
+
     def test_the_prompt_at_which_the_hook_loads_records_nothing(self) -> None:
         # `history 1` at that point is whatever the previous session left
         # behind. The harness types `source .../woswoar.bash`, which used to be

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -247,7 +247,25 @@ __woswoar_widget() {
 # chain onto whoever actually ended up owning the trap rather than whoever
 # happened to load before us -- which makes the order of the lines in .bashrc
 # stop mattering.
-__woswoar_wire_debug() {
+__woswoar_wired=
+
+__woswoar_wire() {
+    [[ -n $__woswoar_wired ]] && return 0
+    __woswoar_wired=1
+
+    # ble.sh does not use either of the mechanisms below. It replaces bash's
+    # prompt machinery outright: PROMPT_COMMAND runs once, at the prompt where
+    # .bashrc finishes, and never again, and the DEBUG trap fires only on
+    # ble.sh's own internals rather than on anything the user typed. Wiring the
+    # trap there records nothing at all -- silently, since every part looks
+    # installed. It offers `blehook` instead, which is a better fit anyway:
+    # PREEXEC is handed the command line as $1, and PRECMD sees the real $?.
+    if [[ -n ${BLE_VERSION-} ]]; then
+        blehook PREEXEC+=__woswoar_preexec
+        blehook PRECMD+=__woswoar_precmd
+        return 0
+    fi
+
     local spec=
     [[ -s $__woswoar_scratch ]] && IFS= read -r -d '' spec <"$__woswoar_scratch"
 
@@ -303,7 +321,7 @@ __woswoar_unboot() {
 # shellcheck disable=SC2016  # single quotes are the point: this expands later
 __woswoar_boot='{
     builtin trap -p DEBUG >"$__woswoar_scratch" 2>/dev/null
-    __woswoar_wire_debug
+    __woswoar_wire
     __woswoar_unboot
 }'
 
@@ -330,6 +348,14 @@ else
     PROMPT_COMMAND=$__woswoar_stamp$'\n'${PROMPT_COMMAND%$'\n'}$'\n'$__woswoar_boot$'\n'__woswoar_precmd
 fi
 unset -v __woswoar_attrs
+
+# Under ble.sh, PROMPT_COMMAND may run only once ever, so the boot entry above
+# is not something to rely on. ble.sh is normally already loaded by the time
+# .bashrc reaches us, so wire straight away when it is; `__woswoar_wire` is
+# idempotent, and boot still covers the case where ble.sh loads after us.
+if [[ -n ${BLE_VERSION-} ]]; then
+    __woswoar_wire
+fi
 
 if [[ -z ${WOSWOAR_NO_BIND:-} ]]; then
     bind -m emacs -x '"\C-r": __woswoar_widget' 2>/dev/null


### PR DESCRIPTION
woswoar recorded **nothing at all** on any machine running ble.sh — silently, because every part of the wiring still looked installed.

## Why

ble.sh replaces bash's prompt machinery rather than hooking into it. Measured with a probe that has nothing to do with woswoar — one plain `PROMPT_COMMAND` entry, one plain DEBUG trap, three commands typed:

```
plain bash:  PROMPT_COMMAND fired 4 times   (source, echo aaa, echo bbb, echo ccc)
ble.sh:      PROMPT_COMMAND fired 1 time    (only where .bashrc finished)
             DEBUG trap fired 71 times      (all ble.sh internals, no user command)
```

So `__woswoar_precmd` ran once at startup and never again.

## The fix

ble.sh offers `blehook PREEXEC` and `blehook PRECMD`, and they are a **better** fit than what they replace — PREEXEC receives the command line as `$1`, PRECMD sees the real `$?`:

```
PRECMD status=0 hist=[    3  echo aaa]
PRECMD status=1 hist=[    4  false]      <- real exit code
PREEXEC argc=1 a1=[sleep 0.2]            <- command line, no `history 1` needed
```

The hook registers with those when `$BLE_VERSION` is set, and falls back to the DEBUG trap otherwise. It wires at source time when ble.sh is already loaded and at the first prompt otherwise, so **load order does not matter**. The existing `PROMPT_COMMAND` entries stay in place harmlessly — if ble.sh is ever detached they take over again, and the history-number check makes a double call a no-op.

## Verified in a real pty

| | |
|---|---|
| plain bash | `false(exit=1)` `sleep 0.2(dur=202)` |
| ble.sh, then woswoar | `false(exit=1)` `sleep 0.2(dur=213)` |
| woswoar, then ble.sh | `false(exit=1)` `sleep 0.2(dur=212)` |
| ble.sh + atuin, then woswoar | `false(exit=1)` `sleep 0.2(dur=216)` |
| title hook + ble.sh + woswoar | `false(exit=1)` `sleep 0.2(dur=213)` |

All five recorded nothing before this change except the first.

## Testing

CI cannot install ble.sh, so the regression test stubs the two-call contract the hook depends on: with `BLE_VERSION` set it must register both handlers; without it, it must not call `blehook` at all. **Fails on the previous commit.**

## The lesson worth keeping

I previously reported this as working. That check **piped its stdin** — and ble.sh only activates on a tty, so it silently never loaded. The verification looked right in every respect except that it was not testing the thing it named. The design doc now records that anything involving ble.sh has to run under a pty.

172 tests, ruff, mypy `--strict`, shellcheck clean.