### PR TITLE
Rename reencrypt to grant, and make it ask before widening access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,9 @@ jobs:
 
           run_as beta init "$BASE/origin.git" --new-identity
           run_as alpha sync
-          run_as alpha reencrypt
+          # --yes because there is no terminal here; grant refuses to widen
+          # who can read the history on an assumed answer.
+          run_as alpha grant --yes
           run_as alpha sync
           run_as beta sync
           run_as beta list --scope global | grep -q 'secret-marker-command'

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Being straight about the limits is part of the security story:
 >   pattern catches everything.
 > - **Lose your key, lose your access.** There is no recovery service, because
 >   there is no service. If a machine loses its identity, re-enrol it and run
->   `woswoar reencrypt` from another machine.
+>   `woswoar grant` from another machine.
 
 ---
 
@@ -225,12 +225,24 @@ Open a new shell. That machine is now recording and syncing.
 On a machine you set up **earlier**, run:
 
 ```bash
-woswoar reencrypt
+woswoar grant
 ```
 
-That is what lets the newcomer read history from before it existed. There is no
-rush: until you run it, the new machine syncs its own commands normally and just
-reports how many older days it cannot read yet.
+That is what lets the newcomer read history from before it existed. It lists the
+machines by name and asks first, because it widens who can read *everything*:
+
+```
+This will let each of these machines read your ENTIRE history,
+including days recorded before it ever existed:
+
+  martinus@box   (this machine)
+  martin@work-laptop
+
+Grant all 2 machines full access? [y/N]
+```
+
+There is no rush: until you run it, the new machine syncs its own commands
+normally and just reports how many older days it cannot read yet.
 
 > [!TIP]
 > `.bashrc` is written with `$HOME`, not your username, so the same one works on
@@ -240,7 +252,7 @@ reports how many older days it cannot read yet.
 <summary>Why that extra step exists — and why the new machine can't do it itself</summary>
 
 History sealed *before* the new machine joined was encrypted to a recipient list
-that did not include it. `reencrypt` re-seals the small per-day keys — not the
+that did not include it. `grant` re-seals the small per-day keys — not the
 history itself — so it takes seconds even with years of commands. It fetches and
 publishes on its own, so it is one command, not a sync sandwich.
 
@@ -362,7 +374,7 @@ were assigned independently.
 | `woswoar doctor` | check bash version, fzf, hook, cache |
 | `woswoar init [url]` | create or join an encrypted history repo |
 | `woswoar sync` | exchange history with the remote |
-| `woswoar reencrypt` | re-seal keys after enrolling a new machine |
+| `woswoar grant` | let newly enrolled machines read the older history |
 | `woswoar compact` | merge old chunks to reduce the working-tree file count |
 
 ### Scopes

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -617,7 +617,7 @@ Measured with age 1.3.1, three `ssh-ed25519` recipients:
 
 A sealed day key is 621 B, so re-sealing two years of them is ~450 KB — which is
 what makes onboarding cheap. Adding a machine re-seals ~730 tiny key files
-rather than ~35,000 chunks, so `reencrypt` takes seconds instead of rewriting
+rather than ~35,000 chunks, so `grant` takes seconds instead of rewriting
 the archive.
 
 **Compress before sealing.** A chunk's plaintext is `<tag><body>`, where the tag
@@ -729,14 +729,25 @@ remote configures a tracking branch that points at nothing — the normal state
 for the first machine to enrol — and pulling from that fails.
 
 `init` publishes immediately for the same class of reason: until a new machine's
-public key is on the remote, `reencrypt` run elsewhere cannot include it, and
+public key is on the remote, `grant` run elsewhere cannot include it, and
 onboarding would appear to succeed while silently granting no access to older
 history.
 
-### `reencrypt`
+### `grant`
 
 Re-sealing every day key to the current recipient list is what lets a newly
-enrolled machine read *old* history. It is deliberately a separate command — it
+enrolled machine read *old* history. It was called `reencrypt`, which named the
+mechanism and hid the consequence: what the command actually does is widen who
+can read the whole archive. It now says so, lists the machines by name, and asks
+before proceeding -- and because woswoar parses `recipients.txt` itself rather
+than handing age the path, it can carry a human label next to each key, without
+which the prompt would list opaque `age1...` strings nobody could consent to.
+`--yes` skips the prompt; a non-interactive run without it refuses rather than
+hanging or assuming.
+
+The list is shown *after* fetching, and the fetched list is passed back into the
+operation, which refuses if it changed in the meantime. A confirmation that can
+under-report what it is about to authorise is worse than none. It is deliberately a separate command — it
 is one of only two operations that rewrite an existing file — but it is a
 *complete* one: it fetches, re-seals, commits and pushes under the same lock
 `sync` takes.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -16,7 +16,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
-from woswoar import cache, search, store, sync
+from woswoar import cache, crypto, search, store, sync
 from woswoar.entry import Entry, format_line
 
 from . import support
@@ -175,7 +175,7 @@ class TestTwoMachines(SyncTestCase):
         # One command on an already-enrolled machine is the whole fix, exactly
         # as documented -- no surrounding sync to fetch beta's key or publish.
         with alpha.active():
-            sync.reencrypt()
+            sync.grant()
         with beta.active():
             report = sync.run()
             self.assertEqual(report.chunks_merged, 1)
@@ -196,7 +196,7 @@ class TestTwoMachines(SyncTestCase):
 
         beta = self.machine("beta")  # init publishes beta's public key
         with alpha.active():
-            report = sync.reencrypt()
+            report = sync.grant()
             self.assertTrue(report.pushed)
             self.assertEqual(report.skipped, 0)
             self.assertGreater(report.resealed, 0)
@@ -220,7 +220,7 @@ class TestTwoMachines(SyncTestCase):
         beta = self.machine("beta")
         with beta.active():
             sync.run()
-            report = sync.reencrypt()
+            report = sync.grant()
             # It re-seals what it owns -- its own name seal -- and skips
             # alpha's day key, so it still cannot read alpha's history.
             self.assertGreater(report.skipped, 0)
@@ -247,7 +247,7 @@ class TestTwoMachines(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "from alpha")
             sync.run()
-            sync.reencrypt()
+            sync.grant()
         with beta.active():
             beta.record("2023-11-14", 1_700_000_050, "from beta")
             sync.run()
@@ -264,7 +264,7 @@ class TestTwoMachines(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "git status")
             sync.run()
-            sync.reencrypt()
+            sync.grant()
         with beta.active():
             sync.run()
             first = len(cache.load_entries())
@@ -277,7 +277,7 @@ class TestTwoMachines(SyncTestCase):
         beta = self.machine("beta")
         with alpha.active():
             sync.run()
-            sync.reencrypt()
+            sync.grant()
         with beta.active():
             sync.run()
 
@@ -299,7 +299,7 @@ class TestTwoMachines(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "git status")
             sync.run()
-            sync.reencrypt()
+            sync.grant()
         with beta.active():
             sync.run()
             # Without this, search would label alpha's entries with its opaque id.
@@ -311,7 +311,7 @@ class TestTwoMachines(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "from alpha")
             sync.run()
-            sync.reencrypt()
+            sync.grant()
         with beta.active():
             beta.record("2023-11-14", 1_700_000_050, "from beta")
             sync.run()
@@ -331,7 +331,7 @@ class TestImmutability(SyncTestCase):
             for i in range(4):
                 alpha.record("2023-11-14", 1_700_000_000 + i, f"alpha {i}")
                 sync.run()
-            sync.reencrypt()
+            sync.grant()
         with beta.active():
             for i in range(3):
                 beta.record("2023-11-15", 1_700_100_000 + i, f"beta {i}")
@@ -436,6 +436,60 @@ class TestChunkPayload(unittest.TestCase):
                 sync.unpack(blob)
 
 
+class TestGrantConfirmation(SyncTestCase):
+    """`grant` widens who can read everything, so it says so and asks first."""
+
+    def test_readers_are_labelled_for_a_human(self) -> None:
+        # `age1ejf3l4f0nhnp9...` is not something anyone can consent to.
+        alpha = self.machine("alpha", display="martinus@box")
+        with alpha.active():
+            labels = dict((label, key) for key, label in sync.reader_labels())
+        self.assertIn("martinus@box", labels)
+
+    def test_an_unlabelled_key_still_gets_a_readable_handle(self) -> None:
+        # recipients.txt written by an older woswoar, or hand-edited.
+        alpha = self.machine("alpha")
+        with alpha.active():
+            path = store.recipients_file()
+            path.write_text("age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwwwwww\n", encoding="utf-8")
+            ((key, label),) = sync.reader_labels()
+            self.assertTrue(label)
+            self.assertNotIn(sync._LABEL_SEP, key)
+
+    def test_a_key_listed_twice_is_offered_to_age_once(self) -> None:
+        """`recipients.txt` is `merge=union`.
+
+        Two machines appending the same key, one labelled and one not, leaves
+        both lines -- and age rejects a repeated recipient.
+        """
+        alpha = self.machine("alpha", display="box")
+        with alpha.active():
+            key = sync.recipients()[0]
+            path = store.recipients_file()
+            path.write_text(f"{key}\n{key}{sync._LABEL_SEP}box\n", encoding="utf-8")
+            self.assertEqual(sync.recipients(), [key])
+            # And it is still usable, which is the point of deduplicating.
+            crypto.encrypt_to_recipients(b"x", sync.recipients())
+
+    def test_granting_refuses_if_the_machines_changed_while_deciding(self) -> None:
+        """A confirmation that can under-report what it authorises is worse
+        than none, so the approved list is checked against the fetched one."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            approved = sync.readers()
+        self.machine("beta")  # enrols behind alpha's back
+
+        with alpha.active(), self.assertRaises(sync.SyncError) as caught:
+            sync.grant(confirmed=approved)
+        self.assertIn("changed while you were deciding", str(caught.exception))
+
+    def test_granting_with_the_approved_list_goes_ahead(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            report = sync.grant(confirmed=sync.readers())
+            self.assertGreater(report.resealed, 0)
+
+
 class TestChunkNaming(support.WoswoarTestCase):
     def test_many_chunks_in_one_second_all_get_distinct_paths(self) -> None:
         """Overwriting a sealed chunk would destroy committed history.
@@ -518,7 +572,7 @@ class TestCompact(SyncTestCase):
                 alpha.record("2023-11-14", 1_700_000_000 + i, f"command {i}")
                 sync.run()
             sync.compact(before="2023-11-15")
-            sync.reencrypt()
+            sync.grant()
         with beta.active():
             sync.run()
             self.assertEqual(beta.commands(), {"command 0", "command 1", "command 2"})

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -251,7 +251,7 @@ def cmd_init(args: argparse.Namespace) -> int:
         print(f"  {kind} {key[:24]}...")
     if args.remote:
         print("\nNext: 'woswoar sync'.")
-        print("On an already-enrolled machine, run 'woswoar reencrypt' so this")
+        print("On a machine that already has access, run 'woswoar grant' so this")
         print("one can read history sealed before it joined.")
     return 0
 
@@ -276,29 +276,66 @@ def cmd_sync(args: argparse.Namespace) -> int:
             f"\n{days} day(s) of history are sealed to recipients that do not include\n"
             "this machine - it joined after they were written. On a machine that was\n"
             "already enrolled run:\n"
-            "    woswoar reencrypt\n"
+            "    woswoar grant\n"
             "then sync here again. Nothing is lost in the meantime.",
             file=sys.stderr,
         )
     return 0
 
 
-def cmd_reencrypt(args: argparse.Namespace) -> int:
-    from . import sync
+def cmd_grant(args: argparse.Namespace) -> int:
+    """Let every enrolled machine read the whole history."""
+    from . import crypto, sync
 
-    report = sync.reencrypt()
-    print(f"re-sealed {report.resealed} key file(s) to the current recipients")
+    keys = sync.readers()
+    if not keys:
+        print("no machines enrolled yet; run 'woswoar init <url>' first", file=sys.stderr)
+        return 1
+
+    try:
+        mine = crypto.recipient_for(sync.identity_path(store.machine())).strip()
+    except (WoswoarError, OSError):
+        mine = ""
+
+    print("This will let each of these machines read your ENTIRE history,")
+    print("including days recorded before it ever existed:\n")
+    for key, label in sync.reader_labels():
+        print(f"  {label}{'   (this machine)' if key == mine else ''}")
+    print(
+        "\nIt re-seals the small per-day keys -- not the history itself -- and"
+        "\npublishes them. Nothing is decrypted, and nothing else is re-uploaded."
+    )
+
+    if not args.yes:
+        if not sys.stdin.isatty():
+            print(
+                "\nRefusing to grant access without confirmation. "
+                "Re-run with --yes if you mean it.",
+                file=sys.stderr,
+            )
+            return 1
+        if input(f"\nGrant all {len(keys)} machines full access? [y/N] ").strip().lower() not in (
+            "y",
+            "yes",
+        ):
+            print("Nothing changed.")
+            return 1
+
+    report = sync.grant(confirmed=keys)
+    print(f"\nre-sealed {report.resealed} key file(s)")
     if report.pushed:
-        print("pushed to remote")
+        print("published to the remote")
+        print("\nOn each machine that was waiting, run:  woswoar sync")
     else:
-        print("no remote configured; nothing published")
+        print("no remote configured, so nothing was published")
+
     if report.skipped:
         # Almost always means this machine is the new one. Saying so beats
         # letting "re-sealed 0 key files" read as success.
         print(
             f"\n{report.skipped} key file(s) could not be opened by this machine, so\n"
             "they were left alone. Re-sealing a key means opening it first, which\n"
-            "only a machine that was already a recipient can do. Run this on one of\n"
+            "only a machine that already had access can do. Run this on one of\n"
             "those instead.",
             file=sys.stderr,
         )
@@ -381,10 +418,15 @@ def build_parser() -> argparse.ArgumentParser:
     p_sync.add_argument("--no-push", action="store_true", help="stay local; do not contact remote")
     p_sync.set_defaults(func=cmd_sync)
 
-    p_reencrypt = subparsers.add_parser(
-        "reencrypt", help="re-seal keys after enrolling a new machine"
+    p_grant = subparsers.add_parser(
+        "grant",
+        # `reencrypt` named the mechanism, which hid what it does to the user's
+        # history. Kept working so older notes and error messages do not rot.
+        aliases=["reencrypt"],
+        help="let newly enrolled machines read the older history",
     )
-    p_reencrypt.set_defaults(func=cmd_reencrypt)
+    p_grant.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
+    p_grant.set_defaults(func=cmd_grant)
 
     p_compact = subparsers.add_parser("compact", help="merge old chunks (reduces file count)")
     p_compact.add_argument("--before", help="only days before this YYYY-MM-DD (default: today)")

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -56,7 +56,7 @@ class Report:
     hosts_seen: set[str] = field(default_factory=set)
     #: "<host>/<day>" entries sealed before this machine was enrolled. Not an
     #: error: it is what a freshly joined machine sees until someone runs
-    #: `reencrypt` on a machine that was already a recipient.
+    #: `grant` on a machine that was already a recipient.
     unreadable: set[str] = field(default_factory=set)
 
 
@@ -90,16 +90,53 @@ def remote_summary() -> str:
     return remotes[0] if remotes else "none (history is local only)"
 
 
+#: Separates a recipient from the human label woswoar appends after it. age
+#: never sees the label, because woswoar parses this file itself rather than
+#: handing age the path -- which is what makes labelling possible at all.
+_LABEL_SEP = " # "
+
+
+def _recipient_lines() -> list[str]:
+    path = store.recipients_file()
+    if not path.is_file():
+        return []
+    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
 def recipients() -> list[str]:
     """Every enrolled machine's public key, in the form age wants on `-r`.
 
     Read here rather than handed to age as a path: `crypto` never names a file
     in $HOME, because a sandboxed age cannot open one.
+
+    Deduplicated by key. `.gitattributes` marks this file ``merge=union``, so a
+    machine that appends a labelled line where another has the same key unlabelled
+    leaves both, and age rejects a repeated recipient.
     """
-    path = store.recipients_file()
-    if not path.is_file():
-        return []
-    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    seen: dict[str, None] = {}
+    for line in _recipient_lines():
+        seen.setdefault(line.split(_LABEL_SEP, 1)[0].strip(), None)
+    return list(seen)
+
+
+def reader_labels() -> list[tuple[str, str]]:
+    """``(key, label)`` for every enrolled machine, for showing to a human.
+
+    Nobody can meaningfully consent to granting `age1ejf3l4f0nhnp9...` access to
+    their history. The label is woswoar's own trailing comment when present, the
+    SSH key's comment field otherwise, and an abbreviated key as a last resort.
+    """
+    out: list[tuple[str, str]] = []
+    for line in _recipient_lines():
+        key, _, label = line.partition(_LABEL_SEP)
+        key = key.strip()
+        if any(key == existing for existing, _ in out):
+            continue
+        if not label:
+            fields = key.split(None, 2)
+            label = fields[2] if len(fields) > 2 else f"{key[:12]}...{key[-6:]}"
+        out.append((key, label.strip()))
+    return out
 
 
 def list_recipients() -> list[tuple[str, str]]:
@@ -326,7 +363,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 day_keys[chunk.day] = open_day_key(known, host_id, chunk.day)
             except (crypto.AgeError, SyncError):
                 # Sealed before this machine was enrolled, and no one has run
-                # `reencrypt` yet. Skip it without advancing the watermark so a
+                # `grant` yet. Skip it without advancing the watermark so a
                 # later sync picks it up -- and above all without aborting, or
                 # one unreadable day would block this machine's own export too.
                 day_keys[chunk.day] = None
@@ -570,7 +607,7 @@ def initialise(
         _commit()
 
     # Publish immediately. Until this machine's public key is on the remote,
-    # `reencrypt` run elsewhere cannot include it, so onboarding would appear to
+    # `grant` run elsewhere cannot include it, so onboarding would appear to
     # succeed and then silently fail to grant access to any older history.
     if publishing:
         _push()
@@ -588,7 +625,7 @@ def _write_repo_metadata(known: Machine, identity: Path) -> bool:
         store.write_atomic(attrs, store.GITATTRIBUTES_CONTENT.encode("utf-8"))
         changed = True
 
-    if add_recipient(crypto.recipient_for(identity)):
+    if add_recipient(crypto.recipient_for(identity), label=known.name):
         changed = True
 
     seal = store.name_seal(known.id)
@@ -609,8 +646,31 @@ class ReencryptReport(NamedTuple):
     pushed: bool
 
 
-def reencrypt() -> ReencryptReport:
+def readers() -> list[str]:
+    """Who would be able to read the whole history if `grant` ran now.
+
+    Fetches first, because the point of granting is to include a machine that
+    enrolled since this one last looked -- reporting the pre-fetch list would
+    show fewer machines than the operation is about to authorise, which is the
+    one direction a security confirmation must never be wrong in.
+    """
+    with lock():
+        if has_remote():
+            _fetch_and_rebase()
+        return recipients()
+
+
+def grant(confirmed: list[str] | None = None) -> ReencryptReport:
     """Re-seal every key file to the current recipient list, and publish it.
+
+    Named for what it does to the user's history rather than to the files:
+    afterwards, every machine in `recipients.txt` can read *everything*,
+    including days recorded before it existed. `reencrypt` described the
+    mechanism and hid that.
+
+    ``confirmed`` is the list a human agreed to. If the fetch below turns up a
+    different one -- someone enrolled a machine in the meantime -- this refuses
+    rather than granting access to a machine nobody approved.
 
     This is what makes a newly onboarded machine able to read *old* history.
     Chunks are encrypted to per-day keys, so only those small key files -- and
@@ -655,6 +715,11 @@ def reencrypt() -> ReencryptReport:
         # recipients and report full success. Reading it once here also saves
         # re-parsing the file for every one of a few thousand key files.
         keys = recipients()
+        if confirmed is not None and sorted(keys) != sorted(confirmed):
+            raise SyncError(
+                "the set of machines changed while you were deciding; "
+                "run 'woswoar grant' again to see the current list"
+            )
 
         for host_id in store.repo_hosts():
             candidates = list(store.iter_day_keys(host_id))
@@ -727,13 +792,20 @@ def compact(before: str) -> tuple[int, int]:
     return days, replaced
 
 
-def add_recipient(recipient: str) -> bool:
-    """Append a public key to recipients.txt if it is not already listed."""
+def add_recipient(recipient: str, label: str = "") -> bool:
+    """Append a public key to recipients.txt if its key is not already listed.
+
+    The label is what `grant` shows a human before widening who can read the
+    history; without it the prompt lists opaque age keys and cannot be consented
+    to in any real sense.
+    """
+    key = recipient.strip()
+    if key in recipients():
+        return False
     path = store.recipients_file()
     existing = path.read_text(encoding="utf-8") if path.is_file() else ""
-    if recipient.strip() in {line.strip() for line in existing.splitlines()}:
-        return False
     path.parent.mkdir(parents=True, exist_ok=True)
     separator = "" if not existing or existing.endswith("\n") else "\n"
-    store.write_atomic(path, f"{existing}{separator}{recipient.strip()}\n".encode())
+    line = f"{key}{_LABEL_SEP}{label}" if label else key
+    store.write_atomic(path, f"{existing}{separator}{line}\n".encode())
     return True


### PR DESCRIPTION
`reencrypt` named the mechanism and hid the consequence. What the command does is **let every enrolled machine read the entire archive**, including days recorded before it existed — silently, on one word, with no confirmation and no indication of who was being let in.

## `woswoar grant`

Describes the effect rather than the implementation. `reencrypt` still works as an alias so older notes and error messages don't rot.

```
This will let each of these machines read your ENTIRE history,
including days recorded before it ever existed:

  martinus@box   (this machine)
  martin@work-laptop

It re-seals the small per-day keys -- not the history itself -- and
publishes them. Nothing is decrypted, and nothing else is re-uploaded.

Grant all 2 machines full access? [y/N] y

re-sealed 3 key file(s)
published to the remote

On each machine that was waiting, run:  woswoar sync
```

## Two details that decide whether the confirmation is worth anything

**The list is shown after fetching, and the approved list is passed back in.** The whole point of granting is to include a machine that enrolled since this one last looked — so the pre-fetch list would show *fewer* machines than the operation is about to authorise, which is the one direction a security prompt must never be wrong in. `grant` refuses if the set changed while you were deciding.

**Recipients now carry a human label.** This is what the prompt looked like without one:

```
  age10fs5uec734z9thxm7f9n9gz4x5rzmuhmxa4t5pd333da29jenp9q5swrml   (this machine)
  age1ejf3l4f0nhnp9u6p0adjr453ehjywdgufn8wckfvha7qnc3wgs9qpk7qpj
```

Nobody can consent to that. `recipients.txt` gains an optional ` # <name>` comment — which works **only** because the previous PR stopped handing age the file path and started parsing it ourselves. Unlabelled lines still work, falling back to the SSH key's comment field or an abbreviated key.

`recipients()` now deduplicates by key, because the file is `merge=union`: two machines appending the same key, one labelled and one not, would leave both lines and hand age a repeated recipient, which it rejects.

`--yes` skips the prompt. A non-interactive run without it refuses rather than hanging on a read that will never return, or assuming consent nobody gave.

## Verified end to end

Two real machines against a bare repo: `grant --yes` on A → `woswoar sync` on B → B reads A's history. Five new tests cover labelling, the unlabelled fallback, `merge=union` deduplication, and both sides of the changed-while-deciding guard.

177 tests, ruff, mypy `--strict` clean.