### PR TITLE
doctor: notice an age that runs but cannot open a key

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -104,6 +104,25 @@ class TestCache(WoswoarTestCase):
         store.cache_file().write_bytes(b"this is not a pickle")
         self.assertEqual([e.cmd for e in cache.load_entries()], ["git status"])
 
+    def test_a_cache_missing_a_newer_attribute_falls_back_to_a_rebuild(self) -> None:
+        """Right class and right version is not the same as right shape.
+
+        Pickle restores ``__dict__`` and never runs ``__init__``, so a file
+        written by a build with one attribute fewer unpickles cleanly and then
+        raises deep inside refresh() -- on the Ctrl-R path. Found in the wild:
+        a cache predating ``unsaved`` crashed `woswoar doctor` outright.
+        """
+        import pickle
+
+        self.write_log(MACHINE_ID, "2026-07-29", [line(100, "git status")])
+        cache.load_entries()
+
+        older = cache.load()
+        del older.__dict__["unsaved"]
+        store.cache_file().write_bytes(pickle.dumps(older, protocol=pickle.HIGHEST_PROTOCOL))
+
+        self.assertEqual([e.cmd for e in cache.load_entries()], ["git status"])
+
     def test_stale_version_falls_back_to_a_rebuild(self) -> None:
         self.write_log(MACHINE_ID, "2026-07-29", [line(100, "git status")])
         cache.load_entries()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,74 @@
+"""`woswoar doctor` has to notice the failures people actually hit.
+
+The one that prompted this: an `age` that runs perfectly and then cannot open a
+key, because it is sandboxed. `age --version` succeeds, so doctor reported
+nothing at all -- in the exact state, before `init` has worked, where someone
+would think to run it.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import stat
+import unittest
+from contextlib import redirect_stdout
+
+from woswoar import crypto
+from woswoar.__main__ import main
+
+from .support import WoswoarTestCase, requires_age
+
+
+@requires_age
+class TestSelftest(unittest.TestCase):
+    def test_a_working_age_reports_nothing_wrong(self) -> None:
+        self.assertEqual(crypto.selftest(), "")
+
+
+class TestDoctorWithABrokenAge(WoswoarTestCase):
+    """A stand-in for a confined age: on PATH, runs, refuses to do the work."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        fake = self.root / "bin"
+        fake.mkdir()
+        for name in ("age", "age-keygen"):
+            script = fake / name
+            script.write_text(
+                "#!/bin/sh\n"
+                f'echo "{name}: error: failed to open input file: permission denied" >&2\n'
+                "exit 1\n"
+            )
+            script.chmod(script.stat().st_mode | stat.S_IXUSR)
+
+        self._path = os.environ["PATH"]
+        os.environ["PATH"] = f"{fake}{os.pathsep}{self._path}"
+        self.addCleanup(lambda: os.environ.__setitem__("PATH", self._path))
+
+    def doctor(self) -> tuple[int, str]:
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            code = main(["doctor"])
+        return code, buffer.getvalue()
+
+    def test_selftest_reports_what_age_said(self) -> None:
+        failure = crypto.selftest()
+        self.assertIn("permission denied", failure)
+
+    def test_doctor_fails_and_shows_the_reason(self) -> None:
+        code, out = self.doctor()
+        self.assertNotEqual(code, 0, out)
+        self.assertRegex(out, r"\[FAIL\] age", out)
+        self.assertIn("permission denied", out)
+
+    def test_doctor_does_not_need_a_repo_to_notice(self) -> None:
+        """The whole point. This used to be gated behind `sync.is_repo()`, so
+        the machine where `init` had just failed got a clean bill of health."""
+        _, out = self.doctor()
+        self.assertIn("no history repo", out, "precondition: no repo in this sandbox")
+        self.assertRegex(out, r"\[FAIL\] age")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -164,7 +164,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     import shutil
     import subprocess
 
-    from . import sync
+    from . import crypto, sync
 
     ok = True
 
@@ -198,8 +198,10 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     fzf = shutil.which("fzf")
     check("fzf", fzf is not None, fzf or "not found - needed for 'woswoar search'")
 
-    machine_file = store.config_dir() / "machine"
-    check("identity", machine_file.is_file(), str(machine_file))
+    machine_file = store.machine_file()
+    # Read before anything calls store.machine(), which would create it.
+    has_machine = machine_file.is_file()
+    check("machine", has_machine, str(machine_file))
 
     hook = store.data_dir() / HOOK_NAME
     check("hook", hook.is_file(), str(hook))
@@ -209,11 +211,30 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     detail = "sources the hook" if sourced else "has no woswoar block"
     check("bashrc", sourced, f"{rcfile} {detail}")
 
-    info("age", shutil.which("age") or "not found - needed for 'woswoar sync' only")
+    # Not just "is age on PATH". A sandboxed age -- snap, flatpak, anything
+    # confined -- answers `--version` perfectly and then cannot open a key,
+    # which is a real failure that used to reach the user as an unexplained
+    # "permission denied" from `init` with doctor reporting nothing at all.
+    age_path = shutil.which("age")
+    if age_path is None:
+        info("age", "not found - needed for 'woswoar sync' only")
+    else:
+        failure = crypto.selftest()
+        check("age", not failure, age_path)
+        for line in failure.splitlines():
+            print(f"     {line}")
+
+    # Checked whether or not a repo exists: `init` is exactly when this breaks,
+    # and gating it behind is_repo() meant doctor was silent in the one state
+    # where someone would think to run it.
+    identity = store.machine().identity if has_machine else ""
+    if identity:
+        status = sync.identity_status(store.machine())
+        check("identity", status.ok, status.detail)
+    else:
+        info("identity", "none yet - chosen by 'woswoar init'")
 
     if sync.is_repo():
-        status = sync.identity_status(store.machine())
-        check("sync", status.ok, status.detail)
         info("remote", sync.remote_summary())
     else:
         info("sync", "no history repo - run 'woswoar init <url>' to sync machines")

--- a/woswoar/cache.py
+++ b/woswoar/cache.py
@@ -112,6 +112,16 @@ def load() -> Cache:
 
     if not isinstance(data, Cache) or data.version != CACHE_VERSION:
         return Cache()
+
+    # Right class and right version is not the same as right *shape*. Pickle
+    # restores __dict__ directly and never runs __init__, so a file written by
+    # a build whose Cache had one attribute fewer unpickles cleanly here and
+    # then raises AttributeError deep inside refresh() -- on the Ctrl-R path,
+    # for a file this module promises is disposable. Found in the wild: a
+    # cache predating `unsaved` crashed `woswoar doctor` outright.
+    fresh = Cache()
+    if data.__dict__.keys() != fresh.__dict__.keys():
+        return fresh
     return data
 
 

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -181,6 +181,29 @@ def recipient_for(identity: Path) -> str:
     return public_of(identity.read_text(encoding="utf-8"))
 
 
+def selftest() -> str:
+    """``""`` if age can actually do the work here, else what went wrong.
+
+    Generates an identity, seals to it, and reopens it with the key delivered on
+    an inherited pipe as ``/dev/fd/N`` -- the path every real decrypt takes, and
+    the one assumption the "never hand age a path" rule still rests on.
+
+    Needs no repo, no configuration and no disk, which is the point: the failure
+    this exists to catch happens during `init`, before there is anything else to
+    check. ``age --version`` proves only that a binary is on PATH, and a
+    sandboxed age passes that and then cannot open a thing.
+    """
+    probe = b"woswoar selftest"
+    try:
+        identity = generate_identity()
+        sealed = encrypt_to(probe, identity.public)
+        if decrypt_with_secret(sealed, identity.secret) != probe:
+            return "age ran but returned different bytes than it was given"
+    except (AgeError, OSError) as exc:
+        return str(exc)
+    return ""
+
+
 def why_unusable(identity: Path) -> str:
     """``""`` if this identity can decrypt unattended, else why not.
 


### PR DESCRIPTION
On the machine where `woswoar init` failed with a bare "permission denied", **`woswoar doctor` said nothing at all**:

```
[--] age          /snap/bin/age
[--] sync         no history repo - run 'woswoar init <url>' to sync machines
```

It checked only that an `age` binary was on PATH — which a sandboxed age passes — and the one check that would have caught it was **gated behind `sync.is_repo()`**, so it never ran on a machine where `init` had just failed. That is the exact state in which someone runs doctor.

## `crypto.selftest()`

Generates an identity, seals to it, and reopens it with the key delivered on an inherited pipe as `/dev/fd/N` — the path every real decrypt takes, and the one assumption the "never hand age a path" rule still rests on. Needs no repo, no configuration and no disk.

The `age` line is a real check when the binary is present, and still just information when it is absent, since age is only needed for sync. With a stand-in for a confined age on PATH:

```
[FAIL] age          /tmp/.../bin/age
     age: error: failed to open input file: permission denied
```

The identity check is likewise no longer gated on having a repo — `init` records the identity *before* the step that was failing, so there is something to check precisely when it matters. The old `identity` label was reporting on the **machine file**, which read as reassurance about the wrong thing; that is now `machine`, and `identity` reports the key.

## A crash the new doctor immediately found

Running it on a real machine hit:

```
AttributeError: 'Cache' object has no attribute 'unsaved'
```

`cache.load()` accepted a pickle of the right class and right version without checking its **shape**. Pickle restores `__dict__` and never runs `__init__`, so a file written by a build whose `Cache` had one attribute fewer unpickles cleanly and then raises deep inside `refresh()` — on the Ctrl-R path, for a file whose own module docstring promises it is *"disposable by design: any corruption, version mismatch, or unreadable state falls back to a full rebuild rather than raising."*

This matters beyond the stale file that found it: any future field added to `Cache` without a version bump would break Ctrl-R for every existing user until they deleted the cache by hand.

## Tests

`tests/test_doctor.py` puts a fake confined age on PATH — present, runs, refuses — and asserts doctor fails, prints what age said, and does so **without a repo**. All four fail on the previous commit, as does the new cache test.

182 tests, ruff, mypy `--strict` clean.