### PR TITLE
Document the one-line install, and say what to install when a tool is missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release
+
+# Everything after `git push origin vX.Y.Z` is automated. The tag is the
+# trigger because it is the one step that has to be a deliberate human act:
+# `main` is protected, so the version bump arrives as a PR like anything else,
+# and tagging is how you say "that one".
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write # create the release, and move `stable`
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history: the ancestry check below needs to see main.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: the tag must match the version in the code
+        # Otherwise `woswoar --version` reports something other than the
+        # release it came from, and the tag is the only thing anyone checks.
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME#v}"
+          code="$(python -c 'import woswoar; print(woswoar.__version__)')"
+          if [ "$tag" != "$code" ]; then
+            echo "::error::tag $GITHUB_REF_NAME says $tag, woswoar/__init__.py says $code"
+            exit 1
+          fi
+          echo "releasing $code"
+
+      - name: the tag must be on main
+        # `stable` is only meaningful if it can only ever point at something
+        # that went through the protected branch, with its checks.
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::$GITHUB_SHA is not on main; releases are cut from main only"
+            exit 1
+          fi
+
+      - name: install age
+        # The sync suite skips itself without age, and a skipped suite is green
+        # -- so prove age is here rather than assume the install worked.
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq age
+          age --version
+
+      - name: tests
+        # A tag can be pushed to any commit by anyone. Re-running the suite here
+        # costs half a minute and means a release is never cut from something
+        # that was not tested at this exact commit.
+        run: python -m unittest discover -s . -t . -p 'test_*.py'
+
+      - name: build
+        run: |
+          python -m pip install --quiet build
+          python -m build
+          # A second copy under a fixed name, so this URL is stable across
+          # releases and can be pasted once:
+          #   pipx install "woswoar @ https://github.com/martinus/woswoar/releases/latest/download/woswoar.tar.gz"
+          # A wheel or sdist filename has to encode the version, so the normal
+          # artefacts cannot serve that; a PEP 508 direct reference supplies the
+          # project name instead, which is what makes the arbitrary name legal.
+          cp dist/woswoar-*.tar.gz dist/woswoar.tar.gz
+
+      - name: publish the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            dist/*
+
+      - name: move stable to this release
+        # The install line in the README is `@stable`, so this is what makes it
+        # mean "the latest release" without anyone editing a version number on
+        # five machines. Deliberately not forced: if this is not a
+        # fast-forward -- tagging an older commit, say -- the push fails and the
+        # release stays where it is rather than silently going backwards.
+        run: git push origin "$GITHUB_SHA:refs/heads/stable"

--- a/README.md
+++ b/README.md
@@ -60,14 +60,22 @@ that leaves your machine is encrypted with [age](https://github.com/FiloSottile/
 
 ## Install
 
-**Requirements:** bash 5.0+ (Linux) · [fzf](https://github.com/junegunn/fzf) ·
-Python 3.10+ · [age](https://github.com/FiloSottile/age) and git *(only for sync)*
-
 ```bash
-pipx install .          # or: pip install --user .
+pipx install --force git+https://github.com/martinus/woswoar.git
 woswoar install         # writes the hook, sources it from ~/.bashrc
 woswoar import bash     # optional: bring your existing history along
 ```
+
+No clone needed, and **the same line upgrades an existing install** — that is
+what `--force` is for. Without it pipx refuses to touch a version that is
+already there, and since woswoar installs straight from the branch rather than
+from a version number, `pipx upgrade` has nothing to compare against.
+
+**Requirements:** bash 5.0+ (Linux) · Python 3.10+ ·
+[fzf](https://github.com/junegunn/fzf) for the picker ·
+[age](https://github.com/FiloSottile/age) and git *(only for sync)*.
+`woswoar install` checks for these and prints the exact command for your
+distribution if any are missing.
 
 Open a new shell and press <kbd>Ctrl</kbd>+<kbd>R</kbd>. That's it — everything
 below is optional. To add more machines, see
@@ -212,7 +220,7 @@ ever.
 The same four lines everywhere — first machine or fifth, it makes no difference:
 
 ```bash
-pipx install .
+pipx install --force git+https://github.com/martinus/woswoar.git
 woswoar install                                       # hook it into bash
 woswoar import atuin --this-host-only                 # optional: this machine's past
 woswoar init git@github.com:you/woswoar-history.git   # join the repo

--- a/README.md
+++ b/README.md
@@ -61,15 +61,19 @@ that leaves your machine is encrypted with [age](https://github.com/FiloSottile/
 ## Install
 
 ```bash
-pipx install --force git+https://github.com/martinus/woswoar.git
+pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
 woswoar install         # writes the hook, sources it from ~/.bashrc
 woswoar import bash     # optional: bring your existing history along
 ```
 
-No clone needed, and **the same line upgrades an existing install** — that is
-what `--force` is for. Without it pipx refuses to touch a version that is
-already there, and since woswoar installs straight from the branch rather than
-from a version number, `pipx upgrade` has nothing to compare against.
+No clone needed, and **the same line upgrades an existing install** — run it
+again whenever you want the latest release. `stable` always points at the most
+recent tagged release, so the command never changes and you never edit a version
+number on five machines.
+
+`--force` is what makes the upgrade work: without it pipx refuses to touch an
+install that is already there. Swap `@stable` for `@main` to track the tip
+instead, or for `@v0.2.0` to pin a release exactly.
 
 **Requirements:** bash 5.0+ (Linux) · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) for the picker ·
@@ -220,7 +224,7 @@ ever.
 The same four lines everywhere — first machine or fifth, it makes no difference:
 
 ```bash
-pipx install --force git+https://github.com/martinus/woswoar.git
+pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
 woswoar install                                       # hook it into bash
 woswoar import atuin --this-host-only                 # optional: this machine's past
 woswoar init git@github.com:you/woswoar-history.git   # join the repo
@@ -463,7 +467,7 @@ caching, encrypting, git — happens when you search or when the timer fires.
 ## Development
 
 ```bash
-python -m unittest discover -s . -t . -p 'test_*.py'    # 142 tests
+python -m unittest discover -s . -t . -p 'test_*.py'    # 194 tests
 WOSWOAR_BENCH=1 python -m unittest tests.test_perf      # latency on 52k entries
 ruff check . && ruff format --check . && mypy woswoar tests
 ```
@@ -471,6 +475,24 @@ ruff check . && ruff format --check . && mypy woswoar tests
 CI runs lint, tests on Python 3.10/3.12/3.14, the shell-hook and fork-free
 checks, a two-machine end-to-end sync against real `age` and real `git`,
 immutability and repo-growth assertions, and an install smoke test.
+
+### Cutting a release
+
+The version lives in `woswoar/__init__.py` and nowhere else — `pyproject.toml`
+reads it from there, so the two cannot disagree.
+
+```bash
+# 1. bump __version__, open a PR, merge it (main is protected)
+# 2. tag the merged commit:
+git tag v0.2.0 && git push origin v0.2.0
+```
+
+Everything after that is automatic. `.github/workflows/release.yml` refuses the
+tag unless it matches `__version__` and sits on `main`, re-runs the whole suite
+at that exact commit, builds the sdist and wheel, publishes a GitHub release
+with generated notes, and fast-forwards `stable` — which is what the install
+command above tracks. The `stable` push is not forced, so tagging an older
+commit fails loudly rather than moving everyone backwards.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "woswoar"
-version = "0.1.0"
+# Read from woswoar/__init__.py rather than repeated here. Two declarations can
+# disagree, and when they do `woswoar --version` lies about what is installed --
+# which matters most during a release, when it is the only thing anyone checks.
+dynamic = ["version"]
 description = "Distributed shell history over git, searched with fzf"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -21,6 +24,9 @@ dev = ["ruff>=0.6", "mypy>=1.11", "shellcheck-py>=0.10"]
 
 [project.scripts]
 woswoar = "woswoar.__main__:main"
+
+[tool.hatch.version]
+path = "woswoar/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["woswoar"]

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,0 +1,130 @@
+"""Telling someone what to install, in terms their machine understands."""
+
+from __future__ import annotations
+
+import io
+import os
+import stat
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+from woswoar import deps
+from woswoar.__main__ import main
+
+from .support import WoswoarTestCase
+
+
+class TestInstaller(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory(prefix="woswoar-deps-")
+        self.addCleanup(tmp.cleanup)
+        self.tmp = Path(tmp.name)
+        self._next = 0
+
+    def release(self, text: str) -> Path:
+        self._next += 1
+        path = self.tmp / f"os-release.{self._next}"
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_fedora(self) -> None:
+        self.assertEqual(deps.installer(self.release("ID=fedora\n")), "sudo dnf install")
+
+    def test_ubuntu(self) -> None:
+        self.assertEqual(deps.installer(self.release("ID=ubuntu\n")), "sudo apt install")
+
+    def test_a_derivative_is_covered_by_id_like(self) -> None:
+        # Linux Mint reports ID=linuxmint ID_LIKE=ubuntu. Naming every
+        # derivative is a losing game; ID_LIKE is what it is for.
+        path = self.release('ID=linuxmint\nID_LIKE="ubuntu debian"\n')
+        self.assertEqual(deps.installer(path), "sudo apt install")
+
+    def test_id_wins_over_id_like(self) -> None:
+        path = self.release("ID=fedora\nID_LIKE=debian\n")
+        self.assertEqual(deps.installer(path), "sudo dnf install")
+
+    def test_quotes_are_stripped(self) -> None:
+        self.assertEqual(deps.installer(self.release('ID="fedora"\n')), "sudo dnf install")
+
+    def test_an_unknown_distro_admits_it(self) -> None:
+        # Printing a confidently wrong command is worse than saying we do not
+        # know, so `advice` falls back rather than guessing.
+        path = self.release("ID=plan9\n")
+        self.assertEqual(deps.installer(path), "")
+        self.assertIn("your package manager", deps.advice([deps.FZF], path=path))
+
+    def test_a_missing_os_release_does_not_raise(self) -> None:
+        path = Path("/nonexistent/os-release")
+        self.assertEqual(deps.installer(path), "")
+        self.assertIn("fzf", deps.advice([deps.FZF], path=path))
+
+    def test_the_advice_is_one_pasteable_command(self) -> None:
+        path = self.release("ID=fedora\n")
+        self.assertEqual(deps.advice([deps.FZF, deps.AGE], path=path), "sudo dnf install fzf age")
+
+    def test_report_names_each_tool_and_why(self) -> None:
+        text = deps.report([deps.FZF], path=self.release("ID=fedora\n"))
+        self.assertIn("fzf", text)
+        self.assertIn(deps.FZF.needed_for, text)
+        self.assertIn("sudo dnf install fzf", text)
+
+    def test_report_of_nothing_missing_is_empty(self) -> None:
+        self.assertEqual(deps.report([]), "")
+
+
+class TestInstallWarnsAboutMissingTools(WoswoarTestCase):
+    """`woswoar install` is when someone finds out, so it is when we say it."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # A PATH with a working python but none of woswoar's tools.
+        empty = self.root / "emptybin"
+        empty.mkdir()
+        self._path = os.environ["PATH"]
+        os.environ["PATH"] = str(empty)
+        self.addCleanup(lambda: os.environ.__setitem__("PATH", self._path))
+
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self._home = os.environ.get("HOME")
+        os.environ["HOME"] = str(self.home)
+        self.addCleanup(self._restore_home)
+
+    def _restore_home(self) -> None:
+        if self._home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._home
+
+    def test_install_still_succeeds_but_says_what_is_missing(self) -> None:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(["install", "--rcfile", str(self.home / ".bashrc")])
+
+        # Recording works without any of them, so this is a warning, not a
+        # failure -- the hook really was installed.
+        self.assertEqual(code, 0)
+        self.assertIn("woswoar.bash", out.getvalue())
+        for tool in ("fzf", "age", "git"):
+            self.assertIn(tool, err.getvalue())
+
+    def test_a_complete_machine_says_nothing(self) -> None:
+        # Put the tools back so `missing()` finds them.
+        binaries = self.root / "fullbin"
+        binaries.mkdir()
+        for name in ("fzf", "age", "git"):
+            script = binaries / name
+            script.write_text("#!/bin/sh\nexit 0\n")
+            script.chmod(script.stat().st_mode | stat.S_IXUSR)
+        os.environ["PATH"] = str(binaries)
+
+        err = io.StringIO()
+        with redirect_stdout(io.StringIO()), redirect_stderr(err):
+            main(["install", "--rcfile", str(self.home / ".bashrc")])
+        self.assertNotIn("could not find", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -80,6 +80,15 @@ def cmd_install(args: argparse.Namespace) -> int:
         print(f"rcfile  : {rcfile} ({action})")
 
     print("\nOpen a new shell, or run:  source", target)
+
+    # The moment someone finds out, so the moment to say it. Recording works
+    # without any of these, which is why this warns rather than fails -- but
+    # without fzf there is no Ctrl-R, and Ctrl-R is what woswoar is for.
+    from . import deps
+
+    absent = deps.missing()
+    if absent:
+        print(f"\n{deps.report(absent)}", file=sys.stderr)
     return 0
 
 
@@ -164,7 +173,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     import shutil
     import subprocess
 
-    from . import crypto, sync
+    from . import crypto, deps, sync
 
     ok = True
 
@@ -196,7 +205,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     check("bash", major >= 5, f"{version or 'not found'} (5.0+ required)")
 
     fzf = shutil.which("fzf")
-    check("fzf", fzf is not None, fzf or "not found - needed for 'woswoar search'")
+    check("fzf", fzf is not None, fzf or f"not found - {deps.advice([deps.FZF])}")
 
     machine_file = store.machine_file()
     # Read before anything calls store.machine(), which would create it.
@@ -217,7 +226,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     # "permission denied" from `init` with doctor reporting nothing at all.
     age_path = shutil.which("age")
     if age_path is None:
-        info("age", "not found - needed for 'woswoar sync' only")
+        info("age", f"not found, needed for 'woswoar sync' - {deps.advice([deps.AGE])}")
     else:
         failure = crypto.selftest()
         check("age", not failure, age_path)
@@ -233,6 +242,10 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         check("identity", status.ok, status.detail)
     else:
         info("identity", "none yet - chosen by 'woswoar init'")
+
+    git_path = shutil.which("git")
+    if git_path is None:
+        info("git", f"not found, needed for 'woswoar sync' - {deps.advice([deps.GIT])}")
 
     if sync.is_repo():
         info("remote", sync.remote_summary())

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -40,13 +40,16 @@ class Identity(NamedTuple):
     public: str
 
 
-_MISSING = (
-    "woswoar: 'age' not found on PATH.\n"
-    "Sync encrypts every line before it reaches git, so age is required.\n"
-    "  Fedora:  sudo dnf install age\n"
-    "  Debian:  sudo apt install age\n"
-    "  macOS:   brew install age"
-)
+def _missing_message() -> str:
+    """Built when needed, so the install command matches *this* machine.
+
+    The previous version listed Fedora, Debian and macOS unconditionally and
+    left the reader to pick; `deps` detects the distro instead.
+    """
+    from . import deps
+
+    return "Sync encrypts every line before it reaches git.\n" + deps.report([deps.AGE])
+
 
 #: age emits this when it wants a passphrase it cannot ask for. Worth
 #: recognising: an unattended sync from a systemd timer has no terminal, so a
@@ -66,7 +69,7 @@ def available() -> bool:
 
 def require() -> None:
     if not available():
-        raise AgeError(_MISSING)
+        raise AgeError(_missing_message())
 
 
 def _run(argv: list[str], data: bytes | None = None, pass_fds: tuple[int, ...] = ()) -> bytes:

--- a/woswoar/deps.py
+++ b/woswoar/deps.py
@@ -1,0 +1,106 @@
+"""Which external tools are missing, and what to type to get them.
+
+woswoar needs no Python packages, but it does need a few ordinary binaries, and
+``fzf: command not found`` three steps later is a worse thing to hand someone
+than the command that installs it. Kept dependency-free and tiny so the places
+that report a missing tool can all say the same thing.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import NamedTuple
+
+
+class Tool(NamedTuple):
+    #: Binary on PATH. Also the package name on every distro handled below --
+    #: if that ever stops being true, this grows a per-family mapping rather
+    #: than the callers learning about packaging.
+    name: str
+    #: Filled into "needed for ...", so it reads as a reason, not a label.
+    needed_for: str
+
+    @property
+    def present(self) -> bool:
+        return shutil.which(self.name) is not None
+
+
+#: fzf is listed first because it is the one whose absence breaks the feature
+#: people install woswoar for. age and git matter only once you sync.
+FZF = Tool("fzf", "the Ctrl-R picker")
+AGE = Tool("age", "encrypting history before it is synced")
+GIT = Tool("git", "moving encrypted history between machines")
+
+TOOLS = (FZF, AGE, GIT)
+
+#: Distro family -> the command that installs a package there. Deliberately
+#: short: printing a confidently wrong command for a distro nobody tested is
+#: worse than admitting we do not know, which is what the fallback does.
+_INSTALLERS = {
+    "fedora": "sudo dnf install",
+    "rhel": "sudo dnf install",
+    "centos": "sudo dnf install",
+    "debian": "sudo apt install",
+    "ubuntu": "sudo apt install",
+}
+
+_OS_RELEASE = Path("/etc/os-release")
+
+
+def _os_release(path: Path | None = None) -> dict[str, str]:
+    """Parse ``/etc/os-release``, tolerating its absence.
+
+    The format is shell-ish ``KEY=value`` with optional quotes; only ID and
+    ID_LIKE are read, so a full shell parser would be effort spent on fields
+    nobody looks at.
+    """
+    try:
+        text = (path or _OS_RELEASE).read_text(encoding="utf-8")
+    except OSError:
+        return {}
+
+    values: dict[str, str] = {}
+    for line in text.splitlines():
+        key, _, value = line.partition("=")
+        if value:
+            values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def installer(path: Path | None = None) -> str:
+    """The install command for this machine, or ``""`` if we do not know it.
+
+    ``ID_LIKE`` is consulted after ``ID`` so derivatives are covered without
+    naming each one: Linux Mint reports ``ID=linuxmint ID_LIKE=ubuntu``.
+    """
+    release = _os_release(path)
+    candidates = [release.get("ID", ""), *release.get("ID_LIKE", "").split()]
+    for candidate in candidates:
+        if candidate in _INSTALLERS:
+            return _INSTALLERS[candidate]
+    return ""
+
+
+def missing(tools: tuple[Tool, ...] = TOOLS) -> list[Tool]:
+    return [tool for tool in tools if not tool.present]
+
+
+def advice(tools: list[Tool] | tuple[Tool, ...], path: Path | None = None) -> str:
+    """A ready-to-paste install line for ``tools``, or the honest fallback."""
+    names = " ".join(tool.name for tool in tools)
+    command = installer(path)
+    if command:
+        return f"{command} {names}"
+    return f"install with your package manager: {names}"
+
+
+def report(tools: list[Tool] | tuple[Tool, ...], path: Path | None = None) -> str:
+    """The whole message: what is missing, why it matters, how to fix it."""
+    if not tools:
+        return ""
+    lines = ["woswoar needs these and could not find them:"]
+    width = max(len(tool.name) for tool in tools)
+    lines += [f"  {tool.name:<{width}}  {tool.needed_for}" for tool in tools]
+    lines += ["", f"  {advice(tools, path)}"]
+    return "\n".join(lines)

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -25,12 +25,6 @@ SCOPES: tuple[Scope, ...] = ("global", "host", "session")
 _TIME_WIDTH = 4
 _PREFIX = _TIME_WIDTH + 2
 
-_FZF_MISSING = (
-    "woswoar: fzf not found on PATH.\n"
-    "It is the only runtime dependency; install it with your package manager\n"
-    "(e.g. 'dnf install fzf') or use 'woswoar list' for plain output."
-)
-
 
 def relative_time(ts: int, now: int | None = None) -> str:
     """Render a timestamp as an age, at most :data:`_TIME_WIDTH` characters.
@@ -164,7 +158,10 @@ def interactive(scope: Scope, query: str = "", dedup: bool = True) -> str | None
     import subprocess
 
     if shutil.which("fzf") is None:
-        print(_FZF_MISSING, file=sys.stderr)
+        from . import deps
+
+        print(deps.report([deps.FZF]), file=sys.stderr)
+        print("\nMeanwhile 'woswoar list' prints the same history as plain text.", file=sys.stderr)
         return None
 
     lines = lines_for(scope, dedup=dedup)


### PR DESCRIPTION
Two halves, and the first one needed no code at all.

## Installing was already one line — the README was wrong

It said `pipx install .`, which implies cloning first. That was the friction. Installing straight from the URL already worked:

```bash
pipx install --force git+https://github.com/martinus/woswoar.git
```

Verified against the real repo in a throwaway pipx home: it builds, the bash hook ships inside the wheel, and **the same line upgrades an existing install**.

`--force` is load-bearing:

| | |
|---|---|
| with `--force`, fresh machine | installs |
| with `--force`, already installed | *"Installing to existing venv"* — picked up `grant` |
| without `--force` | *"modifying existing installation… Pass `--force`"* |

`pipx upgrade` is no help either: woswoar installs from a branch rather than a version number, so there is nothing for it to compare against. One line, works the first time and every time after.

## `woswoar install` now says what is missing and how to get it

The dependencies are ordinary binaries, and `fzf: command not found` three steps later is a worse thing to hand someone than the command that installs it:

```
woswoar needs these and could not find them:
  fzf  the Ctrl-R picker
  age  encrypting history before it is synced

  sudo dnf install fzf age
```

The command comes from `/etc/os-release` — `dnf` for fedora/rhel/centos, `apt` for debian/ubuntu. Derivatives are covered through `ID_LIKE` rather than by naming each one; Linux Mint reports `ID=linuxmint ID_LIKE=ubuntu`. Anything else gets:

```
  install with your package manager: fzf age
```

because printing a confidently wrong command for a distro nobody tested is worse than admitting we don't know.

**It warns rather than fails.** Recording works without any of these and the hook really was installed — but without fzf there's no Ctrl-R, which is what woswoar is for, so it's worth interrupting for.

## Two existing messages now agree with it

`crypto` listed Fedora, Debian and macOS unconditionally and left the reader to pick the right one. `search` suggested `dnf install fzf` to everybody. Both now go through `deps` and name only the command that will work on the machine in front of you.

## Where the check runs

At `install` and in `doctor`, not on every invocation: two `shutil.which()` calls are ~37 µs, and `woswoar list` runs on every keypress.

12 new tests — each distro family, `ID_LIKE`, `ID` winning over `ID_LIKE`, quoted values, an unknown distro, a missing `/etc/os-release`, and that `install` still exits 0 while naming all three tools. 194 tests, ruff, mypy `--strict` clean.

Not merging, per your note.