### PR TITLE
Bump the actions and the dev tooling floors to current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       # shellcheck comes from pip rather than apt so the version CI enforces is
@@ -36,8 +36,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12", "3.14"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: install age
@@ -57,8 +57,8 @@ jobs:
     # check needs strace, and a regression here is felt on every command.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: install strace and locales
@@ -74,8 +74,8 @@ jobs:
     # invariant the storage design rests on: chunks are never rewritten.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - run: sudo apt-get update -qq && sudo apt-get install -y -qq age
@@ -94,8 +94,8 @@ jobs:
   perf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: latency on a 52k-entry history
@@ -110,8 +110,8 @@ jobs:
     # machine that has never seen woswoar before.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - run: pip install .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Full history: the ancestry check below needs to see main.
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,11 @@ keywords = ["shell", "history", "fzf", "git", "bash"]
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["ruff>=0.6", "mypy>=1.11", "shellcheck-py>=0.10"]
+# Floors, not pins -- but recent ones. `ruff format --check` is a *formatter*
+# gate, and its output changes between versions, so a floor three years behind
+# lets a contributor pass locally and fail in CI for no reason they can see.
+# These are the versions the suite is actually run against.
+dev = ["ruff>=0.16", "mypy>=2.3", "shellcheck-py>=0.11"]
 
 [project.scripts]
 woswoar = "woswoar.__main__:main"


### PR DESCRIPTION
The v0.1.0 release run warned that `actions/checkout@v4` and `actions/setup-python@v5` target Node 20 and are being forced onto Node 24.

## Actions: v4/v5 → v7

Both were three majors behind, and **both intervening majors are the Node 24 migration itself** — so this is the fix for the warning, not an unrelated upgrade.

I read the release notes rather than assuming a clean jump:

| | |
|---|---|
| setup-python v6 | Node 24 (the breaking change) |
| setup-python v7 | removed a `pip-install` input — **we never used it** |
| checkout v5/v6 | Node 24 |
| checkout v7 | blocks fork checkouts for `pull_request_target`/`workflow_run` — **we use neither** |

`fetch-depth: 0` in the release workflow and `python-version` in the matrix are unchanged. 14 call sites across both workflows.

## Dev tooling floors

Were `ruff>=0.6, mypy>=1.11, shellcheck-py>=0.10`; current are 0.16, 2.3 and 0.11. Still floors rather than pins, but recent ones — `ruff format --check` is a *formatter* gate whose output changes between versions, so a floor years behind lets someone pass locally and fail in CI for no reason they can see.

**That check turned something up.** mypy is on 2.x, CI has been installing it through `-e .[dev]` for a while, and my local checkout was still on 1.18 — so CI and I had quietly diverged on the type checker. I ran the newest of all three over the whole codebase before raising anything:

```
ruff 0.16.0        All checks passed!
mypy 2.3.0         Success: no issues found in 25 source files
shellcheck 0.11.0  clean
```

## Deliberately not bumped

The test matrix stays **3.10 / 3.12 / 3.14**. 3.10 is the declared `requires-python` floor and testing it is the whole point — dropping it is a support decision, not a version bump. Say the word if you'd rather raise the floor.

194 tests pass.