### PR TITLE
Split the README: install first, security and shell details in docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,13 @@
 
 [![CI](https://github.com/martinus/woswoar/actions/workflows/ci.yml/badge.svg)](https://github.com/martinus/woswoar/actions/workflows/ci.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
-[![Runtime dependencies: 0](https://img.shields.io/badge/runtime%20dependencies-0-brightgreen)](#security)
+[![Runtime dependencies: 0](https://img.shields.io/badge/runtime%20dependencies-0-brightgreen)](docs/security.md#-minimal-supply-chain)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-lightgrey)](LICENSE)
 
 *Austrian for "Was war?"* — "what was it again?" — which is exactly what you ask
 when you need that one command from last Tuesday, on the other machine.
 
 </div>
-
-```console
-$ woswoar install
-$ woswoar import atuin      # or: bash, zsh
-# open a new shell, press Ctrl-R
-```
 
 ```
   woswoar (global) > docker
@@ -28,200 +22,36 @@ $ woswoar import atuin      # or: bash, zsh
   ctrl-g global | ctrl-h host | ctrl-s session
 ```
 
----
-
-## Why woswoar?
-
-Press <kbd>Ctrl</kbd>+<kbd>R</kbd> and fuzzy-search **every command from every
-machine you own** — deduplicated, newest first, with the working directory, exit
-code and duration recorded alongside. Pick one and it lands on your prompt for
-editing, never executed behind your back.
-
-Sync goes through **an ordinary git repository you already own**. There is no
-server to run, no account to create, no daemon in the background. Everything
-that leaves your machine is encrypted with [age](https://github.com/FiloSottile/age).
-
-|  | woswoar |
-|---|---|
-| 🔐 **Encrypted end to end** | commands, paths, hostnames — nothing readable reaches the remote |
-| 🧩 **No server, no database** | a git repo and plain text files you can `grep` |
-| 📦 **Zero Python dependencies** | standard library only — nothing to audit but this repo |
-| ⚡ **~150 µs per command, zero forks** | the hook is pure bash; Python never runs on your prompt |
-| 🔎 **fzf as the UI** | the fuzzy finder you already know, not a bespoke TUI |
-| 🚚 **Imports what you have** | bash, zsh and atuin histories, idempotently |
-| 🧱 **~2900 lines of implementation** | small enough to read in an afternoon |
-
-> [!NOTE]
-> woswoar is a lighter alternative to [atuin](https://github.com/atuinsh/atuin).
-> If you want a sync server, a rich TUI and cross-platform support, atuin is the
-> better tool. woswoar trades those for a design you can hold in your head.
-
----
-
-## Install
+## Quick start
 
 ```bash
 pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
-woswoar install         # writes the hook, sources it from ~/.bashrc
-woswoar import bash     # optional: bring your existing history along
+woswoar install                  # hook it into ~/.bashrc
+woswoar import bash              # optional: bring your existing history along
 ```
 
-No clone needed, and **the same line upgrades an existing install** — run it
-again whenever you want the latest release. `stable` always points at the most
-recent tagged release, so the command never changes and you never edit a version
-number on five machines.
+Open a new shell, press <kbd>Ctrl</kbd>+<kbd>R</kbd>. That is the whole thing on
+one machine.
 
-`--force` is what makes the upgrade work: without it pipx refuses to touch an
-install that is already there. Swap `@stable` for `@main` to track the tip
-instead, or for `@v0.2.0` to pin a release exactly.
+> [!TIP]
+> **The same line upgrades an existing install** — run it again whenever you want
+> the latest release. `stable` tracks the most recent tag, so the command never
+> changes and you never edit a version number on five machines. Swap `@stable`
+> for `@main` to track the tip, or `@v0.1.0` to pin exactly.
 
-**Requirements:** bash 5.0+ (Linux) · Python 3.10+ ·
-[fzf](https://github.com/junegunn/fzf) for the picker ·
-[age](https://github.com/FiloSottile/age) and git *(only for sync)*.
-`woswoar install` checks for these and prints the exact command for your
-distribution if any are missing.
+**Needs:** bash 5.0+ (Linux) · Python 3.10+ ·
+[fzf](https://github.com/junegunn/fzf) ·
+[age](https://github.com/FiloSottile/age) and git *(sync only)*.
+`woswoar install` checks for these and prints the install command for your
+distribution. `woswoar doctor` diagnoses anything else that looks wrong.
 
-Open a new shell and press <kbd>Ctrl</kbd>+<kbd>R</kbd>. That's it — everything
-below is optional. To add more machines, see
-[Sync across machines](#sync-across-machines).
+## Adding another machine
 
-If something looks wrong, `woswoar doctor` checks the bash version, fzf, the
-hook and the cache, and tells you what to fix.
+Sync goes through **an ordinary git repository you already own** — no server, no
+account, no daemon. Create an empty one (`woswoar-history` on GitHub, a bare repo
+on a NAS, a folder on a USB stick). You do that once, ever.
 
-<details>
-<summary>Does this disturb my normal bash, or my other prompt tools?</summary>
-
-**Up-arrow and `~/.bash_history` are untouched.** woswoar never modifies
-`HISTFILE`, `HISTSIZE`, `HISTCONTROL` or the history list — it only *reads*
-`history 1`. It is purely additive: a second, richer log next to the one bash
-already keeps. Your `HISTTIMEFORMAT` is not disturbed either; the hook's
-override is scoped to its own call.
-
-**It shares the DEBUG trap and `PROMPT_COMMAND` rather than taking them.** A
-terminal-title hook, a prompt framework, bash-preexec and atuin all want the same
-two places. woswoar chains onto whatever owns the DEBUG trap *at the first
-prompt* — not at the moment it is sourced — so it picks up whoever ended up
-owning it once your whole `.bashrc` has run. It also restores `$?` after reading
-it, so an exit-code-colouring prompt downstream still sees the real status.
-
-**[ble.sh](https://github.com/akinomyoga/ble.sh) is handled separately**, because
-it replaces bash's prompt machinery rather than hooking into it — neither
-`PROMPT_COMMAND` nor the DEBUG trap sees your commands there. woswoar registers
-with `blehook PREEXEC`/`PRECMD` when it finds ble.sh loaded. Nothing to
-configure; it works in either load order, and alongside atuin.
-
-If something else claims the trap *after* that, you lose the recorded
-**duration** of those commands and nothing else; the commands themselves are
-still recorded. This is all pinned by tests that drive a real interactive bash.
-
-**A half-typed line becomes the search query.** Type `docker comp`, press
-<kbd>Ctrl</kbd>+<kbd>R</kbd>, and fzf opens already filtered to that. Escape
-leaves your line byte-for-byte as it was; picking something replaces the line
-and puts the cursor at the end, never executing it.
-
-`WOSWOAR_NO_BIND=1` skips the <kbd>Ctrl</kbd>+<kbd>R</kbd> binding entirely if
-you would rather keep another tool's.
-
-</details>
-
----
-
-## Security
-
-The whole point of syncing history is that it ends up somewhere off your
-machine. So the question is not *"do I trust GitHub?"* but *"what happens when
-that repository leaks?"* — through a stolen token, a mis-clicked visibility
-toggle, or a backup nobody thought about.
-
-**With woswoar, a leaked repository is a pile of unreadable blobs.**
-
-### 🔒 Nothing readable ever leaves your machine
-
-Commands, arguments, working directories, usernames, hostnames — all of it is
-encrypted before it is committed. Even the *directory names* in the repo are
-opaque random hex, because paths are not encrypted by anything and
-`hosts/martin@desktop/` would publish your machine names for free.
-
-### 🧊 No self-rolled cryptography
-
-Not one line of crypto in this codebase. Python's standard library has no cipher
-at all — only hashing — so instead of reaching for a third-party library and
-composing primitives by hand, woswoar shells out to
-[age](https://github.com/FiloSottile/age): a small, audited, widely deployed
-tool with one job. woswoar's crypto module is a
-[small subprocess wrapper](woswoar/crypto.py). There is no key derivation, no
-nonce management and no mode selection to get wrong, because none of it lives
-here.
-
-### 🔑 No secret is ever copied between machines
-
-age takes **SSH public keys as recipients**, so each machine encrypts to the
-other machines' public keys and keeps its own private key to itself, forever.
-Enrolling a new laptop means publishing a public key — nothing sensitive travels,
-and nothing sensitive is stored in the repo.
-
-<details>
-<summary>What if my SSH key has a passphrase?</summary>
-
-age cannot use ssh-agent, so a passphrase-protected key would break unattended
-syncing from a timer. `woswoar init` detects this by doing a real
-encrypt/decrypt round trip — not by inspecting the key file — and falls back to
-a dedicated age identity at `~/.config/woswoar/identity`. Force either choice
-with `--identity <path>` or `--new-identity`.
-
-</details>
-
-### 📦 Minimal supply chain
-
-The runtime dependency list is **empty**, and
-[intended to stay that way](pyproject.toml). No PyPI packages, no transitive
-tree, no post-install scripts, no crate lockfile to audit — the only Python that
-runs is the code in this repository. `ruff`, `mypy` and `shellcheck` are
-development-only, and `fzf`, `git` and `age` are ordinary system binaries you
-install from your distribution.
-
-### ✅ Guarantees pinned by tests, not by prose
-
-Claims rot. The ones that matter are asserted in CI on every push:
-
-| Claim | How it is enforced |
-|---|---|
-| The hook forks nothing | recording runs under `strace`; the clone/fork/execve count must be **0** |
-| Shell and Python escaping agree | a command containing a literal tab and newline must round-trip byte-for-byte |
-| History is never rewritten | `git log --diff-filter=MD` over chunk files must be **empty** |
-| The repo does not blow up | a simulated multi-day, multi-machine run is measured after `git gc` |
-| Search stays fast | latency measured on 52,000 entries |
-
-### ⚠️ What is *not* protected
-
-Being straight about the limits is part of the security story:
-
-> [!IMPORTANT]
-> - **Local history is plaintext.** `~/.local/share/woswoar/logs/` is readable by
->   anyone who can read your home directory — same as `~/.bash_history`.
->   Encryption protects the *synced copy*, not your disk. Use full-disk
->   encryption for that.
-> - **Metadata leaks.** Anyone with the repo can see how many machines you have,
->   when they synced, and roughly how many commands you ran per day.
-> - **Secrets you type are still secrets.** `WOSWOAR_IGNORE` skips
->   credential-shaped commands by default (`*TOKEN=`, `*SECRET=`, `--password`,
->   …), and bash's own `HISTCONTROL`/`HISTIGNORE` are honoured for free — but no
->   pattern catches everything.
-> - **Lose your key, lose your access.** There is no recovery service, because
->   there is no service. If a machine loses its identity, re-enrol it and run
->   `woswoar grant` from another machine.
-
----
-
-## Sync across machines
-
-First, create an empty repository anywhere you can push to — `woswoar-history`
-on GitHub, a bare repo on a NAS, a folder on a USB stick. You only do this once,
-ever.
-
-### Then, on each machine
-
-The same four lines everywhere — first machine or fifth, it makes no difference:
+Then on **every** machine, first or fifth, the same four lines:
 
 ```bash
 pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
@@ -230,11 +60,8 @@ woswoar import atuin --this-host-only                 # optional: this machine's
 woswoar init git@github.com:you/woswoar-history.git   # join the repo
 ```
 
-Open a new shell. That machine is now recording and syncing.
-
-### One extra step, from the second machine onwards
-
-On a machine you set up **earlier**, run:
+From the **second** machine onwards, one extra step on a machine you set up
+earlier:
 
 ```bash
 woswoar grant
@@ -253,58 +80,14 @@ including days recorded before it ever existed:
 Grant all 2 machines full access? [y/N]
 ```
 
-There is no rush: until you run it, the new machine syncs its own commands
-normally and just reports how many older days it cannot read yet.
+No rush — until you run it the new machine syncs its own commands normally and
+just reports how many older days it cannot read yet.
 
 > [!TIP]
-> `.bashrc` is written with `$HOME`, not your username, so the same one works on
-> every machine — handy if you keep your dotfiles in a repo.
+> `.bashrc` is written with `$HOME` rather than your username, so one shared
+> dotfiles `.bashrc` works on every machine.
 
-<details>
-<summary>Why that extra step exists — and why the new machine can't do it itself</summary>
-
-History sealed *before* the new machine joined was encrypted to a recipient list
-that did not include it. `grant` re-seals the small per-day keys — not the
-history itself — so it takes seconds even with years of commands. It fetches and
-publishes on its own, so it is one command, not a sync sandwich.
-
-**Only a machine that is already a recipient can do this**, and that is the
-point rather than a limitation: re-sealing a key means *opening* it first. If a
-machine nobody had granted access to could re-seal old keys for itself, the
-encryption would not be worth anything. Run it on the new machine and it will
-tell you it could not open those keys.
-
-Until someone runs it, the new machine syncs fine and simply reports how many
-days it cannot read yet. Nothing is lost in the meantime.
-
-</details>
-
-<details>
-<summary>How the repository stays small (and conflict-free)</summary>
-
-Each sync compresses **only the lines added since last time**, seals them, and
-writes a brand-new file that is never modified again:
-
-```
-hosts/<id>/2026-07-29/<synctime>-<rand>.age    a compressed, age-encrypted block
-hosts/<id>/keys/2026-07-29.age                 that day's key, sealed to all recipients
-```
-
-Re-encrypting a whole day file on every sync would write a fresh random blob
-each time, and random data delta-compresses to nothing. Compressing *before*
-sealing is the only chance there is — encrypted bytes are incompressible by
-definition, so once a chunk is written, nothing can ever shrink it again.
-
-Because every machine only ever *adds* files under its own prefix,
-`git pull --rebase` has nothing to conflict over. Not "rarely" — structurally.
-
-`woswoar compact` can later merge a finished day's chunks into one. It reduces
-the *file count*, not the repository: git keeps the replaced chunks forever,
-reachable from the commits that added them.
-
-</details>
-
-### Automatic syncing
+### Sync automatically
 
 ```bash
 mkdir -p ~/.config/systemd/user
@@ -312,33 +95,46 @@ cp contrib/systemd/woswoar-sync.* ~/.config/systemd/user/
 systemctl --user enable --now woswoar-sync.timer
 ```
 
-**One-minute interval by default**, because it turns out to be nearly free. Real
-typing is bursty, so a minute rather than five roughly doubles the number of
-syncs that actually carry something — not five times it. Sync never runs on your
-prompt: a `git push` must not be able to block a shell.
+One-minute interval by default, which costs about **6 MB of repository per
+machine per year** — real typing is bursty, so a minute rather than five roughly
+doubles the syncs that carry anything, not quintuples them. Sync never runs on
+your prompt: a `git push` must not be able to block a shell.
 
-<details>
-<summary>What that costs, measured</summary>
+## Why woswoar?
 
-Two years of one machine's real history — 25,997 commands, 3.61 MB of plaintext
-— replayed through `woswoar sync` itself at a 1-minute cadence:
+Press <kbd>Ctrl</kbd>+<kbd>R</kbd> and fuzzy-search **every command from every
+machine you own** — deduplicated, newest first, with the working directory, exit
+code and duration recorded alongside. Pick one and it lands on your prompt for
+editing, never executed behind your back.
 
-| | repo, packed | per year |
-|---|---|---|
-| before compression + flat paths | 16.22 MB | 7.9 MB |
-| **now** | **12.24 MB** | **5.9 MB** |
+|  | woswoar |
+|---|---|
+| 🔐 **Encrypted end to end** | commands, paths, hostnames — nothing readable reaches the remote |
+| 🧩 **No server, no database** | a git repo and plain text files you can `grep` |
+| 📦 **Zero Python dependencies** | standard library only — nothing to audit but this repo |
+| ⚡ **~150 µs per command, zero forks** | the hook is pure bash; Python never runs on your prompt |
+| 🔎 **fzf as the UI** | the fuzzy finder you already know, not a bespoke TUI |
+| 🚚 **Imports what you have** | bash, zsh and atuin histories, idempotently |
+| 🧱 **~3500 lines of implementation** | small enough to read in an afternoon |
 
-About half of what remains is git's own bookkeeping rather than your commands:
-per sync, 359 B of blob (200 B of that the `age` header), 196 B of tree, 129 B
-of commit. That fixed part is why the interval matters at all — raise
-`OnUnitActiveSec` in the timer if you would rather have the bytes back.
+> [!NOTE]
+> woswoar is a lighter alternative to [atuin](https://github.com/atuinsh/atuin).
+> If you want a sync server, a rich TUI and cross-platform support, atuin is the
+> better tool. woswoar trades those for a design you can hold in your head.
 
-The per-year number tracks how much you type, not the timer; a busier stretch of
-the same history extrapolates to about 16 MB/year.
+## Security
 
-</details>
+Everything that leaves your machine is encrypted with
+[age](https://github.com/FiloSottile/age) — commands, paths, hostnames, even the
+directory names in the repo. Each machine keeps its own private key and no secret
+is ever copied between them. There is no crypto code here at all: age does it,
+and woswoar's wrapper is a few dozen lines of `subprocess`.
 
----
+Your **local** history is plaintext, though, and metadata like "how many machines
+and how often they sync" is visible to anyone holding the repo.
+
+📖 **[The full security model](docs/security.md)** — what is protected, what is
+not, and the guarantees CI asserts on every push.
 
 ## Coming from atuin
 
@@ -347,59 +143,30 @@ woswoar import atuin --dry-run   # see what would happen, changes nothing
 woswoar import atuin
 ```
 
-atuin keeps every machine it has synced with in one sqlite database, so an import
-can carry history from several hosts. woswoar keeps them apart rather than
-flattening them, so `--scope host` and `stats` stay truthful: each atuin machine
-gets its own host entry, and commands from *this* machine merge into its existing
-history.
-
 The database is opened **read-only** — it is very likely a running atuin's live
-database, and woswoar has no business writing to it.
+database. atuin keeps every machine it has synced with in one file, and woswoar
+keeps those apart rather than flattening them, so `--scope host` and `stats` stay
+truthful. Re-running an import is idempotent.
 
 > [!TIP]
-> **If you sync several woswoar machines, use `--this-host-only` on each.**
-> Sync publishes only this machine's own commands, so importing every atuin host
-> on every machine means each peer's history exists twice: once imported
-> locally, once arriving over sync. Letting each machine import just its own
-> keeps exactly one copy of everything.
->
-> Importing everything is the right choice when only one machine runs woswoar —
-> you get all your machines' history, it just stays local.
-
-Re-running an import is idempotent, and woswoar reuses a peer's real host id when
-that peer is already known locally — so importing *after* your machines have
-synced also avoids duplicates. Importing before they have met cannot: the ids
-were assigned independently.
-
----
+> **Syncing several woswoar machines? Use `--this-host-only` on each.** Sync
+> publishes only a machine's own commands, so importing every atuin host on every
+> machine would leave each peer's history stored twice. Import everything only if
+> this stays your single woswoar machine.
 
 ## Reference
 
-### Commands
-
-| | |
+| command | |
 |---|---|
 | `woswoar search` | interactive picker (what <kbd>Ctrl</kbd>+<kbd>R</kbd> runs) |
 | `woswoar list` | plain output, used by fzf's scope-switch reload |
 | `woswoar import bash\|zsh\|atuin` | import an existing history |
 | `woswoar stats` | entry counts, date range, most-used commands |
-| `woswoar doctor` | check bash version, fzf, hook, cache |
+| `woswoar doctor` | check the installation and the tools it needs |
 | `woswoar init [url]` | create or join an encrypted history repo |
 | `woswoar sync` | exchange history with the remote |
 | `woswoar grant` | let newly enrolled machines read the older history |
 | `woswoar compact` | merge old chunks to reduce the working-tree file count |
-
-### Scopes
-
-Switch without leaving the picker:
-
-| key | scope |
-|---|---|
-| <kbd>Ctrl</kbd>+<kbd>G</kbd> | **global** — every machine |
-| <kbd>Ctrl</kbd>+<kbd>H</kbd> | **host** — this machine |
-| <kbd>Ctrl</kbd>+<kbd>S</kbd> | **session** — this shell |
-
-### Configuration
 
 | variable | meaning |
 |---|---|
@@ -407,43 +174,6 @@ Switch without leaving the picker:
 | `WOSWOAR_IGNORE` | extended regex of commands never to record |
 | `WOSWOAR_SCOPE` | default scope for <kbd>Ctrl</kbd>+<kbd>R</kbd> (default `global`) |
 | `WOSWOAR_NO_BIND` | set to skip binding <kbd>Ctrl</kbd>+<kbd>R</kbd> |
-
-### Performance
-
-Measured on a real **54,943-entry** history across ~750 daily files:
-
-| | |
-|---|---|
-| record a command | **~150 µs**, 0 forks |
-| <kbd>Ctrl</kbd>+<kbd>R</kbd>, whole process | **~105 ms** |
-
-No index, no SQLite — a pickle cache that only re-reads what changed is enough,
-and CI re-measures it on every push.
-
-<details>
-<summary>Where those 105 ms go</summary>
-
-| | cumulative |
-|---|---|
-| Python interpreter start | 8.8 ms |
-| importing woswoar | 29 ms |
-| building the argparse parser | 36 ms |
-| loading the cache (unpickling 55k entries) | 67 ms |
-| filter, sort, dedup, render | 87 ms |
-| writing 1.5 MB to fzf | 105 ms |
-
-Roughly half is fixed Python startup and half is proportional to history size.
-Micro-optimising it was measured and did not help: the costs are structural, and
-cutting them further would mean either a resident daemon (which the whole
-no-server design exists to avoid) or an index the measurements do not justify.
-
-The recording hook is a different story — 150 µs is imperceptible, and about
-30 µs of it is the fork-free `history 1` capture that makes multi-line commands
-survive intact.
-
-</details>
-
----
 
 ## How it works
 
@@ -453,16 +183,18 @@ bash hook  ──►  plaintext TSV logs  ──►  pickle cache  ──►  sc
                         └──►  age-encrypted chunks  ──►  git  ──►  remote
 ```
 
-The hot path is a fork-free bash hook using bash 5 builtins (`$EPOCHSECONDS`,
-`$EPOCHREALTIME`, `printf -v`) that appends one escaped line to a per-day TSV
-file. Nothing else touches your prompt. Everything more expensive — parsing,
-caching, encrypting, git — happens when you search or when the timer fires.
+The hot path is a fork-free bash hook using bash 5 builtins that appends one
+escaped line to a per-day TSV file. Nothing else touches your prompt. Everything
+expensive — parsing, caching, encrypting, git — happens when you search, or when
+the timer fires.
 
-- 📐 [docs/woswoar_design_summary.md](docs/woswoar_design_summary.md) —
-  architecture, record format, and the sync/encryption design with measured
-  numbers and the mistakes that shaped them.
-- 🗺️ [docs/milestone-1-plan.md](docs/milestone-1-plan.md) — the implementation
-  plan milestone 1 was built from.
+- 🐚 **[Living in your shell](docs/shell-integration.md)** — what it does to your
+  bash, how it coexists with ble.sh, atuin and prompt frameworks, and what
+  Ctrl-R costs.
+- 🔐 **[Security model](docs/security.md)** — threat model, guarantees, limits.
+- 📐 **[Design summary](docs/woswoar_design_summary.md)** — architecture, record
+  format, the sync and encryption design, with measured numbers and the mistakes
+  that shaped them.
 
 ## Development
 
@@ -476,7 +208,8 @@ CI runs lint, tests on Python 3.10/3.12/3.14, the shell-hook and fork-free
 checks, a two-machine end-to-end sync against real `age` and real `git`,
 immutability and repo-growth assertions, and an install smoke test.
 
-### Cutting a release
+<details>
+<summary>Cutting a release</summary>
 
 The version lives in `woswoar/__init__.py` and nowhere else — `pyproject.toml`
 reads it from there, so the two cannot disagree.
@@ -491,8 +224,10 @@ Everything after that is automatic. `.github/workflows/release.yml` refuses the
 tag unless it matches `__version__` and sits on `main`, re-runs the whole suite
 at that exact commit, builds the sdist and wheel, publishes a GitHub release
 with generated notes, and fast-forwards `stable` — which is what the install
-command above tracks. The `stable` push is not forced, so tagging an older
-commit fails loudly rather than moving everyone backwards.
+command tracks. The `stable` push is not forced, so tagging an older commit
+fails loudly rather than moving everyone backwards.
+
+</details>
 
 ## License
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,94 @@
+# Security model
+
+The whole point of syncing history is that it ends up somewhere off your
+machine. So the question is not *"do I trust GitHub?"* but *"what happens when
+that repository leaks?"* — through a stolen token, a mis-clicked visibility
+toggle, or a backup nobody thought about.
+
+**With woswoar, a leaked repository is a pile of unreadable blobs.**
+
+## 🔒 Nothing readable ever leaves your machine
+
+Commands, arguments, working directories, usernames, hostnames — all of it is
+encrypted before it is committed. Even the *directory names* in the repo are
+opaque random hex, because paths are not encrypted by anything and
+`hosts/martin@desktop/` would publish your machine names for free.
+
+## 🧊 No self-rolled cryptography
+
+Not one line of crypto in this codebase. Python's standard library has no cipher
+at all — only hashing — so instead of reaching for a third-party library and
+composing primitives by hand, woswoar shells out to
+[age](https://github.com/FiloSottile/age): a small, audited, widely deployed
+tool with one job. woswoar's crypto module is a
+[small subprocess wrapper](../woswoar/crypto.py). There is no key derivation, no
+nonce management and no mode selection to get wrong, because none of it lives
+here.
+
+woswoar also never hands age a *path* — it reads key files itself and pipes the
+bytes. That sounds like a detail until you meet a sandboxed age that can run
+perfectly and still not open `~/.ssh`; see
+[the design summary](woswoar_design_summary.md#age-never-gets-a-path) for the
+incident that established the rule.
+
+## 🔑 No secret is ever copied between machines
+
+age takes **SSH public keys as recipients**, so each machine encrypts to the
+other machines' public keys and keeps its own private key to itself, forever.
+Enrolling a new laptop means publishing a public key — nothing sensitive travels,
+and nothing sensitive is stored in the repo.
+
+Widening who can read the archive is therefore a deliberate act: `woswoar grant`
+lists the machines by name and asks before it re-seals anything.
+
+<details>
+<summary>What if my SSH key has a passphrase?</summary>
+
+age cannot use ssh-agent, so a passphrase-protected key would break unattended
+syncing from a timer. `woswoar init` detects this by doing a real
+encrypt/decrypt round trip — not by inspecting the key file — and falls back to
+a dedicated age identity at `~/.config/woswoar/identity`. Force either choice
+with `--identity <path>` or `--new-identity`.
+
+</details>
+
+## 📦 Minimal supply chain
+
+The runtime dependency list is **empty**, and
+[intended to stay that way](../pyproject.toml). No PyPI packages, no transitive
+tree, no post-install scripts, no crate lockfile to audit — the only Python that
+runs is the code in this repository. `ruff`, `mypy` and `shellcheck` are
+development-only, and `fzf`, `git` and `age` are ordinary system binaries you
+install from your distribution.
+
+## ✅ Guarantees pinned by tests, not by prose
+
+Claims rot. The ones that matter are asserted in CI on every push:
+
+| Claim | How it is enforced |
+|---|---|
+| The hook forks nothing | recording runs under `strace`; the clone/fork/execve count must be **0** |
+| Shell and Python escaping agree | a command containing a literal tab and newline must round-trip byte-for-byte |
+| History is never rewritten | `git log --diff-filter=MD` over chunk files must be **empty** |
+| age is never given a file path | every age invocation is inspected; no argument may be an existing path outside `/dev/fd` |
+| The repo does not blow up | a simulated multi-day, multi-machine run is measured after `git gc` |
+| Search stays fast | latency measured on 52,000 entries |
+
+## ⚠️ What is *not* protected
+
+Being straight about the limits is part of the security story:
+
+> [!IMPORTANT]
+> - **Local history is plaintext.** `~/.local/share/woswoar/logs/` is readable by
+>   anyone who can read your home directory — same as `~/.bash_history`.
+>   Encryption protects the *synced copy*, not your disk. Use full-disk
+>   encryption for that.
+> - **Metadata leaks.** Anyone with the repo can see how many machines you have,
+>   when they synced, and roughly how many commands you ran per day.
+> - **Secrets you type are still secrets.** `WOSWOAR_IGNORE` skips
+>   credential-shaped commands by default (`*TOKEN=`, `*SECRET=`, `--password`,
+>   …), and bash's own `HISTCONTROL`/`HISTIGNORE` are honoured for free — but no
+>   pattern catches everything.
+> - **Lose your key, lose your access.** There is no recovery service, because
+>   there is no service. If a machine loses its identity, re-enrol it and run
+>   `woswoar grant` from another machine.

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -1,0 +1,96 @@
+# Living in your shell
+
+woswoar is never the only thing hooked into a real `.bashrc`, and it runs on
+every prompt. Both of those constrain it more than anything else in the design.
+
+## Your normal bash is untouched
+
+**Up-arrow and `~/.bash_history` still work exactly as before.** woswoar never
+modifies `HISTFILE`, `HISTSIZE`, `HISTCONTROL` or the history list — it only
+*reads* `history 1`. It is purely additive: a second, richer log next to the one
+bash already keeps. `HISTTIMEFORMAT` is not disturbed either; the hook's
+override is scoped to its own call.
+
+## It shares the hooks rather than taking them
+
+A terminal-title hook, a prompt framework, bash-preexec and atuin all want the
+same two places: the `DEBUG` trap and `PROMPT_COMMAND`.
+
+woswoar chains onto whatever owns the DEBUG trap **at the first prompt** — not
+at the moment it is sourced — so it picks up whoever ended up owning it once
+your whole `.bashrc` has run. That is not fussiness: a sourced file cannot see
+the DEBUG trap at all, and doing it late means the order of lines in `.bashrc`
+stops mattering.
+
+It also restores `$?` after reading it, so an exit-code-colouring prompt
+downstream still sees the real status rather than the 0 that woswoar's own
+assignment would otherwise leave behind.
+
+If something else claims the trap *after* woswoar, you lose the recorded
+**duration** of those commands and nothing else — the commands themselves are
+still recorded.
+
+### ble.sh
+
+[ble.sh](https://github.com/akinomyoga/ble.sh) needs a different mechanism
+entirely, because it replaces bash's prompt machinery rather than hooking into
+it: `PROMPT_COMMAND` runs once and never again, and the DEBUG trap only ever
+sees ble.sh's own internals. woswoar registers with `blehook PREEXEC`/`PRECMD`
+when it finds ble.sh loaded.
+
+Nothing to configure. It works in either load order and alongside atuin, and it
+is pinned by tests that drive a real interactive bash.
+
+## Ctrl-R
+
+A **half-typed line becomes the search query**. Type `docker comp`, press
+<kbd>Ctrl</kbd>+<kbd>R</kbd>, and fzf opens already filtered to that. Escape
+leaves your line byte-for-byte as it was; picking something replaces the line and
+puts the cursor at the end, never executing it.
+
+Switch scope without leaving the picker:
+
+| key | scope |
+|---|---|
+| <kbd>Ctrl</kbd>+<kbd>G</kbd> | **global** — every machine |
+| <kbd>Ctrl</kbd>+<kbd>H</kbd> | **host** — this machine |
+| <kbd>Ctrl</kbd>+<kbd>S</kbd> | **session** — this shell |
+
+`WOSWOAR_NO_BIND=1` skips the <kbd>Ctrl</kbd>+<kbd>R</kbd> binding entirely if
+you would rather keep another tool's.
+
+## What it costs
+
+Measured on a real **54,943-entry** history across ~750 daily files:
+
+| | |
+|---|---|
+| record a command | **~150 µs**, 0 forks |
+| <kbd>Ctrl</kbd>+<kbd>R</kbd>, whole process | **~105 ms** |
+
+No index, no SQLite — a pickle cache that only re-reads what changed is enough,
+and CI re-measures it on every push.
+
+<details>
+<summary>Where those 105 ms go</summary>
+
+| | cumulative |
+|---|---|
+| Python interpreter start | 8.8 ms |
+| importing woswoar | 29 ms |
+| building the argparse parser | 36 ms |
+| loading the cache (unpickling 55k entries) | 67 ms |
+| filter, sort, dedup, render | 87 ms |
+| writing 1.5 MB to fzf | 105 ms |
+
+Roughly half is fixed Python startup and half is proportional to history size.
+Micro-optimising it was measured and did not help: the costs are structural, and
+cutting them further would mean either a resident daemon (which the whole
+no-server design exists to avoid) or an index the measurements do not justify.
+
+The recording hook is a different story — 150 µs is imperceptible, and about
+30 µs of it is the fork-free `history 1` capture that makes multi-line commands
+survive intact. `$BASH_COMMAND` would be free but lossy: it reports
+`for i in 1 2` for a loop and only the first element of `a && b`.
+
+</details>


### PR DESCRIPTION
The README had grown to **499 lines** and buried both things a visitor actually needs. Install was 60 lines in, behind a feature table. Adding a second machine was **220 lines in**, behind the entire security model.

Restructured after the layout you use in `martinus/oans` — a tight README that answers *"how do I run this"* immediately, with depth in `docs/` behind named links.

## The new shape

| | |
|---|---|
| **Quick start** | install one machine, four lines |
| **Adding another machine** | the git repo, the four lines per machine, `grant` |
| **Why woswoar?** | the feature table — now *after* the answer instead of in front of it |
| **Security** | five sentences and a link |
| **Coming from atuin** | trimmed to what you type plus the one real trap |
| **Reference** | commands and variables, two tables |
| **How it works** | the diagram, then links to the three docs |

**234 lines, down from 499**, and the first screen is the demo and the install command.

## Two new pages — moved, not deleted

**[`docs/security.md`](docs/security.md)** — the whole threat model: what is encrypted, no self-rolled crypto, no secret copied between machines, the empty dependency list, the guarantees CI asserts, and the four things explicitly *not* protected. It also picks up the **"age never gets a path"** rule, which belonged with the rest of the security story rather than living only in a commit message.

**[`docs/shell-integration.md`](docs/shell-integration.md)** — what woswoar does to your bash: up-arrow and `~/.bash_history` untouched, how it shares the DEBUG trap and `PROMPT_COMMAND`, the separate ble.sh mechanism, Ctrl-R behaviour and scopes, and the measured cost of recording and searching.

## What was dropped rather than moved

Two `<details>` blocks from the sync section — compression before sealing, why rebases cannot conflict, why `grant` cannot be run by the machine that needs it, and the repo-growth measurements. All of it was **already covered at greater length** in `docs/woswoar_design_summary.md`, which the README links to.

I checked that rather than assuming: diffed the vocabulary of the old README against the new set of files, took every dropped topic, and confirmed each has a section in the design summary — including the atuin host-id reuse detail, at lines 468 and 479.

## Also checked

A script walks every markdown link and heading anchor across all four documents. **All internal links resolve**, including the "Runtime dependencies: 0" badge, which now points into `docs/security.md#-minimal-supply-chain` rather than a README section that no longer exists.

Corrected the implementation size claim while I was there: 2900 → 3500 lines, which is what `wc -l` actually says now.

No code changes. 194 tests, ruff, mypy clean.