### PR TITLE
Create history owner-only, so installing woswoar is not a privacy downgrade

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -113,7 +113,7 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | The repo key never leaks | the key's bytes appear nowhere in the committed tree |
 | A recalled command is one command | control characters never survive from the picker into the shell buffer |
 | The repo does not blow up | a simulated multi-day, multi-machine run is measured after `git gc` |
-| History is never world-readable | every file and directory woswoar writes is checked under a stock `umask 022` |
+| History is never readable by others | every path woswoar creates is walked under a stock `umask 022`, on both the Python and the shell-hook side |
 | Search stays fast | latency measured on 52,000 entries |
 
 ## ⚠️ What is *not* protected
@@ -123,9 +123,11 @@ Being straight about the limits is part of the security story:
 > [!IMPORTANT]
 > - **Local history is plaintext.** `~/.local/share/woswoar/logs/` holds your
 >   commands unencrypted. woswoar's own directories are created `0700` and its
->   files `0600` — the same as `~/.bash_history`, and `woswoar doctor` fails if
->   anything under them is readable by another user — but that only keeps out
->   other accounts on the same machine. Encryption protects the *synced copy*,
+>   files `0600` — the same as `~/.bash_history` — and `woswoar doctor` fails if
+>   anything under them is readable by another user. The encrypted `history/`
+>   checkout is excluded from that walk: it is ciphertext, and the directory
+>   above it is owner-only. All of which only keeps out other accounts on the
+>   same machine. Encryption protects the *synced copy*,
 >   not your disk. Use full-disk encryption for that.
 > - **Metadata leaks.** Anyone with the repo can see how many machines you have,
 >   when they synced, and roughly how many commands you ran per day.

--- a/docs/security.md
+++ b/docs/security.md
@@ -113,6 +113,7 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | The repo key never leaks | the key's bytes appear nowhere in the committed tree |
 | A recalled command is one command | control characters never survive from the picker into the shell buffer |
 | The repo does not blow up | a simulated multi-day, multi-machine run is measured after `git gc` |
+| History is never world-readable | every file and directory woswoar writes is checked under a stock `umask 022` |
 | Search stays fast | latency measured on 52,000 entries |
 
 ## ⚠️ What is *not* protected
@@ -120,10 +121,12 @@ Claims rot. The ones that matter are asserted in CI on every push:
 Being straight about the limits is part of the security story:
 
 > [!IMPORTANT]
-> - **Local history is plaintext.** `~/.local/share/woswoar/logs/` is readable by
->   anyone who can read your home directory — same as `~/.bash_history`.
->   Encryption protects the *synced copy*, not your disk. Use full-disk
->   encryption for that.
+> - **Local history is plaintext.** `~/.local/share/woswoar/logs/` holds your
+>   commands unencrypted. woswoar's own directories are created `0700` and its
+>   files `0600` — the same as `~/.bash_history`, and `woswoar doctor` fails if
+>   anything under them is readable by another user — but that only keeps out
+>   other accounts on the same machine. Encryption protects the *synced copy*,
+>   not your disk. Use full-disk encryption for that.
 > - **Metadata leaks.** Anyone with the repo can see how many machines you have,
 >   when they synced, and roughly how many commands you ran per day.
 > - **One key across your machines.** Authentication proves a chunk came from

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7,14 +7,17 @@ which differs the moment two machines disagree about the username.
 
 from __future__ import annotations
 
+import io
 import os
 import subprocess
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
+from woswoar import store
 from woswoar.__main__ import main, portable_hook_path
 
-from .support import WoswoarTestCase, requires_bash
+from .support import MACHINE_ID, WoswoarTestCase, make_entry, requires_bash
 
 
 class TestPortableHookPath(unittest.TestCase):
@@ -104,6 +107,66 @@ class TestInstall(WoswoarTestCase):
             env={"HOME": str(self.home), "PATH": os.environ.get("PATH", "/usr/bin:/bin")},
         ).stdout
         self.assertTrue(Path(resolved).is_file(), f"{resolved} was not written by install")
+
+
+class TestPrivateByDefault(WoswoarTestCase):
+    """Recorded history is at least as private as ~/.bash_history.
+
+    bash creates that 0600. woswoar's logs hold strictly more -- the command,
+    the working directory, the exit status, and every other machine's history
+    once sync has run -- so anything looser would make installing woswoar a
+    downgrade on any box with a group- or world-readable home.
+    """
+
+    def modes(self) -> dict[str, int]:
+        paths = [
+            store.data_dir(),
+            store.config_dir(),
+            store.logs_dir(),
+            *store.logs_dir().rglob("*"),
+        ]
+        return {str(p): p.stat().st_mode & 0o777 for p in paths if p.exists()}
+
+    def first_run(self) -> None:
+        """What a real first run writes, through the real entry points.
+
+        The shared harness pre-creates the config directory with a plain
+        mkdir, so a test that only appended entries would be asserting about a
+        directory woswoar never wrote.
+        """
+        store.save_machine(store.machine())
+        store.append_entries(MACHINE_ID, [make_entry(1_700_000_000, "git status")])
+
+    def test_everything_written_is_owner_only(self) -> None:
+        self.first_run()
+        for path, mode in self.modes().items():
+            self.assertEqual(mode & 0o077, 0, f"{path} is {oct(mode)}")
+
+    def test_a_stock_umask_cannot_loosen_them(self) -> None:
+        # 022 is the default nearly everywhere, and is exactly what made the
+        # logs 0644 before: `mkdir` and `open(..., "a")` both honour it.
+        previous = os.umask(0o022)
+        self.addCleanup(os.umask, previous)
+        self.first_run()
+        for path, mode in self.modes().items():
+            self.assertEqual(mode & 0o077, 0, f"{path} is {oct(mode)}")
+
+    def test_an_older_install_is_retightened(self) -> None:
+        self.first_run()
+        for path in (store.data_dir(), store.logs_dir(), *store.logs_dir().rglob("*")):
+            path.chmod(0o755 if path.is_dir() else 0o644)
+        self.assertTrue(store.world_readable(), "the fixture is not actually loose")
+
+        store.harden()
+        self.assertEqual(store.world_readable(), [])
+
+    def test_doctor_reports_an_exposed_history(self) -> None:
+        self.first_run()
+        store.logs_dir().chmod(0o755)
+        out = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(io.StringIO()):
+            main(["doctor"])
+        self.assertRegex(out.getvalue(), r"\[FAIL\] private")
 
 
 if __name__ == "__main__":

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import io
 import os
+import shutil
 import subprocess
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -118,47 +119,65 @@ class TestPrivateByDefault(WoswoarTestCase):
     downgrade on any box with a group- or world-readable home.
     """
 
-    def modes(self) -> dict[str, int]:
-        paths = [
-            store.data_dir(),
-            store.config_dir(),
-            store.logs_dir(),
-            *store.logs_dir().rglob("*"),
-        ]
-        return {str(p): p.stat().st_mode & 0o777 for p in paths if p.exists()}
+    def loose(self) -> list[str]:
+        """Paths another account could read, walked independently of the code.
+
+        Deliberately not `store.readable_by_others()`: asking the helper about
+        itself could not catch it forgetting a path, which is the failure this
+        is guarding against.
+        """
+        roots = [store.data_dir(), store.config_dir(), store.cache_dir()]
+        seen = [r for r in roots if r.is_dir()]
+        seen += [p for r in list(seen) for p in r.rglob("*")]
+        return sorted(
+            f"{p} is {oct(p.stat().st_mode & 0o777)}"
+            for p in seen
+            if p.stat().st_mode & 0o077 and store.history_dir() not in [p, *p.parents]
+        )
 
     def first_run(self) -> None:
         """What a real first run writes, through the real entry points.
 
         The shared harness pre-creates the config directory with a plain
-        mkdir, so a test that only appended entries would be asserting about a
-        directory woswoar never wrote.
+        mkdir; removing it first means the assertions are about directories
+        woswoar actually created rather than ones it inherited.
         """
+        shutil.rmtree(store.config_dir())
         store.save_machine(store.machine())
         store.append_entries(MACHINE_ID, [make_entry(1_700_000_000, "git status")])
 
-    def test_everything_written_is_owner_only(self) -> None:
-        self.first_run()
-        for path, mode in self.modes().items():
-            self.assertEqual(mode & 0o077, 0, f"{path} is {oct(mode)}")
-
-    def test_a_stock_umask_cannot_loosen_them(self) -> None:
+    def test_a_stock_umask_cannot_loosen_what_is_written(self) -> None:
         # 022 is the default nearly everywhere, and is exactly what made the
-        # logs 0644 before: `mkdir` and `open(..., "a")` both honour it.
+        # logs 0644: `mkdir` and `open(..., "a")` both honour it. Pinned rather
+        # than inherited, so the test cannot pass vacuously on a strict runner.
         previous = os.umask(0o022)
         self.addCleanup(os.umask, previous)
         self.first_run()
-        for path, mode in self.modes().items():
-            self.assertEqual(mode & 0o077, 0, f"{path} is {oct(mode)}")
+        self.assertEqual(self.loose(), [])
 
     def test_an_older_install_is_retightened(self) -> None:
         self.first_run()
         for path in (store.data_dir(), store.logs_dir(), *store.logs_dir().rglob("*")):
             path.chmod(0o755 if path.is_dir() else 0o644)
-        self.assertTrue(store.world_readable(), "the fixture is not actually loose")
+        self.assertTrue(self.loose(), "the fixture is not actually loose")
 
         store.harden()
-        self.assertEqual(store.world_readable(), [])
+        self.assertEqual(self.loose(), [])
+
+    def test_creating_a_file_does_not_repermission_a_directory_it_found(self) -> None:
+        """`write_atomic` is a durability primitive, not a permissions one.
+
+        It creates missing parents privately, but must not clamp a directory
+        that was already there -- `history/` arrives from `git clone`, and a
+        user-chosen WOSWOAR_DIR is not woswoar's to re-permission. Migration is
+        `harden`'s job precisely so this one can stay out of it.
+        """
+        borrowed = store.data_dir() / "borrowed"
+        borrowed.mkdir(parents=True)
+        borrowed.chmod(0o755)
+        store.write_atomic(borrowed / "note", b"hello")
+        self.assertEqual(borrowed.stat().st_mode & 0o777, 0o755)
+        self.assertEqual((borrowed / "note").stat().st_mode & 0o777, 0o600)
 
     def test_doctor_reports_an_exposed_history(self) -> None:
         self.first_run()

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -18,7 +18,7 @@ import textwrap
 import unittest
 from pathlib import Path
 
-from woswoar import cache
+from woswoar import cache, store
 from woswoar.entry import MAX_CMD_CHARS, TRUNCATION_MARKER, Entry, escape, unescape
 
 from .support import MACHINE_ID, WoswoarTestCase
@@ -530,11 +530,23 @@ class TestRecordingIsPrivate(ShellHookTestCase):
     """
 
     def test_the_day_file_is_owner_only_under_a_stock_umask(self) -> None:
-        self.run_shell("echo hello\n", env_extra={})
+        self.run_shell("echo hello\n")
         files = list((Path(os.environ["WOSWOAR_DIR"]) / "logs" / "hosts").rglob("*.tsv"))
         self.assertTrue(files, "nothing was recorded")
         for path in files:
             self.assertEqual(path.stat().st_mode & 0o077, 0, f"{path} is world-readable")
+
+    def test_the_hook_agrees_with_store_about_what_private_means(self) -> None:
+        """The hook is copied verbatim, so it cannot import the constants.
+
+        Nothing else would notice `store.DIR_MODE` being relaxed and the hook
+        being left behind, which is the direction that silently reopens the
+        hole this class exists for.
+        """
+        source = HOOK.read_text(encoding="utf-8")
+        self.assertIn("umask 077", source)
+        self.assertEqual(store.DIR_MODE, 0o700)
+        self.assertEqual(store.FILE_MODE, 0o600)
 
     def test_the_hook_leaves_the_shell_umask_alone(self) -> None:
         """It drops to 077 to create the file; it must put it back.

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -521,5 +521,30 @@ class TestForkFree(ShellHookTestCase):
         )
 
 
+@requires_bash5
+class TestRecordingIsPrivate(ShellHookTestCase):
+    """The hook creates the log file, so the hook is where its mode is decided.
+
+    Python never touches that file on the recording path, so a fix in `store`
+    alone would not have covered the case this exists for.
+    """
+
+    def test_the_day_file_is_owner_only_under_a_stock_umask(self) -> None:
+        self.run_shell("echo hello\n", env_extra={})
+        files = list((Path(os.environ["WOSWOAR_DIR"]) / "logs" / "hosts").rglob("*.tsv"))
+        self.assertTrue(files, "nothing was recorded")
+        for path in files:
+            self.assertEqual(path.stat().st_mode & 0o077, 0, f"{path} is world-readable")
+
+    def test_the_hook_leaves_the_shell_umask_alone(self) -> None:
+        """It drops to 077 to create the file; it must put it back.
+
+        Otherwise every file the user creates afterwards would silently become
+        0600 -- a surprising thing for a history tool to do to a shell.
+        """
+        out = self.run_shell("echo start\numask\n")
+        self.assertIn("0022", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -77,11 +77,14 @@ class Fake:
         return self._id
 
     def record(self, day: str, ts: int, cmd: str, session: str = "s1") -> None:
-        """Append a line the way the shell hook would."""
-        path = store.log_file(self.id, day)
-        path.parent.mkdir(parents=True, exist_ok=True)
+        """Append a line the way the shell hook would.
+
+        Through `store.private_append`, because the hook creates its day file
+        owner-only; a raw ``open("a")`` here would leave 0644 files that no
+        real recording path produces.
+        """
         entry = Entry(ts, self.id, session, "~/src", 0, 5, cmd)
-        with path.open("a", encoding="utf-8") as handle:
+        with store.private_append(store.log_file(self.id, day)) as handle:
             handle.write(format_line(entry) + "\n")
 
     def commands(self) -> set[str]:
@@ -652,6 +655,27 @@ class TestLocalOnly(SyncTestCase):
         alpha = self.machine("alpha")
         with alpha.active(), sync.lock(), self.assertRaises(sync.SyncError):
             sync.run()
+
+
+class TestSyncIsPrivate(SyncTestCase):
+    def test_a_sync_that_runs_before_install_leaves_nothing_readable(self) -> None:
+        """The timer can fire on a machine where `install` never ran.
+
+        Everything sync creates on its own -- the data directory, the lock, the
+        state file, a peer's learned name -- has to be owner-only by itself,
+        because `install` is the only thing that re-tightens and it may never
+        have run here.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            # The harness pre-creates WOSWOAR_DIR, which stands in for a user
+            # pointing it at a directory that already existed -- woswoar leaves
+            # those alone by design, so start from the state `install` leaves.
+            store.harden()
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            exposed = store.readable_by_others()
+            self.assertEqual(exposed, [], f"sync left {exposed} readable by others")
 
 
 class TestChunkAuthenticity(SyncTestCase):

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -61,8 +61,11 @@ def cmd_install(args: argparse.Namespace) -> int:
     import shutil
 
     machine = store.machine()
-    target = store.data_dir() / HOOK_NAME
-    target.parent.mkdir(parents=True, exist_ok=True)
+    # Before anything is written, and again on every install: an installation
+    # from before woswoar made its own directories owner-only stays wrong
+    # otherwise, and `install` is the command people re-run to upgrade.
+    store.harden()
+    target = store.private_dir(store.data_dir()) / HOOK_NAME
     shutil.copyfile(_hook_source(), target)
 
     print(f"machine : {machine.name} ({machine.id})")
@@ -264,6 +267,19 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
     logs = list(store.iter_log_files())
     info("logs", f"{len(logs)} file(s) in {store.logs_dir()}")
+
+    # Recorded history is more than ~/.bash_history holds -- the command, the
+    # directory, the exit status, and every other machine's history once sync
+    # has run -- so anything another user can read is a finding, not a note.
+    exposed = store.world_readable()
+    check(
+        "private",
+        not exposed,
+        f"{store.logs_dir()} is owner-only"
+        if not exposed
+        else f"{len(exposed)} path(s) readable by other users, e.g. {exposed[0]}"
+        " - run 'woswoar install' to fix",
+    )
 
     started = time.perf_counter()
     entries = cache.load_entries()

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -61,12 +61,15 @@ def cmd_install(args: argparse.Namespace) -> int:
     import shutil
 
     machine = store.machine()
-    # Before anything is written, and again on every install: an installation
-    # from before woswoar made its own directories owner-only stays wrong
-    # otherwise, and `install` is the command people re-run to upgrade.
-    store.harden()
-    target = store.private_dir(store.data_dir()) / HOOK_NAME
+    store.private_dir(store.data_dir())
+    target = store.data_dir() / HOOK_NAME
     shutil.copyfile(_hook_source(), target)
+    # After the copy, not before: `copyfile` creates at the ambient umask, so
+    # hardening first would leave the one file install itself writes as the one
+    # file its own migration missed. This is also what re-tightens a tree from
+    # a woswoar that predated owner-only directories -- `install` is the
+    # command people re-run to upgrade.
+    store.harden()
 
     print(f"machine : {machine.name} ({machine.id})")
     print(f"logs    : {store.logs_dir()}")
@@ -271,15 +274,13 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     # Recorded history is more than ~/.bash_history holds -- the command, the
     # directory, the exit status, and every other machine's history once sync
     # has run -- so anything another user can read is a finding, not a note.
-    exposed = store.world_readable()
-    check(
-        "private",
-        not exposed,
-        f"{store.logs_dir()} is owner-only"
-        if not exposed
-        else f"{len(exposed)} path(s) readable by other users, e.g. {exposed[0]}"
-        " - run 'woswoar install' to fix",
-    )
+    exposed = store.readable_by_others()
+    if exposed:
+        detail = f"{len(exposed)} path(s) other users can read, e.g. {exposed[0]}"
+        detail += " - run 'woswoar install' to fix"
+    else:
+        detail = f"{store.data_dir()} is owner-only"
+    check("private", not exposed, detail)
 
     started = time.perf_counter()
     entries = cache.load_entries()

--- a/woswoar/importer.py
+++ b/woswoar/importer.py
@@ -416,8 +416,7 @@ def run_atuin(
             # Guarded only against overwriting a name learned from a real sync.
             label = store.name_file(host_id)
             if not label.is_file():
-                label.parent.mkdir(parents=True, exist_ok=True)
-                label.write_text(f"{names[host_id]}\n", encoding="utf-8")
+                store.write_atomic(label, f"{names[host_id]}\n".encode())
 
     return Result(
         parsed=parsed,

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -47,7 +47,19 @@ if [[ -z $__woswoar_id ]]; then
 fi
 
 __woswoar_logdir=$__woswoar_dir/logs/hosts/$__woswoar_id
-mkdir -p "$__woswoar_logdir" 2>/dev/null || return 0
+
+# 077 so the whole chain is owner-only from the moment it exists. `mkdir -p`
+# would otherwise honour the ambient umask, which is 022 almost everywhere, and
+# these files hold more than ~/.bash_history does -- which bash creates 0600.
+#
+# Only creation happens here. Re-tightening a tree from an older woswoar is
+# `woswoar install`'s job: a recursive chmod is proportional to the number of
+# days recorded, and this runs on every interactive shell.
+(umask 077 && mkdir -p "$__woswoar_logdir") 2>/dev/null || return 0
+
+# Captured once, so the hot path can drop to 077 for the one write a day that
+# creates a file and put it straight back without forking to read it.
+__woswoar_umask=$(umask)
 
 # Scratch file for capturing `history 1`. Prefer XDG_RUNTIME_DIR: it is a
 # per-user tmpfs that systemd clears at logout, so a shell killed with -9 cannot
@@ -86,6 +98,8 @@ __woswoar_max=8000
 __woswoar_start=
 __woswoar_status=
 __woswoar_lastnum=
+#: The day whose log file is known to exist already. See __woswoar_precmd.
+__woswoar_today=
 
 # ---------------------------------------------------------------------------
 # Hot path. Builtins only below this line.
@@ -208,6 +222,20 @@ __woswoar_precmd() {
 
     local day
     printf -v day '%(%F)T' -1 # local time, matching store.day_for()
+
+    # A file's mode is set when it is created and never again, so the first
+    # write of each day is the only moment this can be got right -- and `>>`
+    # would create it 0644 under the usual umask. Guarded on the day string
+    # rather than testing the file every time: this runs on every command, and
+    # the answer changes once a day.
+    if [[ $day != "$__woswoar_today" ]]; then
+        __woswoar_today=$day
+        if [[ ! -e $__woswoar_logdir/$day.tsv ]]; then
+            umask 077
+            : >"$__woswoar_logdir/$day.tsv" 2>/dev/null
+            umask "$__woswoar_umask"
+        fi
+    fi
 
     # One O_APPEND write. Linux serialises these under the inode lock, so
     # concurrent shells on this host cannot interleave lines.

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -230,11 +230,12 @@ __woswoar_precmd() {
     # the answer changes once a day.
     if [[ $day != "$__woswoar_today" ]]; then
         __woswoar_today=$day
-        if [[ ! -e $__woswoar_logdir/$day.tsv ]]; then
-            umask 077
-            : >"$__woswoar_logdir/$day.tsv" 2>/dev/null
-            umask "$__woswoar_umask"
-        fi
+        # `>>` rather than `>`: it creates when absent and does nothing when
+        # present, so no separate existence test is needed and a day already
+        # underway cannot be truncated.
+        umask 077
+        : >>"$__woswoar_logdir/$day.tsv" 2>/dev/null
+        umask "$__woswoar_umask"
     fi
 
     # One O_APPEND write. Linux serialises these under the inode lock, so

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -16,7 +16,7 @@ import tempfile
 import time
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import IO, Any, NamedTuple
 
 from .entry import Entry, format_line, parse_line
 
@@ -114,8 +114,14 @@ def log_file(machine_id: str, day: str) -> Path:
 #: the exit status, and every other machine's history once sync has run -- so
 #: anything looser would make installing woswoar a downgrade. The default umask
 #: on most distributions is 022, which is why this cannot be left implicit.
+#:
+#: The shell hook spells 077 itself, because it is copied verbatim rather than
+#: templated; tests/test_shell_hook.py pins the two together.
 DIR_MODE = 0o700
 FILE_MODE = 0o600
+
+#: Group and other bits. "Readable by someone who is not you", once.
+OTHER_BITS = 0o077
 
 
 def private_dir(path: Path) -> Path:
@@ -124,74 +130,81 @@ def private_dir(path: Path) -> Path:
     Each component is created separately because ``Path.mkdir(parents=True,
     mode=...)`` applies the mode to the leaf only and leaves parents at the
     umask default -- which would put a 0755 ``logs/`` above a 0700 host
-    directory and defeat the whole thing. The explicit chmod afterwards covers
-    a umask that would have masked bits out, and re-tightens directories from
-    an install that predates this.
-    """
-    missing: list[Path] = []
-    probe = path
-    while not probe.exists() and probe != probe.parent:
-        missing.append(probe)
-        probe = probe.parent
+    directory and defeat the whole thing.
 
-    for directory in reversed(missing):
-        directory.mkdir(mode=DIR_MODE, exist_ok=True)
-    with contextlib.suppress(OSError):
-        path.chmod(DIR_MODE)
+    Directories that already exist are left exactly as they are. This is called
+    from `write_atomic`, so anything else would make writing a file quietly
+    re-permission whatever directory it was pointed at -- including a
+    ``history/`` that came from ``git clone``. Re-tightening an old tree is
+    :func:`harden`'s job, and keeping the two separate is what lets that
+    docstring be true.
+    """
+    for directory in (*reversed(path.parents), path):
+        if not directory.exists():
+            directory.mkdir(mode=DIR_MODE)
     return path
 
 
-def private_append(path: Path) -> Any:
+def private_append(path: Path, binary: bool = False) -> IO[Any]:
     """Open ``path`` for appending, creating it owner-only if it is not there.
 
     ``open(..., "a")`` creates with 0666 masked by the umask -- 0644 on a stock
     install. The mode only matters at creation, so this is the one moment it
     can be got right.
+
+    ``binary`` because the caller that appends another machine's merged log
+    already holds bytes. Making it decode to fit a text-only helper would put a
+    lossy round trip on data that machine recorded successfully, which is not a
+    decision a function about file modes should be making.
     """
     private_dir(path.parent)
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, FILE_MODE)
+    if binary:
+        return os.fdopen(fd, "ab")
     return os.fdopen(fd, "a", encoding="utf-8")
+
+
+def _private_paths() -> list[Path]:
+    """Everything woswoar owns whose mode is its business.
+
+    Walked rather than listed, so a file added under the data directory later
+    is covered by default instead of by someone remembering. ``history/`` is
+    the one exclusion: it is ciphertext plus a git checkout reaching tens of
+    thousands of files, walking it would make this proportional to the size of
+    the archive rather than to the number of days recorded, and the directory
+    above it being owner-only is what actually stops another user reading it.
+    """
+    roots = [data_dir(), config_dir(), cache_dir()]
+    out = [root for root in roots if root.is_dir()]
+    history = history_dir()
+    for root in list(out):
+        for path in root.rglob("*"):
+            if path == history or history in path.parents:
+                continue
+            out.append(path)
+    return out
 
 
 def harden() -> None:
     """Re-tighten an installation that predates :data:`DIR_MODE`.
 
-    Only the roots and the plaintext logs: the roots are what actually stop
-    another user walking in, and ``history/`` is ciphertext plus a git checkout
-    that can be tens of thousands of files. Cheap enough for `install` and
-    `doctor` to call every time.
+    Separate from :func:`private_dir` on purpose: creating a directory should
+    not silently re-permission one that was already there, but a migration
+    should. `install` is where this runs, because that is the command people
+    re-run to upgrade.
     """
-    for root in (data_dir(), config_dir(), cache_dir()):
-        if root.is_dir():
-            with contextlib.suppress(OSError):
-                root.chmod(DIR_MODE)
-
-    for path in _private_contents():
+    for path in _private_paths():
         with contextlib.suppress(OSError):
             path.chmod(DIR_MODE if path.is_dir() else FILE_MODE)
 
 
-def _private_contents() -> list[Path]:
-    """Everything woswoar owns that holds plaintext or key material.
+def readable_by_others() -> list[Path]:
+    """Everything woswoar owns that another account on this machine could read.
 
-    ``history/`` is left out on purpose: it is ciphertext plus a git checkout
-    that reaches tens of thousands of files, and walking it would make this
-    proportional to the size of the archive rather than to the number of days.
-    The roots above it are owner-only, which is what actually stops another
-    user reading any of it.
+    Named for the check it performs -- the mask is group *and* other, which
+    ``world_readable`` would have misdescribed for anyone adding a caller.
     """
-    out = [logs_dir(), *logs_dir().rglob("*")] if logs_dir().is_dir() else []
-    if config_dir().is_dir():
-        out += [p for p in config_dir().iterdir() if p.is_file()]
-    if cache_file().is_file():
-        out.append(cache_file())
-    return out
-
-
-def world_readable() -> list[Path]:
-    """Anything woswoar owns that another user on this machine could read."""
-    roots = [r for r in (data_dir(), config_dir(), cache_dir()) if r.is_dir()]
-    return [p for p in roots + _private_contents() if p.stat().st_mode & 0o077]
+    return [p for p in _private_paths() if p.stat().st_mode & OTHER_BITS]
 
 
 def write_atomic(path: Path, data: bytes) -> None:

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -109,6 +109,91 @@ def log_file(machine_id: str, day: str) -> Path:
     return host_dir(machine_id) / f"{day}{_LOG_SUFFIX}"
 
 
+#: Everything woswoar owns is private to its owner. `~/.bash_history` is 0600
+#: and woswoar's logs hold strictly more -- the command, the working directory,
+#: the exit status, and every other machine's history once sync has run -- so
+#: anything looser would make installing woswoar a downgrade. The default umask
+#: on most distributions is 022, which is why this cannot be left implicit.
+DIR_MODE = 0o700
+FILE_MODE = 0o600
+
+
+def private_dir(path: Path) -> Path:
+    """Create ``path`` and any missing parents, owner-only from the moment they exist.
+
+    Each component is created separately because ``Path.mkdir(parents=True,
+    mode=...)`` applies the mode to the leaf only and leaves parents at the
+    umask default -- which would put a 0755 ``logs/`` above a 0700 host
+    directory and defeat the whole thing. The explicit chmod afterwards covers
+    a umask that would have masked bits out, and re-tightens directories from
+    an install that predates this.
+    """
+    missing: list[Path] = []
+    probe = path
+    while not probe.exists() and probe != probe.parent:
+        missing.append(probe)
+        probe = probe.parent
+
+    for directory in reversed(missing):
+        directory.mkdir(mode=DIR_MODE, exist_ok=True)
+    with contextlib.suppress(OSError):
+        path.chmod(DIR_MODE)
+    return path
+
+
+def private_append(path: Path) -> Any:
+    """Open ``path`` for appending, creating it owner-only if it is not there.
+
+    ``open(..., "a")`` creates with 0666 masked by the umask -- 0644 on a stock
+    install. The mode only matters at creation, so this is the one moment it
+    can be got right.
+    """
+    private_dir(path.parent)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, FILE_MODE)
+    return os.fdopen(fd, "a", encoding="utf-8")
+
+
+def harden() -> None:
+    """Re-tighten an installation that predates :data:`DIR_MODE`.
+
+    Only the roots and the plaintext logs: the roots are what actually stop
+    another user walking in, and ``history/`` is ciphertext plus a git checkout
+    that can be tens of thousands of files. Cheap enough for `install` and
+    `doctor` to call every time.
+    """
+    for root in (data_dir(), config_dir(), cache_dir()):
+        if root.is_dir():
+            with contextlib.suppress(OSError):
+                root.chmod(DIR_MODE)
+
+    for path in _private_contents():
+        with contextlib.suppress(OSError):
+            path.chmod(DIR_MODE if path.is_dir() else FILE_MODE)
+
+
+def _private_contents() -> list[Path]:
+    """Everything woswoar owns that holds plaintext or key material.
+
+    ``history/`` is left out on purpose: it is ciphertext plus a git checkout
+    that reaches tens of thousands of files, and walking it would make this
+    proportional to the size of the archive rather than to the number of days.
+    The roots above it are owner-only, which is what actually stops another
+    user reading any of it.
+    """
+    out = [logs_dir(), *logs_dir().rglob("*")] if logs_dir().is_dir() else []
+    if config_dir().is_dir():
+        out += [p for p in config_dir().iterdir() if p.is_file()]
+    if cache_file().is_file():
+        out.append(cache_file())
+    return out
+
+
+def world_readable() -> list[Path]:
+    """Anything woswoar owns that another user on this machine could read."""
+    roots = [r for r in (data_dir(), config_dir(), cache_dir()) if r.is_dir()]
+    return [p for p in roots + _private_contents() if p.stat().st_mode & 0o077]
+
+
 def write_atomic(path: Path, data: bytes) -> None:
     """Replace ``path``'s contents in one step.
 
@@ -117,7 +202,7 @@ def write_atomic(path: Path, data: bytes) -> None:
     import watermarks, and the sync state. They all go through here so
     a crash mid-write leaves the previous version rather than a corrupt one.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
+    private_dir(path.parent)
     fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}-", suffix=".tmp")
     try:
         with os.fdopen(fd, "wb") as handle:
@@ -218,18 +303,16 @@ def machine_file() -> Path:
 
 
 def save_machine(known: Machine) -> None:
-    path = machine_file()
-    path.parent.mkdir(parents=True, exist_ok=True)
     lines = [f"id={known.id}", f"name={known.name}"]
     if known.identity:
         lines.append(f"identity={known.identity}")
-    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    # Through write_atomic, which creates via mkstemp at 0600. This file names
+    # the identity key's path; it is not secret, but it is nobody else's.
+    write_atomic(machine_file(), ("\n".join(lines) + "\n").encode("utf-8"))
 
     # Mirrored next to the logs so search can label entries without reading
     # config, and so sync has a single file to seal and share.
-    name_file = host_dir(known.id) / _NAME_FILE
-    name_file.parent.mkdir(parents=True, exist_ok=True)
-    name_file.write_text(f"{known.name}\n", encoding="utf-8")
+    write_atomic(host_dir(known.id) / _NAME_FILE, f"{known.name}\n".encode())
 
 
 def default_machine_name() -> str:
@@ -480,10 +563,9 @@ def append_entries(machine_id: str, entries: list[Entry]) -> dict[str, int]:
     written: dict[str, int] = {}
     for day, group in sorted(by_day.items()):
         path = log_file(machine_id, day)
-        path.parent.mkdir(parents=True, exist_ok=True)
         group.sort(key=lambda e: e.ts)
         payload = "".join(f"{format_line(e)}\n" for e in group)
-        with path.open("a", encoding="utf-8") as handle:
+        with private_append(path) as handle:
             handle.write(payload)
         written[path.name] = len(group)
     return written

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -483,10 +483,10 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report, mac:
 
     for day, blocks in pending.items():
         payload = b"".join(blocks)
-        target = store.log_file(host_id, day)
-        target.parent.mkdir(parents=True, exist_ok=True)
-        with target.open("ab") as handle:
-            handle.write(payload)
+        # Another machine's history is no less private than this one's, and it
+        # lands in the same tree, so it is created with the same mode.
+        with store.private_append(store.log_file(host_id, day)) as handle:
+            handle.write(payload.decode("utf-8", errors="replace"))
         report.lines_imported += payload.count(b"\n")
 
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -198,9 +198,12 @@ class State:
 @contextmanager
 def lock() -> Iterator[None]:
     """Serialise syncs. A prompt-triggered sync and the timer can collide."""
-    path = store.data_dir() / "sync.lock"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    handle = path.open("w")
+    path = store.private_dir(store.data_dir()) / "sync.lock"
+    # Through the same helper as everything else. The file is empty and holds
+    # nothing secret, but `doctor` walks the data directory and a stray 0644
+    # here would report an exposure that is not one -- an alarm that is wrong
+    # in the harmless direction still teaches people to ignore it.
+    handle = store.private_append(path)
     try:
         try:
             fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -287,7 +290,6 @@ def day_public_key(known: Machine, day: str) -> str:
 
     identity = crypto.generate_identity()
     sealed = crypto.encrypt_to_recipients(identity.secret.encode("utf-8"), recipients())
-    pub_path.parent.mkdir(parents=True, exist_ok=True)
     store.write_atomic(store.day_key(known.id, day), sealed)
     store.write_atomic(pub_path, (identity.public + "\n").encode("utf-8"))
     return identity.public
@@ -382,7 +384,6 @@ def export(known: Machine, state: State, report: Report, now: int, mac: bytes) -
         day = store.day_of_log(log.relpath)
         sealed = crypto.encrypt_to(pack(data), day_public_key(known, day))
         chunk = store.new_chunk(known.id, day, now)
-        chunk.parent.mkdir(parents=True, exist_ok=True)
         store.write_atomic(chunk, store.frame_chunk(sealed, crypto.tag(mac, sealed)))
 
         state.exported[log.relpath] = new_offset
@@ -503,8 +504,7 @@ def _merge_name(known: Machine, host_id: str) -> None:
     except (crypto.AgeError, SyncError, OSError):
         # A name we cannot open is cosmetic; the opaque id still works.
         return
-    local.parent.mkdir(parents=True, exist_ok=True)
-    local.write_bytes(name)
+    store.write_atomic(local, name)
 
 
 # ---------------------------------------------------------------------------
@@ -674,7 +674,6 @@ def choose_identity(new_identity: bool = False, explicit: Path | None = None) ->
         return dedicated
 
     identity = crypto.generate_identity()
-    dedicated.parent.mkdir(parents=True, exist_ok=True)
     store.write_atomic(dedicated, identity.secret.encode("utf-8"))
     dedicated.chmod(0o600)
     return dedicated
@@ -694,7 +693,7 @@ def initialise(
 
     history = store.history_dir()
     if not is_repo():
-        history.parent.mkdir(parents=True, exist_ok=True)
+        store.private_dir(history.parent)
         if remote and not any(history.glob("*")):
             git("clone", "--quiet", remote, str(history), cwd=history.parent)
         else:
@@ -745,7 +744,6 @@ def _write_repo_metadata(known: Machine, identity: Path) -> bool:
 
     seal = store.name_seal(known.id)
     if not seal.is_file():
-        seal.parent.mkdir(parents=True, exist_ok=True)
         store.write_atomic(
             seal,
             crypto.encrypt_to_recipients(f"{known.name}\n".encode(), recipients()),
@@ -938,7 +936,6 @@ def add_recipient(recipient: str, label: str = "") -> bool:
         return False
     path = store.recipients_file()
     existing = path.read_text(encoding="utf-8") if path.is_file() else ""
-    path.parent.mkdir(parents=True, exist_ok=True)
     separator = "" if not existing or existing.endswith("\n") else "\n"
     line = f"{key}{_LABEL_SEP}{label}" if label else key
     store.write_atomic(path, f"{existing}{separator}{line}\n".encode())


### PR DESCRIPTION
Closes #18.

## The problem

bash creates `~/.bash_history` mode `0600`. woswoar created its logs `0644` inside `0755` directories, because `mkdir` and `open(..., "a")` both honour the ambient umask and `022` is the default nearly everywhere.

Those logs hold strictly more than bash's file does — the command, the working directory, the exit status, the duration, and **every other machine's history once sync has run**. So on any box with a group- or world-readable home (shared build boxes, NFS homes, most multi-user servers), installing woswoar made your shell history *more* exposed than not installing it, and one machine with loose home permissions exposed the whole fleet.

Reproduced on a clean install under a stock `umask 022`:

```
755 .../woswoar/logs/hosts/<id>
644 .../woswoar/logs/hosts/<id>/2026-07-30.tsv
644 .../woswoar/config/machine

$ stat -c '%a' ~/.bash_history
600
```

`docs/security.md` claimed local logs were "readable by anyone who can read your home directory — same as `~/.bash_history`". They were strictly worse.

## The fix

Directories are created `0700` and files `0600`, on both sides of the split:

- **`store.private_dir`** creates each component explicitly. `Path.mkdir(parents=True, mode=...)` applies the mode to the leaf only and leaves parents at the umask default — which would have put a `0755 logs/` above a `0700` host directory and defeated the point.
- **`store.private_append`** opens with `O_CREAT` and an explicit mode. A file's mode is fixed at creation, so that is the one moment it can be got right; `open(..., "a")` is exactly where `0644` came from.
- **The hook** creates its directory under `umask 077`, and drops to `077` for the one write a day that creates a file, putting the shell's umask straight back.

The hook mattered independently: Python never touches the log file on the recording path, so fixing `store` alone would not have covered the case the issue was actually about.

**The fork-free guarantee is untouched.** `umask` is a builtin, and the branch is guarded on the day string, so the steady-state cost is one string comparison per command. `TestForkFree.test_clone_count_does_not_scale_with_commands` still passes.

## Upgrades

`woswoar install` re-tightens an existing installation — that is the command people already re-run to upgrade, per the README. Verified against a deliberately loose fixture:

```
before:  755 logs/hosts/abc   644 logs/hosts/abc/2023-11-14.tsv
after:   700 logs/hosts/abc   600 logs/hosts/abc/2023-11-14.tsv
```

It deliberately skips `history/`: that is ciphertext plus a git checkout reaching tens of thousands of files, and walking it would make the migration proportional to the size of the archive rather than the number of days. The roots above it are `0700`, which is what actually stops another user reading any of it.

## Tests

213 total, all passing. Six new, split across the two layers that can each regress independently:

| Test | Property |
|---|---|
| `test_everything_written_is_owner_only` | nothing woswoar writes is group/other readable |
| `test_a_stock_umask_cannot_loosen_them` | forces `umask 022`, the exact cause of the bug |
| `test_an_older_install_is_retightened` | `harden()` fixes a pre-existing loose tree |
| `test_doctor_reports_an_exposed_history` | `doctor` FAILs rather than noting it |
| `test_the_day_file_is_owner_only_under_a_stock_umask` | drives the **real hook** in real bash |
| `test_the_hook_leaves_the_shell_umask_alone` | 077 is restored, so the user's own files are unaffected |

That last one is the failure mode a careless fix would introduce: silently leaving every file the user creates afterwards at `0600` is a surprising thing for a history tool to do to a shell.

## Also

- `woswoar doctor` gains a `private` check that FAILs when anything woswoar owns is readable by another user, and points at `woswoar install`.
- `docs/security.md` states what is now true, and the guarantees table gains a row — the claim is asserted in CI rather than in prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
