### PR TITLE
Pin the recent security fixes with tests that actually fail without them

### DIFF
--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -119,5 +119,26 @@ class TestLines(unittest.TestCase):
         self.assertEqual(parsed.cmd, "awk -F'\t' '{print $1}'")
 
 
+class TestParsedCommandsAreBounded(unittest.TestCase):
+    def test_an_over_long_line_is_clamped_on_the_way_in(self) -> None:
+        """`format_line` clamps what this machine writes; `parse_line` clamps
+        what arrives.
+
+        A line can reach the logs from another machine's chunk, where the only
+        thing bounding its length is whatever wrote it -- and every consumer
+        from the cache to the picker assumes MAX_CMD_CHARS holds.
+        """
+        raw = "1700000000\ts1\t~\t0\t5\t" + "x" * (MAX_CMD_CHARS * 3)
+        parsed = parse_line(raw, "host")
+        assert parsed is not None
+        self.assertLessEqual(len(parsed.cmd), MAX_CMD_CHARS + len(TRUNCATION_MARKER))
+        self.assertTrue(parsed.cmd.endswith(TRUNCATION_MARKER))
+
+    def test_an_ordinary_command_is_returned_whole(self) -> None:
+        parsed = parse_line("1700000000\ts1\t~\t0\t5\tgit status", "host")
+        assert parsed is not None
+        self.assertEqual(parsed.cmd, "git status")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_importer_atuin.py
+++ b/tests/test_importer_atuin.py
@@ -432,5 +432,29 @@ class TestFailures(AtuinTestCase):
         self.assertEqual(db.read_bytes(), before)
 
 
+class TestImportIsPrivate(AtuinTestCase):
+    """`import` writes into logs/ too, and used to bypass the store helpers.
+
+    It created a peer's `.name` with a hand-rolled mkdir plus write_text, so
+    `woswoar import` followed by `woswoar doctor` reported an exposure that a
+    current-version command had just caused -- and pointed the user at a
+    migration to fix damage nothing had migrated away from.
+    """
+
+    def test_a_peers_name_file_is_owner_only(self) -> None:
+        previous = os.umask(0o022)
+        self.addCleanup(os.umask, previous)
+        db = self.atuin([(BASE, 0, 0, "make -j8", "/src", "s1", "elsewhere:someone")])
+
+        importer.run("atuin", db)
+
+        names = list(store.logs_dir().rglob(".name"))
+        self.assertTrue(names, "no peer name file was written")
+        for path in [*names, *(p.parent for p in names)]:
+            self.assertEqual(
+                path.stat().st_mode & 0o077, 0, f"{path} is {oct(path.stat().st_mode)}"
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -135,14 +135,18 @@ class TestPrivateByDefault(WoswoarTestCase):
             if p.stat().st_mode & 0o077 and store.history_dir() not in [p, *p.parents]
         )
 
-    def first_run(self) -> None:
-        """What a real first run writes, through the real entry points.
+    def as_if_never_installed(self) -> None:
+        """Drop the config directory the shared harness pre-creates.
 
-        The shared harness pre-creates the config directory with a plain
-        mkdir; removing it first means the assertions are about directories
-        woswoar actually created rather than ones it inherited.
+        It is made with a plain mkdir at the ambient umask, so leaving it would
+        make every assertion here about a directory woswoar inherited rather
+        than one it created.
         """
         shutil.rmtree(store.config_dir())
+
+    def first_run(self) -> None:
+        """What a real first run writes, through the real entry points."""
+        self.as_if_never_installed()
         store.save_machine(store.machine())
         store.append_entries(MACHINE_ID, [make_entry(1_700_000_000, "git status")])
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from woswoar import cache, crypto, search, store, sync
 from woswoar.entry import Entry, format_line
+from woswoar.errors import WoswoarError
 from woswoar.sync import COMMIT_MESSAGE as COMMIT
 
 from . import support
@@ -676,6 +677,75 @@ class TestSyncIsPrivate(SyncTestCase):
             sync.run()
             exposed = store.readable_by_others()
             self.assertEqual(exposed, [], f"sync left {exposed} readable by others")
+
+
+class TestRepoKeyIsNeverMintedTwice(SyncTestCase):
+    """Creation belongs to `initialise`, opening to everything else.
+
+    `mac.age` is one shared path at the repo root, unlike a day key, which
+    lives under a host id nobody else writes. If a routine sync minted it when
+    absent, two machines on the one-minute timer would each tag chunks with a
+    key the other will never hold -- and `.gitattributes` marks ``*.age
+    -merge``, so the rebase conflicts and the timer replays that conflict
+    forever.
+    """
+
+    def test_sync_reports_rather_than_minting_a_replacement(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            before = store.mac_key_file().read_bytes()
+            store.mac_key_file().unlink()
+
+            report = sync.run()
+            self.assertTrue(report.needs_grant, "a missing repo key was papered over")
+            self.assertFalse(store.mac_key_file().is_file(), "sync minted a competing repo key")
+            self.assertEqual(report.chunks_written, 0)
+
+            # And the real one still works once it is back.
+            store.write_atomic(store.mac_key_file(), before)
+            self.assertFalse(sync.run().needs_grant)
+
+    def test_compacting_without_the_repo_key_refuses(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            for i in range(2):
+                alpha.record("2023-11-14", 1_700_000_000 + i, f"command {i}")
+                sync.run()
+            store.mac_key_file().unlink()
+            with self.assertRaises(WoswoarError):
+                sync.compact(before="2023-11-15")
+
+
+class TestMergedHistoryIsStoredFaithfully(SyncTestCase):
+    def test_a_peers_history_lands_verbatim_and_owner_only(self) -> None:
+        """Merging must not decode-and-re-encode another machine's log.
+
+        A command can hold bytes that are not valid UTF-8 -- a mistyped paste,
+        a filename in another charset -- and the recording machine stored them
+        verbatim. Passing them through a lossy decode to fit a text-mode helper
+        would silently rewrite history that machine got right.
+        """
+        alpha = self.machine("alpha")
+        raw = b"1700000001\ts1\t~\t0\t5\tgrep \xff\xfe binary\n"
+        with alpha.active():
+            path = store.log_file(alpha.id, "2023-11-14")
+            with store.private_append(path, binary=True) as handle:
+                handle.write(raw)
+            sync.run()
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+        with beta.active():
+            sync.run()
+            landed = store.log_file(alpha.id, "2023-11-14")
+            merged = landed.read_bytes()
+            mode = landed.stat().st_mode & 0o777
+        self.assertEqual(merged, raw, "the peer's bytes were rewritten in transit")
+        # Another machine's history is no less private than this machine's, and
+        # it lands in the same tree -- so it is created with the same mode.
+        self.assertEqual(mode & 0o077, 0, f"merged history landed {oct(mode)}")
 
 
 class TestChunkAuthenticity(SyncTestCase):

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -488,8 +488,8 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report, mac:
         payload = b"".join(blocks)
         # Another machine's history is no less private than this one's, and it
         # lands in the same tree, so it is created with the same mode.
-        with store.private_append(store.log_file(host_id, day)) as handle:
-            handle.write(payload.decode("utf-8", errors="replace"))
+        with store.private_append(store.log_file(host_id, day), binary=True) as handle:
+            handle.write(payload)
         report.lines_imported += payload.count(b"\n")
 
 


### PR DESCRIPTION
Regression coverage for the fixes in #29, #30 and #31 — plus one live bug the exercise uncovered.

## Method

I wrote these by **mutation testing**, not by reading the diff: revert each fix, re-run the suite, and see whether anything notices. A regression test that passes with the fix reverted is decoration, and there is no way to tell the difference by inspection.

Against the 215 tests on `main`, four of eight reverted fixes went completely unnoticed:

| reverted fix | before | now caught by |
|---|---|---|
| `mac_key` mints the repo key on demand | **MISSED** | `test_sync_reports_rather_than_minting_a_replacement` |
| `parse_line` stops truncating | **MISSED** | `test_an_over_long_line_is_clamped_on_the_way_in` |
| `import` writes a peer `.name` at the ambient umask | **MISSED** | `test_a_peers_name_file_is_owner_only` |
| merged peer history written at the ambient umask | **MISSED** | `test_a_peers_history_lands_verbatim_and_owner_only` |
| `_private_paths` stops pruning `history/` | caught | `test_a_sync_that_runs_before_install_leaves_nothing_readable` |
| `sync.lock` at the ambient umask | caught | same |
| `compact` stops authenticating what it re-seals | caught | `test_compact_refuses_to_launder_a_chunk_this_machine_did_not_write` |
| picker un-escapes control characters | caught | three `TestRecalledCommandIsInert` cases |

All eight are caught now.

## The live bug it found

`private_append` grew a `binary` mode in #30 specifically so that merging a peer's log would stop decoding it with `errors="replace"` — but `sync.py` was never switched over to pass it. The lossy round trip was still there, silently rewriting bytes another machine had recorded successfully (a mistyped paste, a filename in another charset).

One-line fix. It is the only production change in this PR, and it is now pinned by a test that merges a log containing invalid UTF-8 and compares byte for byte.

## Mutation testing also caught a bad test

My first version of the `import` test drove `woswoar import bash` — and passed against the reverted code, because the peer `.name` write only happens on the **atuin** path. Reading the test, it looked fine. Only the mutation showed it never reached the line it claimed to guard. It now lives in `test_importer_atuin.py` and uses that file's existing fixture.

## Checks

221 tests (up from 215), three consecutive clean runs. ruff, mypy strict and shellcheck clean. The mutation harness is not committed — it edits the tree in place, which is not something to leave lying around in a repo where CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)