### PR TITLE
Show fingerprints in the grant prompt, and confirm only what is new

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -76,7 +76,29 @@ Enrolling a new laptop means publishing a public key — nothing sensitive trave
 and nothing sensitive is stored in the repo.
 
 Widening who can read the archive is therefore a deliberate act: `woswoar grant`
-lists the machines by name and asks before it re-seals anything.
+lists the machines and asks before it re-seals anything.
+
+<details>
+<summary>What that prompt shows, and why not just the names</summary>
+
+`recipients.txt` is plain text and `merge=union`, so anyone who can push can
+append a key labelled `martin@laptop` alongside your real one. A confirmation
+that shows only names is therefore a confirmation of attacker-supplied text, and
+approving it hands over the whole archive without breaking any encryption.
+
+So the prompt leads with a **fingerprint**, which is derived from the key and
+cannot be chosen: for an SSH key it is exactly what `ssh-keygen -lf` prints on
+the machine itself, and an age recipient is already its own. Names are printed
+inert and quoted — a label cannot carry an escape sequence that erases the line
+above it — and two keys sharing one name are marked as such.
+
+Only **additions** are put to you. Re-sealing to a set you already approved
+widens nothing, so it does not ask; a prompt that fires when there is nothing to
+decide is one people learn to answer without reading. What you last approved is
+remembered locally, on purpose: a record kept in the repo could be edited by the
+attacker the prompt exists to catch.
+
+</details>
 
 <details>
 <summary>What if my SSH key has a passphrase?</summary>

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -118,6 +118,59 @@ class TestWhyUnusable(unittest.TestCase):
         self.assertNotIn("passphrase", reason)
 
 
+class TestFingerprint(unittest.TestCase):
+    """What `grant` shows instead of a name anyone with push access can write."""
+
+    @requires_ssh_keygen
+    def test_an_ssh_key_gets_the_fingerprint_ssh_keygen_prints(self) -> None:
+        """Not a detail: the value of the fingerprint is that it can be checked
+        against the machine itself, with the tool already installed there."""
+        with tempfile.TemporaryDirectory(prefix="woswoar-fp-") as tmp:
+            key = Path(tmp) / "id_ed25519"
+            subprocess.run(
+                ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", str(key), "-q", "-C", "box"],
+                check=True,
+                timeout=60,
+            )
+            listed = subprocess.run(
+                ["ssh-keygen", "-lf", str(key.with_suffix(".pub"))],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            ).stdout.split()[1]
+            pub = key.with_suffix(".pub").read_text(encoding="utf-8").strip()
+
+        self.assertTrue(listed.startswith("SHA256:"))
+        self.assertEqual(crypto.fingerprint(pub), listed)
+
+    def test_the_comment_field_cannot_change_an_ssh_fingerprint(self) -> None:
+        # The comment is the part a label is usually taken from, and the part
+        # anyone editing recipients.txt can rewrite.
+        blob = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB7Ep0mZ0mCwvvzMLbaXn8g4mBIhnCEE1zLLuqA6IGGz"
+        self.assertEqual(
+            crypto.fingerprint(f"{blob} martin@laptop"),
+            crypto.fingerprint(f"{blob} martin@laptop-but-not-really"),
+        )
+
+    def test_two_keys_never_share_a_fingerprint(self) -> None:
+        first = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB7Ep0mZ0mCwvvzMLbaXn8g4mBIhnCEE1zLLuqA6IGGz"
+        second = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB7Ep0mZ0mCwvvzMLbaXn8g4mBIhnCEE1zLLuqA6IGGy"
+        self.assertNotEqual(crypto.fingerprint(first), crypto.fingerprint(second))
+
+    def test_an_age_recipient_is_its_own_fingerprint(self) -> None:
+        # Short, canonical, and reproducible with `age-keygen -y`, so hashing it
+        # would only make it harder to check.
+        key = "age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwwwwww"
+        self.assertEqual(crypto.fingerprint(f"{key}  "), key)
+
+    def test_a_key_that_parses_as_neither_still_yields_something_printable(self) -> None:
+        # A hand-edited recipients.txt must not take the confirmation down with
+        # a traceback -- that is the one moment it has to still work.
+        self.assertEqual(crypto.fingerprint(""), "")
+        self.assertEqual(crypto.fingerprint("ssh-rsa not-base64!! box"), "ssh-rsa")
+
+
 class TestChunkFraming(unittest.TestCase):
     def test_the_tag_width_store_uses_matches_the_one_crypto_produces(self) -> None:
         """`store` deliberately does not import `crypto`.

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -21,6 +21,23 @@ from .support import requires_age, requires_ssh_keygen
 #: pipe, not a file in $HOME, which is what the rule is actually about.
 _ALLOWED_PATH_PREFIX = "/dev/fd/"
 
+#: A real ed25519 public key, and the same key with its last character changed.
+#: Spelled this way so "these differ in one character of key material" is
+#: visible rather than something a reader has to diff by eye.
+_SSH_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB7Ep0mZ0mCwvvzMLbaXn8g4mBIhnCEE1zLLuqA6IGGz"
+_SSH_KEY_ALMOST = _SSH_KEY[:-1] + "y"
+
+
+def make_ssh_identity(directory: Path, comment: str = "woswoar-test") -> Path:
+    """A throwaway ed25519 keypair, returning the private half's path."""
+    key = directory / "id_ed25519"
+    subprocess.run(
+        ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", str(key), "-q", "-C", comment],
+        check=True,
+        timeout=60,
+    )
+    return key
+
 
 @requires_age
 class TestNoAgeCallNamesAFile(unittest.TestCase):
@@ -43,13 +60,7 @@ class TestNoAgeCallNamesAFile(unittest.TestCase):
         return path
 
     def ssh_identity(self) -> Path:
-        key = self.tmp / "id_ed25519"
-        subprocess.run(
-            ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", str(key), "-q", "-C", "woswoar-test"],
-            check=True,
-            timeout=60,
-        )
-        return key
+        return make_ssh_identity(self.tmp)
 
     def assert_named_no_file(self, spy: mock.Mock) -> None:
         for call in spy.call_args_list:
@@ -126,20 +137,17 @@ class TestFingerprint(unittest.TestCase):
         """Not a detail: the value of the fingerprint is that it can be checked
         against the machine itself, with the tool already installed there."""
         with tempfile.TemporaryDirectory(prefix="woswoar-fp-") as tmp:
-            key = Path(tmp) / "id_ed25519"
-            subprocess.run(
-                ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", str(key), "-q", "-C", "box"],
-                check=True,
-                timeout=60,
-            )
+            key = make_ssh_identity(Path(tmp), comment="box")
+            # Through `recipient_for`, so this exercises the rule the product
+            # uses to find the .pub sibling rather than a second guess at it.
+            pub = crypto.recipient_for(key)
             listed = subprocess.run(
-                ["ssh-keygen", "-lf", str(key.with_suffix(".pub"))],
+                ["ssh-keygen", "-lf", str(key) + ".pub"],
                 check=True,
                 capture_output=True,
                 text=True,
                 timeout=60,
             ).stdout.split()[1]
-            pub = key.with_suffix(".pub").read_text(encoding="utf-8").strip()
 
         self.assertTrue(listed.startswith("SHA256:"))
         self.assertEqual(crypto.fingerprint(pub), listed)
@@ -147,16 +155,13 @@ class TestFingerprint(unittest.TestCase):
     def test_the_comment_field_cannot_change_an_ssh_fingerprint(self) -> None:
         # The comment is the part a label is usually taken from, and the part
         # anyone editing recipients.txt can rewrite.
-        blob = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB7Ep0mZ0mCwvvzMLbaXn8g4mBIhnCEE1zLLuqA6IGGz"
         self.assertEqual(
-            crypto.fingerprint(f"{blob} martin@laptop"),
-            crypto.fingerprint(f"{blob} martin@laptop-but-not-really"),
+            crypto.fingerprint(f"{_SSH_KEY} martin@laptop"),
+            crypto.fingerprint(f"{_SSH_KEY} martin@laptop-but-not-really"),
         )
 
     def test_two_keys_never_share_a_fingerprint(self) -> None:
-        first = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB7Ep0mZ0mCwvvzMLbaXn8g4mBIhnCEE1zLLuqA6IGGz"
-        second = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB7Ep0mZ0mCwvvzMLbaXn8g4mBIhnCEE1zLLuqA6IGGy"
-        self.assertNotEqual(crypto.fingerprint(first), crypto.fingerprint(second))
+        self.assertNotEqual(crypto.fingerprint(_SSH_KEY), crypto.fingerprint(_SSH_KEY_ALMOST))
 
     def test_an_age_recipient_is_its_own_fingerprint(self) -> None:
         # Short, canonical, and reproducible with `age-keygen -y`, so hashing it
@@ -164,11 +169,22 @@ class TestFingerprint(unittest.TestCase):
         key = "age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwwwwww"
         self.assertEqual(crypto.fingerprint(f"{key}  "), key)
 
-    def test_a_key_that_parses_as_neither_still_yields_something_printable(self) -> None:
-        # A hand-edited recipients.txt must not take the confirmation down with
-        # a traceback -- that is the one moment it has to still work.
+    def test_a_line_that_parses_as_neither_is_still_derived_from_itself(self) -> None:
+        """A hand-edited recipients.txt must not take the confirmation down with
+        a traceback -- that is the one moment it has to still work -- and must
+        not render two different lines as the same machine either.
+        """
+        first = crypto.fingerprint("ssh-rsa not-base64!! martin@laptop")
+        second = crypto.fingerprint("ssh-rsa also-not-base64!! martin@laptop")
+        self.assertNotEqual(first, second)
+        self.assertTrue(first.startswith("SHA256:"))
         self.assertEqual(crypto.fingerprint(""), "")
-        self.assertEqual(crypto.fingerprint("ssh-rsa not-base64!! box"), "ssh-rsa")
+
+    def test_the_check_command_matches_the_kind_of_fingerprint(self) -> None:
+        # Telling someone to run ssh-keygen against an age identity is advice
+        # that cannot work, on the one screen where advice has to.
+        self.assertIn("ssh-keygen", crypto.how_to_check(crypto.fingerprint(_SSH_KEY)))
+        self.assertIn("age-keygen", crypto.how_to_check(crypto.fingerprint("age1qqqqwwwwww")))
 
 
 class TestChunkFraming(unittest.TestCase):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -93,18 +93,17 @@ class Fake:
     def commands(self) -> set[str]:
         return {e.cmd for e in cache.load_entries()}
 
+    def append_recipient(self, label: str) -> str:
+        """Add a key to recipients.txt behind woswoar's back, and return it.
 
-def append_recipient(label: str) -> str:
-    """Add a key to recipients.txt behind woswoar's back, and return it.
-
-    Written straight to the file rather than through `sync.add_recipient`,
-    because that is what the other end of a shared repo looks like: a line that
-    arrived by `git pull`, with a label nothing on this machine sanitised.
-    """
-    key = crypto.generate_identity().public
-    with store.recipients_file().open("a", encoding="utf-8") as handle:
-        handle.write(f"{key}{sync._LABEL_SEP}{label}\n")
-    return key
+        Written straight to the file rather than through `sync.add_recipient`,
+        because that is what the other end of a shared repo looks like: a line
+        that arrived by `git pull`, with a label nothing here sanitised.
+        """
+        key = crypto.generate_identity().public
+        with store.recipients_file().open("a", encoding="utf-8") as handle:
+            handle.write(f"{key}{sync._LABEL_SEP}{label}\n")
+        return key
 
 
 @requires_age
@@ -484,21 +483,12 @@ class TestGrantConfirmation(SyncTestCase):
             labels = {reader.label for reader in sync.readers()}
         self.assertIn("martinus@box", labels)
 
-    def test_an_unlabelled_key_still_gets_a_readable_handle(self) -> None:
-        # recipients.txt written by an older woswoar, or hand-edited.
-        alpha = self.machine("alpha")
-        with alpha.active():
-            path = store.recipients_file()
-            path.write_text(f"{crypto.generate_identity().public}\n", encoding="utf-8")
-            (reader,) = sync.readers()
-            self.assertTrue(reader.label)
-            self.assertNotIn(sync._LABEL_SEP, reader.key)
+    def test_an_unlabelled_key_gets_a_handle_that_is_not_the_key(self) -> None:
+        """recipients.txt written by an older woswoar, or hand-edited.
 
-    def test_an_unlabelled_key_is_never_named_after_itself(self) -> None:
-        """The fallback label used to be an abbreviation of the key.
-
-        That let a *chosen* label impersonate one, which is the whole weakness:
-        a name in this file is written by whoever added the key.
+        The fallback label used to be an abbreviation of the key, which let a
+        *chosen* label impersonate one -- and that is the whole weakness: a name
+        in this file is written by whoever added the key.
         """
         alpha = self.machine("alpha")
         with alpha.active():
@@ -506,6 +496,8 @@ class TestGrantConfirmation(SyncTestCase):
             store.recipients_file().write_text(f"{key}\n", encoding="utf-8")
             (reader,) = sync.readers()
 
+        self.assertTrue(reader.label)
+        self.assertNotIn(sync._LABEL_SEP, reader.key)
         # Split on the abbreviation's own ellipsis, so a label built out of both
         # ends of the key is caught rather than only one made of a single run.
         self.assertFalse(
@@ -537,13 +529,13 @@ class TestGrantConfirmation(SyncTestCase):
         self.machine("beta")  # enrols behind alpha's back
 
         with alpha.active(), self.assertRaises(sync.SyncError) as caught:
-            sync.grant(confirmed=approved)
+            sync.grant(approved=approved)
         self.assertIn("changed while you were deciding", str(caught.exception))
 
     def test_granting_with_the_approved_list_goes_ahead(self) -> None:
         alpha = self.machine("alpha")
         with alpha.active():
-            report = sync.grant(confirmed=[reader.key for reader in sync.readers()])
+            report = sync.grant(approved=[reader.key for reader in sync.readers()])
             self.assertGreater(report.resealed, 0)
 
     def test_a_label_cannot_drive_the_terminal(self) -> None:
@@ -555,7 +547,7 @@ class TestGrantConfirmation(SyncTestCase):
         """
         alpha = self.machine("alpha")
         with alpha.active():
-            append_recipient(label="martin@laptop\x1b[2K\x1b[1A")
+            alpha.append_recipient(label="martin@laptop\x1b[2K\x1b[1A")
             for reader in sync.readers():
                 self.assertNotIn("\x1b", reader.label)
                 self.assertNotIn("\n", reader.label)
@@ -574,17 +566,39 @@ class TestGrantConfirmation(SyncTestCase):
             self.assertEqual(len(sync.recipients()), before + 1)
             self.assertNotIn(intruder, sync.recipients())
 
+    def test_a_key_that_is_not_one_line_is_refused_rather_than_written(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active(), self.assertRaises(sync.SyncError) as caught:
+            sync.add_recipient(f"{crypto.generate_identity().public}\nage1intruder", label="laptop")
+        self.assertIn("not one line", str(caught.exception))
+
     def test_two_keys_with_one_name_are_told_apart(self) -> None:
         """The defence is not that duplicate names are impossible -- two
         machines really can share one -- it is that the identity shown is
-        derived from the key."""
+        derived from the key, and that the collision is said out loud.
+        """
         alpha = self.machine("alpha", display="martin@laptop")
         with alpha.active():
-            append_recipient(label="martin@laptop")
+            alpha.append_recipient(label="martin@laptop")
             readers = sync.readers()
 
         self.assertEqual({reader.label for reader in readers}, {"martin@laptop"})
         self.assertEqual(len({reader.fingerprint for reader in readers}), 2)
+        self.assertTrue(all(reader.shares_name for reader in readers))
+
+    def test_a_name_nobody_else_uses_is_not_flagged(self) -> None:
+        alpha = self.machine("alpha", display="martin@laptop")
+        with alpha.active():
+            alpha.append_recipient(label="martin@desktop")
+            self.assertFalse(any(reader.shares_name for reader in sync.readers()))
+
+    def test_the_machine_the_human_is_sitting_at_is_marked(self) -> None:
+        alpha = self.machine("alpha", display="martin@laptop")
+        with alpha.active():
+            mine = crypto.recipient_for(sync.identity_path(store.machine())).strip()
+            alpha.append_recipient(label="martin@desktop")
+            marked = [reader.key for reader in sync.readers() if reader.is_mine]
+        self.assertEqual(marked, [mine])
 
 
 class TestGrantConfirmsAdditions(SyncTestCase):
@@ -609,8 +623,8 @@ class TestGrantConfirmsAdditions(SyncTestCase):
             self.assertFalse(any(reader.is_new for reader in sync.readers()))
 
     def test_a_grant_nobody_approved_does_not_silence_the_next_prompt(self) -> None:
-        """`confirmed=None` means no human saw a list, so no decision was made
-        to remember."""
+        """Omitting `approved` means no human saw a list, so there was no
+        decision to remember."""
         alpha = self.machine("alpha")
         with alpha.active():
             sync.grant()
@@ -623,7 +637,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         # Exactly what push access alone buys: append a key labelled like one of
         # the machines that is already there.
         with alpha.active():
-            forged = append_recipient(label="martin@laptop")
+            forged = alpha.append_recipient(label="martin@laptop")
             new = [reader for reader in sync.readers() if reader.is_new]
 
         self.assertEqual([reader.key for reader in new], [forged])
@@ -632,7 +646,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         alpha = self.machine("alpha", display="martin@laptop")
         self.grant(alpha, "--yes")
         with alpha.active():
-            append_recipient(label="martin@laptop")
+            alpha.append_recipient(label="martin@laptop")
 
         code, out = self.grant(alpha, "--yes")
         self.assertEqual(code, 0)
@@ -652,7 +666,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         hostile = "  martin@desktop\u202e"
         alpha = self.machine("alpha", display="martin@laptop")
         with alpha.active():
-            append_recipient(label=hostile)
+            alpha.append_recipient(label=hostile)
 
         _, out = self.grant(alpha, "--yes")
         self.assertIn("martin@desktop", out)
@@ -677,7 +691,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         alpha = self.machine("alpha")
         self.grant(alpha, "--yes")
         with alpha.active():
-            append_recipient(label="martin@desktop")
+            alpha.append_recipient(label="martin@desktop")
 
         code, _ = self.grant(alpha)
         self.assertEqual(code, 1)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -7,16 +7,18 @@ are enough, and that is only meaningful if it is actually demonstrated.
 
 from __future__ import annotations
 
+import io
 import os
 import subprocess
 import tempfile
 import unittest
 import zlib
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stdout
 from pathlib import Path
 
 from woswoar import cache, crypto, search, store, sync
+from woswoar.__main__ import main
 from woswoar.entry import Entry, format_line
 from woswoar.errors import WoswoarError
 from woswoar.sync import COMMIT_MESSAGE as COMMIT
@@ -90,6 +92,19 @@ class Fake:
 
     def commands(self) -> set[str]:
         return {e.cmd for e in cache.load_entries()}
+
+
+def append_recipient(label: str) -> str:
+    """Add a key to recipients.txt behind woswoar's back, and return it.
+
+    Written straight to the file rather than through `sync.add_recipient`,
+    because that is what the other end of a shared repo looks like: a line that
+    arrived by `git pull`, with a label nothing on this machine sanitised.
+    """
+    key = crypto.generate_identity().public
+    with store.recipients_file().open("a", encoding="utf-8") as handle:
+        handle.write(f"{key}{sync._LABEL_SEP}{label}\n")
+    return key
 
 
 @requires_age
@@ -466,7 +481,7 @@ class TestGrantConfirmation(SyncTestCase):
         # `age1ejf3l4f0nhnp9...` is not something anyone can consent to.
         alpha = self.machine("alpha", display="martinus@box")
         with alpha.active():
-            labels = dict((label, key) for key, label in sync.reader_labels())
+            labels = {reader.label for reader in sync.readers()}
         self.assertIn("martinus@box", labels)
 
     def test_an_unlabelled_key_still_gets_a_readable_handle(self) -> None:
@@ -474,10 +489,29 @@ class TestGrantConfirmation(SyncTestCase):
         alpha = self.machine("alpha")
         with alpha.active():
             path = store.recipients_file()
-            path.write_text("age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwwwwww\n", encoding="utf-8")
-            ((key, label),) = sync.reader_labels()
-            self.assertTrue(label)
-            self.assertNotIn(sync._LABEL_SEP, key)
+            path.write_text(f"{crypto.generate_identity().public}\n", encoding="utf-8")
+            (reader,) = sync.readers()
+            self.assertTrue(reader.label)
+            self.assertNotIn(sync._LABEL_SEP, reader.key)
+
+    def test_an_unlabelled_key_is_never_named_after_itself(self) -> None:
+        """The fallback label used to be an abbreviation of the key.
+
+        That let a *chosen* label impersonate one, which is the whole weakness:
+        a name in this file is written by whoever added the key.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            key = crypto.generate_identity().public
+            store.recipients_file().write_text(f"{key}\n", encoding="utf-8")
+            (reader,) = sync.readers()
+
+        # Split on the abbreviation's own ellipsis, so a label built out of both
+        # ends of the key is caught rather than only one made of a single run.
+        self.assertFalse(
+            any(part and part in key for part in reader.label.split("...")),
+            f"the label {reader.label!r} is made out of the key it names",
+        )
 
     def test_a_key_listed_twice_is_offered_to_age_once(self) -> None:
         """`recipients.txt` is `merge=union`.
@@ -499,7 +533,7 @@ class TestGrantConfirmation(SyncTestCase):
         than none, so the approved list is checked against the fetched one."""
         alpha = self.machine("alpha")
         with alpha.active():
-            approved = sync.readers()
+            approved = [reader.key for reader in sync.readers()]
         self.machine("beta")  # enrols behind alpha's back
 
         with alpha.active(), self.assertRaises(sync.SyncError) as caught:
@@ -509,8 +543,146 @@ class TestGrantConfirmation(SyncTestCase):
     def test_granting_with_the_approved_list_goes_ahead(self) -> None:
         alpha = self.machine("alpha")
         with alpha.active():
-            report = sync.grant(confirmed=sync.readers())
+            report = sync.grant(confirmed=[reader.key for reader in sync.readers()])
             self.assertGreater(report.resealed, 0)
+
+    def test_a_label_cannot_drive_the_terminal(self) -> None:
+        """`\\x1b[1A\\x1b[2K` moves the cursor up a line and erases it.
+
+        A label is free text appended by whoever added the key, so on a shared
+        repo it is attacker input, and the one place it is printed is the prompt
+        where a human decides who may read everything.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            append_recipient(label="martin@laptop\x1b[2K\x1b[1A")
+            for reader in sync.readers():
+                self.assertNotIn("\x1b", reader.label)
+                self.assertNotIn("\n", reader.label)
+
+    def test_a_label_written_here_cannot_forge_a_second_entry(self) -> None:
+        """The label comes from this machine's config file, so it is not
+        guaranteed to be one line just because a name usually is."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            before = len(sync.recipients())
+            intruder = crypto.generate_identity().public
+            sync.add_recipient(
+                crypto.generate_identity().public,
+                label=f"laptop\n{intruder}{sync._LABEL_SEP}desktop",
+            )
+            self.assertEqual(len(sync.recipients()), before + 1)
+            self.assertNotIn(intruder, sync.recipients())
+
+    def test_two_keys_with_one_name_are_told_apart(self) -> None:
+        """The defence is not that duplicate names are impossible -- two
+        machines really can share one -- it is that the identity shown is
+        derived from the key."""
+        alpha = self.machine("alpha", display="martin@laptop")
+        with alpha.active():
+            append_recipient(label="martin@laptop")
+            readers = sync.readers()
+
+        self.assertEqual({reader.label for reader in readers}, {"martin@laptop"})
+        self.assertEqual(len({reader.fingerprint for reader in readers}), 2)
+
+
+class TestGrantConfirmsAdditions(SyncTestCase):
+    """A confirmation listing everything makes the one new line easy to miss."""
+
+    def grant(self, fake: Fake, *args: str) -> tuple[int, str]:
+        buffer = io.StringIO()
+        with fake.active(), redirect_stdout(buffer):
+            code = main(["grant", *args])
+        return code, buffer.getvalue()
+
+    def test_the_first_grant_reports_every_machine_as_new(self) -> None:
+        alpha = self.machine("alpha", display="martin@laptop")
+        with alpha.active():
+            self.assertTrue(all(reader.is_new for reader in sync.readers()))
+
+    def test_granting_remembers_who_was_approved(self) -> None:
+        alpha = self.machine("alpha")
+        code, _ = self.grant(alpha, "--yes")
+        self.assertEqual(code, 0)
+        with alpha.active():
+            self.assertFalse(any(reader.is_new for reader in sync.readers()))
+
+    def test_a_grant_nobody_approved_does_not_silence_the_next_prompt(self) -> None:
+        """`confirmed=None` means no human saw a list, so no decision was made
+        to remember."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.grant()
+            self.assertTrue(all(reader.is_new for reader in sync.readers()))
+
+    def test_a_key_appended_afterwards_is_the_only_one_reported_as_new(self) -> None:
+        alpha = self.machine("alpha", display="martin@laptop")
+        self.grant(alpha, "--yes")
+
+        # Exactly what push access alone buys: append a key labelled like one of
+        # the machines that is already there.
+        with alpha.active():
+            forged = append_recipient(label="martin@laptop")
+            new = [reader for reader in sync.readers() if reader.is_new]
+
+        self.assertEqual([reader.key for reader in new], [forged])
+
+    def test_a_new_key_is_put_to_the_human_even_with_a_familiar_name(self) -> None:
+        alpha = self.machine("alpha", display="martin@laptop")
+        self.grant(alpha, "--yes")
+        with alpha.active():
+            append_recipient(label="martin@laptop")
+
+        code, out = self.grant(alpha, "--yes")
+        self.assertEqual(code, 0)
+        self.assertIn("1 machine(s) NOT yet granted", out)
+        self.assertIn("SAME NAME AS ANOTHER KEY", out)
+
+    def test_no_label_can_put_an_escape_sequence_on_the_prompt(self) -> None:
+        """The second half of the defence, and independent of the first.
+
+        `make_inert` handles C0; printing with `repr` covers what is left --
+        anything Python calls unprintable, a bidi override among them -- and
+        quotes the label so leading whitespace is visible rather than shifting
+        the line it is on.
+        """
+        # U+202E flips the direction of everything after it, and is neither a
+        # control character nor anything `make_inert` touches.
+        hostile = "  martin@desktop\u202e"
+        alpha = self.machine("alpha", display="martin@laptop")
+        with alpha.active():
+            append_recipient(label=hostile)
+
+        _, out = self.grant(alpha, "--yes")
+        self.assertIn("martin@desktop", out)
+        self.assertNotIn(hostile, out)
+        self.assertNotIn("\u202e", out)
+
+    def test_re_sealing_to_an_unchanged_set_does_not_ask(self) -> None:
+        """Nothing is widened, so there is nothing to consent to -- and a prompt
+        that fires when there is nothing to decide is one people stop reading.
+
+        Driven without `--yes` and without a terminal, which is exactly what the
+        old code refused.
+        """
+        alpha = self.machine("alpha")
+        self.grant(alpha, "--yes")
+
+        code, out = self.grant(alpha)
+        self.assertEqual(code, 0)
+        self.assertIn("No machine is new", out)
+
+    def test_a_new_machine_without_yes_and_without_a_terminal_is_refused(self) -> None:
+        alpha = self.machine("alpha")
+        self.grant(alpha, "--yes")
+        with alpha.active():
+            append_recipient(label="martin@desktop")
+
+        code, _ = self.grant(alpha)
+        self.assertEqual(code, 1)
+        with alpha.active():
+            self.assertTrue(any(reader.is_new for reader in sync.readers()))
 
 
 class TestChunkNaming(support.WoswoarTestCase):

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -300,7 +300,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
 
 def cmd_init(args: argparse.Namespace) -> int:
-    from . import sync
+    from . import crypto, sync
 
     known, identity = sync.initialise(
         remote=args.remote,
@@ -312,8 +312,11 @@ def cmd_init(args: argparse.Namespace) -> int:
     print(f"repo     : {store.history_dir()}")
     print(f"remote   : {sync.remote_summary()}")
     print(f"\nRecipients now enrolled ({store.recipients_file()}):")
-    for kind, key in sync.list_recipients():
-        print(f"  {kind} {key[:24]}...")
+    # By fingerprint, not by a truncated key. A prefix of a key looks checkable
+    # and is not -- it is the abbreviation `grant` stopped using for exactly
+    # that reason, and this is the listing someone reads first.
+    for key in sync.recipients():
+        print(f"  {crypto.fingerprint(key)}")
     if args.remote:
         print("\nNext: 'woswoar sync'.")
         print("On a machine that already has access, run 'woswoar grant' so this")
@@ -363,22 +366,21 @@ def cmd_sync(args: argparse.Namespace) -> int:
     return 0
 
 
-def _show_readers(readers: list[Reader], mine: str, duplicated: set[str]) -> None:
+def _show_readers(readers: list[Reader]) -> None:
     """One line per machine: fingerprint first, then the name.
 
     The fingerprint leads because it is the only part of the line the repo
-    cannot choose. A label is printed with `repr`, so leading spaces, a tab, or
-    anything Python considers unprintable -- a bidi override, say -- shows up as
-    an escape instead of rearranging the line it is on.
+    cannot choose. Everything the notes report is decided in `sync.readers`;
+    this is only where it is worded.
     """
     for reader in readers:
         notes = []
-        if reader.key == mine:
+        if reader.is_mine:
             notes.append("this machine")
-        if reader.label in duplicated:
+        if reader.shares_name:
             notes.append("SAME NAME AS ANOTHER KEY")
         suffix = f"   ({', '.join(notes)})" if notes else ""
-        print(f"  {reader.fingerprint}  {reader.label!r}{suffix}")
+        print(f"  {reader.fingerprint}  {reader.display_name()}{suffix}")
 
 
 def cmd_grant(args: argparse.Namespace) -> int:
@@ -390,43 +392,24 @@ def cmd_grant(args: argparse.Namespace) -> int:
         print("no machines enrolled yet; run 'woswoar init <url>' first", file=sys.stderr)
         return 1
 
-    try:
-        mine = crypto.recipient_for(sync.identity_path(store.machine())).strip()
-    except (WoswoarError, OSError):
-        mine = ""
-
-    # Two keys may legitimately share a name -- two machines really can both be
-    # called `martin@laptop`. Saying so is the point: it is also what a key
-    # added by someone else looks like, and the fingerprints then differ.
-    counts = Counter(reader.label for reader in readers)
-    duplicated = {label for label, count in counts.items() if count > 1}
-
     new = [reader for reader in readers if reader.is_new]
     known = [reader for reader in readers if not reader.is_new]
 
     if new:
         print(f"{len(new)} machine(s) NOT yet granted. Granting lets each of them read")
         print("your ENTIRE history, including days recorded before it ever existed:\n")
-        _show_readers(new, mine, duplicated)
+        _show_readers(new)
         if known:
             print(f"\nAlready granted, and unchanged ({len(known)}):\n")
-            _show_readers(known, mine, duplicated)
+            _show_readers(known)
     else:
-        print(f"No machine is new since you last granted. Re-sealing to the same {len(readers)}:\n")
-        _show_readers(readers, mine, duplicated)
+        print(f"No machine is new since you last granted. Re-sealing to the same {len(known)}:\n")
+        _show_readers(known)
 
     # Named for the kinds actually listed. A blanket ssh-keygen line is wrong
     # advice on a fleet that uses `--new-identity` everywhere, and advice that
     # does not fit what is on screen is advice nobody follows.
-    kinds = {reader.fingerprint.startswith("SHA256:") for reader in readers}
-    checks = [
-        command
-        for is_ssh, command in (
-            (True, "ssh-keygen -lf ~/.ssh/id_ed25519.pub"),
-            (False, "age-keygen -y ~/.config/woswoar/identity"),
-        )
-        if is_ssh in kinds
-    ]
+    checks = dict.fromkeys(crypto.how_to_check(reader.fingerprint) for reader in readers)
     print(
         "\nThe name beside a key is free text written by whoever added it, so check"
         f"\nthe key itself on the machine it belongs to:  {'  or  '.join(checks)}"
@@ -452,7 +435,7 @@ def cmd_grant(args: argparse.Namespace) -> int:
             print("Nothing changed.")
             return 1
 
-    report = sync.grant(confirmed=[reader.key for reader in readers])
+    report = sync.grant(approved=[reader.key for reader in readers])
     print(f"\nre-sealed {report.resealed} key file(s)")
     if report.pushed:
         print("published to the remote")

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -9,9 +9,13 @@ import sys
 import time
 from collections import Counter
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from . import __version__, cache, importer, search, store
 from .errors import WoswoarError
+
+if TYPE_CHECKING:  # `sync` is imported lazily; only the annotation needs it.
+    from .sync import Reader
 
 #: Both "no repo key yet" and "some days unreadable" have the same fix, and
 #: used to say so in two independently worded paragraphs.
@@ -359,12 +363,30 @@ def cmd_sync(args: argparse.Namespace) -> int:
     return 0
 
 
+def _show_readers(readers: list[Reader], mine: str, duplicated: set[str]) -> None:
+    """One line per machine: fingerprint first, then the name.
+
+    The fingerprint leads because it is the only part of the line the repo
+    cannot choose. A label is printed with `repr`, so leading spaces, a tab, or
+    anything Python considers unprintable -- a bidi override, say -- shows up as
+    an escape instead of rearranging the line it is on.
+    """
+    for reader in readers:
+        notes = []
+        if reader.key == mine:
+            notes.append("this machine")
+        if reader.label in duplicated:
+            notes.append("SAME NAME AS ANOTHER KEY")
+        suffix = f"   ({', '.join(notes)})" if notes else ""
+        print(f"  {reader.fingerprint}  {reader.label!r}{suffix}")
+
+
 def cmd_grant(args: argparse.Namespace) -> int:
     """Let every enrolled machine read the whole history."""
     from . import crypto, sync
 
-    keys = sync.readers()
-    if not keys:
+    readers = sync.readers()
+    if not readers:
         print("no machines enrolled yet; run 'woswoar init <url>' first", file=sys.stderr)
         return 1
 
@@ -373,16 +395,49 @@ def cmd_grant(args: argparse.Namespace) -> int:
     except (WoswoarError, OSError):
         mine = ""
 
-    print("This will let each of these machines read your ENTIRE history,")
-    print("including days recorded before it ever existed:\n")
-    for key, label in sync.reader_labels():
-        print(f"  {label}{'   (this machine)' if key == mine else ''}")
+    # Two keys may legitimately share a name -- two machines really can both be
+    # called `martin@laptop`. Saying so is the point: it is also what a key
+    # added by someone else looks like, and the fingerprints then differ.
+    counts = Counter(reader.label for reader in readers)
+    duplicated = {label for label, count in counts.items() if count > 1}
+
+    new = [reader for reader in readers if reader.is_new]
+    known = [reader for reader in readers if not reader.is_new]
+
+    if new:
+        print(f"{len(new)} machine(s) NOT yet granted. Granting lets each of them read")
+        print("your ENTIRE history, including days recorded before it ever existed:\n")
+        _show_readers(new, mine, duplicated)
+        if known:
+            print(f"\nAlready granted, and unchanged ({len(known)}):\n")
+            _show_readers(known, mine, duplicated)
+    else:
+        print(f"No machine is new since you last granted. Re-sealing to the same {len(readers)}:\n")
+        _show_readers(readers, mine, duplicated)
+
+    # Named for the kinds actually listed. A blanket ssh-keygen line is wrong
+    # advice on a fleet that uses `--new-identity` everywhere, and advice that
+    # does not fit what is on screen is advice nobody follows.
+    kinds = {reader.fingerprint.startswith("SHA256:") for reader in readers}
+    checks = [
+        command
+        for is_ssh, command in (
+            (True, "ssh-keygen -lf ~/.ssh/id_ed25519.pub"),
+            (False, "age-keygen -y ~/.config/woswoar/identity"),
+        )
+        if is_ssh in kinds
+    ]
     print(
-        "\nIt re-seals the small per-day keys -- not the history itself -- and"
+        "\nThe name beside a key is free text written by whoever added it, so check"
+        f"\nthe key itself on the machine it belongs to:  {'  or  '.join(checks)}"
+        "\n\nGranting re-seals the small per-day keys -- not the history itself -- and"
         "\npublishes them. Nothing is decrypted, and nothing else is re-uploaded."
     )
 
-    if not args.yes:
+    # Only additions are put to a human. Re-sealing to a set that was already
+    # approved widens nothing, and a prompt that fires when there is nothing to
+    # decide is a prompt people learn to answer without reading.
+    if new and not args.yes:
         if not sys.stdin.isatty():
             print(
                 "\nRefusing to grant access without confirmation. "
@@ -390,14 +445,14 @@ def cmd_grant(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
-        if input(f"\nGrant all {len(keys)} machines full access? [y/N] ").strip().lower() not in (
+        if input(f"\nGrant {len(new)} new machine(s) full access? [y/N] ").strip().lower() not in (
             "y",
             "yes",
         ):
             print("Nothing changed.")
             return 1
 
-    report = sync.grant(confirmed=keys)
+    report = sync.grant(confirmed=[reader.key for reader in readers])
     print(f"\nre-sealed {report.resealed} key file(s)")
     if report.pushed:
         print("published to the remote")

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -206,6 +206,41 @@ def recipient_for(identity: Path) -> str:
     return public_of(identity.read_text(encoding="utf-8"))
 
 
+def fingerprint(recipient: str) -> str:
+    """A short name for a recipient that is derived from the key, not chosen.
+
+    The label beside a key in ``recipients.txt`` is free text, appended by
+    whoever added the key, and `merge=union` keeps both sides of any conflict.
+    So a human asked to approve *a label* is approving a string an attacker with
+    push access wrote -- ``martin@laptop`` twice, and one of them is not.
+
+    For an SSH key this is byte-for-byte what ``ssh-keygen -lf id_ed25519.pub``
+    prints, which is the point: it can be checked against the machine itself
+    rather than against the repo making the claim. An age recipient is already
+    short, canonical, and derived from its own secret -- ``age-keygen -y``
+    reproduces it -- so it is its own fingerprint and is returned unchanged.
+    """
+    # Imported here rather than at module scope: this runs once per machine on
+    # the `grant` path, while the module is loaded by every sync, and base64
+    # pulls in `re`.
+    import base64
+    import hashlib
+
+    fields = recipient.split()
+    if not fields:
+        return ""
+    if len(fields) >= 2:
+        try:
+            blob = base64.b64decode(fields[1], validate=True)
+        except ValueError:  # binascii.Error is a subclass
+            blob = b""
+        if blob:
+            digest = base64.b64encode(hashlib.sha256(blob).digest()).decode("ascii")
+            # ssh-keygen prints the digest unpadded.
+            return "SHA256:" + digest.rstrip("=")
+    return fields[0]
+
+
 # ---------------------------------------------------------------------------
 # Authenticity. Answers "did one of my machines write this?", which age cannot.
 # ---------------------------------------------------------------------------

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -219,26 +219,46 @@ def fingerprint(recipient: str) -> str:
     rather than against the repo making the claim. An age recipient is already
     short, canonical, and derived from its own secret -- ``age-keygen -y``
     reproduces it -- so it is its own fingerprint and is returned unchanged.
+
+    Anything else -- a hand-edited line, a key type this does not parse -- is
+    hashed whole. It matches no external tool, but it is still derived from the
+    line rather than chosen, which is the property the caller is promised: two
+    malformed entries must not come out looking like the same machine.
     """
-    # Imported here rather than at module scope: this runs once per machine on
-    # the `grant` path, while the module is loaded by every sync, and base64
-    # pulls in `re`.
+    # `hashlib` is imported here rather than at module scope because it costs a
+    # measured 1.3 ms (mostly `_hashlib`) and nothing else pulls it in -- `hmac`
+    # does not, since `tag` passes the digest name as a string. This module is
+    # loaded by every sync, and this function runs once per machine on `grant`.
+    # `base64` is already loaded by then; it is deferred only to sit with it.
     import base64
     import hashlib
+
+    def digest(data: bytes) -> str:
+        # ssh-keygen prints the digest unpadded.
+        return "SHA256:" + base64.b64encode(hashlib.sha256(data).digest()).decode().rstrip("=")
 
     fields = recipient.split()
     if not fields:
         return ""
-    if len(fields) >= 2:
-        try:
-            blob = base64.b64decode(fields[1], validate=True)
-        except ValueError:  # binascii.Error is a subclass
-            blob = b""
-        if blob:
-            digest = base64.b64encode(hashlib.sha256(blob).digest()).decode("ascii")
-            # ssh-keygen prints the digest unpadded.
-            return "SHA256:" + digest.rstrip("=")
-    return fields[0]
+    if len(fields) == 1:
+        return fields[0]
+    try:
+        return digest(base64.b64decode(fields[1], validate=True))
+    except ValueError:  # binascii.Error is a subclass
+        return digest(recipient.encode())
+
+
+#: How to reproduce a fingerprint, keyed by whether it is one we computed.
+#: Beside `fingerprint` on purpose: the format and the command that reproduces
+#: it are one decision, and splitting them is how a prompt ends up telling
+#: someone to run ssh-keygen against an age identity.
+_CHECK_SSH = "ssh-keygen -lf ~/.ssh/id_ed25519.pub"
+_CHECK_AGE = "age-keygen -y ~/.config/woswoar/identity"
+
+
+def how_to_check(fingerprint: str) -> str:
+    """The command that reproduces ``fingerprint`` on the machine it names."""
+    return _CHECK_SSH if fingerprint.startswith("SHA256:") else _CHECK_AGE
 
 
 # ---------------------------------------------------------------------------

--- a/woswoar/entry.py
+++ b/woswoar/entry.py
@@ -112,6 +112,41 @@ def unescape(value: str) -> str:
     return "".join(out)
 
 
+#: Control characters that carry meaning worth preserving are rendered back
+#: into visible escapes; everything else is dropped.
+_INERT = {"\n": "\\n", "\r": "\\r"}
+
+#: C0 plus DEL, minus tab. Everything left either ends a command, forges a line
+#: in a record file, or moves a terminal cursor around. Tab is excluded
+#: deliberately: it is ordinary inside a command -- `awk -F'\t'` is written with
+#: a real one -- and does none of those.
+_CONTROL = frozenset(chr(code) for code in [*range(0x20), 0x7F]) - {"\t"}
+
+
+def make_inert(text: str) -> str:
+    """``text`` with no raw control characters, so it cannot act on its own.
+
+    Two callers, one property. Leaving the fzf picker, this is what keeps a
+    recalled command one command: `escape` maps newlines for *display*, and
+    without this `unescape` would undo that exactly as the text lands in the
+    shell's edit buffer, where bash runs a multi-line buffer as several commands
+    on a single Enter. fzf clips a long line, so the picker can genuinely show
+    one command while handing over two.
+
+    Around a recipient label, it keeps free text that anyone with push access
+    can write from forging a line in ``recipients.txt`` or from driving the
+    terminal during the `grant` confirmation -- ``\\x1b[1A\\x1b[2K`` erases the
+    line above it, which is one way to hide a machine from the list approving
+    it.
+
+    Never applied to what is stored in a log: the history keeps the command as
+    it was typed. A recalled multi-line command therefore comes back with a
+    visible ``\\n`` in it -- wrong to run as-is, but obviously wrong, which beats
+    silently running a command the picker never showed.
+    """
+    return "".join(_INERT.get(char, "") if char in _CONTROL else char for char in text)
+
+
 def truncate(cmd: str) -> str:
     """Clamp an over-long command, mirroring what the shell hook does."""
     if len(cmd) <= MAX_CMD_CHARS:

--- a/woswoar/entry.py
+++ b/woswoar/entry.py
@@ -112,9 +112,12 @@ def unescape(value: str) -> str:
     return "".join(out)
 
 
-#: Control characters that carry meaning worth preserving are rendered back
-#: into visible escapes; everything else is dropped.
-_INERT = {"\n": "\\n", "\r": "\\r"}
+#: The two control characters worth keeping as something readable rather than
+#: dropping. Taken from `_ESCAPES` rather than restated: `search` recovers a
+#: command as ``make_inert(unescape(line))``, so if `escape` ever rendered a
+#: newline differently, a second literal here would send the picker's round trip
+#: silently out of step.
+_INERT = {char: _ESCAPES[char] for char in ("\n", "\r")}
 
 #: C0 plus DEL, minus tab. Everything left either ends a command, forges a line
 #: in a record file, or moves a terminal cursor around. Tab is excluded
@@ -124,20 +127,24 @@ _CONTROL = frozenset(chr(code) for code in [*range(0x20), 0x7F]) - {"\t"}
 
 
 def make_inert(text: str) -> str:
-    """``text`` with no raw control characters, so it cannot act on its own.
+    """``text`` with no raw C0 control character left in it.
 
-    Two callers, one property. Leaving the fzf picker, this is what keeps a
-    recalled command one command: `escape` maps newlines for *display*, and
-    without this `unescape` would undo that exactly as the text lands in the
-    shell's edit buffer, where bash runs a multi-line buffer as several commands
-    on a single Enter. fzf clips a long line, so the picker can genuinely show
-    one command while handing over two.
+    Leaving the fzf picker, this is what keeps a recalled command one command:
+    `escape` maps newlines for *display*, and without this `unescape` would undo
+    that exactly as the text lands in the shell's edit buffer, where bash runs a
+    multi-line buffer as several commands on a single Enter. fzf clips a long
+    line, so the picker can genuinely show one command while handing over two.
 
-    Around a recipient label, it keeps free text that anyone with push access
-    can write from forging a line in ``recipients.txt`` or from driving the
-    terminal during the `grant` confirmation -- ``\\x1b[1A\\x1b[2K`` erases the
-    line above it, which is one way to hide a machine from the list approving
-    it.
+    Around a recipient label it does the same job for a different reader: it
+    stops free text that anyone with push access can write from forging a line
+    in ``recipients.txt``, or from driving the terminal during the `grant`
+    confirmation -- ``\\x1b[1A\\x1b[2K`` erases the line above it, which is one
+    way to hide a machine from the list approving it.
+
+    C0 and no further, deliberately: widening it would mangle the UTF-8 in a
+    recalled command, which is the caller with the stronger claim. What that
+    leaves -- a bidi override, say -- is not dangerous in an edit buffer, and is
+    handled where it is dangerous, by `sync.Reader.display_name`.
 
     Never applied to what is stored in a log: the history keeps the command as
     it was typed. A recalled multi-line command therefore comes back with a

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -14,7 +14,7 @@ from operator import attrgetter
 from typing import Literal
 
 from . import cache, store
-from .entry import Entry, escape, unescape
+from .entry import Entry, escape, make_inert, unescape
 
 Scope = Literal["global", "host", "session"]
 SCOPES: tuple[Scope, ...] = ("global", "host", "session")
@@ -97,31 +97,6 @@ def render(entries: list[Entry], now: int | None = None) -> list[str]:
     if now is None:
         now = int(time.time())
     return [f"{relative_time(e.ts, now):>{_TIME_WIDTH}}  {escape(e.cmd)}" for e in entries]
-
-
-#: Control characters are rendered back into visible escapes on the way out of
-#: the picker. `escape` maps them for *display*, so one entry is one line;
-#: without this, `unescape` would undo that exactly as the text lands in the
-#: shell's edit buffer, and bash runs a multi-line buffer as several commands on
-#: a single Enter. fzf clips a long line, so the picker can genuinely show one
-#: command while handing over two.
-_INERT = {"\n": "\\n", "\r": "\\r"}
-
-#: C0 plus DEL, minus tab. Everything left either ends a command or moves a
-#: terminal cursor around. Tab is excluded deliberately: it is ordinary inside a
-#: command -- `awk -F'\t'` is written with a real one -- and does neither.
-_CONTROL = frozenset(chr(code) for code in [*range(0x20), 0x7F]) - {"\t"}
-
-
-def make_inert(cmd: str) -> str:
-    """A command with no raw control characters, so it is exactly one command.
-
-    Applied to what leaves the picker, never to what is stored: the log keeps
-    the command as it was typed. A recalled multi-line command therefore comes
-    back with a visible ``\\n`` in it -- wrong to run as-is, but obviously
-    wrong, which beats silently running a command the picker never showed.
-    """
-    return "".join(_INERT.get(char, "") if char in _CONTROL else char for char in cmd)
 
 
 def command_from_line(line: str) -> str:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -24,6 +24,7 @@ import fcntl
 import subprocess
 import time
 import zlib
+from collections import Counter
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -129,20 +130,22 @@ def _labelled_recipients() -> list[tuple[str, str]]:
     this is only a name.
 
     Made inert on the way in. Every byte of it was written by whoever added the
-    key, and on a shared repo that is not necessarily one of your machines.
+    key, and on a shared repo that is not necessarily one of your machines. That
+    covers C0 only, which is what a *record* needs; making it safe to put on a
+    terminal is `Reader.display_name`.
     """
-    out: list[tuple[str, str]] = []
+    out: dict[str, str] = {}
     for line in _recipient_lines():
         key, _, label = line.partition(_LABEL_SEP)
         key = key.strip()
-        if not key or any(key == existing for existing, _ in out):
+        if not key or key in out:
             continue
         label = label.strip()
         if not label:
             fields = key.split(None, 2)
             label = fields[2] if len(fields) > 2 else "(unnamed)"
-        out.append((key, make_inert(label)))
-    return out
+        out[key] = make_inert(label)
+    return list(out.items())
 
 
 def recipients() -> list[str]:
@@ -152,15 +155,6 @@ def recipients() -> list[str]:
     in $HOME, because a sandboxed age cannot open one.
     """
     return [key for key, _ in _labelled_recipients()]
-
-
-def list_recipients() -> list[tuple[str, str]]:
-    """``(kind, key)`` for every enrolled machine.
-
-    Parsed here rather than in the CLI because this module is the only writer of
-    recipients.txt, so the record shape is its to know.
-    """
-    return [(kind, rest) for kind, _, rest in (line.partition(" ") for line in recipients())]
 
 
 def is_repo() -> bool:
@@ -779,7 +773,13 @@ class ReencryptReport(NamedTuple):
 
 
 class Reader(NamedTuple):
-    """One enrolled machine, as a human has to see it before granting."""
+    """One enrolled machine, as a human has to see it before granting.
+
+    Everything a confirmation needs to say about a machine is decided here
+    rather than at the print, including the two facts that depend on the rest of
+    the list. They were computed in the CLI first, which put security-relevant
+    conclusions somewhere only a test that greps stdout could reach them.
+    """
 
     key: str
     #: Free text written by whoever added the key. A name, not an identity.
@@ -791,6 +791,26 @@ class Reader(NamedTuple):
     #: read everything already, so re-listing it only makes the one extra line
     #: that matters easier to miss.
     is_new: bool
+    #: The machine the human is sitting at.
+    is_mine: bool
+    #: Another key in the list carries the same name. Legitimate -- two machines
+    #: really can both be `martin@laptop` -- and also exactly what a key added by
+    #: someone else looks like, which is why it is said out loud.
+    shares_name: bool
+
+    def display_name(self) -> str:
+        """The label, in a form that cannot rearrange the line it is printed on.
+
+        `make_inert` has already removed C0, so this is about the rest: `repr`
+        escapes everything Python calls unprintable -- a bidi override among
+        them -- and quotes the result, so leading and trailing whitespace is
+        visible rather than shifting the columns around it.
+
+        A method rather than a rule the caller has to remember: printing
+        `label` directly is the bug this whole change exists to fix, and it
+        should not be reachable by forgetting a `!r`.
+        """
+        return repr(self.label)
 
 
 def readers() -> list[Reader]:
@@ -809,13 +829,31 @@ def readers() -> list[Reader]:
         if has_remote():
             _fetch_and_rebase()
         granted = set(State.load().granted)
+        labelled = _labelled_recipients()
+
+        # Not fatal if this machine's own key cannot be worked out: the list is
+        # still true, it just loses the "(this machine)" note. `grant` is the
+        # command someone runs *because* something is wrong with enrolment.
+        try:
+            mine = crypto.recipient_for(identity_path(store.machine())).strip()
+        except (WoswoarError, OSError):
+            mine = ""
+
+        names = Counter(label for _, label in labelled)
         return [
-            Reader(key, label, crypto.fingerprint(key), key not in granted)
-            for key, label in _labelled_recipients()
+            Reader(
+                key=key,
+                label=label,
+                fingerprint=crypto.fingerprint(key),
+                is_new=key not in granted,
+                is_mine=key == mine,
+                shares_name=names[label] > 1,
+            )
+            for key, label in labelled
         ]
 
 
-def grant(confirmed: list[str] | None = None) -> ReencryptReport:
+def grant(approved: list[str] | None = None) -> ReencryptReport:
     """Re-seal every key file to the current recipient list, and publish it.
 
     Named for what it does to the user's history rather than to the files:
@@ -823,9 +861,13 @@ def grant(confirmed: list[str] | None = None) -> ReencryptReport:
     including days recorded before it existed. `reencrypt` described the
     mechanism and hid that.
 
-    ``confirmed`` is the list a human agreed to. If the fetch below turns up a
-    different one -- someone enrolled a machine in the meantime -- this refuses
-    rather than granting access to a machine nobody approved.
+    ``approved`` is the list a human at this machine agreed to, and passing it
+    asserts exactly that. It does two jobs, both following from that one
+    meaning: if the fetch below turns up a different list -- someone enrolled a
+    machine in the meantime -- this refuses rather than granting access to a
+    machine nobody approved; and the list is remembered, so the next
+    confirmation can show what has appeared since. Omit it and neither happens,
+    which is what an unattended caller wants.
 
     This is what makes a newly onboarded machine able to read *old* history.
     Chunks are encrypted to per-day keys, so only those small key files -- and
@@ -870,7 +912,7 @@ def grant(confirmed: list[str] | None = None) -> ReencryptReport:
         # recipients and report full success. Reading it once here also saves
         # re-parsing the file for every one of a few thousand key files.
         keys = recipients()
-        if confirmed is not None and sorted(keys) != sorted(confirmed):
+        if approved is not None and sorted(keys) != sorted(approved):
             raise SyncError(
                 "the set of machines changed while you were deciding; "
                 "run 'woswoar grant' again to see the current list"
@@ -897,12 +939,12 @@ def grant(confirmed: list[str] | None = None) -> ReencryptReport:
             store.write_atomic(path, crypto.encrypt_to_recipients(plain, keys))
             resealed += 1
 
-        if confirmed is not None:
-            # What is recorded is a *human's* decision, which is why this hangs
-            # off `confirmed` rather than off how many files were re-sealed: it
-            # is what the next confirmation subtracts to find the machines
-            # nobody here has agreed to yet. A grant with no approved list
-            # behind it -- an unattended one -- must not silence that.
+        if approved is not None:
+            # Recorded rather than counted: what the next confirmation subtracts
+            # is the set a human agreed to, not the set that happened to be
+            # re-sealable from here. A machine that could open nothing still
+            # approved these, and a grant with no approved list behind it -- an
+            # unattended one -- must not silence the next prompt.
             state = State.load()
             state.granted = keys
             state.save()
@@ -983,11 +1025,16 @@ def add_recipient(recipient: str, label: str = "") -> bool:
     without it the prompt lists opaque age keys and cannot be consented to in
     any real sense.
 
-    One line per key, guaranteed rather than assumed: the label comes from this
-    machine's config, and a newline in it would append a second entry that
-    nobody added.
+    One line per key, guaranteed rather than assumed: both halves come from this
+    machine's own files, and a newline in either would append a second entry
+    that nobody added. The label is made inert, which is enough because it is
+    free text; a key with a newline in it is malformed rather than merely ugly,
+    so it is refused instead of rewritten into something age would reject later
+    and less clearly.
     """
     key = recipient.strip()
+    if "\n" in key:
+        raise SyncError(f"the public key for this machine is not one line: {key!r}")
     if key in recipients():
         return False
     path = store.recipients_file()

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from . import crypto, store
+from .entry import make_inert
 from .errors import WoswoarError
 from .store import Machine
 
@@ -114,40 +115,43 @@ def _recipient_lines() -> list[str]:
     return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
 
 
-def recipients() -> list[str]:
-    """Every enrolled machine's public key, in the form age wants on `-r`.
+def _labelled_recipients() -> list[tuple[str, str]]:
+    """``(key, label)`` for every enrolled machine, deduplicated by key.
 
-    Read here rather than handed to age as a path: `crypto` never names a file
-    in $HOME, because a sandboxed age cannot open one.
+    Deduplicated because `.gitattributes` marks this file ``merge=union``, so a
+    machine that appends a labelled line where another has the same key
+    unlabelled leaves both, and age rejects a repeated recipient.
 
-    Deduplicated by key. `.gitattributes` marks this file ``merge=union``, so a
-    machine that appends a labelled line where another has the same key unlabelled
-    leaves both, and age rejects a repeated recipient.
-    """
-    seen: dict[str, None] = {}
-    for line in _recipient_lines():
-        seen.setdefault(line.split(_LABEL_SEP, 1)[0].strip(), None)
-    return list(seen)
+    The label is woswoar's own trailing comment when present and the SSH key's
+    comment field otherwise. It is never derived from the key -- an abbreviated
+    key used to be the last-resort label, which let a *chosen* label impersonate
+    one. `crypto.fingerprint` is the thing to show when the identity matters;
+    this is only a name.
 
-
-def reader_labels() -> list[tuple[str, str]]:
-    """``(key, label)`` for every enrolled machine, for showing to a human.
-
-    Nobody can meaningfully consent to granting `age1ejf3l4f0nhnp9...` access to
-    their history. The label is woswoar's own trailing comment when present, the
-    SSH key's comment field otherwise, and an abbreviated key as a last resort.
+    Made inert on the way in. Every byte of it was written by whoever added the
+    key, and on a shared repo that is not necessarily one of your machines.
     """
     out: list[tuple[str, str]] = []
     for line in _recipient_lines():
         key, _, label = line.partition(_LABEL_SEP)
         key = key.strip()
-        if any(key == existing for existing, _ in out):
+        if not key or any(key == existing for existing, _ in out):
             continue
+        label = label.strip()
         if not label:
             fields = key.split(None, 2)
-            label = fields[2] if len(fields) > 2 else f"{key[:12]}...{key[-6:]}"
-        out.append((key, label.strip()))
+            label = fields[2] if len(fields) > 2 else "(unnamed)"
+        out.append((key, make_inert(label)))
     return out
+
+
+def recipients() -> list[str]:
+    """Every enrolled machine's public key, in the form age wants on `-r`.
+
+    Read here rather than handed to age as a path: `crypto` never names a file
+    in $HOME, because a sandboxed age cannot open one.
+    """
+    return [key for key, _ in _labelled_recipients()]
 
 
 def list_recipients() -> list[tuple[str, str]]:
@@ -178,21 +182,34 @@ class State:
     exported: dict[str, int] = field(default_factory=dict)
     #: "<host>/<day>" -> newest chunk filename already merged into logs/.
     merged: dict[str, str] = field(default_factory=dict)
+    #: Keys a human at this machine last approved in `grant`. Local like the
+    #: rest of State, and here that is the whole point: "which machines are new
+    #: since *you* last agreed to this?" is a question only this machine can
+    #: answer, and a record kept in the repo could be edited by exactly the
+    #: attacker the confirmation exists to catch.
+    granted: list[str] = field(default_factory=list)
 
     @classmethod
     def load(cls) -> State:
         raw = store.load_json(store.state_file())
         exported = raw.get("exported", {})
         merged = raw.get("merged", {})
+        granted = raw.get("granted", [])
         if not isinstance(exported, dict) or not isinstance(merged, dict):
             return cls()
         return cls(
             exported={str(k): int(v) for k, v in exported.items()},
             merged={str(k): str(v) for k, v in merged.items()},
+            # A malformed list costs the prompt its memory, which shows every
+            # machine as new -- the safe direction to be wrong in.
+            granted=[str(k) for k in granted] if isinstance(granted, list) else [],
         )
 
     def save(self) -> None:
-        store.save_json(store.state_file(), {"exported": self.exported, "merged": self.merged})
+        store.save_json(
+            store.state_file(),
+            {"exported": self.exported, "merged": self.merged, "granted": self.granted},
+        )
 
 
 @contextmanager
@@ -761,18 +778,41 @@ class ReencryptReport(NamedTuple):
     pushed: bool
 
 
-def readers() -> list[str]:
+class Reader(NamedTuple):
+    """One enrolled machine, as a human has to see it before granting."""
+
+    key: str
+    #: Free text written by whoever added the key. A name, not an identity.
+    label: str
+    #: Derived from the key and so not chooseable. This is the identity.
+    fingerprint: str
+    #: Not among the keys this machine last granted. These are what a
+    #: confirmation is actually about: a machine that was already granted can
+    #: read everything already, so re-listing it only makes the one extra line
+    #: that matters easier to miss.
+    is_new: bool
+
+
+def readers() -> list[Reader]:
     """Who would be able to read the whole history if `grant` ran now.
 
     Fetches first, because the point of granting is to include a machine that
     enrolled since this one last looked -- reporting the pre-fetch list would
     show fewer machines than the operation is about to authorise, which is the
     one direction a security confirmation must never be wrong in.
+
+    One read of recipients.txt, not two. The list shown to the human and the
+    list handed back to `grant` as their answer used to come from separate
+    parses either side of the prompt, so they could describe different sets.
     """
     with lock():
         if has_remote():
             _fetch_and_rebase()
-        return recipients()
+        granted = set(State.load().granted)
+        return [
+            Reader(key, label, crypto.fingerprint(key), key not in granted)
+            for key, label in _labelled_recipients()
+        ]
 
 
 def grant(confirmed: list[str] | None = None) -> ReencryptReport:
@@ -857,6 +897,16 @@ def grant(confirmed: list[str] | None = None) -> ReencryptReport:
             store.write_atomic(path, crypto.encrypt_to_recipients(plain, keys))
             resealed += 1
 
+        if confirmed is not None:
+            # What is recorded is a *human's* decision, which is why this hangs
+            # off `confirmed` rather than off how many files were re-sealed: it
+            # is what the next confirmation subtracts to find the machines
+            # nobody here has agreed to yet. A grant with no approved list
+            # behind it -- an unattended one -- must not silence that.
+            state = State.load()
+            state.granted = keys
+            state.save()
+
         _commit()
         if remote:
             _push()
@@ -929,9 +979,13 @@ def compact(before: str) -> tuple[int, int]:
 def add_recipient(recipient: str, label: str = "") -> bool:
     """Append a public key to recipients.txt if its key is not already listed.
 
-    The label is what `grant` shows a human before widening who can read the
-    history; without it the prompt lists opaque age keys and cannot be consented
-    to in any real sense.
+    The label is the name `grant` shows a human beside the key's fingerprint;
+    without it the prompt lists opaque age keys and cannot be consented to in
+    any real sense.
+
+    One line per key, guaranteed rather than assumed: the label comes from this
+    machine's config, and a newline in it would append a second entry that
+    nobody added.
     """
     key = recipient.strip()
     if key in recipients():
@@ -939,6 +993,6 @@ def add_recipient(recipient: str, label: str = "") -> bool:
     path = store.recipients_file()
     existing = path.read_text(encoding="utf-8") if path.is_file() else ""
     separator = "" if not existing or existing.endswith("\n") else "\n"
-    line = f"{key}{_LABEL_SEP}{label}" if label else key
+    line = f"{key}{_LABEL_SEP}{make_inert(label)}" if label else key
     store.write_atomic(path, f"{existing}{separator}{line}\n".encode())
     return True


### PR DESCRIPTION
Fixes #19 — the sole P0.

## The hole

`woswoar grant` is the one place a human agrees to widen who can read the whole archive, and it showed only the label from `recipients.txt`. That file is plain text, and `.gitattributes` marks it `merge=union`, so anyone who can push appends a key labelled like one of your machines and waits. The next `grant` hands them everything — without breaking any encryption.

What the old prompt showed:

```
  'martin@laptop'
  'martin@laptop'                      <- someone else's key
  'martin@desktop\x1b[2K\x1b[1A'       <- erases the line above it
```

## What it shows now

```
2 machine(s) NOT yet granted. Granting lets each of them read
your ENTIRE history, including days recorded before it ever existed:

  age1wu74tgg8hxlpj9zqvtlhqpvt3h7jqlhlr0w7fd3xdqrnad44zsaq9uhjpu  'martin@desktop'
  age1fzk4uskdzc8wxfkva2l8tjjf7em70z8qzden6utx0s24t6gzj9wsxj0nuk  'martin@laptop[2K[1A'

Already granted, and unchanged (1):

  age1u7e8tj5s4ycrapmpzxq77f29xlaxt90s3u0zp3ezk9eyzq3l4pus5l56l3  'martin@laptop'   (this machine)

The name beside a key is free text written by whoever added it, so check
the key itself on the machine it belongs to:  age-keygen -y ~/.config/woswoar/identity
```

Three changes, each addressing one part of the issue:

**The identity shown is the key, not the name.** Every line leads with a fingerprint derived from the key material. For an SSH key it is byte-for-byte what `ssh-keygen -lf` prints, so it can be checked against the machine itself rather than against the repo making the claim; an age recipient is already canonical and is its own. The last-resort label used to be an *abbreviation of the key*, which let a chosen label impersonate one — unnamed keys are now `(unnamed)`, and `woswoar init` stopped printing `key[:24]...` for the same reason.

**Labels cannot act.** Made inert on the way in (so a newline cannot forge a second entry) and printed with `repr` on the way out, which also catches what is not a control character — a bidi override — and makes leading whitespace visible instead of column-shifting.

**Only additions are put to you.** Re-sealing to a set you already approved widens nothing, so it does not ask; a prompt that fires when there is nothing to decide is one people learn to answer without reading. What was approved is remembered in the *local* state file, never in the repo — a shared record could be edited by exactly the attacker the prompt exists to catch.

Also folded in: `readers()` now reads `recipients.txt` once and returns everything the prompt needs. The list shown to the human and the list handed back as their answer used to come from two separate parses either side of the prompt, so they could describe different sets.

## Tests

Every fix is pinned by a test that **fails when the fix is reverted** — verified by mutation, not assumed. 19 mutations run, all 19 killed their guarding test; three tests were decorative on the first pass and were rewritten until they weren't. `docs/security.md` gains a section describing what the prompt guarantees, alongside the tests that back it.

241 tests pass. The two-machine CI flow was replayed by hand end to end.

## /simplify

Run before opening, per the working agreements, and it found real things — the second commit is the whole list. The one worth calling out: `crypto.fingerprint` returned an unparseable line's first field, so two malformed entries would have rendered as the same machine, defeating the column's entire purpose on exactly the hand-edited file this is about.

Nothing was skipped as out of scope. Three findings became issues instead: #34 (there is still no way to *remove* a recipient once you spot one — the missing half of this fix), #35 (grant fetches twice and re-seals every key file even when nothing changed), #36 (four test files hand-roll a CLI runner, none capturing stderr).