### PR TITLE
Add 'woswoar revoke', so a key you did not add can be taken out

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -76,7 +76,44 @@ Enrolling a new laptop means publishing a public key — nothing sensitive trave
 and nothing sensitive is stored in the repo.
 
 Widening who can read the archive is therefore a deliberate act: `woswoar grant`
-lists the machines and asks before it re-seals anything.
+lists the machines and asks before it re-seals anything. Narrowing it is
+`woswoar revoke <fingerprint>`.
+
+<details>
+<summary>What revoking does, and the three things it cannot do</summary>
+
+`woswoar revoke` appends a **tombstone** to `recipients.txt` rather than
+deleting the line. The file is `merge=union` — the property that makes two
+machines enrolling at once conflict-free — and union keeps both sides of every
+difference, so a deleted line comes straight back from any peer that still has
+it. Every machine subtracts the tombstoned key on its next fetch, and the
+withdrawal is permanent: a key that reappears below its own tombstone stays out,
+because whoever the revocation was aimed at has push access by assumption.
+
+The remaining sealed keys are then re-sealed without it, so a copy of the repo
+taken afterwards cannot be opened with that key at all, and every day key minted
+from then on excludes it.
+
+What it does **not** do, all three said on screen before you confirm:
+
+- **It does not un-publish anything.** History already in the repo stays
+  readable by that key if it kept a copy.
+- **It does not revoke git access.** If the key got in through a stolen token or
+  a mis-scoped deploy key, that credential needs rotating too, or it can simply
+  fetch again.
+- **It does not stop that machine writing history yours will accept.** The
+  authentication key above is shared across your fleet, and rotating it would
+  make every existing chunk fail authentication, so it cannot be rotated without
+  rebuilding the repo.
+
+There is also a bounded window on reads: a day key is minted once and every
+chunk of that day is sealed to it, so commands recorded on a day whose key
+already exists stay readable by the revoked machine. In practice that is the
+rest of today, and `revoke` prints exactly which days. Rotating those mid-day
+would strand the chunks already sealed to them on every machine that has not
+merged them yet.
+
+</details>
 
 <details>
 <summary>What that prompt shows, and why not just the names</summary>
@@ -133,6 +170,8 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | Forged history is refused | a chunk sealed to a host's published day key, but untagged, is rejected and reported |
 | Tampering is refused | flipping one byte of a real chunk fails authentication, not merely decryption |
 | The repo key never leaks | the key's bytes appear nowhere in the committed tree |
+| A revoked machine stops receiving history | two real machines through a bare repo: after `revoke`, the revoked one still has what came before and never gets what comes after |
+| A revocation cannot be undone by pushing | re-adding the key, by command or by appending the line, leaves it subtracted |
 | A recalled command is one command | control characters never survive from the picker into the shell buffer |
 | The repo does not blow up | a simulated multi-day, multi-machine run is measured after `git gc` |
 | History is never readable by others | every path woswoar creates is walked under a stock `umask 022`, on both the Python and the shell-hook side |
@@ -162,3 +201,8 @@ Being straight about the limits is part of the security story:
 > - **Lose your key, lose your access.** There is no recovery service, because
 >   there is no service. If a machine loses its identity, re-enrol it and run
 >   `woswoar grant` from another machine.
+> - **Revoking is forward-looking only.** `woswoar revoke` stops a machine
+>   receiving new history; it cannot take back what was already published, and
+>   the revoked machine keeps the shared authentication key, so it can still
+>   write history your machines accept. A key that has genuinely fallen into
+>   someone else's hands is a reason to rebuild the repo, not only to revoke.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -14,11 +14,11 @@ import tempfile
 import unittest
 import zlib
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager, redirect_stdout
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
 
 from woswoar import cache, crypto, search, store, sync
-from woswoar.__main__ import main
+from woswoar.__main__ import _GRANT_REMEDY, main
 from woswoar.entry import Entry, format_line
 from woswoar.errors import WoswoarError
 from woswoar.sync import COMMIT_MESSAGE as COMMIT
@@ -134,6 +134,18 @@ class SyncTestCase(unittest.TestCase):
     def git_in_repo(self, fake: Fake, *args: str) -> str:
         with fake.active():
             return sync.git(*args)
+
+    def run_cli(self, fake: Fake, *argv: str) -> tuple[int, str]:
+        """Drive the real CLI as ``fake``, returning ``(exit code, stdout)``.
+
+        Only stdout: several commands put their warnings on stderr, and a test
+        that means "it warned" has to say which stream it is asserting on. The
+        two that need stderr capture it themselves.
+        """
+        buffer = io.StringIO()
+        with fake.active(), redirect_stdout(buffer):
+            code = main(list(argv))
+        return code, buffer.getvalue()
 
 
 class TestSingleMachine(SyncTestCase):
@@ -601,14 +613,247 @@ class TestGrantConfirmation(SyncTestCase):
         self.assertEqual(marked, [mine])
 
 
+class TestRevokeSubtraction(SyncTestCase):
+    """A withdrawal has to survive `merge=union`, which never deletes a line."""
+
+    def test_a_revoked_key_stops_being_a_recipient(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            gone = alpha.append_recipient(label="old-laptop")
+            self.assertIn(gone, sync.recipients())
+
+            sync.revoke(sync.find_reader(crypto.fingerprint(gone)))
+            self.assertNotIn(gone, sync.recipients())
+
+    def test_a_tombstone_above_its_key_still_subtracts(self) -> None:
+        """Union merges interleave two machines' appends in whatever order the
+        rebase produces, so the withdrawal can land above the enrolment.
+
+        Skipping tombstones as they are met, rather than collecting them in a
+        pass of their own, would make this depend on line order.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            mine = sync.recipients()
+            gone = crypto.generate_identity().public
+            store.recipients_file().write_text(
+                f"-{gone}{sync._LABEL_SEP}revoked\n{gone}{sync._LABEL_SEP}old-laptop\n"
+                + "".join(f"{key}\n" for key in mine),
+                encoding="utf-8",
+            )
+            self.assertNotIn(gone, sync.recipients())
+
+    def test_a_revoked_key_cannot_be_re_added(self) -> None:
+        """Otherwise whoever the revocation was aimed at un-revokes themselves
+        by appending the line again -- they have push access, that is the whole
+        premise. Re-enrolling a real machine means a new identity."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            gone = alpha.append_recipient(label="old-laptop")
+            sync.revoke(sync.find_reader(crypto.fingerprint(gone)))
+
+            with self.assertRaises(sync.SyncError) as caught:
+                sync.add_recipient(gone, label="back-again")
+            self.assertIn("revocation is permanent", str(caught.exception))
+
+            # And appending the line by hand, which is all push access buys,
+            # does not bring it back either.
+            with store.recipients_file().open("a", encoding="utf-8") as handle:
+                handle.write(f"{gone}{sync._LABEL_SEP}back-again\n")
+            self.assertNotIn(gone, sync.recipients())
+
+    def test_revoking_re_seals_so_the_key_can_no_longer_open_the_repo(self) -> None:
+        """The list is what future keys are minted from; this is what makes a
+        copy of the repo taken *after* the revocation useless to that key."""
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            sync.run()
+            beta_identity = sync.identity_path(store.machine())
+            beta_key = crypto.recipient_for(beta_identity).strip()
+
+        with alpha.active():
+            sync.grant(approved=[reader.key for reader in sync.readers()])
+            # Opens for beta here, which is what makes the failure below a
+            # consequence of the revocation rather than of never having access.
+            crypto.decrypt_with_file(store.mac_key_file().read_bytes(), beta_identity)
+
+            report = sync.revoke(sync.find_reader(crypto.fingerprint(beta_key)))
+            self.assertGreater(report.resealed, 0)
+            resealed = store.mac_key_file().read_bytes()
+
+        with self.assertRaises(crypto.AgeError):
+            crypto.decrypt_with_file(resealed, beta_identity)
+
+    def test_a_revoked_machine_cannot_read_history_recorded_afterwards(self) -> None:
+        """The end-to-end claim, driven through real age and real git."""
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            sync.run()
+        with alpha.active():
+            sync.grant(approved=[reader.key for reader in sync.readers()])
+            alpha.record("2023-11-14", 1_700_000_001, "before-revocation")
+            sync.run()
+        with beta.active():
+            sync.run()
+            self.assertIn("before-revocation", beta.commands())
+            beta_key = crypto.recipient_for(sync.identity_path(store.machine())).strip()
+
+        with alpha.active():
+            sync.revoke(sync.find_reader(crypto.fingerprint(beta_key)))
+            # A fresh day, so the key is minted from the reduced list. Same-day
+            # keys already exist and are reported as still readable instead.
+            alpha.record("2023-11-15", 1_700_100_002, "after-revocation")
+            sync.run()
+
+        with beta.active():
+            sync.run()
+            self.assertNotIn("after-revocation", beta.commands())
+        with alpha.active():
+            self.assertIn("after-revocation", alpha.commands())
+
+    def test_days_already_keyed_are_reported_rather_than_left_to_be_guessed(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "recorded today")
+            sync.run()
+            gone = alpha.append_recipient(label="old-laptop")
+            report = sync.revoke(sync.find_reader(crypto.fingerprint(gone)))
+        self.assertEqual(report.still_readable, ["2023-11-14"])
+
+    def test_revoking_this_machine_is_refused(self) -> None:
+        # It would seal the history away from the machine doing the sealing.
+        alpha = self.machine("alpha")
+        with alpha.active():
+            (mine,) = [reader for reader in sync.readers() if reader.is_mine]
+            with self.assertRaises(sync.SyncError) as caught:
+                sync.revoke(mine)
+        self.assertIn("lock this machine out", str(caught.exception))
+
+    def test_revoking_the_only_other_machine_leaves_the_history_readable(self) -> None:
+        """Sealing to an empty recipient list is how you lose an archive."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            # Only one recipient, and it is not this machine -- so `is_mine`
+            # does not catch it and the emptiness guard is what has to.
+            store.recipients_file().write_text("", encoding="utf-8")
+            only = alpha.append_recipient(label="only-one")
+            (other,) = sync.readers()
+            with self.assertRaises(sync.SyncError) as caught:
+                sync.revoke(other)
+            self.assertIn(only, sync.recipients())
+        self.assertIn("only machine left", str(caught.exception))
+
+    def test_the_revoked_machine_is_told_that_rather_than_to_ask_for_a_grant(self) -> None:
+        """It is the machine that can no longer decrypt anything, so it is also
+        the one that would otherwise see "ask someone to run grant" forever."""
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            sync.run()
+            beta_key = crypto.recipient_for(sync.identity_path(store.machine())).strip()
+        with alpha.active():
+            sync.grant(approved=[reader.key for reader in sync.readers()])
+            sync.revoke(sync.find_reader(crypto.fingerprint(beta_key)))
+
+        with beta.active():
+            report = sync.run()
+        self.assertTrue(report.needs_grant)
+        self.assertTrue(report.revoked)
+
+        buffer = io.StringIO()
+        with beta.active(), redirect_stderr(buffer):
+            self.assertEqual(main(["sync"]), 0)
+        message = buffer.getvalue()
+        self.assertIn("was revoked", message)
+        self.assertNotIn(_GRANT_REMEDY, message)
+
+    def test_a_machine_merely_waiting_for_a_grant_is_not_told_it_was_revoked(self) -> None:
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            report = sync.run()
+        self.assertTrue(report.needs_grant)
+        self.assertFalse(report.revoked)
+
+    def test_a_key_shaped_like_a_tombstone_is_refused(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active(), self.assertRaises(sync.SyncError) as caught:
+            sync.add_recipient(f"-{crypto.generate_identity().public}", label="sneaky")
+        self.assertIn("may not start with", str(caught.exception))
+
+
+class TestFindReader(SyncTestCase):
+    """Revocation is by fingerprint: the name is the part an attacker writes."""
+
+    def test_a_full_fingerprint_selects_one_machine(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            other = alpha.append_recipient(label="old-laptop")
+            self.assertEqual(sync.find_reader(crypto.fingerprint(other)).key, other)
+
+    def test_an_unambiguous_prefix_is_enough(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            other = alpha.append_recipient(label="old-laptop")
+            found = sync.find_reader(crypto.fingerprint(other)[:20])
+        self.assertEqual(found.key, other)
+
+    def test_an_ambiguous_prefix_is_refused_rather_than_resolved(self) -> None:
+        # Guessing here removes somebody's access.
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.append_recipient(label="old-laptop")
+            with self.assertRaises(sync.SyncError) as caught:
+                sync.find_reader("age1")
+        self.assertIn("matches 2 machines", str(caught.exception))
+
+    def test_a_fingerprint_nobody_has_is_refused(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active(), self.assertRaises(sync.SyncError) as caught:
+            sync.find_reader("SHA256:nothing-like-this")
+        self.assertIn("no enrolled machine", str(caught.exception))
+
+
+class TestRevokeConfirmation(SyncTestCase):
+    def test_without_yes_and_without_a_terminal_nothing_changes(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            gone = alpha.append_recipient(label="old-laptop")
+
+        code, _ = self.run_cli(alpha, "revoke", crypto.fingerprint(gone))
+        self.assertEqual(code, 1)
+        with alpha.active():
+            self.assertIn(gone, sync.recipients())
+
+    def test_the_limits_are_stated_before_the_decision(self) -> None:
+        """They are the reasons someone would answer no and go do something
+        else first, so printing them after the fact is printing them too late.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            gone = alpha.append_recipient(label="old-laptop")
+
+        code, out = self.run_cli(alpha, "revoke", crypto.fingerprint(gone), "--yes")
+        self.assertEqual(code, 0)
+        self.assertIn("does not un-publish", out)
+        self.assertIn("does not revoke git access", out)
+        self.assertIn("WRITING", out)
+        with alpha.active():
+            self.assertNotIn(gone, sync.recipients())
+
+
 class TestGrantConfirmsAdditions(SyncTestCase):
     """A confirmation listing everything makes the one new line easy to miss."""
-
-    def grant(self, fake: Fake, *args: str) -> tuple[int, str]:
-        buffer = io.StringIO()
-        with fake.active(), redirect_stdout(buffer):
-            code = main(["grant", *args])
-        return code, buffer.getvalue()
 
     def test_the_first_grant_reports_every_machine_as_new(self) -> None:
         alpha = self.machine("alpha", display="martin@laptop")
@@ -617,7 +862,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
 
     def test_granting_remembers_who_was_approved(self) -> None:
         alpha = self.machine("alpha")
-        code, _ = self.grant(alpha, "--yes")
+        code, _ = self.run_cli(alpha, "grant", "--yes")
         self.assertEqual(code, 0)
         with alpha.active():
             self.assertFalse(any(reader.is_new for reader in sync.readers()))
@@ -632,7 +877,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
 
     def test_a_key_appended_afterwards_is_the_only_one_reported_as_new(self) -> None:
         alpha = self.machine("alpha", display="martin@laptop")
-        self.grant(alpha, "--yes")
+        self.run_cli(alpha, "grant", "--yes")
 
         # Exactly what push access alone buys: append a key labelled like one of
         # the machines that is already there.
@@ -644,11 +889,11 @@ class TestGrantConfirmsAdditions(SyncTestCase):
 
     def test_a_new_key_is_put_to_the_human_even_with_a_familiar_name(self) -> None:
         alpha = self.machine("alpha", display="martin@laptop")
-        self.grant(alpha, "--yes")
+        self.run_cli(alpha, "grant", "--yes")
         with alpha.active():
             alpha.append_recipient(label="martin@laptop")
 
-        code, out = self.grant(alpha, "--yes")
+        code, out = self.run_cli(alpha, "grant", "--yes")
         self.assertEqual(code, 0)
         self.assertIn("1 machine(s) NOT yet granted", out)
         self.assertIn("SAME NAME AS ANOTHER KEY", out)
@@ -668,7 +913,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         with alpha.active():
             alpha.append_recipient(label=hostile)
 
-        _, out = self.grant(alpha, "--yes")
+        _, out = self.run_cli(alpha, "grant", "--yes")
         self.assertIn("martin@desktop", out)
         self.assertNotIn(hostile, out)
         self.assertNotIn("\u202e", out)
@@ -681,19 +926,19 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         old code refused.
         """
         alpha = self.machine("alpha")
-        self.grant(alpha, "--yes")
+        self.run_cli(alpha, "grant", "--yes")
 
-        code, out = self.grant(alpha)
+        code, out = self.run_cli(alpha, "grant")
         self.assertEqual(code, 0)
         self.assertIn("No machine is new", out)
 
     def test_a_new_machine_without_yes_and_without_a_terminal_is_refused(self) -> None:
         alpha = self.machine("alpha")
-        self.grant(alpha, "--yes")
+        self.run_cli(alpha, "grant", "--yes")
         with alpha.active():
             alpha.append_recipient(label="martin@desktop")
 
-        code, _ = self.grant(alpha)
+        code, _ = self.run_cli(alpha, "grant")
         self.assertEqual(code, 1)
         with alpha.active():
             self.assertTrue(any(reader.is_new for reader in sync.readers()))

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -328,6 +328,17 @@ def cmd_sync(args: argparse.Namespace) -> int:
     from . import sync
 
     report = sync.run(push=not args.no_push)
+    if report.revoked:
+        print(
+            "This machine's access to the shared history was revoked, so it can\n"
+            "no longer publish or read it. This is not something 'woswoar grant'\n"
+            "can undo -- a revocation is permanent, deliberately.\n\n"
+            "Commands are still being recorded locally, and 'woswoar list' still\n"
+            "shows everything this machine had before. To take part again, enrol\n"
+            "with a fresh identity:  woswoar init <url> --new-identity",
+            file=sys.stderr,
+        )
+        return 0
     if report.needs_grant:
         print(
             "This machine cannot publish or read history yet: the repo's\n"
@@ -364,6 +375,30 @@ def cmd_sync(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
     return 0
+
+
+def _confirm(question: str, yes: bool) -> bool:
+    """Whether a human here agreed to change who can read the history.
+
+    One gate for every command that does, because the ``isatty`` branch is a
+    security control and not formatting: nothing may widen or narrow access on
+    an assumed answer, and an unattended caller has to say ``--yes`` and mean
+    it. Copied per command, the third copy is the one that quietly drops it and
+    still reads exactly like the other two.
+    """
+    if yes:
+        return True
+    if not sys.stdin.isatty():
+        print(
+            "\nRefusing to change who can read your history without confirmation. "
+            "Re-run with --yes if you mean it.",
+            file=sys.stderr,
+        )
+        return False
+    if input(f"\n{question} [y/N] ").strip().lower() not in ("y", "yes"):
+        print("Nothing changed.")
+        return False
+    return True
 
 
 def _show_readers(readers: list[Reader]) -> None:
@@ -420,20 +455,8 @@ def cmd_grant(args: argparse.Namespace) -> int:
     # Only additions are put to a human. Re-sealing to a set that was already
     # approved widens nothing, and a prompt that fires when there is nothing to
     # decide is a prompt people learn to answer without reading.
-    if new and not args.yes:
-        if not sys.stdin.isatty():
-            print(
-                "\nRefusing to grant access without confirmation. "
-                "Re-run with --yes if you mean it.",
-                file=sys.stderr,
-            )
-            return 1
-        if input(f"\nGrant {len(new)} new machine(s) full access? [y/N] ").strip().lower() not in (
-            "y",
-            "yes",
-        ):
-            print("Nothing changed.")
-            return 1
+    if new and not _confirm(f"Grant {len(new)} new machine(s) full access?", args.yes):
+        return 1
 
     report = sync.grant(approved=[reader.key for reader in readers])
     print(f"\nre-sealed {report.resealed} key file(s)")
@@ -451,6 +474,67 @@ def cmd_grant(args: argparse.Namespace) -> int:
             "they were left alone. Re-sealing a key means opening it first, which\n"
             "only a machine that already had access can do. Run this on one of\n"
             "those instead.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def cmd_revoke(args: argparse.Namespace) -> int:
+    """Withdraw one machine's access to history recorded from now on."""
+    from . import sync
+
+    reader = sync.find_reader(args.fingerprint)
+
+    print("This withdraws access for:\n")
+    _show_readers([reader])
+    print(
+        "\nFrom now on it cannot read newly minted day keys, and a copy of the"
+        "\nrepository taken after this cannot be opened with that key at all."
+    )
+    # Said before the prompt, not after it. These are the reasons someone might
+    # answer no and go do something else first, so printing them alongside the
+    # result would be printing them too late to act on.
+    print(
+        "\nWhat this does NOT do:"
+        "\n  - It does not un-publish anything. Everything already in the repo"
+        "\n    stays readable by that key if it kept a copy."
+        "\n  - It does not revoke git access. If the key got in through a stolen"
+        "\n    token or deploy key, rotate that too, or it can simply fetch again."
+        "\n  - It does not stop that machine WRITING history yours will accept."
+        "\n    The authentication key is shared and cannot be rotated without"
+        "\n    rebuilding the repo."
+    )
+
+    if not _confirm("Revoke this machine's access?", args.yes):
+        return 1
+
+    report = sync.revoke(reader)
+    print(f"\nrevoked; re-sealed {report.resealed} key file(s)")
+    if report.pushed:
+        print("published to the remote")
+        print("\nOn each machine that is still enrolled, run:  woswoar sync")
+    else:
+        print("no remote configured, so nothing was published")
+
+    if report.still_readable:
+        days = ", ".join(report.still_readable)
+        print(
+            f"\nCommands this machine records on {days} still go to a day key that\n"
+            "was minted before the revocation, so they remain readable by the\n"
+            "revoked key. Rotating it now would strand the chunks already sealed\n"
+            "to it on every machine that has not merged them yet. From the next\n"
+            "day onward, nothing new is readable by it.\n"
+            "Your other machines have the same gap for the days they are recording\n"
+            "into; this one cannot see which those are.",
+            file=sys.stderr,
+        )
+
+    if report.skipped:
+        print(
+            f"\n{report.skipped} key file(s) could not be opened by this machine, so\n"
+            "they are still sealed to the revoked key. Re-sealing means opening\n"
+            "first, which only a machine that already had access can do. Run this\n"
+            "on one of those as well.",
             file=sys.stderr,
         )
     return 0
@@ -541,6 +625,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_grant.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
     p_grant.set_defaults(func=cmd_grant)
+
+    p_revoke = subparsers.add_parser(
+        "revoke", help="withdraw a machine's access to history recorded from now on"
+    )
+    p_revoke.add_argument(
+        "fingerprint",
+        help="the fingerprint 'woswoar grant' shows, or an unambiguous prefix of it",
+    )
+    p_revoke.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
+    p_revoke.set_defaults(func=cmd_revoke)
 
     p_compact = subparsers.add_parser("compact", help="merge old chunks (reduces file count)")
     p_compact.add_argument("--before", help="only days before this YYYY-MM-DD (default: today)")

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -586,6 +586,15 @@ def day_of_log(relpath: str) -> str:
     return relpath.rsplit("/", 1)[-1].removesuffix(_LOG_SUFFIX)
 
 
+def day_of_key(path: Path) -> str:
+    """``hosts/<id>/keys/2026-07-29.age`` -> ``2026-07-29``.
+
+    The inverse of `day_key`, and here rather than at the caller for the same
+    reason `iter_day_keys` is: the suffix is this module's to know.
+    """
+    return path.name.removesuffix(_CHUNK_SUFFIX)
+
+
 def append_entries(machine_id: str, entries: list[Entry]) -> dict[str, int]:
     """Append entries to their day files, returning lines written per file.
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -71,6 +71,10 @@ class Report:
     #: True when this machine cannot open the repo key yet, so it can neither
     #: publish nor read. Recording carries on regardless; `grant` unblocks it.
     needs_grant: bool = False
+    #: ...unless this machine's own key was revoked, in which case `grant` never
+    #: will, and saying otherwise sends someone to another machine to run a
+    #: command that cannot help. Only meaningful with `needs_grant`.
+    revoked: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -108,6 +112,22 @@ def remote_summary() -> str:
 #: handing age the path -- which is what makes labelling possible at all.
 _LABEL_SEP = " # "
 
+#: Marks a line as a *withdrawal* of the key that follows it rather than an
+#: enrolment of it.
+#:
+#: A tombstone rather than deleting the line, because `.gitattributes` marks
+#: this file ``merge=union`` -- the thing that makes two machines enrolling at
+#: once conflict-free. Union keeps both sides of every difference, so a line
+#: deleted here and still present in any peer's checkout comes straight back on
+#: the next rebase. Dropping ``merge=union`` to make deletion stick would
+#: reintroduce exactly the conflicts the append-only design exists to avoid, on
+#: the one file every machine writes.
+#:
+#: ``-`` cannot collide with a key: age recipients start ``age1`` and SSH keys
+#: with their type. `add_recipient` refuses one that would, so this stays a
+#: decision about the first character rather than a guess.
+_REVOKED = "-"
+
 
 def _recipient_lines() -> list[str]:
     path = store.recipients_file()
@@ -116,12 +136,83 @@ def _recipient_lines() -> list[str]:
     return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
 
 
+class _Line(NamedTuple):
+    """One parsed line of recipients.txt. The file's grammar, stated once.
+
+    Both passes over the file go through this. Parsing the key inline in one of
+    them and through a helper in the other is how the two drift: a field added
+    to the line format then has to be added to two parsers that must agree, and
+    nothing fails when only one of them is updated.
+    """
+
+    withdrawn: bool
+    key: str
+    label: str
+
+
+def _parse(line: str) -> _Line:
+    key, _, label = line.removeprefix(_REVOKED).partition(_LABEL_SEP)
+    return _Line(line.startswith(_REVOKED), key.strip(), label.strip())
+
+
+def _revoked_in(lines: list[str]) -> set[str]:
+    parsed = (_parse(line) for line in lines)
+    return {entry.key for entry in parsed if entry.withdrawn}
+
+
+def revoked_keys() -> set[str]:
+    """Every key withdrawn by a tombstone, whether or not it is still listed."""
+    return _revoked_in(_recipient_lines())
+
+
+def _append_recipient_line(line: str) -> None:
+    """Add one line to recipients.txt, keeping it one line per record.
+
+    The only writer. Both callers -- enrolling a key and withdrawing one --
+    need the same three things right: append rather than rewrite, do not run
+    two records together when the file has no trailing newline, and replace the
+    file atomically. `revoke` grew its own copy of that first, which put the
+    newline rule in two places on the one file every machine in the fleet
+    writes and that ``merge=union`` makes unforgiving about stray lines.
+    """
+    path = store.recipients_file()
+    existing = path.read_text(encoding="utf-8") if path.is_file() else ""
+    separator = "" if not existing or existing.endswith("\n") else "\n"
+    store.write_atomic(path, f"{existing}{separator}{line}\n".encode())
+
+
+def _this_machine_revoked(known: Machine) -> bool:
+    """Whether this machine is the one that was withdrawn.
+
+    Answerable locally and without any key: `recipients.txt` is plaintext, a
+    revoked machine can still fetch it, and its own public key is on disk. Which
+    is the point -- the machine that most needs to be told is the one that can
+    no longer decrypt anything to be told with.
+    """
+    try:
+        return crypto.recipient_for(identity_path(known)).strip() in revoked_keys()
+    except (WoswoarError, OSError):
+        return False
+
+
 def _labelled_recipients() -> list[tuple[str, str]]:
     """``(key, label)`` for every enrolled machine, deduplicated by key.
 
     Deduplicated because `.gitattributes` marks this file ``merge=union``, so a
     machine that appends a labelled line where another has the same key
     unlabelled leaves both, and age rejects a repeated recipient.
+
+    Tombstones are collected in a pass of their own first, not skipped as they
+    are met: union merges interleave two machines' appends in whatever order the
+    rebase produces, so a withdrawal can perfectly well land *above* the
+    enrolment it withdraws. Subtracting in one pass would then depend on line
+    order, which nothing guarantees.
+
+    Withdrawal is deliberately permanent: a key that reappears below its own
+    tombstone stays out. Re-enrolling a machine means giving it a new identity,
+    which is the cheap half of the operation -- whereas "whoever the revocation
+    was aimed at can un-revoke themselves by appending the line again" is not a
+    property worth having, and they have push access by assumption.
 
     The label is woswoar's own trailing comment when present and the SSH key's
     comment field otherwise. It is never derived from the key -- an abbreviated
@@ -134,17 +225,21 @@ def _labelled_recipients() -> list[tuple[str, str]]:
     covers C0 only, which is what a *record* needs; making it safe to put on a
     terminal is `Reader.display_name`.
     """
+    lines = _recipient_lines()
+    revoked = _revoked_in(lines)
+
     out: dict[str, str] = {}
-    for line in _recipient_lines():
-        key, _, label = line.partition(_LABEL_SEP)
-        key = key.strip()
-        if not key or key in out:
+    for line in lines:
+        entry = _parse(line)
+        # Tombstones need no case of their own: their key is in `revoked` by
+        # construction, so the same test that drops the enrolment drops them.
+        if not entry.key or entry.key in out or entry.key in revoked:
             continue
-        label = label.strip()
+        label = entry.label
         if not label:
-            fields = key.split(None, 2)
+            fields = entry.key.split(None, 2)
             label = fields[2] if len(fields) > 2 else "(unnamed)"
-        out[key] = make_inert(label)
+        out[entry.key] = make_inert(label)
     return list(out.items())
 
 
@@ -562,7 +657,13 @@ def run(push: bool = True, now: int | None = None) -> Report:
             # shell hook keeps recording into logs/, the backlog exports whole
             # on the first sync after `grant`, and a timer firing every minute
             # must not turn a normal waiting state into a stream of failures.
+            #
+            # Which of the two states this is decides the advice, so it is
+            # settled here rather than left to the caller: "ask someone to run
+            # grant" is exactly wrong for a machine that was revoked, and it is
+            # the message that machine would see forever.
             report.needs_grant = True
+            report.revoked = _this_machine_revoked(known)
             return report
 
         export(known, state, report, int(time.time()) if now is None else now, mac)
@@ -853,6 +954,88 @@ def readers() -> list[Reader]:
         ]
 
 
+class _AccessChange(NamedTuple):
+    identity: Path
+    known: Machine
+    remote: bool
+
+
+@contextmanager
+def _access_change() -> Iterator[_AccessChange]:
+    """The protocol every command that changes who can read history follows.
+
+    Fetch, act under the lock, commit, push -- in that order, and the order is
+    the point. Reading `recipients.txt` before the fetch re-seals to a stale
+    list and reports full success while granting or revoking nothing, which is
+    a silent wrong answer rather than a failure.
+
+    `_reseal` factored out the *loop* the access-changing commands share; this
+    is the transaction around it, which is the half that encodes the ordering.
+    Leaving it copied per command made the hazard `_reseal`'s docstring names
+    -- picked up by widening access and forgotten by narrowing it -- true one
+    level up, where nothing would fail loudly.
+
+    Raising inside the block skips the commit and the push, so a refusal leaves
+    the working tree as it was rather than half-applied.
+    """
+    crypto.require()
+    if not is_repo():
+        raise SyncError("no history repo yet; run 'woswoar init' first")
+
+    known = store.machine()
+    identity = identity_path(known)
+    _ensure_repo_config()
+    remote = has_remote()
+
+    # The same lock sync takes: this rewrites files in the working tree, and a
+    # timer-driven sync must not be reading them halfway through.
+    with lock():
+        if remote:
+            _fetch_and_rebase()
+        yield _AccessChange(identity, known, remote)
+        _commit()
+        if remote:
+            _push()
+
+
+def _reseal(identity: Path, keys: list[str]) -> tuple[int, int]:
+    """Re-seal every sealed-to-recipients file to ``keys``. ``(resealed, skipped)``.
+
+    The mechanism both `grant` and `revoke` are made of, and the reason they are
+    two commands rather than one flag: the files rewritten and the way they are
+    rewritten are identical, and only the intent behind the recipient list
+    differs. One loop means a file that starts being sealed to the recipients
+    cannot be picked up by widening access and forgotten by narrowing it.
+
+    Only a machine that is *already* a recipient can do this: re-sealing means
+    opening the existing file first. That is the point rather than a limitation
+    -- if a machine nobody had granted access to could re-seal old keys, the
+    encryption would not be worth anything.
+    """
+    # The repo key first: it is what a newly enrolled machine needs before it
+    # can authenticate anything at all, and unlike the per-host keys there is
+    # exactly one of it.
+    sealed = [store.mac_key_file()]
+    for host_id in store.repo_hosts():
+        sealed.extend(store.iter_day_keys(host_id))
+        sealed.append(store.name_seal(host_id))
+
+    resealed = skipped = 0
+    for path in sealed:
+        if not path.is_file():
+            continue
+        try:
+            plain = crypto.decrypt_with_file(path.read_bytes(), identity)
+        except (crypto.AgeError, OSError):
+            # Not ours to re-seal: keys sealed before this machine joined, or
+            # left behind by one since removed.
+            skipped += 1
+            continue
+        store.write_atomic(path, crypto.encrypt_to_recipients(plain, keys))
+        resealed += 1
+    return resealed, skipped
+
+
 def grant(approved: list[str] | None = None) -> ReencryptReport:
     """Re-seal every key file to the current recipient list, and publish it.
 
@@ -875,11 +1058,8 @@ def grant(approved: list[str] | None = None) -> ReencryptReport:
     untouched. Any machine already enrolled can do it for every host, because
     all hosts seal their keys to the same recipient list.
 
-    Only a machine that is *already* a recipient can do this: re-sealing means
-    opening the existing key first. That is the point rather than a limitation
-    -- if a machine nobody had granted access to could re-seal old keys, the
-    encryption would not be worth anything. So the new machine cannot onboard
-    itself, and one that cannot open a key skips it silently.
+    `_reseal` explains why only an already-enrolled machine can do this, so the
+    new machine cannot onboard itself and one that cannot open a key skips it.
 
     Fetching first is not optional, for the same reason `run` exports after
     fetching: the recipient list this re-seals to is a *file in the working
@@ -890,27 +1070,13 @@ def grant(approved: list[str] | None = None) -> ReencryptReport:
     This is one of only two operations that rewrite an existing file. It is
     deliberately explicit rather than part of sync.
     """
-    crypto.require()
-    if not is_repo():
-        raise SyncError("no history repo yet; run 'woswoar init' first")
-
-    known = store.machine()
-    identity = identity_path(known)
-    _ensure_repo_config()
-    remote = has_remote()
-    resealed = skipped = 0
-
-    # The same lock sync takes: this rewrites files in the working tree, and a
-    # timer-driven sync must not be reading them halfway through.
-    with lock():
-        if remote:
-            _fetch_and_rebase()
-
-        # Read *after* the fetch, never before. The whole point of this command
-        # is to seal to a machine that enrolled since the last sync, so taking
-        # the list from a pre-fetch checkout would re-seal everything to the old
-        # recipients and report full success. Reading it once here also saves
-        # re-parsing the file for every one of a few thousand key files.
+    with _access_change() as change:
+        # Read *after* the fetch `_access_change` did, never before. The whole
+        # point of this command is to seal to a machine that enrolled since the
+        # last sync, so taking the list from a pre-fetch checkout would re-seal
+        # everything to the old recipients and report full success. Reading it
+        # once here also saves re-parsing the file for every one of a few
+        # thousand key files.
         keys = recipients()
         if approved is not None and sorted(keys) != sorted(approved):
             raise SyncError(
@@ -918,26 +1084,7 @@ def grant(approved: list[str] | None = None) -> ReencryptReport:
                 "run 'woswoar grant' again to see the current list"
             )
 
-        # The repo key first: it is what a newly enrolled machine needs before
-        # it can authenticate anything at all, and unlike the per-host keys
-        # there is exactly one of it.
-        sealed = [store.mac_key_file()]
-        for host_id in store.repo_hosts():
-            sealed.extend(store.iter_day_keys(host_id))
-            sealed.append(store.name_seal(host_id))
-
-        for path in sealed:
-            if not path.is_file():
-                continue
-            try:
-                plain = crypto.decrypt_with_file(path.read_bytes(), identity)
-            except (crypto.AgeError, OSError):
-                # Not ours to re-seal: keys sealed before this machine
-                # joined, or left behind by one since removed.
-                skipped += 1
-                continue
-            store.write_atomic(path, crypto.encrypt_to_recipients(plain, keys))
-            resealed += 1
+        resealed, skipped = _reseal(change.identity, keys)
 
         if approved is not None:
             # Recorded rather than counted: what the next confirmation subtracts
@@ -949,11 +1096,109 @@ def grant(approved: list[str] | None = None) -> ReencryptReport:
             state.granted = keys
             state.save()
 
-        _commit()
-        if remote:
-            _push()
+    return ReencryptReport(resealed, skipped, pushed=change.remote)
 
-    return ReencryptReport(resealed, skipped, pushed=remote)
+
+class RevokeReport(NamedTuple):
+    """What `revoke` did, and -- just as much -- what it could not do."""
+
+    resealed: int
+    skipped: int
+    pushed: bool
+    #: Days *this host* has a key for already and is still recording into, so
+    #: commands added to them stay readable by the revoked key. In practice
+    #: today. Reported rather than left to be worked out, because it is the one
+    #: gap someone might act on.
+    #:
+    #: Per-host, and the wording that carries it says so: every other enrolled
+    #: machine has the same gap for the days it is recording into, and this one
+    #: cannot see which those are.
+    still_readable: list[str]
+
+
+def find_reader(fingerprint: str) -> Reader:
+    """The one enrolled machine ``fingerprint`` names, or a useful refusal.
+
+    Matched on the fingerprint rather than the name, because the name is the
+    part anyone with push access can choose -- revoking by a string an attacker
+    wrote is how you revoke the wrong machine. A unique prefix is accepted, the
+    way git takes a short commit id; an ambiguous one is refused rather than
+    resolved, since guessing here removes somebody's access.
+    """
+    wanted = fingerprint.strip()
+    if not wanted:
+        raise SyncError("no fingerprint given; run 'woswoar grant' to see them")
+
+    candidates = [reader for reader in readers() if reader.fingerprint.startswith(wanted)]
+    if not candidates:
+        raise SyncError(f"no enrolled machine has a fingerprint starting {wanted!r}")
+    if len(candidates) > 1:
+        shown = "\n".join(f"  {reader.fingerprint}" for reader in candidates)
+        raise SyncError(f"{wanted!r} matches {len(candidates)} machines:\n{shown}")
+    return candidates[0]
+
+
+def _still_readable(host_id: str) -> list[str]:
+    """Days this host has both a key for and a log it may still append to."""
+    keyed = {store.day_of_key(path) for path in store.iter_day_keys(host_id)}
+    logged = {
+        store.day_of_log(log.relpath) for log in store.iter_log_files() if log.host_id == host_id
+    }
+    return sorted(keyed & logged)
+
+
+def revoke(reader: Reader) -> RevokeReport:
+    """Withdraw one machine's access, and re-seal what is left without it.
+
+    Three things happen, and it is worth being exact about which of them is a
+    guarantee:
+
+    1. A tombstone is appended, so every machine subtracts this key from the
+       recipient list on its next fetch. Permanent, and survives ``merge=union``
+       -- see `_REVOKED`.
+    2. Every sealed key file is re-sealed to the remaining recipients, so a copy
+       of the repo taken *after* this cannot be opened with that key.
+    3. Day keys minted from now on exclude it, which is what actually stops the
+       revoked machine reading tomorrow's commands.
+
+    What this cannot undo: anything the revoked machine already read or already
+    cloned, and any day whose key it already holds -- reported as
+    ``still_readable`` rather than left for the caller to work out. Rotating
+    those mid-day is not an option: a day key is minted once and every chunk of
+    that day is sealed to it, so replacing it would strand the chunks already
+    written on every machine that has not merged them yet.
+
+    It also does not touch git access -- a revoked machine can still fetch --
+    and it still holds the authentication key, so it can still *write* history
+    other machines will accept. Those want the git credential rotated and, for
+    the authentication key, a rebuilt repo.
+    """
+    if reader.is_mine:
+        raise SyncError(
+            "that is this machine's own key; revoking it here would lock this "
+            "machine out of its own history. Run 'woswoar revoke' from another one."
+        )
+
+    with _access_change() as change:
+        # Checked before the tombstone is written, so a refusal leaves the file
+        # as it was rather than tombstoned-but-not-re-sealed.
+        if set(recipients()) <= {reader.key}:
+            raise SyncError(
+                "that is the only machine left; revoking it would seal the "
+                "history to nobody and lose it. Enrol another machine first."
+            )
+
+        # No date in the tombstone: the commit carries one already, and a date
+        # written into a shared file is a date the machine that wrote it chose.
+        _append_recipient_line(f"{_REVOKED}{reader.key}{_LABEL_SEP}revoked")
+
+        # Read back rather than filtered by hand. What a tombstone subtracts is
+        # `_labelled_recipients`' rule, and a second copy of it here is a second
+        # thing to keep in step -- the reason the file is written first.
+        resealed, skipped = _reseal(change.identity, recipients())
+        still_readable = _still_readable(change.known.id)
+
+    return RevokeReport(resealed, skipped, pushed=change.remote, still_readable=still_readable)
 
 
 def compact(before: str) -> tuple[int, int]:
@@ -1035,11 +1280,21 @@ def add_recipient(recipient: str, label: str = "") -> bool:
     key = recipient.strip()
     if "\n" in key:
         raise SyncError(f"the public key for this machine is not one line: {key!r}")
+    if key.startswith(_REVOKED):
+        # No real key starts with "-", so this is not a shape anyone reaches by
+        # accident -- but one that did would be indistinguishable from a
+        # tombstone, and would silently withdraw whatever key followed it.
+        raise SyncError(f"a public key may not start with {_REVOKED!r}: {key!r}")
+    if key in revoked_keys():
+        # Loudly, and not as "already enrolled". Appending the line would be
+        # harmless -- `_labelled_recipients` subtracts it either way -- but this
+        # machine would then record and sync for days while reading nothing, and
+        # the reason would sit in a file it never prints.
+        raise SyncError(
+            "this key was revoked, and a revocation is permanent. Re-enrol this "
+            "machine with a new identity:  woswoar init <url> --new-identity"
+        )
     if key in recipients():
         return False
-    path = store.recipients_file()
-    existing = path.read_text(encoding="utf-8") if path.is_file() else ""
-    separator = "" if not existing or existing.endswith("\n") else "\n"
-    line = f"{key}{_LABEL_SEP}{make_inert(label)}" if label else key
-    store.write_atomic(path, f"{existing}{separator}{line}\n".encode())
+    _append_recipient_line(f"{key}{_LABEL_SEP}{make_inert(label)}" if label else key)
     return True


### PR DESCRIPTION
Fixes #34 — the missing half of #19.

#19 made it possible to *notice* a foreign key in the `grant` prompt. There was no way to get rid of one: `add_recipient` was the only writer of `recipients.txt` and had no counterpart, and hand-editing does not stick, because `.gitattributes` marks the file `merge=union` and union keeps both sides of every difference — a deleted line comes straight back from any peer that still has it.

## The tombstone

`woswoar revoke <fingerprint>` appends `-<key> # revoked` instead of deleting. Union preserves it, every machine subtracts it on the next fetch, and it is **permanent**: a key that reappears below its own tombstone stays out, because whoever the revocation was aimed at has push access by assumption. Re-enrolling a real machine means a new identity, and `add_recipient` now says that rather than silently appending a line that would never take effect.

Selection is by fingerprint, never by name — the name is the part an attacker writes. Unique-prefix matching like a short commit id, and a refusal on ambiguity, since guessing removes somebody's access.

## What it guarantees, and what it doesn't

Verified end-to-end with two real machines through a bare repo: after `revoke`, the revoked machine still has what came before and never receives what comes after.

Three limits print **before** the prompt — they are the reasons someone might answer no and go do something else first:

- it does not un-publish anything;
- it does not revoke git access (rotate that credential too, or it can simply fetch again);
- it does not stop that machine *writing* history yours will accept — the authentication key is shared and cannot be rotated without rebuilding the repo. Filed as **#38**.

There is also a bounded read window: a day key is minted once and every chunk of that day is sealed to it, so commands recorded on a day whose key already exists stay readable. Rotating mid-day would strand chunks already sealed to it on every machine that has not merged them. `revoke` prints which days, and says the same gap exists on your other machines for the days they are recording into.

A revoked machine's own `woswoar sync` now says it was revoked, instead of telling it to ask someone for a `grant` that can never help. It answers that with no key at all — `recipients.txt` is plaintext and its own public key is on disk.

## /simplify

Run before opening, per the working agreements, and applied rather than deferred. The reviews were right about a real gap: `_reseal` had factored out the shared *loop*, but `grant` and `revoke` still each spelled out the transaction around it — fetch, act under the lock, commit, push — and that ordering is the security-relevant half. Getting it wrong fails silently with "re-sealed N key file(s)". That is now `_access_change()`. Likewise `_parse` (one grammar for `recipients.txt`, which two passes were parsing two ways), `_append_recipient_line` (one writer), and `_confirm` (one gate — its `isatty` branch is a security control, and the third copy is the one that quietly drops it while reading like the other two).

## Tests

21 mutations, all 21 killing their guarding test. Two rounds were needed and both were my error, not the tests':

- three "surviving" tests were actually **no-op mutations** — `[] or sorted(...)` and a heading rename that left the asserted claims on screen;
- one was a **stale-`.pyc` artefact**. Two consecutive mutations changed the file by exactly the same number of bytes inside one second, and the pyc header is `(mtime_seconds, size)`, so the second run validated against the first's cached bytecode and reported the wrong result. The harness now clears `__pycache__` and runs with `-B`. I re-ran the **already-merged #19** set under the fixed harness: all 19 still hold, no false negatives there.

Also removed three genuinely decorative test lines the reviews caught, including an assertion about a stale snapshot that passed regardless of what `revoke` did.

`docs/security.md` gains a section on what revoking does and the three things it cannot, plus two rows in the guarantees table.

258 tests pass. Startup is unchanged (`import woswoar.search` 28.4 ms vs 28.5 ms on main, no new module-scope imports); `recipients()` costs 20.5 µs at a realistic five recipients.