### PR TITLE
Record what has been merged as a set, and say what a compaction replaced

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -207,6 +207,8 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | The hook forks nothing | recording runs under `strace`; the clone/fork/execve count must be **0** |
 | Shell and Python escaping agree | a command containing a literal tab and newline must round-trip byte-for-byte |
 | History is never rewritten | `git log --diff-filter=MD` over chunk files must be **empty** |
+| Compaction does not duplicate history | a peer that already merged a day, and one that merged only part of it, both end up holding each command exactly once |
+| A failed chunk is retried, not dropped | an earlier chunk that fails while a later one succeeds is merged once it is repaired |
 | age is never given a file path | every age invocation is inspected; no argument may be an existing path outside `/dev/fd` |
 | Forged history is refused | a chunk sealed to a host's published day key, but absent from that host's signed manifest, is rejected and reported |
 | Tampering is refused | flipping one byte of a real chunk fails authentication, not merely decryption |

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -720,7 +720,7 @@ happens on a timer where nothing is waiting for it.
 2. **Fetch and rebase first.**
 3. Seal each own log file's unsealed tail into a new chunk; commit.
 4. Push, retrying once after a fetch/rebase if someone else pushed meanwhile.
-5. For each other host, decrypt chunks newer than the merge watermark and append
+5. For each other host, decrypt chunks it has not already merged and append
    the plaintext to `logs/`.
 
 > Step 2 has to come before step 3, and this was learned the hard way. Creating

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -16,6 +16,7 @@ import zlib
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest import mock
 
 from woswoar import cache, crypto, search, store, sync
 from woswoar.__main__ import _GRANT_REMEDY, main
@@ -1456,7 +1457,8 @@ class TestChunkAuthenticity(SyncTestCase):
         entry = Entry(1_700_000_900, host_id, "s1", "~", 0, 5, cmd)
         payload = sync.pack((format_line(entry) + "\n").encode("utf-8"))
         # Named far in the future so it sorts above whatever the real machine
-        # has published; a forgery the watermark skips proves nothing.
+        # has published; a forgery that lands among chunks already merged
+        # proves nothing.
         target = work / "hosts" / host_id / day / f"{name}.age"
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(crypto.encrypt_to(payload, pub))
@@ -1528,7 +1530,9 @@ class TestChunkAuthenticity(SyncTestCase):
             signer.write_text(f"{verify_key}\n{owner}\n", encoding="utf-8")
             chunk = work / "hosts" / "deadbeefdeadbeef" / "2023-11-14" / "9999999999-ffffff.age"
             body = sync._manifest_body(
-                "deadbeefdeadbeef", "2023-11-14", {chunk.name: sync.digest_of(chunk.read_bytes())}
+                "deadbeefdeadbeef",
+                "2023-11-14",
+                {chunk.name: sync.Entry(sync.digest_of(chunk.read_bytes()))},
             )
             manifest = work / "hosts" / "deadbeefdeadbeef" / "manifests" / "2023-11-14"
             manifest.parent.mkdir(parents=True, exist_ok=True)
@@ -1588,15 +1592,8 @@ class TestChunkAuthenticity(SyncTestCase):
         with alpha.active():
             before = {c.name for c in store.iter_chunks(alpha.id)}
             alpha.record("2023-11-14", 1_700_000_002, "cargo build")
-            # An explicit, strictly later timestamp. Two chunks written in the
-            # same wall-clock second share a prefix and differ only by a random
-            # suffix, so the merge watermark -- a plain string compare -- skips
-            # the second one about half the time and it is never examined at
-            # all. That is issue #27's mechanism, and it made this test flake
-            # 40% of runs; pinning the second is what makes it deterministic.
             sync.run(now=2_000_000_000)
             fresh = ({c.name for c in store.iter_chunks(alpha.id)} - before).pop()
-            self.assertGreater(fresh, max(before), "the tampered chunk must be past the watermark")
 
         def flip(work: Path) -> None:
             target = work / "hosts" / alpha.id / "2023-11-14" / fresh
@@ -1625,7 +1622,9 @@ class TestChunkAuthenticity(SyncTestCase):
             theirs = self.root / "attacker-key"
             crypto.generate_signing_key(theirs)
             body = sync._manifest_body(
-                alpha.id, "2023-11-14", {chunk.name: sync.digest_of(chunk.read_bytes())}
+                alpha.id,
+                "2023-11-14",
+                {chunk.name: sync.Entry(sync.digest_of(chunk.read_bytes()))},
             )
             signature = crypto.sign(body.encode("utf-8"), theirs, sync._MANIFEST_MAGIC)
             manifest = work / "hosts" / alpha.id / "manifests" / "2023-11-14"
@@ -1705,6 +1704,248 @@ class TestExportWillNotDisownItsOwnHistory(SyncTestCase):
             report = sync.run(now=1_900_000_000)
             self.assertEqual(report.chunks_written, 1)
             self.assertEqual(report.unsignable, {"2023-11-14"})
+
+
+class TestTheMergeWatermark(SyncTestCase):
+    """What a machine has merged is a *set*, not a high-water mark.
+
+    A single "highest name seen" cannot express "all but that one", and chunk
+    names are only loosely ordered -- two written in the same second differ by a
+    random suffix. So a high-water mark gets both of these wrong, in opposite
+    directions, depending only on iteration order.
+    """
+
+    def alpha_with_two_chunks(self) -> tuple[Fake, Fake, list[store.Chunk]]:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "first command")
+            sync.run(now=1_700_000_500)
+            alpha.record("2023-11-14", 1_700_000_002, "second command")
+            sync.run(now=1_700_000_600)
+            chunks = sorted(store.iter_chunks(alpha.id), key=lambda c: c.name)
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+        return alpha, beta, chunks
+
+    def test_a_chunk_that_failed_once_is_retried_rather_than_skipped(self) -> None:
+        """The silent half, and the worse one.
+
+        If an earlier-named chunk fails while a later-named one succeeds, a
+        high-water mark advances past the failure and that chunk is never looked
+        at again -- its commands are simply missing, with nothing said after the
+        run in which it failed.
+        """
+        alpha, beta, chunks = self.alpha_with_two_chunks()
+        first, _later = chunks
+        original = first.path.read_bytes()
+
+        with alpha.active():
+            # Damaged in place: its digest no longer matches the signed
+            # manifest, so beta refuses it -- while the later chunk is fine.
+            first.path.write_bytes(b"corrupted" + original)
+            sync.run(now=1_700_000_700)
+
+        with beta.active():
+            report = sync.run()
+            self.assertTrue(report.unauthenticated)
+            self.assertIn("second command", beta.commands())
+            self.assertNotIn("first command", beta.commands())
+
+        # Repaired at the source, as a transient failure would be.
+        with alpha.active():
+            first.path.write_bytes(original)
+            sync.run(now=1_700_000_800)
+
+        with beta.active():
+            sync.run()
+            self.assertIn("first command", beta.commands(), "the failed chunk was never retried")
+
+    def test_a_chunk_already_merged_is_not_read_again(self) -> None:
+        """The other half: nothing already consumed may be reconsidered.
+
+        A set says this directly. Under a high-water mark it held only because
+        every later name happened to sort above every earlier one.
+        """
+        _alpha, beta, _chunks = self.alpha_with_two_chunks()
+        with beta.active():
+            self.assertEqual(sync.run().chunks_merged, 2)
+            self.assertEqual(sync.run().chunks_merged, 0)
+            self.assertEqual(len(cache.load_entries()), 2)
+
+
+class TestCompactionDoesNotDuplicateOnPeers(SyncTestCase):
+    """`compact` replaces a day's chunks with one holding the same lines.
+
+    A peer that already merged the originals must not merge the replacement as
+    though it were new. Whether it did used to be a coin flip: the compacted
+    chunk carries the timestamp of the last chunk it replaced and a fresh random
+    suffix, so it sorted above the old high-water mark about half the time
+    (measured 4/10 before this was fixed).
+    """
+
+    def fleet(self) -> tuple[Fake, Fake]:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            for i in range(3):
+                alpha.record("2023-11-14", 1_700_000_000 + i, f"command {i}")
+                sync.run(now=1_700_000_500 + i)
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+        return alpha, beta
+
+    def merged_entries(self, beta: Fake) -> int:
+        with beta.active():
+            sync.run()
+            return len(cache.load_entries())
+
+    def test_a_peer_that_already_merged_the_day_gains_nothing(self) -> None:
+        # Counted as *entries*, not unique commands: `commands()` is a set, and
+        # a set is exactly what hides this. The test that missed this bug for
+        # three releases compared sets.
+        alpha, beta = self.fleet()
+        before = self.merged_entries(beta)
+        self.assertEqual(before, 3)
+
+        with alpha.active():
+            # The suffix pinned to the highest it can be, so the compacted chunk
+            # certainly sorts above the peer's old high-water mark. Left random,
+            # this reproduced about half the time -- which is a coin flip, not a
+            # regression test.
+            with mock.patch("woswoar.store.secrets.token_hex", return_value="ffffff"):
+                days, replaced = sync.compact(before="2023-11-15")
+            self.assertEqual((days, replaced), (1, 3))
+            sync.run(now=1_700_000_900)
+
+        self.assertEqual(self.merged_entries(beta), before, "compaction duplicated merged history")
+
+    def test_a_peer_that_merged_only_part_of_the_day_ends_up_with_all_of_it(self) -> None:
+        """The case a high-water mark cannot get right in either direction.
+
+        Skipping the compacted chunk loses the lines the peer never had;
+        appending it duplicates the ones it did. Neither is acceptable, so a
+        chunk that subsumes others replaces the day rather than adding to it.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_000, "command 0")
+            sync.run(now=1_700_000_500)
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+        with beta.active():
+            sync.run()
+            self.assertEqual(len(cache.load_entries()), 1)
+
+        # beta is away while alpha records more and then compacts the day.
+        with alpha.active():
+            for i in (1, 2):
+                alpha.record("2023-11-14", 1_700_000_000 + i, f"command {i}")
+                sync.run(now=1_700_000_500 + i)
+            sync.compact(before="2023-11-15")
+            sync.run(now=1_700_000_900)
+
+        with beta.active():
+            sync.run()
+            entries = cache.load_entries()
+        self.assertEqual(len(entries), 3, "beta should hold each command exactly once")
+        self.assertEqual({e.cmd for e in entries}, {"command 0", "command 1", "command 2"})
+
+    def test_a_chunk_sorting_below_the_compacted_one_survives(self) -> None:
+        """A day rewritten by a compacted chunk keeps what that chunk does not hold.
+
+        Chunk names carry the timestamp of the sync that wrote them, and the
+        compacted chunk takes the timestamp of the last chunk it replaced -- so
+        a chunk written afterwards with an earlier timestamp sorts *below* it and
+        is merged first. Discarding what had been accumulated would lose it.
+        """
+        alpha, beta = self.fleet()
+        self.assertEqual(self.merged_entries(beta), 3)
+
+        with alpha.active():
+            sync.compact(before="2023-11-15")
+            # Named below the compacted chunk, which took ts 1_700_000_502.
+            alpha.record("2023-11-14", 1_700_000_009, "written after compaction")
+            sync.run(now=1_700_000_400)
+            names = sorted(c.name for c in store.iter_chunks(alpha.id))
+        self.assertLess(names[0], names[1], "the fixture no longer builds the case")
+
+        with beta.active():
+            sync.run()
+            entries = cache.load_entries()
+        self.assertEqual(len(entries), 4)
+        self.assertIn("written after compaction", {e.cmd for e in entries})
+
+
+class TestUpgradingFromAHighWaterMark(SyncTestCase):
+    """A state file written before the watermark became a set.
+
+    Its `merged` values are single strings, and a string is iterable -- so a
+    loader that just iterates them turns one chunk name into twenty-one
+    one-character entries, nothing matches, every chunk looks unmerged, and the
+    first sync after upgrading duplicates every peer's history. That is the very
+    bug this change was made to fix, reintroduced by the fix.
+    """
+
+    def test_a_string_watermark_is_discarded_rather_than_read_as_characters(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            store.save_json(
+                store.state_file(),
+                {"exported": {}, "merged": {"abc/2023-11-14": "1700000000-abcdef.age"}},
+            )
+            merged = sync.State.load().merged
+        self.assertEqual(merged, {}, "the old string was read as a set of characters")
+
+    def test_the_day_is_re_merged_once_and_not_duplicated(self) -> None:
+        """Losing the record costs one re-merge, which must not double the day.
+
+        The chunks are merged again, appended to a log that already holds them.
+        Nothing can prevent that -- the record of what was merged is gone -- but
+        it must be the *only* consequence, and it must not repeat.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "before the upgrade")
+            sync.run(now=1_700_000_500)
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+        with beta.active():
+            sync.run()
+            self.assertEqual(len(cache.load_entries()), 1)
+
+            # Downgrade the state file to what the previous version wrote.
+            state = store.load_json(store.state_file())
+            state["merged"] = {key: sorted(names)[-1] for key, names in state["merged"].items()}
+            store.save_json(store.state_file(), state)
+
+            sync.run()
+            after = len(cache.load_entries())
+            sync.run()
+            self.assertEqual(len(cache.load_entries()), after, "it re-merged a second time")
+
+    def test_an_idle_sync_does_not_rewrite_the_state_file(self) -> None:
+        """Recording every merged chunk name made this file about a megabyte.
+
+        `run` saves at the end of every sync and the timer fires once a minute,
+        so writing it out to say nothing happened is a lot of disk for no
+        information -- and an idle sync is the overwhelmingly common one.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "something")
+            sync.run(now=1_700_000_500)
+            before = store.state_file().stat().st_mtime_ns
+
+            sync.run(now=1_700_000_600)
+            self.assertEqual(store.state_file().stat().st_mtime_ns, before)
+
+            # And it still writes when there is something to say.
+            alpha.record("2023-11-14", 1_700_000_002, "something else")
+            sync.run(now=1_700_000_700)
+            self.assertNotEqual(store.state_file().stat().st_mtime_ns, before)
 
 
 if __name__ == "__main__":

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -505,8 +505,11 @@ def chunk_dir(machine_id: str, day: str) -> Path:
 def new_chunk(machine_id: str, day: str, ts: int) -> Path:
     """A chunk path that has never existed before.
 
-    Zero-padded seconds sort chronologically as strings, which is what lets the
-    merge watermark be a plain string comparison.
+    Zero-padded seconds sort chronologically as strings, so a day's chunks are
+    walked oldest-first. That ordering is a convenience, not a guarantee: two
+    chunks written in the same second differ only by the random suffix, which is
+    why what a machine has merged is recorded as a *set* of names rather than a
+    high-water mark.
 
     Uniqueness is a guarantee, not a probability. A collision would silently
     overwrite an already-sealed chunk, destroying committed history in a design
@@ -525,7 +528,7 @@ def new_chunk(machine_id: str, day: str, ts: int) -> Path:
 
 class Chunk(NamedTuple):
     day: str
-    #: Filename only. Sorts chronologically, and is what the watermark stores.
+    #: Filename only. Sorts chronologically, and is what `State.merged` records.
     name: str
     path: Path
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -303,8 +303,20 @@ class State:
 
     #: log relpath -> plaintext bytes already sealed into a chunk.
     exported: dict[str, int] = field(default_factory=dict)
-    #: "<host>/<day>" -> newest chunk filename already merged into logs/.
-    merged: dict[str, str] = field(default_factory=dict)
+    #: "<host>/<day>" -> the chunk filenames already merged into logs/.
+    #:
+    #: A set, not a high-water mark. A single "highest name seen" cannot say
+    #: "all of these except that one", and chunk names are only loosely ordered:
+    #: two written in the same wall-clock second share a timestamp and differ by
+    #: a random suffix. So a mark got it wrong in both directions -- a chunk that
+    #: failed while a later-named one succeeded was skipped for good, and a
+    #: chunk that failed while being the newest was re-read every minute forever.
+    #:
+    #: A set here and a sorted list in the file. JSON has no set, and converting
+    #: at that boundary is the only place that knows about the file -- `merge`
+    #: kept its own mirror to get a fast membership test, which was one more
+    #: thing to keep in step and rebuilt itself once per chunk.
+    merged: dict[str, set[str]] = field(default_factory=dict)
     #: Keys a human at this machine last approved in `grant`. Local like the
     #: rest of State, and here that is the whole point: "which machines are new
     #: since *you* last agreed to this?" is a question only this machine can
@@ -317,6 +329,9 @@ class State:
     #: `hosts/<id>/signer.pub` included, so the key a host is held to has to be
     #: remembered somewhere the remote cannot reach.
     signers: dict[str, str] = field(default_factory=dict)
+    #: What was on disk when this was loaded, so `save` can tell whether there
+    #: is anything to write. Not part of the state itself.
+    _loaded: dict[str, object] = field(default_factory=dict, repr=False, compare=False)
 
     @classmethod
     def load(cls) -> State:
@@ -327,9 +342,17 @@ class State:
         signers = raw.get("signers", {})
         if not isinstance(exported, dict) or not isinstance(merged, dict):
             return cls()
-        return cls(
+        state = cls(
             exported={str(k): int(v) for k, v in exported.items()},
-            merged={str(k): str(v) for k, v in merged.items()},
+            # Guarded per value, not just on `merged` being a dict. A state
+            # file from before this became a set holds one *string* per day, and
+            # a string is iterable: without this, every day's record turns into
+            # its own characters, every chunk looks unmerged, and the first sync
+            # after upgrading duplicates every peer's history wholesale -- which
+            # is the bug this change exists to fix.
+            merged={
+                str(k): {str(name) for name in v} for k, v in merged.items() if isinstance(v, list)
+            },
             # A malformed list costs the prompt its memory, which shows every
             # machine as new -- the safe direction to be wrong in.
             granted=[str(k) for k in granted] if isinstance(granted, list) else [],
@@ -340,17 +363,38 @@ class State:
             if isinstance(signers, dict)
             else {},
         )
+        state._loaded = state.as_json()
+        return state
+
+    def as_json(self) -> dict[str, object]:
+        """This state as the file holds it.
+
+        Every container is rebuilt rather than shared, so the snapshot `save`
+        compares against cannot be mutated from underneath by whoever holds the
+        `State`.
+        """
+        return {
+            "exported": dict(self.exported),
+            "merged": {key: sorted(names) for key, names in self.merged.items()},
+            "granted": list(self.granted),
+            "signers": dict(self.signers),
+        }
 
     def save(self) -> None:
-        store.save_json(
-            store.state_file(),
-            {
-                "exported": self.exported,
-                "merged": self.merged,
-                "granted": self.granted,
-                "signers": self.signers,
-            },
-        )
+        """Write, unless nothing changed since it was loaded.
+
+        Recording every merged chunk name rather than a high-water mark made
+        this file two orders of magnitude bigger -- about 1 MiB at 35k chunks --
+        and `run` saves at the end of every sync, on a one-minute timer. Writing
+        a megabyte a minute to say nothing happened is a lot of disk for no
+        information, and an idle sync is the overwhelmingly common one. `cache`
+        makes the same call for the same reason.
+        """
+        current = self.as_json()
+        if current == self._loaded:
+            return
+        store.save_json(store.state_file(), current)
+        self._loaded = current
 
 
 @contextmanager
@@ -719,7 +763,20 @@ def _manifest_header(host_id: str, day: str) -> str:
     return f"{_MANIFEST_MAGIC} {host_id} {day}"
 
 
-def _manifest_body(host_id: str, day: str, digests: dict[str, str]) -> str:
+class Entry(NamedTuple):
+    """One line of a manifest: a chunk, and what it replaced.
+
+    ``subsumes`` is empty for an ordinary chunk and holds the names `compact`
+    merged into this one otherwise. It is in the *signed* bytes because it
+    decides what a peer does with the chunk, and anything that decides that has
+    to be something only the publishing machine can say.
+    """
+
+    digest: str
+    subsumes: tuple[str, ...] = ()
+
+
+def _manifest_body(host_id: str, day: str, entries: dict[str, Entry]) -> str:
     """The signed part of a manifest: what this host claims it wrote that day.
 
     The header names the host and the day, so a genuine manifest cannot be
@@ -731,19 +788,21 @@ def _manifest_body(host_id: str, day: str, digests: dict[str, str]) -> str:
     a sync that adds nothing rewrites nothing.
     """
     lines = [_manifest_header(host_id, day)]
-    lines += [f"{name} {digests[name]}" for name in sorted(digests)]
+    for name in sorted(entries):
+        entry = entries[name]
+        lines.append(" ".join([name, entry.digest, *entry.subsumes]))
     return "\n".join(lines) + "\n"
 
 
-def write_manifest(known: Machine, day: str, digests: dict[str, str]) -> None:
+def write_manifest(known: Machine, day: str, entries: dict[str, Entry]) -> None:
     """Sign this host's chunk list for ``day`` and write it."""
-    body = _manifest_body(known.id, day, digests)
+    body = _manifest_body(known.id, day, entries)
     signature = crypto.sign(body.encode("utf-8"), store.signing_key_file(), _MANIFEST_MAGIC)
     blob = signature.decode("utf-8").strip() + _MANIFEST_SEPARATOR + body
     store.write_atomic(store.day_manifest(known.id, day), blob.encode("utf-8"))
 
 
-def read_manifest(host_id: str, day: str, verify_key: str) -> dict[str, str]:
+def read_manifest(host_id: str, day: str, verify_key: str) -> dict[str, Entry]:
     """The digests ``host_id`` signed for ``day``, or ``{}`` if it did not.
 
     Empty rather than an exception for an unsigned, malformed, mis-signed or
@@ -773,12 +832,13 @@ def read_manifest(host_id: str, day: str, verify_key: str) -> dict[str, str]:
     if not lines or lines[0] != _manifest_header(host_id, day):
         return {}
 
-    digests: dict[str, str] = {}
+    entries: dict[str, Entry] = {}
     for line in lines[1:]:
-        name, _, value = line.partition(" ")
-        if name and value:
-            digests[name] = value
-    return digests
+        name, _, rest = line.partition(" ")
+        digest, _, subsumed = rest.partition(" ")
+        if name and digest:
+            entries[name] = Entry(digest, tuple(subsumed.split()))
+    return entries
 
 
 # ---------------------------------------------------------------------------
@@ -877,7 +937,7 @@ def export(known: Machine, state: State, report: Report, now: int) -> None:
             sealed = crypto.encrypt_to(pack(data), day_public_key(known, day))
             written = store.new_chunk(known.id, day, now)
             store.write_atomic(written, sealed)
-            listed[written.name] = digest_of(sealed)
+            listed[written.name] = Entry(digest_of(sealed))
 
             state.exported[relpath] = new_offset
             report.chunks_written += 1
@@ -974,14 +1034,18 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
     #: Likewise for manifests, which cost a subprocess each. One per day rather
     #: than one per chunk is the whole reason signatures are affordable here:
     #: over a year of three machines that is ~3.6 s against nearly two minutes.
-    manifests: dict[str, dict[str, str]] = {}
+    manifests: dict[str, dict[str, Entry]] = {}
     pending: dict[str, list[bytes]] = {}
+    #: Days whose local log is being replaced rather than appended to, because a
+    #: chunk arrived that subsumes others.
+    replaced: set[str] = set()
 
     for chunk in store.iter_chunks(host_id):
         key = f"{host_id}/{chunk.day}"
-        # Chunk names are zero-padded timestamps, so "newer than the watermark"
-        # is a plain string comparison.
-        if chunk.name <= state.merged.get(key, ""):
+        # `get`, not `setdefault`: a day this machine only ever *looks* at --
+        # never granted, or a manifest it cannot verify -- must not gain an
+        # empty record that is then written out on every sync forever.
+        if chunk.name in state.merged.get(key, ()):
             continue
 
         if chunk.day not in manifests:
@@ -999,7 +1063,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 day_keys[chunk.day] = open_day_key(known, host_id, chunk.day)
             except (crypto.AgeError, SyncError):
                 # Sealed before this machine was enrolled, and no one has run
-                # `grant` yet. Skip it without advancing the watermark so a
+                # `grant` yet. Skip it without recording it as merged, so a
                 # later sync picks it up -- and above all without aborting, or
                 # one unreadable day would block this machine's own export too.
                 day_keys[chunk.day] = None
@@ -1011,7 +1075,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         # Authenticated before it is decrypted or decompressed, so age, zlib and
         # the parser only ever see bytes one of this user's own machines wrote.
         try:
-            blob = open_chunk(chunk.path, listed[chunk.name])
+            blob = open_chunk(chunk.path, listed[chunk.name].digest)
         except (OSError, ValueError):
             report.unauthenticated.add(key)
             continue
@@ -1027,19 +1091,59 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             report.unreadable.add(key)
             continue
 
+        if listed[chunk.name].subsumes:
+            # A compacted chunk: the same lines its originals held, under a new
+            # name. Appending it to a day this machine already merged would
+            # duplicate every one of them, and skipping it would lose whatever
+            # arrived after the last sync. It is a complete statement of the
+            # chunks it names, so the day is rewritten rather than added to, and
+            # all three cases -- merged all of them, some, or none -- land on
+            # the same content.
+            #
+            # Marking the day is all it does: what has been accumulated stays,
+            # in chunk-name order, so a chunk that is *not* subsumed and happens
+            # to sort below the compacted one is still written. Replacing the
+            # accumulated blocks instead was tried and drops exactly that chunk.
+            #
+            # The subsumed names are left in the merged set on purpose. They are
+            # already there from when this machine merged the originals, and
+            # that membership is what stops those lines being written twice if
+            # the original files are still visible -- a peer mid-fetch, or a
+            # repo someone put them back into.
+            replaced.add(chunk.day)
         pending.setdefault(chunk.day, []).append(plaintext)
-        state.merged[key] = chunk.name
+        state.merged.setdefault(key, set()).add(chunk.name)
         report.chunks_merged += 1
 
     if pending:
         store.private_dir(store.host_dir(host_id))
     for day, blocks in pending.items():
         payload = b"".join(blocks)
-        # Another machine's history is no less private than this one's, and it
-        # lands in the same tree, so it is created with the same mode.
-        with store.private_append(store.log_file(host_id, day), binary=True) as handle:
-            handle.write(payload)
-        report.lines_imported += payload.count(b"\n")
+        path = store.log_file(host_id, day)
+        if day in replaced:
+            # One atomic replacement, not unlink-then-append: search runs
+            # outside the sync lock and reads these files, so a truncate leaves
+            # a window where a day looks empty or half-written, and a crash in
+            # it loses the day silently. `write_atomic` also owns the 0600.
+            before = _line_count(path)
+            store.write_atomic(path, payload)
+            # Only the growth. A peer that already held the whole day and then
+            # received its compaction gained nothing, and saying it merged five
+            # thousand lines would be a lie in the reassuring direction.
+            report.lines_imported += max(0, payload.count(b"\n") - before)
+        else:
+            # Another machine's history is no less private than this one's, and
+            # it lands in the same tree, so it is created with the same mode.
+            with store.private_append(path, binary=True) as handle:
+                handle.write(payload)
+            report.lines_imported += payload.count(b"\n")
+
+
+def _line_count(path: Path) -> int:
+    try:
+        return path.read_bytes().count(b"\n")
+    except OSError:
+        return 0
 
 
 def _merge_name(known: Machine, host_id: str) -> None:
@@ -1712,7 +1816,11 @@ def compact(before: str) -> tuple[int, int]:
                 )
             try:
                 plain = b"".join(
-                    unpack(crypto.decrypt_with_secret(open_chunk(c.path, listed[c.name]), secret))
+                    unpack(
+                        crypto.decrypt_with_secret(
+                            open_chunk(c.path, listed[c.name].digest), secret
+                        )
+                    )
                     for c in chunks
                 )
             except ValueError as exc:
@@ -1724,7 +1832,12 @@ def compact(before: str) -> tuple[int, int]:
             for chunk in chunks:
                 chunk.path.unlink()
                 del listed[chunk.name]
-            listed[merged.name] = digest_of(sealed)
+            # What it replaced, recorded and signed. A peer that already merged
+            # any of those must not merge this as if it were new history, and it
+            # cannot work that out from the bytes -- the lines are the same ones.
+            listed[merged.name] = Entry(
+                digest_of(sealed), tuple(sorted(chunk.name for chunk in chunks))
+            )
             write_manifest(known, day, listed)
             days += 1
             replaced += len(chunks)


### PR DESCRIPTION
Fixes #41. Fixes #27.

Two bugs, one cause: `State.merged` held a high-water **string** per `(host, day)`, compared against chunk filenames whose suffix is random.

## #41 — a mark cannot say "all of these except that one"

If an earlier-named chunk failed and a later-named one then succeeded, the mark advanced past the failure and that chunk was **never looked at again** — its commands simply missing, with nothing said after the run it failed in. The mirror case was as bad: a chunk that failed while being the newest was re-read on every tick of a one-minute timer, forever.

It is now the set of names merged — a set in memory, a sorted list in the file, converted at the JSON boundary because that is the only place that knows about the file.

## #27 — compaction duplicated a day peers already had

`compact` replaces a day's chunks with one holding the same lines, named with the timestamp of the last chunk it replaced plus a fresh random suffix. Whether that sorted above the peer's mark was a coin flip. Reproduced **4/10 before, 0/12 after**.

A peer cannot tell from the bytes that it has seen those lines before, so the manifest now says so: a compacted entry records the names it subsumed, **inside the signed body** — what a peer does with a chunk has to be something only the publishing machine can state. A day holding such a chunk is *rewritten* rather than appended to, which is the only answer right for all three cases at once:

| peer had merged | appending | skipping | rewriting |
|---|---|---|---|
| all of it | duplicates | correct | correct |
| part of it | duplicates | loses the rest | correct |
| none of it | correct | loses all | correct |

## Why the suite missed both

The existing compaction test compares `commands()`, which returns a **set** — duplicate entries collapse before the assertion sees them. The new tests count entries. The duplication test also pins the random suffix to `ffffff`, because a regression test that reproduces half the time is a coin flip, not a test.

## Found while reviewing this, four of them mine

- **A state file written by the previous version would have been shredded.** Its `merged` values are single strings, and a string is iterable — loading one turned each day's record into twenty-one one-character entries, nothing matched, and the first sync after upgrading would have duplicated every peer's history wholesale. The exact bug being fixed, reintroduced by the fix. Guarded per value now, with a test.
- Writing the set back inside the per-chunk loop re-sorted the whole day on every chunk: **0.04 ms at 40 chunks/day, 637 ms at 4000**. And `done.setdefault(key, set(...))` rebuilt the day's set on every iteration *including the skip path* — the steady state. Both gone: `State` holds the set, so there is no second copy to build or write back.
- Rewriting a day discarded what had already been accumulated, so a chunk that is *not* subsumed and sorts below the compacted one was dropped. Marking the day is all the replacement does now.
- The rewrite was unlink-then-append, which is not atomic — search runs outside the sync lock, so there was a window where a day looked empty. `store.write_atomic` already does this properly.
- `lines_imported` counted a rewritten day as freshly imported, telling a peer that gained nothing it had merged the whole day.

`state.json` also grew two orders of magnitude (~1 MiB at 35k chunks) and was saved at the end of every sync regardless — about a megabyte a minute to say nothing happened. It now writes only when the contents differ, the same call `cache` makes for the same reason. Idle sync measured at **0.01 s** on a year of history.

## Tests

276 pass. **9 mutations, all killing their guarding test.** A tenth test was written and removed: the scenario turned out to be self-correcting for reasons other than the lines it was meant to guard, so no reverting mutation made it fail — and CLAUDE.md's bar for that is decoration.

No format break: the manifest gains an optional field, and old-shaped state files are discarded rather than misread (costing one re-merge of each day, which the tests pin does not repeat).