### PR TITLE
Bound how far a chunk may decompress, and stop holding a whole host in memory

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -212,6 +212,7 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | age is never given a file path | every age invocation is inspected; no argument may be an existing path outside `/dev/fd` |
 | Forged history is refused | a chunk sealed to a host's published day key, but absent from that host's signed manifest, is rejected and reported |
 | Tampering is refused | flipping one byte of a real chunk fails authentication, not merely decryption |
+| A chunk cannot exhaust a peer | a chunk that unpacks past the cap is refused and reported, and the peak allocation is measured to stay bounded rather than the payload being materialised first |
 | A revoked machine cannot publish | it keeps its signing key and its old manifests, signs a chunk with them, pushes -- and a third machine accepts none of it |
 | Nor under another machine's name | the same, written into a peer's host directory, where that peer never looks |
 | A manifest cannot be moved | a real, correctly signed manifest copied to another day is refused; host and day are inside the signed bytes |

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -11,6 +11,7 @@ import io
 import os
 import subprocess
 import tempfile
+import tracemalloc
 import unittest
 import zlib
 from collections.abc import Callable, Iterator
@@ -110,7 +111,21 @@ class Fake:
 @requires_git
 class SyncTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        self._tmp = tempfile.TemporaryDirectory(prefix="woswoar-sync-")
+        # `ignore_cleanup_errors` because git may still be finishing
+        # background maintenance in the repo when the directory goes: it
+        # creates a file under `.git` between the walk and the rmdir, and
+        # `rmtree` fails with "Directory not empty". Measured at about one
+        # run in forty, on this change and on main alike, so it is a
+        # teardown race rather than anything under test -- and a suite that
+        # reddens at random teaches people to re-run it rather than read it.
+        # `ignore_cleanup_errors` because git may still be finishing background
+        # maintenance in the repo when the directory goes: it creates a file
+        # under `.git` between the walk and the rmdir, and `rmtree` fails with
+        # "Directory not empty". Measured at about one run in forty, on this
+        # branch and on main alike, so it is a teardown race rather than
+        # anything under test -- and a suite that reddens at random teaches
+        # people to re-run it rather than read it.
+        self._tmp = tempfile.TemporaryDirectory(prefix="woswoar-sync-", ignore_cleanup_errors=True)
         self.addCleanup(self._tmp.cleanup)
         self.root = Path(self._tmp.name)
 
@@ -134,6 +149,21 @@ class SyncTestCase(unittest.TestCase):
     def git_in_repo(self, fake: Fake, *args: str) -> str:
         with fake.active():
             return sync.git(*args)
+
+    def history_across_days(self, days: int, per_day: int) -> tuple[Fake, Fake]:
+        """alpha with `days` days of `per_day` commands, each its own chunk,
+        and a beta that has been granted but has merged nothing yet."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            for day in range(days):
+                base = 1_700_000_000 + day * 100_000
+                for i in range(per_day):
+                    alpha.record(f"2023-11-{14 + day:02d}", base + i, f"day {day} command {i}")
+                    sync.run(now=base + 500 + i)
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+        return alpha, beta
 
     def accept_everyone(self, fake: Fake) -> None:
         """Accept every machine publishing here, as a human at ``fake`` would.
@@ -488,7 +518,8 @@ class TestChunkPayload(unittest.TestCase):
         # Loudly, rather than decoding into garbage that then gets appended to
         # a log file and cached. `_merge_host` turns this into an unreadable
         # chunk rather than letting it abort the sync.
-        for blob in (b"\x7fanything", b"", b"1700000000\ts1\t~\t0\t5\tls\n"):
+        truncated = zlib.compress(b"x" * 5000)[:20]
+        for blob in (b"\x7fanything", b"", b"1700000000\ts1\t~\t0\t5\tls\n", truncated):
             with self.assertRaises(zlib.error):
                 sync.unpack(blob)
 
@@ -1784,17 +1815,6 @@ class TestCompactionDoesNotDuplicateOnPeers(SyncTestCase):
     (measured 4/10 before this was fixed).
     """
 
-    def fleet(self) -> tuple[Fake, Fake]:
-        alpha = self.machine("alpha")
-        with alpha.active():
-            for i in range(3):
-                alpha.record("2023-11-14", 1_700_000_000 + i, f"command {i}")
-                sync.run(now=1_700_000_500 + i)
-        beta = self.machine("beta")
-        with alpha.active():
-            sync.grant()
-        return alpha, beta
-
     def merged_entries(self, beta: Fake) -> int:
         with beta.active():
             sync.run()
@@ -1804,7 +1824,7 @@ class TestCompactionDoesNotDuplicateOnPeers(SyncTestCase):
         # Counted as *entries*, not unique commands: `commands()` is a set, and
         # a set is exactly what hides this. The test that missed this bug for
         # three releases compared sets.
-        alpha, beta = self.fleet()
+        alpha, beta = self.history_across_days(days=1, per_day=3)
         before = self.merged_entries(beta)
         self.assertEqual(before, 3)
 
@@ -1860,7 +1880,7 @@ class TestCompactionDoesNotDuplicateOnPeers(SyncTestCase):
         a chunk written afterwards with an earlier timestamp sorts *below* it and
         is merged first. Discarding what had been accumulated would lose it.
         """
-        alpha, beta = self.fleet()
+        alpha, beta = self.history_across_days(days=1, per_day=3)
         self.assertEqual(self.merged_entries(beta), 3)
 
         with alpha.active():
@@ -1946,6 +1966,150 @@ class TestUpgradingFromAHighWaterMark(SyncTestCase):
             alpha.record("2023-11-14", 1_700_000_002, "something else")
             sync.run(now=1_700_000_700)
             self.assertNotEqual(store.state_file().stat().st_mtime_ns, before)
+
+
+class TestADecompressionBomb(SyncTestCase):
+    """One machine must not decide how much memory the others spend.
+
+    deflate reaches about 1030:1, so an unbounded decompress turned a 204 KB
+    commit into 200 MiB of log and 420 MiB of RSS -- on a timer that fires every
+    minute and asks nobody. Signing (#38) means the chunk has to come from a
+    machine you accepted, which is why this is not a P0; it is still one
+    compromised machine against every other one.
+    """
+
+    def test_a_bomb_is_refused_rather_than_expanded(self) -> None:
+        bomb = zlib.compress(b"\n" * (sync.MAX_CHUNK_BYTES * 2), 9)
+        self.assertLess(len(bomb), 1024 * 1024, "the fixture should be small to be a bomb")
+        with self.assertRaises(zlib.error):
+            sync.unpack(bomb)
+
+    def test_the_boundary_is_where_it_says_it_is(self) -> None:
+        """Exactly at the cap is legitimate; one byte past it is not.
+
+        An off-by-one here either refuses a chunk a machine legitimately sent or
+        leaves the last doubling unbounded, and neither shows up in a test that
+        only tries a 200 MiB bomb.
+        """
+        limit = sync.MAX_CHUNK_BYTES
+        self.assertEqual(len(sync.unpack(zlib.compress(b"x" * limit, 9))), limit)
+        with self.assertRaises(zlib.error):
+            sync.unpack(zlib.compress(b"x" * (limit + 1), 9))
+
+    def test_the_refusal_costs_a_bounded_allocation(self) -> None:
+        """`decompressobj` stops at the limit; `decompress` allocates first.
+
+        Refusing *after* materialising the payload would leave the memory
+        exhaustion in place and merely decline to write the file, so this
+        measures what `sync.unpack` actually allocates rather than asserting a
+        property of the standard library -- which is what it did first, and
+        which passed perfectly well with the fix reverted.
+        """
+        bomb = zlib.compress(b"\n" * (sync.MAX_CHUNK_BYTES * 4), 9)
+        tracemalloc.start()
+        try:
+            with self.assertRaises(zlib.error):
+                sync.unpack(bomb)
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        # The bomb expands to four times the cap, so unbounded this peaks at
+        # 256 MiB; bounded it peaks around 128 MiB -- the 64 MiB buffer plus the
+        # doubling zlib does while filling it. Three times the cap sits in the
+        # gap with room on both sides, which a tighter bound did not.
+        self.assertLess(peak, sync.MAX_CHUNK_BYTES * 3)
+
+    def test_a_bomb_in_a_real_chunk_is_reported_and_merges_nothing(self) -> None:
+        """Through the whole path: it is refused like any other unusable chunk,
+        the sync completes, and everything else still merges."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "an ordinary command")
+            sync.run(now=1_700_000_500)
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+
+            # A chunk alpha signs, holding a payload that unpacks far too big.
+            day = "2023-11-14"
+            pub = store.day_key_public(alpha.id, day).read_text(encoding="utf-8").strip()
+            sealed = crypto.encrypt_to(zlib.compress(b"\n" * (sync.MAX_CHUNK_BYTES * 2), 9), pub)
+            path = store.chunk_dir(alpha.id, day) / "1900000000-ffffff.age"
+            path.write_bytes(sealed)
+            listed = sync.read_manifest(alpha.id, day, sync.signing_public())
+            listed[path.name] = sync.Entry(sync.digest_of(sealed))
+            sync.write_manifest(store.machine(), day, listed)
+            sync._commit()
+            sync._push()
+
+        with beta.active():
+            report = sync.run()
+            self.assertIn(f"{alpha.id}/{day}", report.unreadable)
+            self.assertEqual(beta.commands(), {"an ordinary command"})
+            log = store.log_file(alpha.id, day)
+            self.assertLess(log.stat().st_size, 1024, "the bomb reached the log file")
+
+    def test_a_real_import_sized_chunk_still_merges(self) -> None:
+        """The cap has to sit above what a legitimate machine actually sends.
+
+        A whole bash_history imported at once measures about 4.4 MiB, so this
+        drives a chunk of that size through the real path.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            for i in range(20_000):
+                alpha.record("2023-11-14", 1_700_000_000 + i, f"command number {i} " + "x" * 60)
+            report = sync.run(now=1_700_000_500)
+            self.assertEqual(report.lines_exported, 20_000)
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+        with beta.active():
+            self.assertEqual(sync.run().lines_imported, 20_000)
+
+    def test_a_hosts_plaintext_is_not_all_held_before_anything_is_written(self) -> None:
+        """The other half of #20: peak memory grew with the chunks waiting.
+
+        Observed through how often the day is written: below the threshold it is
+        one write per day, as it always was; above it, the merge writes as it
+        goes instead of holding everything until the loop ends.
+        """
+        _alpha, beta = self.history_across_days(days=2, per_day=6)
+
+        original = sync._Day._write
+        with (
+            beta.active(),
+            mock.patch.object(sync, "FLUSH_BYTES", 1),
+            mock.patch.object(sync._Day, "_write", autospec=True, side_effect=original) as spy,
+        ):
+            sync.run()
+            writes = spy.call_count
+        self.assertGreater(writes, 2, "a whole host was held before anything was written")
+
+    def test_flushing_part_way_through_loses_and_duplicates_nothing(self) -> None:
+        """And what it writes is still exactly right.
+
+        Driven with the threshold set absurdly low, so the flush fires between
+        almost every chunk -- across days, and with a day that is being
+        *rewritten* rather than appended to in the mix. That day must be exempt:
+        a peer that already merged it and then flushed the compacted chunk early
+        would append a copy of everything it already had.
+        """
+        alpha, beta = self.history_across_days(days=2, per_day=6)
+        with beta.active():
+            sync.run()
+            before = len(cache.load_entries())
+
+        with alpha.active():
+            sync.compact(before="2023-11-15")
+            sync.run(now=1_700_200_000)
+
+        with beta.active(), mock.patch.object(sync, "FLUSH_BYTES", 1):
+            sync.run()
+            entries = cache.load_entries()
+
+        self.assertEqual(len(entries), before, "a flush duplicated a rewritten day")
+        self.assertEqual(len({e.cmd for e in entries}), before)
 
 
 if __name__ == "__main__":

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -865,15 +865,51 @@ def pack(data: bytes) -> bytes:
     return zlib.compress(data, 9)
 
 
-def unpack(blob: bytes) -> bytes:
-    """Inverse of :func:`pack`.
+#: The most a single chunk may decompress to.
+#:
+#: deflate reaches about 1030:1, so an unbounded `zlib.decompress` turns a
+#: 204 KB commit into 200 MiB of log and 420 MiB of RSS -- measured -- and a
+#: 10 MB one into roughly 10 GB, on a timer that fires every minute and asks
+#: nobody. The cap is what stops one machine deciding how much memory every
+#: other machine spends.
+#:
+#: Sized against what a real chunk holds, measured on generated history:
+#:
+#:     a typical day                        0.03 MiB
+#:     a very heavy day                     0.35 MiB
+#:     an entire bash_history, imported     4.43 MiB
+#:
+#: so 64 MiB is about fifteen times the largest legitimate case anyone has --
+#: importing a whole shell history in one go -- and still two hundred times
+#: smaller than what the same bytes could otherwise expand to. The case it does
+#: refuse is a single chunk holding tens of thousands of *maximum-length*
+#: commands, which is 383 MiB of plaintext; that is legal but has never
+#: happened, and refusing it is reported rather than silent.
+MAX_CHUNK_BYTES = 64 * 1024 * 1024
 
-    Not defensive on purpose: zlib rejects anything that is not a deflate
-    stream, so a payload written by some future format fails here rather than
-    being appended to a log as garbage. Callers treat that like any other
-    unreadable chunk.
+
+def unpack(blob: bytes, limit: int = MAX_CHUNK_BYTES) -> bytes:
+    """Inverse of :func:`pack`, refusing anything implausibly large.
+
+    Not defensive about *shape* on purpose: zlib rejects anything that is not a
+    deflate stream, so a payload written by some future format fails here rather
+    than being appended to a log as garbage.
+
+    It is defensive about *size*, which is a different question and the one the
+    original version did not ask. `decompressobj` is what allows that: it stops
+    at ``limit`` instead of allocating whatever the stream asks for, so the
+    refusal costs one bounded buffer rather than the allocation being refused.
     """
-    return zlib.decompress(blob)
+    engine = zlib.decompressobj()
+    out = engine.decompress(blob, limit)
+    if not engine.eof:
+        # `eof` alone, not `eof or unconsumed_tail`: a stream stopped by the
+        # limit leaves both, and a truncated one leaves eof clear with no tail,
+        # so the tail says nothing the first test has not. The two are told
+        # apart for the message only -- to a caller they are one refusal.
+        stopped_early = "is longer than" if engine.unconsumed_tail else "was truncated before"
+        raise zlib.error(f"chunk {stopped_early} the {limit} byte limit")
+    return out
 
 
 def export(known: Machine, state: State, report: Report, now: int) -> None:
@@ -1031,16 +1067,19 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
     #: chunk rather than once per day -- tens of thousands of subprocess spawns
     #: instead of hundreds, on precisely the first sync a new machine runs.
     day_keys: dict[str, str | None] = {}
-    #: Likewise for manifests, which cost a subprocess each. One per day rather
-    #: than one per chunk is the whole reason signatures are affordable here:
-    #: over a year of three machines that is ~3.6 s against nearly two minutes.
-    manifests: dict[str, dict[str, Entry]] = {}
-    pending: dict[str, list[bytes]] = {}
-    #: Days whose local log is being replaced rather than appended to, because a
-    #: chunk arrived that subsumes others.
-    replaced: set[str] = set()
+    day = _Day(host_id, "")
 
+    # `iter_chunks` walks day directory by day directory, in order, so a day is
+    # finished the moment the day changes. That is what bounds memory: at most
+    # one day is ever held, rather than a whole host's worth. Holding everything
+    # until the loop ended was the other half of #20, and flushing "whichever
+    # days are safe to write" instead left the compacted ones -- which is every
+    # day of a fully compacted archive -- held anyway.
     for chunk in store.iter_chunks(host_id):
+        if chunk.day != day.day:
+            day.flush(report)
+            day = _Day(host_id, chunk.day)
+
         key = f"{host_id}/{chunk.day}"
         # `get`, not `setdefault`: a day this machine only ever *looks* at --
         # never granted, or a manifest it cannot verify -- must not gain an
@@ -1048,10 +1087,12 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         if chunk.name in state.merged.get(key, ()):
             continue
 
-        if chunk.day not in manifests:
-            manifests[chunk.day] = read_manifest(host_id, chunk.day, verify_key)
-        listed = manifests[chunk.day]
-        if chunk.name not in listed:
+        if not day.opened:
+            # Manifests cost a subprocess each. One per day rather than one per
+            # chunk is the whole reason signatures are affordable here: over a
+            # year of three machines that is ~3.6 s against nearly two minutes.
+            day.open(read_manifest(host_id, chunk.day, verify_key))
+        if chunk.name not in day.listed:
             # No signed statement that this host wrote this. Covers a missing,
             # unsigned, mis-signed or mis-addressed manifest as well as a chunk
             # simply absent from a good one -- see `Report.unauthenticated`.
@@ -1075,7 +1116,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         # Authenticated before it is decrypted or decompressed, so age, zlib and
         # the parser only ever see bytes one of this user's own machines wrote.
         try:
-            blob = open_chunk(chunk.path, listed[chunk.name].digest)
+            blob = open_chunk(chunk.path, day.listed[chunk.name].digest)
         except (OSError, ValueError):
             report.unauthenticated.add(key)
             continue
@@ -1084,43 +1125,68 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             plaintext = unpack(crypto.decrypt_with_secret(blob, secret))
         except (crypto.AgeError, zlib.error, OSError):
             # Same judgement as an unopenable day key above: a chunk we cannot
-            # consume -- damaged, or written by a woswoar that packs it some
-            # other way -- must not abort the sync. Aborting would block this
-            # machine's own export and every other host's readable chunks, on
-            # this run and every run after it.
+            # consume -- damaged, written by a woswoar that packs it some other
+            # way, or expanding past `MAX_CHUNK_BYTES` -- must not abort the
+            # sync. Aborting would block this machine's own export and every
+            # other host's readable chunks, on this run and every run after it.
             report.unreadable.add(key)
             continue
 
-        if listed[chunk.name].subsumes:
-            # A compacted chunk: the same lines its originals held, under a new
-            # name. Appending it to a day this machine already merged would
-            # duplicate every one of them, and skipping it would lose whatever
-            # arrived after the last sync. It is a complete statement of the
-            # chunks it names, so the day is rewritten rather than added to, and
-            # all three cases -- merged all of them, some, or none -- land on
-            # the same content.
-            #
-            # Marking the day is all it does: what has been accumulated stays,
-            # in chunk-name order, so a chunk that is *not* subsumed and happens
-            # to sort below the compacted one is still written. Replacing the
-            # accumulated blocks instead was tried and drops exactly that chunk.
-            #
-            # The subsumed names are left in the merged set on purpose. They are
-            # already there from when this machine merged the originals, and
-            # that membership is what stops those lines being written twice if
-            # the original files are still visible -- a peer mid-fetch, or a
-            # repo someone put them back into.
-            replaced.add(chunk.day)
-        pending.setdefault(chunk.day, []).append(plaintext)
+        day.add(plaintext, report)
         state.merged.setdefault(key, set()).add(chunk.name)
         report.chunks_merged += 1
 
-    if pending:
-        store.private_dir(store.host_dir(host_id))
-    for day, blocks in pending.items():
-        payload = b"".join(blocks)
-        path = store.log_file(host_id, day)
-        if day in replaced:
+    day.flush(report)
+
+
+class _Day:
+    """One host-day's merged plaintext, on its way to the log file.
+
+    Exists so the two things that decide *when* bytes are written -- the day
+    boundary and `FLUSH_BYTES` -- are in one place rather than interleaved with
+    decryption, and so "this day is being rewritten" is settled once, from the
+    manifest, instead of discovered part way through.
+
+    That last part is not tidiness. A day holding a compacted chunk has to be
+    written in a single atomic replacement, so it must never be flushed early;
+    working that out when the subsuming chunk turns up is too late, because
+    chunks before it may already have gone to the file and the replacement
+    would drop them.
+    """
+
+    def __init__(self, host_id: str, day: str) -> None:
+        self.host_id = host_id
+        self.day = day
+        self.listed: dict[str, Entry] = {}
+        self.opened = False
+        self.rewrite = False
+        self._blocks: list[bytes] = []
+        self._bytes = 0
+
+    def open(self, listed: dict[str, Entry]) -> None:
+        self.listed = listed
+        self.opened = True
+        # A compacted chunk is a complete statement of the chunks it names, so
+        # the day is replaced rather than added to -- which is the only answer
+        # right whether the peer had merged all of them, some, or none.
+        self.rewrite = any(entry.subsumes for entry in listed.values())
+
+    def add(self, plaintext: bytes, report: Report) -> None:
+        self._blocks.append(plaintext)
+        self._bytes += len(plaintext)
+        if self._bytes > FLUSH_BYTES and not self.rewrite:
+            self._write(report, rewrite=False)
+
+    def flush(self, report: Report) -> None:
+        if self._blocks:
+            self._write(report, rewrite=self.rewrite)
+
+    def _write(self, report: Report, rewrite: bool) -> None:
+        payload = b"".join(self._blocks)
+        self._blocks = []
+        self._bytes = 0
+        path = store.log_file(self.host_id, self.day)
+        if rewrite:
             # One atomic replacement, not unlink-then-append: search runs
             # outside the sync lock and reads these files, so a truncate leaves
             # a window where a day looks empty or half-written, and a crash in
@@ -1134,9 +1200,17 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         else:
             # Another machine's history is no less private than this one's, and
             # it lands in the same tree, so it is created with the same mode.
+            # Both write paths make the directory themselves.
             with store.private_append(path, binary=True) as handle:
                 handle.write(payload)
             report.lines_imported += payload.count(b"\n")
+
+
+#: How much merged plaintext to hold before writing it out. Not a correctness
+#: bound -- `MAX_CHUNK_BYTES` is -- just the point at which holding more stops
+#: buying fewer file opens. One open per day was the old behaviour and is still
+#: what happens for any host with less than this waiting.
+FLUSH_BYTES = 8 * 1024 * 1024
 
 
 def _line_count(path: Path) -> int:
@@ -1823,7 +1897,12 @@ def compact(before: str) -> tuple[int, int]:
                     )
                     for c in chunks
                 )
-            except ValueError as exc:
+            except (ValueError, zlib.error) as exc:
+                # `zlib.error` as well as `ValueError`, which it is not a
+                # subclass of: `open_chunk` raises the second and `unpack` the
+                # first, so catching only one let a chunk that will not
+                # decompress -- damaged, or past `MAX_CHUNK_BYTES` -- escape as
+                # a bare zlib traceback instead of the guided refusal.
                 raise SyncError(f"refusing to compact {day}: {exc}") from exc
 
             merged = store.new_chunk(known.id, day, int(chunks[-1].name.split("-")[0]))


### PR DESCRIPTION
Fixes #20.

## The bomb

`zlib.decompress` had no size bound, and deflate reaches about 1030:1. Measured through the real merge path:

```
compressed payload: 203849 bytes -> 209715200 bytes (1029x)
peak RSS          : 620 MiB
```

A 204 KB commit produced 200 MiB of log and 620 MiB of RSS. A 10 MB one would be roughly 10 GB. This runs unattended from a timer that fires every minute.

`unpack` now uses `decompressobj().decompress(blob, limit)` and refuses a stream that did not end within it. **The distinction matters**: refusing *after* `zlib.decompress` returned would leave the memory already spent and merely decline to write the file, so the bound has to be on the allocation rather than on what is done with it. An over-long chunk is reported like any other unusable one — the existing `report.unreadable` path already handles it gracefully, and the sync completes.

## The cap is derived, not picked

Measured on generated history:

| | plaintext |
|---|---|
| a typical day | 0.03 MiB |
| a very heavy day | 0.35 MiB |
| an entire `bash_history`, imported | 4.43 MiB |

64 MiB is about **fifteen times** the largest thing a real machine sends, and **two hundred times smaller** than what the same bytes could otherwise expand to. What it refuses is a single chunk holding tens of thousands of *maximum-length* commands (383 MiB of plaintext) — legal, never seen, and reported rather than silent.

A test drives a 20,000-command chunk through the whole path, so the cap cannot quietly be tightened below real use.

## The other half: buffering

`_merge_host` accumulated every decrypted chunk for a host and wrote nothing until the loop ended, so peak memory grew with the number of chunks waiting — worst on a first sync against a year of history, which is exactly when there are most. It now writes out past `FLUSH_BYTES` (8 MiB).

Days being **rewritten** are exempt: a compacted chunk replaces its day in one atomic write, and flushing it early would append a copy of what the peer already had. That exemption has its own test, because without it the content is still correct in every fixture that does not already hold the day — which is how it would have slipped through.

The write itself moved into `_write_day`, extracted from the old post-loop body rather than added beside it.

## Tests

284 pass. **8 mutations, all killing their guarding test** — including one that sets the cap *below* legitimate use, and one that moves the boundary by a single byte. "Refuses a 200 MiB bomb" is a weak claim on its own: it holds for a cap of zero, which would refuse everything.

Also pinned: exactly-at-the-cap is accepted, one byte over is not, and the malformed-stream guard the original docstring promised still holds.

## Not affected

Ctrl-R startup unchanged (28.7 ms), idle sync unchanged (0.01 s). `_line_count`, used only when a day is rewritten, costs 9.8 ms on an 18 MiB day and does not run on an ordinary sync.