### PR TITLE
Keep usernames and hostnames out of the one plaintext file in the repo

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -14,6 +14,14 @@ encrypted before it is committed. Even the *directory names* in the repo are
 opaque random hex, because paths are not encrypted by anything and
 `hosts/martin@desktop/` would publish your machine names for free.
 
+The one file that is deliberately plaintext, `recipients.txt`, holds public
+keys and nothing else. It used to carry `$USER@$(uname -n)` beside each one so
+that `woswoar grant` had a name to show, and an SSH key's own trailing comment
+went with it — which published exactly what the opaque directories were there
+to withhold. The name comes from the sealed `name.age` now, and the comment is
+stripped before the key is written; a test walks every committed byte and
+fails if a machine name appears in any of them.
+
 ## 🧊 No self-rolled cryptography
 
 Almost no crypto in this codebase, and none of the parts that are easy to get
@@ -211,6 +219,7 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | A failed chunk is retried, not dropped | an earlier chunk that fails while a later one succeeds is merged once it is repaired |
 | age is never given a file path | every age invocation is inspected; no argument may be an existing path outside `/dev/fd` |
 | Forged history is refused | a chunk sealed to a host's published day key, but absent from that host's signed manifest, is rejected and reported |
+| The repo names no machine | every committed byte is searched for the username and hostname; a leaked archive says how many machines there are, not which |
 | Tampering is refused | flipping one byte of a real chunk fails authentication, not merely decryption |
 | A chunk cannot exhaust a peer | a chunk that unpacks past the cap is refused and reported, and the peak allocation is measured to stay bounded rather than the payload being materialised first |
 | A revoked machine cannot publish | it keeps its signing key and its old manifests, signs a chunk with them, pushes -- and a third machine accepts none of it |
@@ -239,7 +248,8 @@ Being straight about the limits is part of the security story:
 >   same machine. Encryption protects the *synced copy*,
 >   not your disk. Use full-disk encryption for that.
 > - **Metadata leaks.** Anyone with the repo can see how many machines you have,
->   when they synced, and roughly how many commands you ran per day.
+>   when they synced, and roughly how many commands you ran per day. Not *which*
+>   machines: no username or hostname is committed.
 > - **Trust on first use.** Cloning pins whatever machines the repository shows
 >   at that moment. A machine planted *before* you clone is accepted; one that
 >   appears afterwards is refused until you say otherwise. `woswoar init` prints

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import io
 import os
+import secrets
 import subprocess
 import tempfile
 import tracemalloc
@@ -25,7 +26,7 @@ from woswoar.entry import Entry, format_line
 from woswoar.sync import COMMIT_MESSAGE as COMMIT
 
 from . import support
-from .support import requires_age, requires_git
+from .support import requires_age, requires_git, requires_ssh_keygen
 
 #: One authoritative list, plus HOME which only these tests need to redirect.
 _ENV = (*support.ENV_KEYS, "HOME")
@@ -94,16 +95,27 @@ class Fake:
     def commands(self) -> set[str]:
         return {e.cmd for e in cache.load_entries()}
 
-    def append_recipient(self, label: str) -> str:
-        """Add a key to recipients.txt behind woswoar's back, and return it.
+    def append_recipient(self, name: str = "") -> str:
+        """Enrol a machine behind woswoar's back, and return its recipient.
 
-        Written straight to the file rather than through `sync.add_recipient`,
-        because that is what the other end of a shared repo looks like: a line
-        that arrived by `git pull`, with a label nothing here sanitised.
+        Written straight into the repo rather than through `sync.add_recipient`,
+        because that is what the other end of a shared repo looks like: files
+        that arrived by `git pull`, whose contents nothing here sanitised.
+
+        ``name`` fabricates the host directory that gives the key a name --
+        `signer.pub` to claim it and a `.name` mirror to hold it -- because that
+        is where a name lives now. It is not a trusted path: sealing a file to
+        the published recipients needs no secret, so a name is still attacker
+        text and is still shown quoted beside a fingerprint.
         """
         key = crypto.generate_identity().public
         with store.recipients_file().open("a", encoding="utf-8") as handle:
-            handle.write(f"{key}{sync._LABEL_SEP}{label}\n")
+            handle.write(f"{key}\n")
+        if name:
+            host = secrets.token_hex(8)
+            verify_key = crypto.generate_signing_key(self.root / f"signer-{host}")
+            store.write_atomic(store.signer_public(host), f"{verify_key}\n{key}\n".encode())
+            store.write_atomic(store.name_file(host), f"{name}\n".encode())
         return key
 
 
@@ -534,27 +546,21 @@ class TestGrantConfirmation(SyncTestCase):
             labels = {reader.label for reader in sync.readers()}
         self.assertIn("martinus@box", labels)
 
-    def test_an_unlabelled_key_gets_a_handle_that_is_not_the_key(self) -> None:
-        """recipients.txt written by an older woswoar, or hand-edited.
+    def test_a_key_with_no_name_yet_is_not_named_after_itself(self) -> None:
+        """The fallback label used to be an abbreviation of the key.
 
-        The fallback label used to be an abbreviation of the key, which let a
-        *chosen* label impersonate one -- and that is the whole weakness: a name
-        in this file is written by whoever added the key.
+        That let a *chosen* label impersonate one, which was the whole weakness.
+        A name can no longer be derived from a key at all -- it comes from the
+        sealed `name.age` or it is the placeholder -- so this pins the placeholder
+        rather than the abbreviation it replaced.
         """
         alpha = self.machine("alpha")
         with alpha.active():
-            key = crypto.generate_identity().public
-            store.recipients_file().write_text(f"{key}\n", encoding="utf-8")
-            (reader,) = sync.readers()
+            key = alpha.append_recipient()
+            (reader,) = [r for r in sync.readers() if r.key == key]
 
-        self.assertTrue(reader.label)
-        self.assertNotIn(sync._LABEL_SEP, reader.key)
-        # Split on the abbreviation's own ellipsis, so a label built out of both
-        # ends of the key is caught rather than only one made of a single run.
-        self.assertFalse(
-            any(part and part in key for part in reader.label.split("...")),
-            f"the label {reader.label!r} is made out of the key it names",
-        )
+        self.assertEqual(reader.label, sync.UNNAMED)
+        self.assertFalse(any(part and part in key for part in reader.label.split("...")))
 
     def test_a_key_listed_twice_is_offered_to_age_once(self) -> None:
         """`recipients.txt` is `merge=union`.
@@ -598,29 +604,15 @@ class TestGrantConfirmation(SyncTestCase):
         """
         alpha = self.machine("alpha")
         with alpha.active():
-            alpha.append_recipient(label="martin@laptop\x1b[2K\x1b[1A")
+            alpha.append_recipient(name="martin@laptop\x1b[2K\x1b[1A")
             for reader in sync.readers():
                 self.assertNotIn("\x1b", reader.label)
                 self.assertNotIn("\n", reader.label)
 
-    def test_a_label_written_here_cannot_forge_a_second_entry(self) -> None:
-        """The label comes from this machine's config file, so it is not
-        guaranteed to be one line just because a name usually is."""
-        alpha = self.machine("alpha")
-        with alpha.active():
-            before = len(sync.recipients())
-            intruder = crypto.generate_identity().public
-            sync.add_recipient(
-                crypto.generate_identity().public,
-                label=f"laptop\n{intruder}{sync._LABEL_SEP}desktop",
-            )
-            self.assertEqual(len(sync.recipients()), before + 1)
-            self.assertNotIn(intruder, sync.recipients())
-
     def test_a_key_that_is_not_one_line_is_refused_rather_than_written(self) -> None:
         alpha = self.machine("alpha")
         with alpha.active(), self.assertRaises(sync.SyncError) as caught:
-            sync.add_recipient(f"{crypto.generate_identity().public}\nage1intruder", label="laptop")
+            sync.add_recipient(f"{crypto.generate_identity().public}\nage1intruder")
         self.assertIn("not one line", str(caught.exception))
 
     def test_two_keys_with_one_name_are_told_apart(self) -> None:
@@ -630,7 +622,7 @@ class TestGrantConfirmation(SyncTestCase):
         """
         alpha = self.machine("alpha", display="martin@laptop")
         with alpha.active():
-            alpha.append_recipient(label="martin@laptop")
+            alpha.append_recipient(name="martin@laptop")
             readers = sync.readers()
 
         self.assertEqual({reader.label for reader in readers}, {"martin@laptop"})
@@ -640,14 +632,46 @@ class TestGrantConfirmation(SyncTestCase):
     def test_a_name_nobody_else_uses_is_not_flagged(self) -> None:
         alpha = self.machine("alpha", display="martin@laptop")
         with alpha.active():
-            alpha.append_recipient(label="martin@desktop")
+            alpha.append_recipient(name="martin@desktop")
             self.assertFalse(any(reader.shares_name for reader in sync.readers()))
+
+    def test_machines_whose_name_is_not_known_yet_do_not_count_as_duplicates(self) -> None:
+        """Names arrive with a sync, so several can be pending at once.
+
+        `(unnamed)` is a placeholder, not a name. Counting it as one turns the
+        signal that means "look closely at these two" into something an ordinary
+        first sync prints about every machine that has not been merged yet.
+        """
+        alpha = self.machine("alpha", display="martin@laptop")
+        with alpha.active():
+            for _ in range(3):
+                alpha.append_recipient()
+            unnamed = [r for r in sync.readers() if r.label == sync.UNNAMED]
+            self.assertEqual(len(unnamed), 3)
+            self.assertFalse(any(r.shares_name for r in unnamed))
+
+            # And the placeholder is not a name a peer can claim its way into.
+            # Sealing a `name.age` needs no secret, so anything spelled here can
+            # be spelled there; two peers claiming it are told apart from a
+            # machine whose name simply has not arrived.
+            alpha.append_recipient(name=sync.UNNAMED)
+            alpha.append_recipient(name=sync.UNNAMED)
+            flagged = [r for r in sync.readers() if r.shares_name]
+            self.assertEqual(len(flagged), 2)
+            still_unknown = [r for r in sync.readers() if not r.shares_name]
+            self.assertEqual(len([r for r in still_unknown if r.label == sync.UNNAMED]), 3)
+
+            # A real repeat is still called out.
+            alpha.append_recipient(name="martin@laptop")
+            named = [r for r in sync.readers() if r.label == "martin@laptop"]
+        self.assertEqual(len(named), 2)
+        self.assertTrue(all(r.shares_name for r in named))
 
     def test_the_machine_the_human_is_sitting_at_is_marked(self) -> None:
         alpha = self.machine("alpha", display="martin@laptop")
         with alpha.active():
             mine = crypto.recipient_for(sync.identity_path(store.machine())).strip()
-            alpha.append_recipient(label="martin@desktop")
+            alpha.append_recipient(name="martin@desktop")
             marked = [reader.key for reader in sync.readers() if reader.is_mine]
         self.assertEqual(marked, [mine])
 
@@ -658,7 +682,7 @@ class TestRevokeSubtraction(SyncTestCase):
     def test_a_revoked_key_stops_being_a_recipient(self) -> None:
         alpha = self.machine("alpha")
         with alpha.active():
-            gone = alpha.append_recipient(label="old-laptop")
+            gone = alpha.append_recipient(name="old-laptop")
             self.assertIn(gone, sync.recipients())
 
             sync.revoke(sync.find_reader(crypto.fingerprint(gone)))
@@ -688,11 +712,11 @@ class TestRevokeSubtraction(SyncTestCase):
         premise. Re-enrolling a real machine means a new identity."""
         alpha = self.machine("alpha")
         with alpha.active():
-            gone = alpha.append_recipient(label="old-laptop")
+            gone = alpha.append_recipient(name="old-laptop")
             sync.revoke(sync.find_reader(crypto.fingerprint(gone)))
 
             with self.assertRaises(sync.SyncError) as caught:
-                sync.add_recipient(gone, label="back-again")
+                sync.add_recipient(gone)
             self.assertIn("revocation is permanent", str(caught.exception))
 
             # And appending the line by hand, which is all push access buys,
@@ -762,7 +786,7 @@ class TestRevokeSubtraction(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "recorded today")
             sync.run()
-            gone = alpha.append_recipient(label="old-laptop")
+            gone = alpha.append_recipient(name="old-laptop")
             report = sync.revoke(sync.find_reader(crypto.fingerprint(gone)))
         self.assertEqual(report.still_readable, ["2023-11-14"])
 
@@ -782,7 +806,7 @@ class TestRevokeSubtraction(SyncTestCase):
             # Only one recipient, and it is not this machine -- so `is_mine`
             # does not catch it and the emptiness guard is what has to.
             store.recipients_file().write_text("", encoding="utf-8")
-            only = alpha.append_recipient(label="only-one")
+            only = alpha.append_recipient(name="only-one")
             (other,) = sync.readers()
             with self.assertRaises(sync.SyncError) as caught:
                 sync.revoke(other)
@@ -830,7 +854,7 @@ class TestRevokeSubtraction(SyncTestCase):
     def test_a_key_shaped_like_a_tombstone_is_refused(self) -> None:
         alpha = self.machine("alpha")
         with alpha.active(), self.assertRaises(sync.SyncError) as caught:
-            sync.add_recipient(f"-{crypto.generate_identity().public}", label="sneaky")
+            sync.add_recipient(f"-{crypto.generate_identity().public}")
         self.assertIn("may not start with", str(caught.exception))
 
 
@@ -1011,13 +1035,13 @@ class TestFindReader(SyncTestCase):
     def test_a_full_fingerprint_selects_one_machine(self) -> None:
         alpha = self.machine("alpha")
         with alpha.active():
-            other = alpha.append_recipient(label="old-laptop")
+            other = alpha.append_recipient(name="old-laptop")
             self.assertEqual(sync.find_reader(crypto.fingerprint(other)).key, other)
 
     def test_an_unambiguous_prefix_is_enough(self) -> None:
         alpha = self.machine("alpha")
         with alpha.active():
-            other = alpha.append_recipient(label="old-laptop")
+            other = alpha.append_recipient(name="old-laptop")
             found = sync.find_reader(crypto.fingerprint(other)[:20])
         self.assertEqual(found.key, other)
 
@@ -1025,7 +1049,7 @@ class TestFindReader(SyncTestCase):
         # Guessing here removes somebody's access.
         alpha = self.machine("alpha")
         with alpha.active():
-            alpha.append_recipient(label="old-laptop")
+            alpha.append_recipient(name="old-laptop")
             with self.assertRaises(sync.SyncError) as caught:
                 sync.find_reader("age1")
         self.assertIn("matches 2 machines", str(caught.exception))
@@ -1041,7 +1065,7 @@ class TestRevokeConfirmation(SyncTestCase):
     def test_without_yes_and_without_a_terminal_nothing_changes(self) -> None:
         alpha = self.machine("alpha")
         with alpha.active():
-            gone = alpha.append_recipient(label="old-laptop")
+            gone = alpha.append_recipient(name="old-laptop")
 
         code, _ = self.run_cli(alpha, "revoke", crypto.fingerprint(gone))
         self.assertEqual(code, 1)
@@ -1054,7 +1078,7 @@ class TestRevokeConfirmation(SyncTestCase):
         """
         alpha = self.machine("alpha")
         with alpha.active():
-            gone = alpha.append_recipient(label="old-laptop")
+            gone = alpha.append_recipient(name="old-laptop")
 
         code, out = self.run_cli(alpha, "revoke", crypto.fingerprint(gone), "--yes")
         self.assertEqual(code, 0)
@@ -1095,7 +1119,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         # Exactly what push access alone buys: append a key labelled like one of
         # the machines that is already there.
         with alpha.active():
-            forged = alpha.append_recipient(label="martin@laptop")
+            forged = alpha.append_recipient(name="martin@laptop")
             new = [reader for reader in sync.readers() if reader.is_new]
 
         self.assertEqual([reader.key for reader in new], [forged])
@@ -1104,7 +1128,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         alpha = self.machine("alpha", display="martin@laptop")
         self.run_cli(alpha, "grant", "--yes")
         with alpha.active():
-            alpha.append_recipient(label="martin@laptop")
+            alpha.append_recipient(name="martin@laptop")
 
         code, out = self.run_cli(alpha, "grant", "--yes")
         self.assertEqual(code, 0)
@@ -1124,7 +1148,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         hostile = "  martin@desktop\u202e"
         alpha = self.machine("alpha", display="martin@laptop")
         with alpha.active():
-            alpha.append_recipient(label=hostile)
+            alpha.append_recipient(name=hostile)
 
         _, out = self.run_cli(alpha, "grant", "--yes")
         self.assertIn("martin@desktop", out)
@@ -1149,7 +1173,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         alpha = self.machine("alpha")
         self.run_cli(alpha, "grant", "--yes")
         with alpha.active():
-            alpha.append_recipient(label="martin@desktop")
+            alpha.append_recipient(name="martin@desktop")
 
         code, _ = self.run_cli(alpha, "grant")
         self.assertEqual(code, 1)
@@ -2110,6 +2134,124 @@ class TestADecompressionBomb(SyncTestCase):
 
         self.assertEqual(len(entries), before, "a flush duplicated a rewritten day")
         self.assertEqual(len({e.cmd for e in entries}), before)
+
+
+class TestRecipientsPublishNoNames(SyncTestCase):
+    """#22: the one plaintext file in the repo named every machine.
+
+    `docs/security.md` says host directories are opaque hex so that a leaked
+    archive does not publish usernames and hostnames. `recipients.txt` undid
+    that one file over -- with woswoar's own `$USER@$(uname -n)` label, and
+    again with the SSH key's own comment, which ssh-keygen writes by default.
+    """
+
+    @requires_ssh_keygen
+    def test_an_ssh_recipient_loses_its_comment(self) -> None:
+        """The second half of #22, and the one that leaks without woswoar's help.
+
+        An SSH public key ends in a free-text comment, conventionally
+        `user@host`, and `ssh-keygen` puts it there by default. Publishing the
+        key verbatim publishes that -- twice since signatures landed, because
+        `signer.pub` names the owning recipient too.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            key = self.root / "with-a-comment"
+            subprocess.run(
+                [
+                    "ssh-keygen",
+                    "-t",
+                    "ed25519",
+                    "-N",
+                    "",
+                    "-q",
+                    "-C",
+                    "martinus@secret-box",
+                    "-f",
+                    str(key),
+                ],
+                check=True,
+                timeout=60,
+            )
+            recipient = crypto.recipient_for(key)
+            self.assertNotIn("secret-box", recipient)
+            # And it is still a recipient age will seal to.
+            crypto.encrypt_to_recipients(b"payload", [recipient])
+
+    @requires_ssh_keygen
+    def test_a_file_written_before_the_comment_was_stripped_enrols_one_key(self) -> None:
+        """The upgrade case, and the one a producer-side strip alone gets wrong.
+
+        `recipients.txt` already holds the key with its comment. Normalising
+        only what this machine *writes* leaves the old spelling live beside the
+        new one: the same key enrolled twice, listed twice by `grant` under one
+        fingerprint, and a tombstone matching only one of the two.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            key = self.root / "legacy_id_ed25519"
+            subprocess.run(
+                [
+                    "ssh-keygen",
+                    "-t",
+                    "ed25519",
+                    "-N",
+                    "",
+                    "-q",
+                    "-C",
+                    "martinus@secret-box",
+                    "-f",
+                    str(key),
+                ],
+                check=True,
+                timeout=60,
+            )
+            with_comment = key.with_suffix(".pub").read_text(encoding="utf-8").strip()
+            store.recipients_file().write_text(
+                f"{with_comment}{sync._LABEL_SEP}martinus@box\n", encoding="utf-8"
+            )
+
+            machine = store.machine()._replace(identity=str(key))
+            store.save_machine(machine)
+            sync._write_repo_metadata(machine, key)
+
+            enrolled = sync.recipients()
+        self.assertEqual(len(enrolled), 1, "the same key was enrolled under two spellings")
+        self.assertNotIn("secret-box", enrolled[0])
+
+    def test_nothing_in_the_repo_names_the_machine(self) -> None:
+        """The claim, checked across every committed byte rather than one file.
+
+        `docs/security.md` says the repo does not publish machine names. This is
+        what makes that a guarantee instead of a sentence.
+        """
+        alpha = self.machine("alpha", display="martinus@secret-box")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            # `.git` included, deliberately: it is where git would record an
+            # author identity, so leaving it out would skip the weakest link in
+            # the claim. `_ensure_repo_config` pins the author to a constant,
+            # and this is what keeps that true.
+            committed = b"".join(
+                path.read_bytes() for path in store.history_dir().rglob("*") if path.is_file()
+            )
+        self.assertNotIn(b"secret-box", committed)
+        self.assertNotIn(b"martinus", committed)
+
+    def test_no_name_is_written_into_recipients_at_all(self) -> None:
+        """#22: the label used to be `$USER@$(uname -n)`, in cleartext.
+
+        The host directories beside it are opaque hex precisely so a leaked
+        archive does not name the machines, and this file undid that one line
+        over. There is now nothing in it but keys.
+        """
+        alpha = self.machine("alpha", display="martinus@secret-box")
+        with alpha.active():
+            written = store.recipients_file().read_text(encoding="utf-8")
+        self.assertNotIn("secret-box", written)
+        self.assertNotIn("martinus", written)
+        self.assertNotIn(sync._LABEL_SEP, written)
 
 
 if __name__ == "__main__":

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -193,23 +193,47 @@ def recipient_for(identity: Path) -> str:
 
     For an SSH key this is the contents of its ``.pub`` sibling, which is what
     other machines will encrypt to; for an age identity, age derives it.
+
+    Normalised through `without_comment`, and here rather than at the call
+    sites, because this string is not only handed to age: it is written to
+    `recipients.txt`, compared for deduplication, and named by a tombstone. Two
+    machines disagreeing about whether the comment is part of it would enrol the
+    same key twice and revoke neither.
     """
     pub = public_half(identity)
     if pub.is_file():
-        return pub.read_text(encoding="utf-8").strip()
+        return without_comment(pub.read_text(encoding="utf-8").strip())
     # Reading the file ourselves, then reusing public_of, which already knows
     # both how to skip the subprocess when the identity carries its own
     # `# public key:` comment and how to feed age on stdin when it does not.
     return public_of(identity.read_text(encoding="utf-8"))
 
 
+def without_comment(recipient: str) -> str:
+    """A recipient with any trailing SSH comment removed.
+
+    An SSH public key ends in a free-text comment, conventionally
+    ``user@host`` -- so publishing one publishes a username and a hostname, in
+    the one file in the repo that is deliberately plaintext. The repo goes to
+    lengths to avoid that: host directories are opaque hex precisely so a
+    leaked archive does not name the machines.
+
+    age never needed it. It reads the type and the key material and ignores the
+    rest, so dropping it costs nothing and is not a downgrade of any kind.
+    """
+    fields = recipient.split()
+    if len(fields) > 2 and fields[0].startswith("ssh-"):
+        return " ".join(fields[:2])
+    return recipient
+
+
 def fingerprint(recipient: str) -> str:
     """A short name for a recipient that is derived from the key, not chosen.
 
-    The label beside a key in ``recipients.txt`` is free text, appended by
-    whoever added the key, and `merge=union` keeps both sides of any conflict.
-    So a human asked to approve *a label* is approving a string an attacker with
-    push access wrote -- ``martin@laptop`` twice, and one of them is not.
+    The name shown beside a key is free text a machine publishes about itself,
+    in a `name.age` that sealing needs no secret to write. So a human asked to
+    approve *a name* is approving a string an attacker with push access chose --
+    ``martin@laptop`` twice, and one of them is not.
 
     For an SSH key this is byte-for-byte what ``ssh-keygen -lf id_ed25519.pub``
     prints, which is the point: it can be checked against the machine itself

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -354,6 +354,19 @@ def default_machine_name() -> str:
     return f"{user}@{host}"
 
 
+def host_name(machine_id: str) -> str:
+    """A host's friendly name, or ``""`` if none has arrived here yet.
+
+    The one place that knows where a name is kept. `sync.name_for` wants the
+    empty answer so it can say "(unnamed)"; `host_names` wants the id instead,
+    so the fallback belongs to the callers rather than here.
+    """
+    try:
+        return name_file(machine_id).read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
 def host_names() -> dict[str, str]:
     """Map machine id -> friendly name for every host present in the logs.
 
@@ -368,11 +381,7 @@ def host_names() -> dict[str, str]:
     for entry in sorted(root.iterdir()):
         if not entry.is_dir():
             continue
-        name_file = entry / _NAME_FILE
-        try:
-            names[entry.name] = name_file.read_text(encoding="utf-8").strip() or entry.name
-        except OSError:
-            names[entry.name] = entry.name
+        names[entry.name] = host_name(entry.name) or entry.name
     return names
 
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -137,9 +137,12 @@ def remote_summary() -> str:
     return remotes[0] if remotes else "none (history is local only)"
 
 
-#: Separates a recipient from the human label woswoar appends after it. age
-#: never sees the label, because woswoar parses this file itself rather than
-#: handing age the path -- which is what makes labelling possible at all.
+#: Separates a key from the text after it. Only two things ever wrote such
+#: text: `revoke`, which marks a tombstone, and -- until #22 -- an enrolment
+#: label holding `$USER@$(uname -n)`, published in cleartext in the one file of
+#: the repo that is not encrypted. Names come from the sealed `name.age` now,
+#: so what follows a key is a constant or nothing, and `_parse` still strips
+#: whatever a file written by an older woswoar left here.
 _LABEL_SEP = " # "
 
 #: Marks a line as a *withdrawal* of the key that follows it rather than an
@@ -177,12 +180,25 @@ class _Line(NamedTuple):
 
     withdrawn: bool
     key: str
+    #: Whatever followed the key. Nothing reads it: enrolment labels are gone
+    #: and a tombstone's is a constant. Kept because `_parse` has to know the
+    #: grammar in order to strip it from lines older versions wrote.
     label: str
 
 
 def _parse(line: str) -> _Line:
+    """One line of recipients.txt, as a key this machine can compare.
+
+    The key is normalised here, not only where one is produced, and that is what
+    makes the property `crypto.recipient_for` claims actually hold. A line
+    written before SSH comments were stripped still carries `user@host`, so a
+    producer-side strip alone enrols the same key a second time -- same
+    fingerprint, listed twice in `grant`, and a tombstone matching only one of
+    the two spellings. Normalising what is read makes enrolment, deduplication
+    and withdrawal agree by construction, including with the file's own past.
+    """
     key, _, label = line.removeprefix(_REVOKED).partition(_LABEL_SEP)
-    return _Line(line.startswith(_REVOKED), key.strip(), label.strip())
+    return _Line(line.startswith(_REVOKED), crypto.without_comment(key.strip()), label.strip())
 
 
 def _revoked_in(lines: list[str]) -> set[str]:
@@ -229,12 +245,12 @@ def _this_machine_revoked(known: Machine) -> bool:
         return False
 
 
-def _labelled_recipients() -> list[tuple[str, str]]:
-    """``(key, label)`` for every enrolled machine, deduplicated by key.
+def recipients() -> list[str]:
+    """Every enrolled machine's public key, in the form age wants on `-r`.
 
-    Deduplicated because `.gitattributes` marks this file ``merge=union``, so a
-    machine that appends a labelled line where another has the same key
-    unlabelled leaves both, and age rejects a repeated recipient.
+    Deduplicated, because `.gitattributes` marks the file ``merge=union``, so
+    two machines appending the same key leaves both lines and age rejects a
+    repeated recipient.
 
     Tombstones are collected in a pass of their own first, not skipped as they
     are met: union merges interleave two machines' appends in whatever order the
@@ -248,42 +264,91 @@ def _labelled_recipients() -> list[tuple[str, str]]:
     was aimed at can un-revoke themselves by appending the line again" is not a
     property worth having, and they have push access by assumption.
 
-    The label is woswoar's own trailing comment when present and the SSH key's
-    comment field otherwise. It is never derived from the key -- an abbreviated
-    key used to be the last-resort label, which let a *chosen* label impersonate
-    one. `crypto.fingerprint` is the thing to show when the identity matters;
-    this is only a name.
-
-    Made inert on the way in. Every byte of it was written by whoever added the
-    key, and on a shared repo that is not necessarily one of your machines. That
-    covers C0 only, which is what a *record* needs; making it safe to put on a
-    terminal is `Reader.display_name`.
+    Read here rather than handed to age as a path: `crypto` never names a file
+    in $HOME, because a sandboxed age cannot open one.
     """
     lines = _recipient_lines()
     revoked = _revoked_in(lines)
 
-    out: dict[str, str] = {}
+    out: dict[str, None] = {}
     for line in lines:
-        entry = _parse(line)
         # Tombstones need no case of their own: their key is in `revoked` by
         # construction, so the same test that drops the enrolment drops them.
-        if not entry.key or entry.key in out or entry.key in revoked:
-            continue
-        label = entry.label
-        if not label:
-            fields = entry.key.split(None, 2)
-            label = fields[2] if len(fields) > 2 else "(unnamed)"
-        out[entry.key] = make_inert(label)
-    return list(out.items())
+        key = _parse(line).key
+        if key and key not in revoked:
+            out.setdefault(key, None)
+    return list(out)
 
 
-def recipients() -> list[str]:
-    """Every enrolled machine's public key, in the form age wants on `-r`.
+#: Stands in for a machine whose name this one has not learned yet -- it has
+#: enrolled but its `name.age` has not been merged here. Not a name, which is
+#: why `Reader.shares_name` ignores it: three machines waiting to be named do
+#: not share anything, and saying they do turns the one signal that means
+#: "look closely" into noise on an ordinary first sync.
+UNNAMED = "(unnamed)"
 
-    Read here rather than handed to age as a path: `crypto` never names a file
-    in $HOME, because a sandboxed age cannot open one.
+
+def _host_owners() -> dict[str, str]:
+    """``owning recipient -> host id``, from what each host publishes.
+
+    Built once per prompt rather than rescanned per recipient: `read_signer`
+    opens a file per host, so asking "which host owns this key?" separately for
+    each of them is quadratic -- 0.35 ms at five machines, 89 ms at a hundred.
+
+    Untrusted, like everything else `signer.pub` says: it decides a *label*, and
+    a label is shown quoted beside a fingerprint that cannot be chosen.
     """
-    return [key for key, _ in _labelled_recipients()]
+    owners: dict[str, str] = {}
+    for host_id in store.repo_hosts():
+        signer = read_signer(host_id)
+        if signer is not None:
+            owners.setdefault(signer.owner, host_id)
+    return owners
+
+
+def name_of(recipient: str) -> str:
+    """A human name for an enrolled machine, for a prompt to show.
+
+    Not read from `recipients.txt`, and that is the point of #22. The label
+    woswoar used to write there was `$USER@$(uname -n)`, published in cleartext
+    in the one file of the repo that is deliberately not encrypted -- while the
+    host directories beside it are opaque hex precisely so a leaked archive does
+    not name the machines. The name was already being published *sealed*, in
+    `hosts/<id>/name.age`, so it is taken from there instead.
+
+    Resolved through the local mirror `_merge_name` writes, so this costs no
+    subprocess and works for a machine that has synced. One that has not shows
+    ``(unnamed)`` and its fingerprint, which is the identity anyway -- a name is
+    a convenience and was never the thing being consented to.
+    """
+    return name_for(_host_owners().get(recipient)).text
+
+
+class Name(NamedTuple):
+    """A machine's name, and whether it is one.
+
+    ``known`` is a field rather than a comparison against `UNNAMED` because the
+    placeholder is a string a *peer* can write: sealing a `name.age` needs no
+    secret, so anything spelled here can be spelled there. Telling the two apart
+    by their text would let a machine call itself `(unnamed)` and slip out of
+    the duplicate-name warning it is the point of.
+    """
+
+    text: str
+    known: bool
+
+
+def name_for(host_id: str | None) -> Name:
+    """The name a host publishes, or the placeholder if this machine has none.
+
+    Read from the local mirror `_merge_name` writes rather than
+    `store.host_names()`, whose fallback is the opaque id -- an id beside a
+    fingerprint is two unreadable strings where one would do.
+    """
+    if host_id is None:
+        return Name(UNNAMED, known=False)
+    name = store.host_name(host_id)
+    return Name(make_inert(name), known=True) if name else Name(UNNAMED, known=False)
 
 
 def is_repo() -> bool:
@@ -644,7 +709,7 @@ def trust_candidates() -> list[Candidate]:
 
         known = store.machine()
         state = State.load()
-        names = {key: label for key, label in _labelled_recipients()}
+        live = set(recipients())
 
         out: list[Candidate] = []
         for host_id in store.repo_hosts():
@@ -654,19 +719,19 @@ def trust_candidates() -> list[Candidate]:
             if signer is None:
                 continue
             # Only hosts whose owning recipient is *live* are offered. That
-            # covers both cases in one test, because `_labelled_recipients`
-            # already subtracts tombstoned keys: a withdrawn machine is not in
-            # `names`, and neither is a host nothing ties to a recipient -- which
+            # covers both cases in one test, because `recipients` already
+            # subtracts tombstoned keys: a withdrawn machine is not in
+            # `live`, and neither is a host nothing ties to a recipient -- which
             # must also stay unacceptable, or the tombstone that would stop it
             # later would have nothing to act on.
-            if signer.owner not in names:
+            if signer.owner not in live:
                 continue
             pinned = state.signers.get(host_id)
             out.append(
                 Candidate(
                     host_id=host_id,
                     verify_key=signer.verify_key,
-                    label=names[signer.owner],
+                    label=name_for(host_id).text,
                     fingerprint=crypto.fingerprint(signer.verify_key),
                     pinned=pinned,
                     pinned_fingerprint=crypto.fingerprint(pinned) if pinned else "",
@@ -1484,7 +1549,7 @@ def _write_repo_metadata(known: Machine, identity: Path) -> bool:
         changed = True
 
     recipient = crypto.recipient_for(identity).strip()
-    if add_recipient(recipient, label=known.name):
+    if add_recipient(recipient):
         changed = True
 
     # Published before the first chunk is, so a peer that fetches between
@@ -1566,7 +1631,8 @@ def readers() -> list[Reader]:
         if has_remote():
             _fetch_and_rebase()
         granted = set(State.load().granted)
-        labelled = _labelled_recipients()
+        enrolled = recipients()
+        owners = _host_owners()
 
         # Not fatal if this machine's own key cannot be worked out: the list is
         # still true, it just loses the "(this machine)" note. `grant` is the
@@ -1576,17 +1642,18 @@ def readers() -> list[Reader]:
         except (WoswoarError, OSError):
             mine = ""
 
-        names = Counter(label for _, label in labelled)
+        labelled = [(key, name_for(owners.get(key))) for key in enrolled]
+        names = Counter(name.text for _, name in labelled if name.known)
         return [
             Reader(
                 key=key,
-                label=label,
+                label=name.text,
                 fingerprint=crypto.fingerprint(key),
                 is_new=key not in granted,
                 is_mine=key == mine,
-                shares_name=names[label] > 1,
+                shares_name=name.known and names[name.text] > 1,
             )
-            for key, label in labelled
+            for key, name in labelled
         ]
 
 
@@ -1829,7 +1896,7 @@ def revoke(reader: Reader) -> RevokeReport:
         _append_recipient_line(f"{_REVOKED}{reader.key}{_LABEL_SEP}revoked")
 
         # Read back rather than filtered by hand. What a tombstone subtracts is
-        # `_labelled_recipients`' rule, and a second copy of it here is a second
+        # `recipients`' rule, and a second copy of it here is a second
         # thing to keep in step -- the reason the file is written first.
         resealed, skipped = _reseal(change.identity, recipients())
         still_readable = _still_readable(change.known.id)
@@ -1927,19 +1994,20 @@ def compact(before: str) -> tuple[int, int]:
     return days, replaced
 
 
-def add_recipient(recipient: str, label: str = "") -> bool:
-    """Append a public key to recipients.txt if its key is not already listed.
+def add_recipient(recipient: str) -> bool:
+    """Append a public key to recipients.txt if it is not already listed.
 
-    The label is the name `grant` shows a human beside the key's fingerprint;
-    without it the prompt lists opaque age keys and cannot be consented to in
-    any real sense.
+    Nothing but the key. woswoar used to append ``# $USER@$(uname -n)`` here so
+    that `grant` had a name to show, which published a username and a hostname
+    in the one file of the repo that is deliberately plaintext -- while the host
+    directories beside it are opaque hex for exactly the opposite reason. The
+    name comes from the sealed `name.age` now; see `name_of`.
 
-    One line per key, guaranteed rather than assumed: both halves come from this
-    machine's own files, and a newline in either would append a second entry
-    that nobody added. The label is made inert, which is enough because it is
-    free text; a key with a newline in it is malformed rather than merely ugly,
-    so it is refused instead of rewritten into something age would reject later
-    and less clearly.
+    One line per key, guaranteed rather than assumed: the key comes from this
+    machine's own files, and a newline in it would append a second entry that
+    nobody added. It is refused rather than rewritten, because a key with a
+    newline in it is malformed rather than merely ugly, and age would reject it
+    later and less clearly.
     """
     key = recipient.strip()
     if "\n" in key:
@@ -1951,7 +2019,7 @@ def add_recipient(recipient: str, label: str = "") -> bool:
         raise SyncError(f"a public key may not start with {_REVOKED!r}: {key!r}")
     if key in revoked_keys():
         # Loudly, and not as "already enrolled". Appending the line would be
-        # harmless -- `_labelled_recipients` subtracts it either way -- but this
+        # harmless -- `recipients` subtracts it either way -- but this
         # machine would then record and sync for days while reading nothing, and
         # the reason would sit in a file it never prints.
         raise SyncError(
@@ -1960,5 +2028,5 @@ def add_recipient(recipient: str, label: str = "") -> bool:
         )
     if key in recipients():
         return False
-    _append_recipient_line(f"{key}{_LABEL_SEP}{make_inert(label)}" if label else key)
+    _append_recipient_line(key)
     return True


### PR DESCRIPTION
Fixes #22.

`docs/security.md` says host directories are opaque hex specifically so a leaked archive does not publish machine names. `recipients.txt` — the one file in the repo that is deliberately not encrypted — undid that one file over, **twice**:

```
ssh-ed25519 AAAAC3Nza…IAlU2Eh martinus@secret-hostname # martinus@box
                               └── the SSH key's own comment    └── woswoar's label
```

- woswoar appended `# $USER@$(uname -n)` so `grant` had a name to show;
- an SSH identity carries its key's trailing comment, which `ssh-keygen` writes by default — published *twice* since signing landed, because `signer.pub` names the owning recipient too.

## The fix

`recipients.txt` now holds keys and tombstones, nothing else. The name comes from `hosts/<id>/name.age`, where it was already published **sealed**, resolved through the recipient→host join `signer.pub` provides. The comment is stripped by `crypto.without_comment`; age never read it.

After: `recipients.txt` is one bare key, and neither the username nor the hostname appears anywhere under `history/` — including `.git`.

## Stripping on write alone was not enough

The first version of this did exactly that, and the review caught it. A `recipients.txt` from before the change still holds the key *with* its comment, so the next sync appends the stripped spelling beside it:

```
recipients after upgrade: 2
  SHA256:eA5HnO2oDwmSJVLn21LmwJBcwRkxsgUGxL54e1rJfHo  …8EKK88cW martinus@secret-box
  SHA256:eA5HnO2oDwmSJVLn21LmwJBcwRkxsgUGxL54e1rJfHo  …RyUTLeqi7ln7hXFqix1I8EKK88cW
```

Same key, same fingerprint, enrolled twice — and a tombstone would match only one of the two spellings. Normalising in `_parse` instead makes enrolment, deduplication and withdrawal agree by construction, including with the file's own past. There is a test for the upgrade.

## Moving a name does not make it trusted

Worth stating, because it would be easy to assume otherwise: sealing a `name.age` needs no secret, so a name is still text a peer chose. It is still made inert and still shown quoted beside a fingerprint that cannot be chosen.

That has a new edge — `(unnamed)` is a string a peer can spell — so a name now carries whether it is **known**, and the duplicate warning ignores placeholders rather than comparing text. Otherwise two peers claiming the placeholder would raise a false alarm against a machine whose name simply has not arrived yet.

## Also from the review

- `readers()` was O(recipients × hosts) file reads and `trust_candidates` re-scanned every host directory to rediscover an id it already held — **89 ms at a hundred machines**, now one pass.
- `store.host_name` is the one place that knows where a name is kept.
- The "nothing names the machine" test no longer excludes `.git`, which was skipping the one place git records an author identity — so it now guards `_ensure_repo_config` too.

`recipients()` on the per-sync path got **cheaper**: 0.021 ms, with no label building and no host scan.

## Tests

287 pass. **8 mutations, all killing their guarding test.** One existing test was retargeted rather than kept: it guarded a fallback that derived a label from the key, which no longer exists in any form, so it passed either way.