### PR TITLE
Write down what this session lost time to, so the next one does not

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,12 +83,45 @@ Priority is *implementation order*, not just severity. When ranking, weigh:
 State the reasoning in the issue when the ranking is not obvious from the title.
 If new information changes the picture, relabel the issue and say why.
 
+## 6. Never discard a change you cannot get back
+
+`git checkout -- <file>`, `git restore`, `git stash` and `git reset --hard` have
+each destroyed uncommitted work here. There is no reflog for a tree that was
+never committed, so the only recovery is to write it again from memory — the
+single largest waste of a session so far, twice over.
+
+- Commit a checkpoint before anything that rewrites files in bulk. Mutation
+  testing especially: it edits sources in a loop and restores them in a
+  `finally`, and an interrupted run leaves the tree mutated.
+- To undo your own edit, rewrite the text you changed. Do not discard the file.
+- Tell subagents explicitly when they may not write. A review agent asked only
+  to *read* a diff has reverted the tree on its own initiative; verify the tree
+  yourself before believing a report that mentions touching it.
+
+## 7. Branch before the first commit
+
+Not after. Undoing a commit that landed on `main` means branching at `HEAD` and
+then `git reset --hard origin/main` — the operation rule 6 is about.
+
 ## Repository conventions worth matching
 
 - Comments explain **why**, especially why an obvious alternative was rejected.
   Match that density; it is deliberate.
 - The shell hook must not fork on the per-command path, and CI asserts it.
-- `ruff check`, `ruff format --check`, `mypy` (strict) and `shellcheck` all run
-  in CI. Run them before pushing.
 - Claims in `docs/security.md` are backed by tests, not prose. If you change
   what the code guarantees, change the claim and the test together.
+- Preflight before pushing — the same checks CI runs, in one line:
+
+  ```sh
+  ruff check . && ruff format --check . && mypy woswoar tests \
+    && shellcheck --shell=bash woswoar/shell/woswoar.bash \
+    && python -m unittest discover -s . -t . -p 'test_*.py'
+  ```
+
+- Run mutation tests with `python -B` **and** delete `woswoar/__pycache__`
+  between mutations. A `.pyc` is validated against `(mtime_seconds, size)`, so
+  two mutations that change a file by the same number of bytes inside one second
+  run each other's cached bytecode — which reports a test as surviving when it
+  does not, and has sent a correct test to be rewritten as "decoration".
+- Before blaming your branch for a CI failure, measure the same job on `main`,
+  enough times to see a one-in-forty flake. Two runs of green proves nothing.


### PR DESCRIPTION
Six security fixes landed in a row (#37, #39, #40, #43, #44, #46). Four things
cost real rework along the way, and none of them were written down anywhere.

### Rule 6 — never discard a change you cannot get back

`git checkout -- <file>` destroyed uncommitted work **twice**: once by the agent
doing the work, mid-task, and once by a review subagent that reverted the tree
on its own initiative while it had only been asked to read a diff. A tree that
was never committed has no reflog, so both times the only recovery was to write
the change again from memory. That is the single largest waste of the session.

The rule names the specific commands, says to checkpoint before anything that
rewrites files in bulk (mutation testing edits sources in a loop), and says to
tell subagents explicitly when they may not write.

### Rule 7 — branch before the first commit

A commit landed on `main` and had to be unpicked with branch-at-`HEAD` plus
`git reset --hard origin/main`, which is exactly the operation rule 6 is about.

### Conventions — the mutation-harness trap

The harness reported a **correct** test as decoration. A `.pyc` is validated
against `(mtime_seconds, size)`, so two mutations that change a file by the same
number of bytes inside one second run each other's cached bytecode. A real test
was nearly rewritten on the strength of that verdict, and the already-merged #19
set had to be re-run to confirm it had not happened there too. `python -B` plus
deleting `woswoar/__pycache__` between mutations is now written down next to
rule 3, which is what asks for the mutation testing in the first place.

### Conventions — preflight, and CI flakes

- The exact check invocations were recovered from `.github/workflows/ci.yml`
  once per task. They are now one copy-pasteable line. Verified against this
  tree: all four checks clean, 287 tests pass.
- A `TemporaryDirectory` teardown failure on 3.14 was attributed to the branch
  twice before being measured properly — 1/40 on the branch and 1/40 on `main`,
  i.e. pre-existing. Two green runs prove nothing about a flake that rare.

### On rule 1

`/simplify` was **not** run. The diff is markdown only, so its four angles
(reuse, simplification, efficiency, altitude) have nothing to inspect, and
spending four agents on a rules document would be the exact cost this PR exists
to reduce. Flagging it rather than dropping it silently, per rule 1's own
instruction. Say the word if you would rather it ran anyway.

No code changed, so there is no regression test to write — rule 3 does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)