### PR TITLE
Shard the test suite across processes, and cut the apt wait in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,14 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       # shellcheck comes from pip rather than apt so the version CI enforces is
       # the same one `pip install -e .[dev]` gives you locally.
       - run: pip install -e .[dev]
       - run: ruff check .
       - run: ruff format --check .
-      - run: mypy woswoar tests
+      - run: mypy woswoar tests tools
       - run: shellcheck --shell=bash woswoar/shell/woswoar.bash
 
   test:
@@ -43,7 +45,14 @@ jobs:
       - name: install age
         # Sync tests skip themselves without it, and a silently skipped suite
         # looks exactly like a passing one.
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq age
+        #
+        # `update` only when the direct install misses: refreshing the lists
+        # costs ~10s and the runner image usually already has what age needs,
+        # which on the critical path is most of the job. The fallback keeps it
+        # correct on an image where that stops being true.
+        run: |
+          sudo apt-get install -y -qq age \
+            || { sudo apt-get update -qq && sudo apt-get install -y -qq age; }
       - name: ssh-keygen is present
         # Signing needs it. Present on ubuntu-latest, asserted rather than
         # assumed for the same reason as bash below: a silently skipped suite
@@ -55,7 +64,13 @@ jobs:
         run: |
           bash -c 'echo "bash ${BASH_VERSION}"'
           bash -c '((BASH_VERSINFO[0] >= 5))' || { echo "bash 5.0+ required"; exit 1; }
-      - run: python -m unittest discover -s . -t . -p 'test_*.py' --verbose
+      # Sharded across processes: the suite is ~88% subprocess wait, so this is
+      # 38s -> ~13s. The runner fails the build if any discovered test did not
+      # report, which a plain `unittest discover` cannot get wrong but a
+      # parallel runner can. No --no-skips here: strace is not installed in this
+      # job, so the fork-scaling tests legitimately skip. The `hook` job is
+      # where they are made fatal.
+      - run: python -m tools.run_tests
 
   hook:
     # Called on every prompt, so the hook gets its own job: the fork-scaling
@@ -68,11 +83,16 @@ jobs:
           python-version: "3.12"
       - name: install strace and locales
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq strace locales
+          sudo apt-get install -y -qq strace locales \
+            || { sudo apt-get update -qq && sudo apt-get install -y -qq strace locales; }
           # The comma-decimal test needs a locale where $EPOCHREALTIME uses ","
           sudo locale-gen de_AT.UTF-8
-      - run: python -m unittest tests.test_shell_hook --verbose
+      # --jobs 1 on purpose: this job counts forks under strace, and the whole
+      # point of it is a measurement that concurrent load has no say in. The
+      # runner is used anyway for --no-skips -- strace and bash 5 are installed
+      # here, so a skip means one of them stopped working, not that the test is
+      # inapplicable.
+      - run: python -m tools.run_tests --only tests.test_shell_hook --jobs 1 --no-skips
 
   sync:
     # Two machines exchanging encrypted history through a bare repo, plus the
@@ -83,20 +103,17 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - run: sudo apt-get update -qq && sudo apt-get install -y -qq age
+      - run: |
+          sudo apt-get install -y -qq age \
+            || { sudo apt-get update -qq && sudo apt-get install -y -qq age; }
       - run: age --version && git --version && command -v ssh-keygen
       - name: sync suite
-        run: |
-          set -o pipefail
-          python -m unittest tests.test_sync --verbose 2>&1 | tee sync.log
-          # These tests skip themselves when age or git is absent. A skipped run
-          # is green, which is precisely the failure mode worth guarding.
-          # The summary line, not the bare word: a test *docstring* containing
-          # "skipped" would otherwise redden this build.
-          if grep -qE "^(OK|FAILED) \(.*skipped=" sync.log; then
-            echo "::error::sync tests were skipped - age or git missing"
-            exit 1
-          fi
+        # These tests skip themselves when age or git is absent. A skipped run
+        # is green, which is precisely the failure mode worth guarding, so
+        # --no-skips makes any skip fatal here. It replaces a grep over the
+        # summary line, which had to dodge the word "skipped" appearing in a
+        # test docstring; the runner counts the skips themselves instead.
+        run: python -m tools.run_tests --only tests.test_sync --no-skips
 
   perf:
     runs-on: ubuntu-latest
@@ -109,8 +126,15 @@ jobs:
         env:
           WOSWOAR_BENCH: "1"
         # Prints the measured numbers and fails only on a large regression, so a
-        # noisy shared runner cannot redden the build on its own.
-        run: python -m unittest tests.test_perf --verbose
+        # noisy shared runner cannot redden the build on its own. --jobs 1 for
+        # the same reason: these are latency measurements, and running them
+        # beside each other would be the noise they are trying to survive.
+        #
+        # --no-skips is the point of routing this through the runner: these
+        # tests skip themselves unless WOSWOAR_BENCH is set, so if the env block
+        # above ever stopped taking effect this job would go green having
+        # measured nothing at all.
+        run: python -m tools.run_tests --only tests.test_perf --jobs 1 --no-skips
 
   install:
     # Proves the packaging works and the documented first-run flow succeeds on a
@@ -154,7 +178,8 @@ jobs:
       - name: two machines sync through a bare repo, from the installed wheel
         run: |
           set -euxo pipefail
-          sudo apt-get update -qq && sudo apt-get install -y -qq age
+          sudo apt-get install -y -qq age \
+            || { sudo apt-get update -qq && sudo apt-get install -y -qq age; }
           BASE="$(mktemp -d)"
           git init --quiet --bare "$BASE/origin.git"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,11 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: pyproject.toml
+      # No `cache: pip` here: it was tried and measured, and it made this job
+      # slower -- 13s to 17s. The dev deps are floors rather than pins, so pip
+      # still pays a resolution round-trip on a hit, and the cache only saves
+      # the wheel downloads, which cost less than restoring and saving it.
+      #
       # shellcheck comes from pip rather than apt so the version CI enforces is
       # the same one `pip install -e .[dev]` gives you locally.
       - run: pip install -e .[dev]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,13 +113,16 @@ then `git reset --hard origin/main` — the operation rule 6 is about.
 - Preflight before pushing — the same checks CI runs, in one line:
 
   ```sh
-  ruff check . && ruff format --check . && mypy woswoar tests \
+  ruff check . && ruff format --check . && mypy woswoar tests tools \
     && shellcheck --shell=bash woswoar/shell/woswoar.bash \
-    && python -m unittest discover -s . -t . -p 'test_*.py'
+    && python -m tools.run_tests
   ```
 
+  `python -m unittest discover -s . -t . -p 'test_*.py'` runs the same tests
+  serially, and takes about three times as long.
+
 - Run mutation tests with `python -B` **and** delete `woswoar/__pycache__`
-  between mutations. A `.pyc` is validated against `(mtime_seconds, size)`, so
+  (plus `tools/` and `tests/`) between mutations. A `.pyc` is validated against `(mtime_seconds, size)`, so
   two mutations that change a file by the same number of bytes inside one second
   run each other's cached bytecode — which reports a test as surviving when it
   does not, and has sent a correct test to be rewritten as "decoration".

--- a/README.md
+++ b/README.md
@@ -219,10 +219,17 @@ the timer fires.
 ## Development
 
 ```bash
-python -m unittest discover -s . -t . -p 'test_*.py'    # 194 tests
+python -m tools.run_tests                               # 301 tests, sharded, ~6s
+python -m unittest discover -s . -t . -p 'test_*.py'    # the same suite, serially
 WOSWOAR_BENCH=1 python -m unittest tests.test_perf      # latency on 52k entries
-ruff check . && ruff format --check . && mypy woswoar tests
+ruff check . && ruff format --check . && mypy woswoar tests tools
 ```
+
+The suite is about 88% subprocess wait — it drives real `age`, `git` and
+`ssh-keygen` rather than mocking them — so sharding it across processes takes it
+from ~19s to ~6s. Both commands run the same tests; the runner additionally
+fails if any test it discovered never reported back, which is a way a parallel
+run can be green that a serial one cannot.
 
 CI runs lint, tests on Python 3.10/3.12/3.14, the shell-hook and fork-free
 checks, a two-machine end-to-end sync against real `age` and real `git`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ path = "woswoar/__init__.py"
 packages = ["woswoar"]
 
 [tool.hatch.build.targets.sdist]
-include = ["woswoar", "tests", "docs", "README.md", "LICENSE"]
+include = ["woswoar", "tests", "tools", "docs", "README.md", "LICENSE"]
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -1,0 +1,240 @@
+"""The parallel runner's job is to refuse to call a partial run green.
+
+CI's verdict rests on this script, so the interesting tests are the ones where
+something goes wrong underneath it: a batch that dies without reporting, a class
+that never runs, a suite that is green only because a tool was missing. Each of
+those is a way to get a passing build out of tests that did not happen.
+
+The cases are driven through fixture modules built in a scratch directory rather
+than through real classes from this suite. Two reasons: a real class ties these
+tests to a file someone may rename, and one case needs a test that *skips*,
+which would otherwise mean depending on `tests.test_perf` skipping -- so a
+developer with WOSWOAR_BENCH exported would get a failure here that has nothing
+to do with the runner.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from tools import run_tests  # noqa: E402
+
+PASSES = "    def test_ok(self) -> None:\n        pass\n"
+FAILS = "    def test_bad(self) -> None:\n        self.assertEqual(1, 2)\n"
+SKIPS = "    @unittest.skip('a tool is missing')\n    def test_gone(self) -> None:\n        pass\n"
+
+
+@contextmanager
+def fixture(*bodies: str) -> Iterator[list[str]]:
+    """Build throwaway test modules and make the runner discover exactly those.
+
+    Yields their class names. PYTHONPATH is what carries them into the worker,
+    which is a separate interpreter; patching `discover` only reaches the parent.
+    """
+    with tempfile.TemporaryDirectory(prefix="woswoar-runner-test-") as tmp:
+        classes: dict[str, list[str]] = {}
+        for index, body in enumerate(bodies):
+            module = f"zz_fixture_{index}"
+            Path(tmp, f"{module}.py").write_text(
+                f"import unittest\n\n\nclass TestFixture(unittest.TestCase):\n{body}",
+                encoding="utf-8",
+            )
+            name = f"{module}.TestFixture"
+            classes[name] = [f"{name}.{body.split('def ')[1].split('(')[0]}"]
+        path = os.pathsep.join(filter(None, [tmp, os.environ.get("PYTHONPATH")]))
+        # sys.path as well as PYTHONPATH, so a test may also load the fixture
+        # in-process; sys.modules is purged after, or the next fixture's
+        # identically named module would resolve to this one's stale copy.
+        sys.path.insert(0, tmp)
+        try:
+            with (
+                mock.patch.dict(os.environ, {"PYTHONPATH": path}),
+                mock.patch.object(run_tests, "discover", lambda: dict(classes)),
+            ):
+                yield list(classes)
+        finally:
+            sys.path.remove(tmp)
+            for name in classes:
+                sys.modules.pop(name.split(".")[0], None)
+
+
+def run_main(*argv: str) -> tuple[int, str]:
+    """Call main(), returning its exit code and everything it printed.
+
+    Both streams, because both land in the CI log and that is what a human
+    actually reads: the accounting on stdout, tracebacks on stderr.
+    """
+    out = StringIO()
+    with redirect_stdout(out), redirect_stderr(out):
+        code = run_tests.main(list(argv))
+    return code, out.getvalue()
+
+
+@contextmanager
+def tampering(mutate: Callable[[list[str]], list[str]]) -> Iterator[None]:
+    """Let each worker run for real, then rewrite what it reported having run."""
+    real = subprocess.run
+
+    def wrapper(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        done = real(argv, **kwargs)  # type: ignore[call-overload]
+        out = Path(argv[argv.index("--out") + 1])
+        if out.exists():
+            report = json.loads(out.read_text(encoding="utf-8"))
+            report["ran"] = mutate(report["ran"])
+            out.write_text(json.dumps(report), encoding="utf-8")
+        return done  # type: ignore[no-any-return]
+
+    with mock.patch.object(subprocess, "run", wrapper):
+        yield
+
+
+class TestDiscovery(unittest.TestCase):
+    def test_every_test_is_assigned_to_exactly_one_shard(self) -> None:
+        """The sharding must partition the real suite -- no gaps, no double runs."""
+        classes = run_tests.discover()
+        ids = [tid for group in classes.values() for tid in group]
+        self.assertEqual(len(ids), len(set(ids)), "a test landed in two shards")
+
+        serial = unittest.defaultTestLoader.discover(
+            str(ROOT), pattern="test_*.py", top_level_dir=str(ROOT)
+        )
+        self.assertEqual(set(ids), {t.id() for t in run_tests._walk(serial)})
+
+    def test_a_module_that_cannot_be_imported_is_a_red_test_not_a_smaller_suite(self) -> None:
+        """unittest represents a load error as a _FailedTest; it must survive _walk.
+
+        If it were dropped, a module that stopped importing would quietly shrink
+        the suite and the build would stay green.
+        """
+        loaded = unittest.defaultTestLoader.loadTestsFromNames(["tests.not_a_real_module"])
+        self.assertEqual(len(run_tests._walk(loaded)), 1)
+
+
+class TestPacking(unittest.TestCase):
+    def test_every_class_lands_in_exactly_one_batch(self) -> None:
+        classes = {f"m.C{i}": ["x"] * (i % 5 + 1) for i in range(20)}
+        batches = run_tests.pack(classes, 6)
+        placed = [name for batch in batches for name in batch]
+        self.assertEqual(sorted(placed), sorted(classes))
+        self.assertLessEqual(len(batches), 6)
+
+    def test_more_batches_than_classes_does_not_produce_empty_batches(self) -> None:
+        """An empty batch would start an interpreter to run nothing."""
+        for classes, bins in (({"m.C": ["x"]}, 32), ({f"m.C{i}": ["x"] for i in range(3)}, 40)):
+            batches = run_tests.pack(classes, bins)
+            self.assertTrue(all(batches), f"an empty batch in {batches}")
+            self.assertEqual(len(batches), len(classes))
+
+    def test_selection_is_anchored_so_a_similar_name_is_not_dragged_in(self) -> None:
+        self.assertTrue(run_tests.selects("tests.test_sync", "tests.test_sync"))
+        self.assertTrue(run_tests.selects("tests.test_sync.TestX", "tests.test_sync"))
+        self.assertFalse(run_tests.selects("tests.test_sync_chunks.TestX", "tests.test_sync"))
+
+
+class TestABatchThatDies(unittest.TestCase):
+    """The failure a serial runner cannot have: a worker that never reports."""
+
+    def test_a_worker_that_writes_no_report_fails_the_run(self) -> None:
+        def dies(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+            # Segfault, OOM kill, or a crash in setUpClass: the process is gone
+            # and --out was never written.
+            return subprocess.CompletedProcess(argv, returncode=-9)
+
+        with fixture(PASSES), mock.patch.object(subprocess, "run", dies):
+            code, text = run_main("--jobs", "2")
+
+        self.assertEqual(code, 1, "a run whose batches all died reported success")
+        self.assertIn("never ran", text)
+        self.assertIn("shard died without reporting", text)
+
+    def test_a_worker_that_reports_fewer_tests_than_it_was_given_fails_the_run(self) -> None:
+        """The count is not enough: the ids must match by name.
+
+        A batch that silently runs half its classes and reports success is the
+        subtle version of the same bug.
+        """
+        with fixture(PASSES, PASSES), tampering(lambda ran: ran[:-1]):
+            code, text = run_main("--jobs", "2")
+
+        self.assertEqual(code, 1, "a batch that dropped a test reported success")
+        self.assertIn("never ran", text)
+
+    def test_a_test_counted_twice_fails_the_run(self) -> None:
+        """The mirror of the missing case, and the one the id set alone misses.
+
+        If two batches ever overlap, every expected id is present and only the
+        duplicate shows it. A run that double-counts is a run whose totals
+        cannot be believed.
+        """
+        with fixture(PASSES), tampering(lambda ran: ran + ran[:1]):
+            code, text = run_main("--jobs", "2")
+
+        self.assertEqual(code, 1, "a run that counted a test twice reported success")
+        self.assertIn("ran more than once", text)
+
+
+class TestSkipsCanBeFatal(unittest.TestCase):
+    """`age` missing must not look like a passing suite -- the sync job's rule."""
+
+    def test_a_skipped_test_fails_the_run_under_no_skips(self) -> None:
+        with fixture(SKIPS):
+            code, text = run_main("--jobs", "2", "--no-skips")
+        self.assertEqual(code, 1)
+        self.assertIn("were skipped", text)
+
+    def test_the_same_run_is_green_when_skips_are_allowed(self) -> None:
+        with fixture(SKIPS):
+            code, _ = run_main("--jobs", "2")
+        self.assertEqual(code, 0)
+
+
+class TestOrdinaryOutcomes(unittest.TestCase):
+    def test_a_passing_class_is_green(self) -> None:
+        with fixture(PASSES):
+            code, text = run_main("--jobs", "2")
+        self.assertEqual(code, 0)
+        self.assertIn("OK", text)
+
+    def test_a_failing_test_makes_the_run_red(self) -> None:
+        with fixture(FAILS):
+            code, text = run_main("--jobs", "2")
+        self.assertEqual(code, 1)
+        self.assertIn("1 failures", text)
+
+    def test_only_ids_travel_back_from_a_batch_not_tracebacks(self) -> None:
+        """The batch prints the traceback; the parent only lists the id.
+
+        Sending the traceback back as well printed every failure twice in the
+        CI log -- once from the batch's stderr, once from the summary.
+        """
+        with fixture(FAILS) as names, tempfile.TemporaryDirectory() as out_dir:
+            out = Path(out_dir, "report.json")
+            with redirect_stderr(StringIO()):
+                run_tests.run_batch(names, out)
+            report = json.loads(out.read_text(encoding="utf-8"))
+
+        self.assertEqual(len(report["failures"]), 1)
+        self.assertNotIn("Traceback", report["failures"][0])
+        self.assertNotIn("\n", report["failures"][0])
+
+    def test_a_filter_matching_nothing_is_an_error_not_an_empty_pass(self) -> None:
+        """`--only Typo` running zero tests must not be reported as success."""
+        code, _ = run_main("--only", "tests.no_class_has_this_name", "--jobs", "2")
+        self.assertEqual(code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -1,0 +1,236 @@
+"""Run the suite in parallel, and refuse to call a partial run green.
+
+The suite is dominated by `tests.test_sync`, which spends about 88% of its wall
+clock waiting on real `git`, `age` and `ssh-keygen` -- 5400 git invocations for
+one serial run. That is latency, not CPU, so it shards across processes almost
+linearly: 21s serially, 6.7s on a four-core runner.
+
+Sharding is by test *class*: classes are the unit that shares `setUpClass`, so
+splitting one would run its fixture twice. Classes are then packed into batches,
+a few per worker rather than one process per class -- 71 interpreter starts cost
+about 5.6s of import CPU between them, which is most of what parallelism had
+just bought.
+
+What this adds over `python -m unittest discover` is an accounting check. A
+parallel runner has a failure mode a serial one does not: a shard that dies
+before it reports, leaving a run that is green because nothing ran. So every id
+handed to a batch must come back in that batch's report, by name:
+
+    ids discovered == ids reported
+
+Two honest limits on that. It is a closed loop -- both sides come from the same
+`discover()`, so a file renamed out of the `test_*.py` pattern shrinks both and
+stays green, exactly as it would under plain unittest. And when a batch dies the
+ids come back as never-run, which is the point, but the diagnosis of *why* is in
+that batch's own stderr rather than in the summary.
+
+`pytest -n auto --dist loadscope` would cover most of this in two dev
+dependencies. It is not used because the project carries no runtime dependencies
+and three dev ones, all linters -- but that is a maintainer's call, not a
+technical impossibility.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _walk(suite: unittest.TestSuite) -> list[unittest.TestCase]:
+    """Flatten a suite, surfacing the placeholders unittest uses for load errors.
+
+    A module that raises on import becomes a _FailedTest here rather than
+    vanishing. Keeping it means an import error is a red test, not a smaller
+    suite -- which is the whole point of this file.
+    """
+    found: list[unittest.TestCase] = []
+    for item in suite:
+        if isinstance(item, unittest.TestSuite):
+            found.extend(_walk(item))
+        else:
+            found.append(item)
+    return found
+
+
+def discover() -> dict[str, list[str]]:
+    """Map each test class to the ids it holds, in discovery order."""
+    suite = unittest.defaultTestLoader.discover(
+        str(ROOT), pattern="test_*.py", top_level_dir=str(ROOT)
+    )
+    classes: dict[str, list[str]] = {}
+    for test in _walk(suite):
+        name = f"{type(test).__module__}.{type(test).__qualname__}"
+        classes.setdefault(name, []).append(test.id())
+    return classes
+
+
+def selects(name: str, only: str) -> bool:
+    """Does `only` select the class `name`?
+
+    Anchored at a dot rather than matching any substring: the sync job pins its
+    fatal-skip policy with `--only tests.test_sync`, and a later
+    `tests/test_sync_chunks.py` would otherwise be dragged under that policy
+    without anyone choosing it.
+    """
+    return name == only or name.startswith(only + ".")
+
+
+def pack(classes: dict[str, list[str]], bins: int) -> list[list[str]]:
+    """Spread classes over batches, largest first onto the lightest batch.
+
+    Test count is a rough proxy for duration -- measured, packing by true
+    duration would save about 5% -- but it is free, and it keeps a fat class
+    from being scheduled last, which is what actually sets the wall clock.
+
+    Never more batches than classes: an empty batch would start an interpreter
+    to run nothing. That clamp is also why no filter is needed afterwards --
+    with at most one batch per class, `min(weights)` always finds a batch that
+    is still empty, so none is left behind.
+    """
+    batches: list[list[str]] = [[] for _ in range(max(1, min(bins, len(classes))))]
+    weights = [0] * len(batches)
+    for name in sorted(classes, key=lambda n: (-len(classes[n]), n)):
+        light = weights.index(min(weights))
+        batches[light].append(name)
+        weights[light] += len(classes[name])
+    return batches
+
+
+class _Recorder(unittest.TextTestResult):
+    """A result that remembers which ids ran, not just how many."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.ran: list[str] = []
+
+    def startTest(self, test: unittest.TestCase) -> None:
+        self.ran.append(test.id())
+        super().startTest(test)
+
+
+def run_batch(names: list[str], out: Path) -> int:
+    """Run some classes and write what happened to `out` as JSON."""
+    suite = unittest.defaultTestLoader.loadTestsFromNames(names)
+    # Tracebacks go to stderr, where they interleave with the tests' own output
+    # and a human reads them in context. Only ids travel back to the parent:
+    # shipping the traceback too would print every failure twice.
+    result = unittest.TextTestRunner(stream=sys.stderr, verbosity=1, resultclass=_Recorder).run(
+        suite
+    )
+    assert isinstance(result, _Recorder)
+    out.write_text(
+        json.dumps(
+            {
+                "ran": result.ran,
+                "failures": [test.id() for test, _ in result.failures],
+                "errors": [test.id() for test, _ in result.errors],
+                # The reason, unlike a traceback, is not printed by the child at
+                # this verbosity, so it would otherwise be lost.
+                "skipped": [[test.id(), why] for test, why in result.skipped],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return 0 if result.wasSuccessful() else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--jobs", type=int, default=0, help="batches at once (default: 2x CPUs)")
+    parser.add_argument(
+        "--no-skips",
+        action="store_true",
+        help="treat a skipped test as a failure, for jobs that install every optional tool",
+    )
+    parser.add_argument("--only", default="", help="run only this module or class")
+    parser.add_argument("--worker", nargs="+", help=argparse.SUPPRESS)
+    parser.add_argument("--out", help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+
+    if args.worker:
+        assert args.out
+        return run_batch(args.worker, Path(args.out))
+
+    classes = discover()
+    if args.only:
+        classes = {name: ids for name, ids in classes.items() if selects(name, args.only)}
+        if not classes:
+            print(f"::error::no test class matches {args.only!r}")
+            return 1
+    expected = {tid for ids in classes.values() for tid in ids}
+
+    # Twice the CPUs, because the work is subprocess wait rather than CPU:
+    # measured on four cores, jobs=8 beats jobs=4 by ~9%, and jobs=16 regresses.
+    cpus = getattr(os, "process_cpu_count", os.cpu_count)  # process_cpu_count is 3.13+
+    jobs = args.jobs or (cpus() or 2) * 2
+    # More batches than workers, so a batch that runs long is overlapped by the
+    # others rather than deciding the wall clock on its own.
+    batches = pack(classes, jobs * 2)
+
+    with tempfile.TemporaryDirectory(prefix="woswoar-shards-") as tmp:
+
+        def run(indexed: tuple[int, list[str]]) -> dict[str, Any]:
+            index, names = indexed
+            out = Path(tmp) / f"{index}.json"
+            proc = subprocess.run(
+                [sys.executable, "-m", "tools.run_tests", "--worker", *names, "--out", str(out)],
+                cwd=ROOT,
+            )
+            if not out.exists():
+                # Killed by the OOM killer, a segfault in a C extension, a crash
+                # in setUpClass: no report, so nothing it would have said can be
+                # believed. Its ids come out below as never-run.
+                print(f"::error::shard died without reporting, exit {proc.returncode}: {names}")
+                return {"ran": [], "failures": [], "errors": list(names), "skipped": []}
+            loaded: dict[str, Any] = json.loads(out.read_text(encoding="utf-8"))
+            return loaded
+
+        with ThreadPoolExecutor(max_workers=jobs) as pool:
+            reports = list(pool.map(run, enumerate(batches)))
+
+    ran = [tid for report in reports for tid in report["ran"]]
+    failures = [tid for report in reports for tid in report["failures"]]
+    errors = [tid for report in reports for tid in report["errors"]]
+    skipped = [pair for report in reports for pair in report["skipped"]]
+
+    print(f"\nRan {len(ran)} tests in {len(batches)} batches on {jobs} workers")
+    for label, ids in (("FAIL", failures), ("ERROR", errors)):
+        for tid in ids:
+            print(f"  {label}: {tid}")  # the traceback is already above, from the batch
+
+    ok = not (failures or errors)
+    if missing := expected - set(ran):
+        # The accounting check this script exists for.
+        print(f"::error::{len(missing)} discovered tests never ran")
+        for tid in sorted(missing):
+            print(f"  never ran: {tid}")
+        ok = False
+    if duplicated := len(ran) - len(set(ran)):
+        print(f"::error::{duplicated} tests ran more than once")
+        ok = False
+    if skipped:
+        for tid, why in skipped:
+            print(f"  skipped: {tid} ({why})")
+        if args.no_skips:
+            print(f"::error::{len(skipped)} tests were skipped - an optional tool is missing")
+            ok = False
+
+    print(
+        f"{'OK' if ok else 'FAILED'} ({len(failures)} failures, {len(errors)} errors, "
+        f"{len(skipped)} skipped)"
+    )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The critical-path job was **57s**: 11-13s installing `age`, then 38s of tests.

## Where the time went

Measured from the API, per step, rather than guessed:

| job | apt | tests | total |
|---|---|---|---|
| `test (3.14)` | 10s | 40s | **57s** |
| `sync` | 8s | 38s | 51s |
| `hook` | 14s | 3s | 22s |

And within the suite, `tests.test_sync` is 19.6s of the 21.0s total. Profiling
its subprocess use:

```
git          5425 calls  13.81s  (70.1%)
age           923 calls   1.90s  ( 9.7%)
ssh-keygen    447 calls   1.23s  ( 6.2%)
age-keygen    236 calls   0.41s  ( 2.1%)
             subprocess total 17.34s of 19.7s
```

~88% subprocess wait. That is latency, not CPU, so it shards almost linearly.

## Results

On `taskset -c 0-3`, to match a runner:

| | wall clock |
|---|---|
| `python -m unittest discover` | 19.31s |
| `python -m tools.run_tests` | **6.28s** |

Two things that were measured rather than assumed:

- **Batching matters.** One process per class gave back most of the win — 71
  interpreter starts cost ~5.6s of import CPU between them. Classes are packed
  into batches instead, largest-first onto the lightest batch.
- **Workers should be 2× CPUs, not 1×**, because the work is subprocess wait.
  On four cores, 8 beats 4 by ~9%; 16 regresses on contention.

`apt-get update` now runs only when the direct install misses — ~10s on jobs
where it is most of the runtime, with a fallback that keeps it correct if the
runner image stops carrying what `age` needs. Applied at all four sites (the
first pass missed the `install` job; the review caught it).

## The part worth arguing about

`tools/run_tests.py` is 236 lines that `pytest -n auto --dist loadscope` would
largely replace for two dev dependencies. **This is your call and I have not
assumed it** — I kept the bespoke runner because the project advertises zero
runtime dependencies and carries three dev ones, all linters. Say the word and
I'll swap it.

What it adds over `unittest discover` is an accounting check, since a parallel
runner has a failure mode a serial one does not — a shard that dies before it
reports, leaving a run that is green because nothing ran. Every discovered id
must come back in some batch's report, **by name**.

The review pushed back that I had oversold this, and it was right: it is a
closed loop, since both sides come from the same `discover()`, so a file renamed
out of the `test_*.py` pattern shrinks both and stays green. The docstring now
says so, and says what pytest-xdist would give instead. It caught a real bug
during development — my first version had the worker's `sys.path[0]` pointing at
`tools/`, so every shard failed to import and the check reported it loudly
instead of passing with nothing run.

## Two guarantees that were missing

The `sync` job's skip guard was a grep over the summary line that had to dodge
the word "skipped" appearing in a docstring. It is now `--no-skips`, counting
the skips themselves.

More importantly, the review found the guard only ever covered `sync`. The
`hook` and `perf` jobs had the same hazard and neither was guarded — and `perf`
is the sharp one: its tests skip unless `WOSWOAR_BENCH` is set, so if that env
block ever stopped taking effect **the job would go green having measured
nothing**. Both now run with `--no-skips`, and both with `--jobs 1`, because a
fork count and a latency measurement should not have concurrent load as an input.

## Verification

- **12 mutations, all killing their guarding test.** Two survived the first
  round: one was a bad mutation on my part, the other found genuinely dead code
  — the empty-batch filter is unreachable because the bin count is already
  clamped. Removed it and re-guarded the clamp.
- **12 consecutive runs on 4 CPUs, no flakes.** Parallelism is exactly the thing
  that surfaces races, so this was measured rather than hoped.
- One race fixed before it could bite: a test wrote a fixture module into
  `tests/`, which another shard's `discover()` could pick up. Fixtures now live
  in a scratch dir on `PYTHONPATH`.
- `ruff check`, `ruff format --check`, `mypy --strict` (now over `tools` too),
  `shellcheck`, and both the sharded and serial suites: clean.


## Measured in CI, after the change

Per-step from the API, not estimated:

| job | before | after |
|---|---|---|
| `test (3.10/3.12/3.14)` | 55-57s | **29-33s** |
| `sync` | 51s | 32-35s |
| `hook` | 22s | 12-19s |
| `install` | 26s | 15-25s |
| `lint` | 13s | 12s |
| **wall clock** (slowest job) | **57s** | **~33s** |

The test step itself went 38-40s to 18-19s; `apt` 10-14s to 3-6s.

### One thing I tried and reverted

I added `cache: pip` to the `lint` job. Measured, it made that job **slower** —
13s before, 18s cold, 17s warm. The dev deps are floors rather than pins, so pip
pays a resolution round-trip either way, and the cache only saves the wheel
downloads, which cost less than restoring and saving it. Removed in the second
commit, with the measurement recorded in the workflow so nobody re-adds it.

## Applied from `/simplify`, and skipped

Applied: the missed `install` job apt site; one apt idiom instead of three;
tracebacks no longer shipped back and printed twice; `--only` anchored at a dot
so a later `test_sync_chunks.py` cannot be dragged under the sync job's
fatal-skip policy; `main(argv)` matching `woswoar/__main__.py`; the duplicated
tamper helpers merged; fixtures instead of coupling to `tests.test_entry` and
`tests.test_perf`; `tools/` made a package so both `sys.path` hacks go away;
README's documented command updated; `tools` added to the sdist.

Skipped: **`run_main` is a fifth hand-rolled run-main-and-capture helper**
(#36). Consolidating all five is that issue's job, not this PR's — but it is now
five sites, not four.

Filed **#50** for the root cause this PR routes around rather than fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

