### PR TITLE
Catch the credential shapes WOSWOAR_IGNORE was only pretending to

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ truthful. Re-running an import is idempotent.
 |---|---|
 | `WOSWOAR_DIR` | data directory (default `~/.local/share/woswoar`) |
 | `WOSWOAR_IGNORE` | extended regex of commands never to record |
+| `WOSWOAR_IGNORE_EXTRA` | extra regex joined onto the default, instead of replacing it |
 | `WOSWOAR_SCOPE` | default scope for <kbd>Ctrl</kbd>+<kbd>R</kbd> (default `global`) |
 | `WOSWOAR_NO_BIND` | set to skip binding <kbd>Ctrl</kbd>+<kbd>R</kbd> |
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -259,9 +259,13 @@ Being straight about the limits is part of the security story:
 >   trust` on each machine that will read it. That is the price of an anchor the
 >   remote cannot rewrite.
 > - **Secrets you type are still secrets.** `WOSWOAR_IGNORE` skips
->   credential-shaped commands by default (`*TOKEN=`, `*SECRET=`, `--password`,
->   …), and bash's own `HISTCONTROL`/`HISTIGNORE` are honoured for free — but no
->   pattern catches everything.
+>   credential-shaped commands by default — assignments like
+>   `AWS_SECRET_ACCESS_KEY=`, options like `--password`, credentials inside a
+>   URL, and `Authorization` headers — and bash's own `HISTCONTROL`/`HISTIGNORE`
+>   are honoured for free. But **no pattern catches everything**, and a secret
+>   with no tell (`deploy.sh AKIA…`) is indistinguishable from any other
+>   argument. [What it does and does not catch](shell-integration.md#commands-that-are-never-recorded)
+>   is written down; read it before relying on it.
 > - **Lose your key, lose your access.** There is no recovery service, because
 >   there is no service. If a machine loses its identity, re-enrol it and run
 >   `woswoar grant` from another machine. If it loses its *signing* key it mints

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -59,6 +59,77 @@ Switch scope without leaving the picker:
 `WOSWOAR_NO_BIND=1` skips the <kbd>Ctrl</kbd>+<kbd>R</kbd> binding entirely if
 you would rather keep another tool's.
 
+## Commands that are never recorded
+
+Anything bash itself keeps out of history is invisible to woswoar, so
+`HISTCONTROL=ignorespace` (a leading space) and `HISTIGNORE` work exactly as they
+already do — a command bash declines to store is never seen here.
+
+On top of that, `$WOSWOAR_IGNORE` is an extended regex matched against every
+command, and anything it matches is dropped before it reaches a file that gets
+synced. What the default catches:
+
+| | example |
+|---|---|
+| an assignment whose name reads like a credential | `AWS_SECRET_ACCESS_KEY=…`, `PGPASSWORD=…`, `API_KEY=…` |
+| a long option that names one | `--password`, `--token`, `--secret-key`, `--with-token`, `--from-literal=` |
+| credentials inside a URL | `https://user:token@github.com/…` |
+| an `Authorization` header | `curl -H "Authorization: Bearer …"` |
+| three tools that exist to take a password — and only these three | `sshpass`, `htpasswd`, `openssl passwd` |
+| the short options that carry one | `curl -u`, `mysql -p<pw>`, `docker login -p`, `ssh-keygen -N` |
+
+### What it does not catch
+
+This list is the point of this section, and every line of it is pinned by a test
+(`DOCUMENTED_GAPS` in `tests/test_shell_hook.py`) so it cannot quietly stop being
+true. **No pattern catches everything**:
+
+- **A secret with no tell.** `deploy.sh AKIAIOSFODNN7EXAMPLE` looks like any
+  other argument. Nothing can find that.
+- **A tool that is not on the list above**, or one that takes its secret as a
+  positional argument or a bare flag: `redis-cli -a`, `az login -p`,
+  `mongosh -p`, `aws configure set aws_secret_access_key …`,
+  `vault kv put … value=…`, `smbclient -U user%pass`. These *are* secrets and
+  they *are* recorded. Chasing them means an unbounded list of program names,
+  and the filter is priced per character on every prompt — so they are written
+  down here instead of half-covered.
+- **A bare `KEY=` or `PASS=`.** `KEY` and `PASS` are matched only after an
+  underscore (`SSH_KEY=`, `DB_PASS=`), because matching them anywhere would eat
+  `MONKEY=`, `KEYS=` and `PASSAGE=`. Deleting real history silently is the worse
+  failure.
+- **Lower-case assignments.** `token=abc` is not matched; `TOKEN=abc` is.
+- **A heredoc or a pasted multi-line block**, where the secret is on a line bash
+  never put in history as its own command.
+- **Anything typed into a prompt** rather than onto the command line — which is
+  why `mysql -p` with no value, `docker login` with no `-p`, and `gh auth login`
+  without `--with-token` are all deliberately recorded: there is no secret on
+  the line.
+
+It errs the other way once: `docker login --password-stdin` is dropped even
+though the password arrives on stdin. Over-matching a login command costs one
+history entry, so it is not worth another alternative to exclude.
+
+### Adding a rule of your own
+
+`WOSWOAR_IGNORE_EXTRA` is joined onto the default:
+
+```bash
+export WOSWOAR_IGNORE_EXTRA='deploy-to-prod|MYCORP_[A-Z_]*='
+```
+
+Prefer this to overriding `WOSWOAR_IGNORE`. Replacing the default means copying
+~450 characters into your `.bashrc` and never receiving the next fix to them —
+and the default grew precisely because an earlier version missed
+`AWS_SECRET_ACCESS_KEY=`. Setting `WOSWOAR_IGNORE=` empty disables the filter
+entirely.
+
+> [!TIP]
+> The filter runs on every command and bash recompiles the regex each time, so
+> its cost is proportional to the pattern's *length*, not to how much of it can
+> match. Broadening the default to the table above measured **1.8×** the previous
+> pattern's cost and **+12%** on the whole record path. A much longer custom
+> pattern is felt on every prompt.
+
 ## What it costs
 
 Measured on a real **54,943-entry** history across ~750 daily files:

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -149,13 +149,20 @@ inside a live shell:
 | | |
 |---|---|
 | capture (`history 1 > f; read -d '' < f`) | 30 µs |
-| `WOSWOAR_IGNORE` regex test | 12 µs |
+| `WOSWOAR_IGNORE` regex test | 54 µs † |
 | escaping (command and cwd) | 12 µs |
 | strip the history number | 7 µs |
 | the appending `printf` | 9 µs |
 | `printf -v day '%(%F)T'` | 4 µs |
 | cwd anchoring, timing, dispatch | ~10 µs |
 | each extra `PROMPT_COMMAND` entry | ~8 µs |
+
+† The one row not from the run above. The pattern was broadened in issue #23,
+and re-measuring it on a different machine gave 30 µs for the old pattern and
+54 µs for the new one, against a record path of 288 µs → 324 µs. Treat the ratio
+(**1.8×**, **+12%** end to end) as the finding and the absolutes as
+machine-dependent; the other rows in this table have not been re-measured on
+that machine, so they are not directly comparable.
 
 That last row is why the wiring below keeps its `PROMPT_COMMAND` footprint to
 two entries: the status capture, which has to be there, and `__woswoar_precmd`.
@@ -264,7 +271,16 @@ them, so the user's existing configuration just works.
 
 On top of that, `$WOSWOAR_IGNORE` (an extended regex, overridable) drops
 credential-shaped commands so they never reach a file that will be synced. It
-defaults to things like `…TOKEN=`, `…PASSWORD=`, `--password`, `--token`.
+covers credential-shaped assignments (`AWS_SECRET_ACCESS_KEY=`), long options
+(`--password`, `--token`), credentials in a URL, `Authorization` headers, and
+the few short options that carry a secret. `docs/shell-integration.md` lists
+what it deliberately does not catch.
+
+Its cost is proportional to the pattern's *length*, because `[[ =~ ]]`
+recompiles on every command and bash caches nothing. That is why it carries no
+leading anchor, and why `--([a-z]+-)*` is spelled out rather than `--[a-z-]*`:
+the flat form is quadratic in a run of dashes, and measured 654 ms for a single
+8000-character command. The reasoning for both lives next to the pattern.
 
 ### Known limitation
 

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -436,13 +437,21 @@ class TestEscapingThroughAShell(ShellHookTestCase):
 
 @requires_bash5
 class TestFiltering(ShellHookTestCase):
-    def test_ignore_pattern_suppresses_secrets(self) -> None:
-        self.run_shell("export MY_SECRET_TOKEN=abc123\necho safe\n")
-        self.assertEqual(self.commands(), ["echo safe"])
-
     def test_custom_ignore_pattern(self) -> None:
         self.run_shell("echo keep-me\necho drop-me\n", env_extra={"WOSWOAR_IGNORE": "drop-me"})
         self.assertEqual(self.commands(), ["echo keep-me"])
+
+    def test_an_extra_pattern_adds_to_the_default_rather_than_replacing_it(self) -> None:
+        """Otherwise one custom rule silently freezes the built-in protection.
+
+        The default grew because it missed `AWS_SECRET_ACCESS_KEY=`; a user who
+        had pasted the old one into ~/.bashrc to add a rule would never see that.
+        """
+        self.run_shell(
+            "deploy-to-prod\nexport GITHUB_TOKEN=ghp_x\necho safe\n",
+            env_extra={"WOSWOAR_IGNORE_EXTRA": "deploy-to-prod"},
+        )
+        self.assertEqual(self.commands(), ["echo safe"])
 
     def test_histcontrol_ignorespace_is_respected(self) -> None:
         # The hook defers to bash's own history rules rather than reimplementing
@@ -452,6 +461,218 @@ class TestFiltering(ShellHookTestCase):
         )
         self.assertNotIn(" echo hidden", self.commands())
         self.assertIn("echo visible", self.commands())
+
+    def test_an_aws_secret_never_reaches_the_log(self) -> None:
+        """The case from #23, driven all the way through a real bash.
+
+        `AWS_SECRET_ACCESS_KEY=` is the shape everyone assumes is covered, and
+        it was not: the old pattern needed the keyword flush against the `=`.
+        """
+        self.run_shell("export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI\necho safe\n")
+        self.assertEqual(self.commands(), ["echo safe"])
+
+        logs = (Path(os.environ["WOSWOAR_DIR"]) / "logs").rglob("*.tsv")
+        for path in logs:
+            self.assertNotIn("wJalrXUtnFEMI", path.read_text(encoding="utf-8"))
+
+    def test_a_pathological_command_does_not_stall_the_prompt(self) -> None:
+        """A long run of dashes must not make the filter quadratic.
+
+        The first version of this pattern used `--[a-z-]*`, which can start a
+        match attempt at every interior `-` and rescan the rest each time. 8000
+        dashes measured 654ms for a single command -- paid on the prompt, and
+        before the truncation at `__woswoar_max` gets a chance to shorten
+        anything.
+
+        The match itself is timed rather than the whole shell: one bash startup
+        is ~100ms, which would swallow the very regression this guards. Ten
+        iterations cost ~6ms healthy and ~6.5s quadratic, so the bound below has
+        two orders of magnitude of headroom in both directions.
+        """
+        out = self.run_shell(
+            'line=$(printf -- "-%.0s" {1..8000})\n'
+            "t0=${EPOCHREALTIME//[.,]/}\n"
+            "for _ in {1..10}; do [[ $line =~ $WOSWOAR_IGNORE ]]; done\n"
+            "t1=${EPOCHREALTIME//[.,]/}\n"
+            'printf "ELAPSED %s\\n" "$(( t1 - t0 ))"\n'
+        )
+        match = re.search(r"^ELAPSED (\d+)$", out, re.MULTILINE)
+        assert match is not None, f"the shell did not report a timing:\n{out}"
+        micros = int(match.group(1))
+        self.assertLess(micros, 1_000_000, "the ignore pattern went superlinear again")
+
+
+#: Command shapes the default `WOSWOAR_IGNORE` must drop. Most come from #23,
+#: which listed them as *not* caught by the pattern this replaces.
+SECRET_SHAPES = [
+    "export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI",
+    "export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7",
+    "AWS_SESSION_TOKEN=abc aws s3 ls",
+    "export MY_SECRET_TOKEN=abc123",
+    "export GITHUB_TOKEN=ghp_xxx",
+    "API_KEY=abc",
+    "APIKEY=abc",
+    "PGPASSWORD=hunter2 psql",
+    "export PASSWORD=x",
+    "export SECRET_KEY_BASE=deadbeef",
+    "export DB_PASSWD=x",
+    "export DB_PASS=x",
+    "export MY_AUTH_TOKEN=x",
+    "export STRIPE_API_KEY=sk_live_x",
+    "mysql --password=hunter2",
+    "wget --password hunter2 http://x",
+    "curl --token abc https://x",
+    "gh auth login --with-token",
+    "kubectl create secret generic s --from-literal=password=x",
+    "aws --secret-key x",
+    "helm install --api-key=abc",
+    "s3cmd --access-key AKIAIOSFODNN7",
+    'curl -H "Authorization: Bearer eyJ0eXAi"',
+    'curl -H "authorization: Basic dXNlcg=="',
+    "curl -u user:pass https://api.example.com",
+    'psql "postgres://user:pass@host/db"',
+    "git clone https://user:token@github.com/o/r",
+    "sshpass -p hunter2 ssh host",
+    "htpasswd -b .htpasswd user pass",
+    "openssl passwd -6 hunter2",
+    "mysql -pSECRETpw -u root",
+    "mysql -u root -pSECRETpw",
+    "docker login -p hunter2 -u me",
+    "ssh-keygen -t ed25519 -N hunter2 -f k",
+]
+
+#: Ordinary commands the pattern must leave alone. A filter that eats these is
+#: worse than useless: it deletes history and says nothing.
+INNOCENT_SHAPES = [
+    "git status",
+    "ls -la",
+    "make -j8",
+    "ssh-keygen -t ed25519 -C me@host",
+    "ssh-keygen -lf ~/.ssh/id_ed25519.pub",
+    "ssh-keygen -R oldhost",
+    "git clone https://github.com/martinus/woswoar",
+    'curl -H "Accept: application/json" https://api.example.com',
+    "curl -sSL https://example.com/install.sh | bash",
+    "curl -fsSL -o out.json https://api.example.com/v1/items",
+    "docker run -p 8080:80 nginx",
+    "docker run -u 1000:1000 alpine",
+    "docker compose up -d --build",
+    "mysql --protocol=tcp -u root",
+    "mysql -u root -h db01 mydb",
+    "mysql < dump.sql",
+    "kubectl get secret",
+    "kubectl describe secrets",
+    "vault kv get secret/app",
+    "psql postgres://localhost/mydb",
+    "export EDITOR=vim",
+    "export MONKEY=banana",
+    "export KEYS=3",
+    "export KEYBOARD=us",
+    "export PASSAGE=x",
+    "export PATH=/usr/bin:$PATH",
+    "make KEYS=3",
+    "aws s3 ls",
+    "aws configure list",
+    "openssl req -new -x509",
+    "openssl x509 -in c.pem -text",
+    "grep -r password .",
+    "vim ~/.aws/credentials",
+    "cat /etc/passwd",
+    "git log --oneline -20",
+    "git commit -m 'add auth handler'",
+    "ssh -p 2222 user@host",
+    "npm install --save-dev typescript",
+    "touch a_key_file.txt",
+    "man curl",
+    # A long option that merely *starts* with a keyword. This is what the
+    # `([=[:space:]]|$)` boundary after each keyword is for: without it, `auth`
+    # matches inside `--auth-mode` and a real azure command disappears.
+    "az storage blob list --auth-mode login",
+]
+
+
+#: Shapes the pattern does **not** catch, each one a claim `docs/shell-integration.md`
+#: makes in prose. They are pinned here because an unbacked claim in a security
+#: document is worse than a known gap: a later broadening would falsify the
+#: document with CI green, and nobody would look.
+#:
+#: Not a wish list. Some of these genuinely carry a secret and are recorded
+#: anyway -- `redis-cli -a`, `aws configure set`, `vault kv put`. Chasing them
+#: means an unbounded list of tool names priced per character on every prompt,
+#: so the project documents them instead of pretending otherwise.
+DOCUMENTED_GAPS = [
+    # No secret is on these lines at all -- the tool prompts for it.
+    "mysql -p",
+    "docker login",
+    "gh auth login",
+    # A secret with no tell: nothing distinguishes it from any other argument.
+    "deploy.sh AKIAIOSFODNN7EXAMPLE",
+    # Lower-case assignment. Upper case is the convention and the pattern's cost
+    # is proportional to its length, so both cases are not spelled out.
+    "token=abc",
+    # A tool that takes a secret as a positional argument or a bare flag.
+    "aws configure set aws_secret_access_key wJalr",
+    "vault kv put secret/app value=hunter2",
+    "redis-cli -a hunter2",
+]
+
+
+@requires_bash5
+class TestTheDefaultIgnorePattern(ShellHookTestCase):
+    """What the shipped pattern does and does not catch.
+
+    Evaluated by the same bash that will run it, against the value the hook
+    actually sets -- not against a copy in this file, which could drift from the
+    hook and keep passing. One shell tests the whole corpus, because starting a
+    bash per command would cost more than the rest of the suite.
+    """
+
+    def classify(self, commands: list[str]) -> dict[str, bool]:
+        """Ask a real bash which of `commands` the default pattern matches."""
+        array = " ".join(shlex.quote(command) for command in commands)
+        out = self.run_shell(
+            f"__corpus=({array})\n"
+            'printf "PATTERN %s\\n" "${#WOSWOAR_IGNORE}"\n'
+            'for i in "${!__corpus[@]}"; do\n'
+            '  [[ ${__corpus[i]} =~ $WOSWOAR_IGNORE ]] && printf "MATCH %s\\n" "$i" '
+            '|| printf "KEEP %s\\n" "$i"\n'
+            "done\n"
+        )
+
+        self.assertRegex(out, r"PATTERN [1-9]", "the hook set no default pattern")
+        verdicts = {}
+        for line in out.splitlines():
+            fields = line.split()
+            if len(fields) == 2 and fields[0] in {"MATCH", "KEEP"}:
+                verdicts[commands[int(fields[1])]] = fields[0] == "MATCH"
+        self.assertEqual(len(verdicts), len(commands), "some commands were not classified")
+        return verdicts
+
+    def test_every_credential_shape_is_dropped(self) -> None:
+        verdicts = self.classify(SECRET_SHAPES)
+        missed = [command for command, matched in verdicts.items() if not matched]
+        self.assertEqual(missed, [], f"{len(missed)} secret-bearing commands would be recorded")
+        # Counted, not just "nothing missed": a harness that classified nothing
+        # would satisfy the assertion above while testing the pattern not at all.
+        self.assertEqual(sum(verdicts.values()), len(SECRET_SHAPES))
+
+    def test_the_documented_gaps_really_are_gaps(self) -> None:
+        """Pin the "what it does not catch" section to the pattern's behaviour."""
+        verdicts = self.classify(DOCUMENTED_GAPS)
+        caught = [command for command, matched in verdicts.items() if matched]
+        self.assertEqual(
+            caught,
+            [],
+            "the pattern now catches something docs/shell-integration.md says it does not; "
+            "update the document in the same commit",
+        )
+        self.assertEqual(len(verdicts), len(DOCUMENTED_GAPS))
+
+    def test_no_ordinary_command_is_dropped(self) -> None:
+        verdicts = self.classify(INNOCENT_SHAPES)
+        eaten = [command for command, matched in verdicts.items() if matched]
+        self.assertEqual(eaten, [], f"{len(eaten)} ordinary commands would be silently discarded")
+        self.assertEqual(len(verdicts), len(INNOCENT_SHAPES))
 
 
 @requires_bash5

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -82,7 +82,45 @@ export WOSWOAR_SESSION
 # HISTCONTROL/HISTIGNORE already apply for free -- anything bash declines to put
 # in history is invisible to us -- so this is only for things you want in your
 # local history but never written to a file that gets synced.
-: "${WOSWOAR_IGNORE=(^|[[:space:]])[A-Za-z_]*(TOKEN|SECRET|PASSWORD|PASSWD|API_?KEY)=|--password[=[:space:]]|--token[=[:space:]]}"
+#
+# `docs/shell-integration.md` owns the catalogue of what this catches and, more
+# importantly, what it does not. Only what a reader of the regex itself needs is
+# here.
+#
+# KEY, PASS and AUTH are matched only after `_` (`AWS_ACCESS_KEY_ID=`), never
+# bare, or `MONKEY=`, `KEYS=` and `PASSAGE=` would all be dropped. TOKEN,
+# SECRET, PASSW, CREDENTIAL and APIKEY are distinctive enough to match anywhere
+# in the name, which is what catches `PGPASSWORD=` and `AWS_SECRET_ACCESS_KEY=`.
+#
+# Two shapes here are deliberate and easy to "tidy" into a bug:
+#
+# 1. No `(^|[[:space:]])[A-Za-z0-9_]*` in front of the assignment keywords, even
+#    though that is the obvious way to say "this is a variable name". It costs
+#    more than twice as much -- the leading `*` retries at every position -- and
+#    buys nothing, because `[A-Za-z0-9_]*=` cannot cross a space anyway.
+#
+# 2. `--([a-z]+-)*` rather than `--[a-z-]*` before the option keywords. The
+#    flat `[a-z-]*` is quadratic in the length of a `[a-z-]` run: it can start
+#    an attempt at every interior `-`, and each attempt rescans the rest. A
+#    command of 8000 dashes measured 654ms -- on the prompt path, before the
+#    8000-char truncation below. Requiring a letter between dashes makes it
+#    linear: the same input is 0.6ms.
+#
+# `[[ =~ ]]` recompiles on every command (bash caches nothing), so cost tracks
+# the pattern's *length*, not how much of it can match. Measured here: 30us for
+# the four-keyword pattern this replaces, 54us for this one, against a 288us ->
+# 324us record path. Weigh anything added against that.
+: "${WOSWOAR_IGNORE=(TOKEN|SECRET|PASSW|CREDENTIAL|APIKEY|_KEY|_PASS|_AUTH)[A-Za-z0-9_]*=|--([a-z]+-)*((passw|token|secret|credential)[a-z-]*|api-?key|access-?key|auth)([=[:space:]]|\$)|--from-literal=|://[^/[:space:]]+:[^/@[:space:]]+@|[Aa]uthorization:[[:space:]]*[A-Za-z]|(sshpass|htpasswd|openssl passwd)[[:space:]]|curl[^|;&]*[[:space:]]-u[[:space:]]|mysql[a-z]*[^|;&]*[[:space:]]-p[^-[:space:]]|docker login[^|;&]*[[:space:]]-p|ssh-keygen[^|;&]*[[:space:]]-N[[:space:]]}"
+
+# Appended, not merged into the default above, so that adding one rule of your
+# own does not pin you to today's default forever. Overriding `WOSWOAR_IGNORE`
+# outright means copying 450 characters into ~/.bashrc and never receiving the
+# next fix to them -- and this very pattern grew because the old one missed
+# `AWS_SECRET_ACCESS_KEY=`. Joined once at startup rather than tested as a
+# second variable on every command, so an unused knob costs nothing.
+if [[ -n ${WOSWOAR_IGNORE_EXTRA:-} ]]; then
+    WOSWOAR_IGNORE=${WOSWOAR_IGNORE:+$WOSWOAR_IGNORE|}$WOSWOAR_IGNORE_EXTRA
+fi
 
 #: Mirrors MAX_CMD_CHARS in woswoar/entry.py.
 __woswoar_max=8000


### PR DESCRIPTION
Closes #23.

## The bug

The default pattern matched `NAME=` only when the name **ended** in one of five
keywords. `AWS_SECRET_ACCESS_KEY=` — the archetypal case, and the one everyone
assumes is covered — was recorded in full, along with credentials in a URL,
`Authorization` headers, `sshpass`, `curl -u`, `mysql -p<pw>`, and every long
option except `--password`/`--token`.

Reproduced end to end before changing anything: driving the real hook in a real
bash, the value from `export AWS_SECRET_ACCESS_KEY=…` is present in the `.tsv`
the hook writes with the old pattern and absent with the new one. That is now
the test.

## What dictated the shape

This runs on every prompt, so I measured rather than guessed. `[[ =~ ]]`
recompiles the pattern on **every command** — bash caches nothing, which I
verified by alternating two patterns and seeing no difference. So cost tracks
the pattern's *length*, not how much of it can match. Two consequences:

**No anchor.** The obvious `(^|[[:space:]])[A-Za-z0-9_]*` before each keyword —
the natural way to say "this is a variable name" — costs more than twice as
much, because the leading `*` retries at every position. It also buys nothing:
`[A-Za-z0-9_]*=` cannot cross a space, so the `=` is in the same word regardless.
Dropping it took that alternative from 66 µs to 9 µs.

**`--([a-z]+-)*`, not `--[a-z-]*`.** This one is the reason to read the diff.
My first version was **quadratic** in a run of dashes — it can start a match
attempt at every interior `-` and rescan the rest each time:

| dashes | first version | shipped |
|---|---|---|
| 1000 | 10.9 ms | 0.2 ms |
| 4000 | 162 ms | 0.4 ms |
| 8000 | **654 ms** | 0.6 ms |

Paid on the prompt path, and *before* the 8000-character truncation. The
`/simplify` efficiency pass caught it after I had already convinced myself the
pattern was cheap. Requiring a letter between dashes makes it linear, and the
fixed form is also 32 characters shorter. There is a timing test now.

## Cost

Medians of five, one machine, loop overhead subtracted:

| | old | new |
|---|---|---|
| the filter alone | 30 µs | 54 µs |
| whole record path | 288 µs | 324 µs |

**+12% per recorded command.** That is the honest price of the fix and I have
not tried to talk it down. The three places that documented these numbers are
corrected, and the design summary now says which figures are machine-dependent —
my first draft scaled one number by a ratio from a different machine and
presented it in a table captioned "measured".

## Not over-matching

A filter that eats ordinary commands deletes history and says nothing, which is
the worse failure. `KEY`, `PASS` and `AUTH` match only after `_`, or `MONKEY=`,
`KEYS=` and `PASSAGE=` would all vanish. `INNOCENT_SHAPES` pins ~40 ordinary
commands — `docker run -p 8080:80`, `mysql --protocol=tcp -u root`,
`az … --auth-mode login`, `cat /etc/passwd` — against exactly that.

## Two things beyond the issue

**`WOSWOAR_IGNORE_EXTRA`.** `WOSWOAR_IGNORE` is all-or-nothing: adding one rule
of your own means pasting 450 characters into `.bashrc` and never receiving the
next fix to them — which is precisely what this PR is. The extra pattern is
joined on at startup, so the hot path is untouched and an unused knob costs
nothing.

**The gaps are now a test, not just prose.** `aws configure set`,
`vault kv put … value=`, `redis-cli -a` and a bare `token=` genuinely carry
secrets and genuinely are recorded. Chasing them means an unbounded list of
program names priced per character on every prompt. Better written down than
half-covered — so `DOCUMENTED_GAPS` fails if one quietly stops being true, and
`docs/security.md` cannot go stale with CI green. I also stopped the docs
describing the tool list as a category ("tools whose job is to take a password")
when it is a closed list of three.

## Verification

- **14 mutations, all killing their guarding test**, including the quadratic
  form, the `_`-prefix rule, and each individual alternative.
- **8 consecutive full runs, no flakes.** One flake was found and fixed on the
  way: a test asserted a fixed order from `commands()`, which sorts by
  `(ts, duration_ms)` — three commands in the same second tie, and it failed
  3 runs in 10.
- `ruff`, `ruff format --check`, `mypy --strict`, `shellcheck`: clean.

## From `/simplify`

Applied: the quadratic `--[a-z-]*`; `password|passwd` collapsed to `passw`; two
`--` alternatives merged; `shlex.quote` instead of a hand-rolled one; `classify()`
reduced from 2N+1 generated lines to one bash loop; two subsumed end-to-end tests
deleted; the catalogue de-duplicated so the docs own it and the code comment
keeps only what a reader of the regex needs.

Filed **#52** for the gap the altitude pass found, which is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
