### PR TITLE
Filter credentials on import, not only on the prompt

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -262,9 +262,10 @@ Being straight about the limits is part of the security story:
 >   credential-shaped commands by default — assignments like
 >   `AWS_SECRET_ACCESS_KEY=`, options like `--password`, credentials inside a
 >   URL, and `Authorization` headers — and bash's own `HISTCONTROL`/`HISTIGNORE`
->   are honoured for free. But **no pattern catches everything**, and a secret
->   with no tell (`deploy.sh AKIA…`) is indistinguishable from any other
->   argument. [What it does and does not catch](shell-integration.md#commands-that-are-never-recorded)
+>   are honoured for free. `woswoar import` applies the same rules to history
+>   recorded long before woswoar existed, and additionally recognises well-known
+>   token formats, which is where the risk is concentrated. But **no pattern
+>   catches everything**. [What it does and does not catch](shell-integration.md#commands-that-are-never-recorded)
 >   is written down; read it before relying on it.
 > - **Lose your key, lose your access.** There is no recovery service, because
 >   there is no service. If a machine loses its identity, re-enrol it and run

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -81,18 +81,20 @@ synced. What the default catches:
 ### What it does not catch
 
 This list is the point of this section, and every line of it is pinned by a test
-(`DOCUMENTED_GAPS` in `tests/test_shell_hook.py`) so it cannot quietly stop being
+(`DOCUMENTED_GAPS` in `tests/credential_shapes.py`) so it cannot quietly stop being
 true. **No pattern catches everything**:
 
 - **A secret with no tell.** `deploy.sh AKIAIOSFODNN7EXAMPLE` looks like any
-  other argument. Nothing can find that.
+  other argument to the hook. (`woswoar import` recognises the well-known token
+  formats — see below — but the hook cannot afford to.)
 - **A tool that is not on the list above**, or one that takes its secret as a
   positional argument or a bare flag: `redis-cli -a`, `az login -p`,
   `mongosh -p`, `aws configure set aws_secret_access_key …`,
-  `vault kv put … value=…`, `smbclient -U user%pass`. These *are* secrets and
-  they *are* recorded. Chasing them means an unbounded list of program names,
-  and the filter is priced per character on every prompt — so they are written
-  down here instead of half-covered.
+  `vault kv put … value=…`, `smbclient -U user%pass`, `pscp -pw`. These *are* secrets and
+  the **hook** does record them. Chasing them means an unbounded list of program
+  names, and the hook is priced per character on every prompt — so they are
+  written down here instead of half-covered. `woswoar import` does catch them
+  (see below), because it runs once rather than on every keystroke.
 - **A bare `KEY=` or `PASS=`.** `KEY` and `PASS` are matched only after an
   underscore (`SSH_KEY=`, `DB_PASS=`), because matching them anywhere would eat
   `MONKEY=`, `KEYS=` and `PASSAGE=`. Deleting real history silently is the worse
@@ -109,19 +111,55 @@ It errs the other way once: `docker login --password-stdin` is dropped even
 though the password arrives on stdin. Over-matching a login command costs one
 history entry, so it is not worth another alternative to exclude.
 
+### `woswoar import` filters too, and looks harder
+
+The same rules run over anything `woswoar import` reads. That matters more than
+the hook does on day one: a `~/.bash_history` or an atuin database was recorded
+over years with no filter of any kind, and importing it publishes the lot.
+
+Because an import runs once instead of on every prompt, it can afford what the
+hook cannot, and so it also recognises:
+
+- **token formats on sight** — `AKIA…`, `ghp_…`, `glpat-…`, `xox…`,
+  `sk_live_…`, `AIza…`, a JWT, a `-----BEGIN … PRIVATE KEY-----` block
+- **the tools listed as gaps above**, which is all of them — `aws configure
+  set …secret…`, `vault kv put … value=`, `redis-cli -a`, `mongosh -p`,
+  `az login -p`, `smbclient -U user%pass`, `pscp -pw`
+
+It reports what it dropped rather than doing it quietly:
+
+```console
+$ woswoar import bash
+~/.bash_history: 8213 parsed, imported 8196, 17 skipped as credential-shaped
+```
+
+There is deliberately **no entropy heuristic**. Shell history is full of
+high-entropy strings that are not secrets — git SHAs, checksums, UUIDs, base64
+payloads — and dropping a command is silent and permanent, so precision matters
+more than recall.
+
 ### Adding a rule of your own
 
-`WOSWOAR_IGNORE_EXTRA` is joined onto the default:
+`WOSWOAR_IGNORE_EXTRA` is joined onto the default, and applies to imports as
+well as to the hook:
 
 ```bash
 export WOSWOAR_IGNORE_EXTRA='deploy-to-prod|MYCORP_[A-Z_]*='
 ```
 
-Prefer this to overriding `WOSWOAR_IGNORE`. Replacing the default means copying
-~450 characters into your `.bashrc` and never receiving the next fix to them —
-and the default grew precisely because an earlier version missed
-`AWS_SECRET_ACCESS_KEY=`. Setting `WOSWOAR_IGNORE=` empty disables the filter
-entirely.
+Prefer this to overriding `WOSWOAR_IGNORE`, for two reasons. Replacing the
+default means copying ~450 characters into your `.bashrc` and never receiving
+the next fix to them — and the default grew precisely because an earlier version
+missed `AWS_SECRET_ACCESS_KEY=`.
+
+> [!IMPORTANT]
+> `WOSWOAR_IGNORE` reaches the **hook only**. It is a POSIX extended regex,
+> which Python cannot compile, so `woswoar import` does not read it. A rule you
+> put there filters what you type and *not* what you import. Put it in
+> `WOSWOAR_IGNORE_EXTRA`, which both paths honour.
+
+Setting `WOSWOAR_IGNORE=` empty disables the filter for the hook; the importer's
+built-in rules always apply.
 
 > [!TIP]
 > The filter runs on every command and bash recompiles the regex each time, so

--- a/tests/credential_shapes.py
+++ b/tests/credential_shapes.py
@@ -1,0 +1,124 @@
+"""Command shapes the credential filters are held to, shared by two test modules.
+
+The bash hook (`woswoar/shell/woswoar.bash`) and the importer
+(`woswoar/credentials.py`) implement the same rules in two languages, for two
+very different budgets -- one recompiles a regex on every prompt, the other runs
+once over a decade of history. This is the corpus that keeps them from drifting.
+"""
+
+from __future__ import annotations
+
+#: Command shapes the default `WOSWOAR_IGNORE` must drop. Most come from #23,
+#: which listed them as *not* caught by the pattern this replaces.
+SECRET_SHAPES = [
+    "export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI",
+    "export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7",
+    "AWS_SESSION_TOKEN=abc aws s3 ls",
+    "export MY_SECRET_TOKEN=abc123",
+    "export GITHUB_TOKEN=ghp_xxx",
+    "API_KEY=abc",
+    "APIKEY=abc",
+    "PGPASSWORD=hunter2 psql",
+    "export PASSWORD=x",
+    "export SECRET_KEY_BASE=deadbeef",
+    "export DB_PASSWD=x",
+    "export DB_PASS=x",
+    "export MY_AUTH_TOKEN=x",
+    "export STRIPE_API_KEY=sk_live_x",
+    "mysql --password=hunter2",
+    "wget --password hunter2 http://x",
+    "curl --token abc https://x",
+    "gh auth login --with-token",
+    "kubectl create secret generic s --from-literal=password=x",
+    "aws --secret-key x",
+    "helm install --api-key=abc",
+    "s3cmd --access-key AKIAIOSFODNN7",
+    'curl -H "Authorization: Bearer eyJ0eXAi"',
+    'curl -H "authorization: Basic dXNlcg=="',
+    "curl -u user:pass https://api.example.com",
+    'psql "postgres://user:pass@host/db"',
+    "git clone https://user:token@github.com/o/r",
+    "sshpass -p hunter2 ssh host",
+    "htpasswd -b .htpasswd user pass",
+    "openssl passwd -6 hunter2",
+    "mysql -pSECRETpw -u root",
+    "mysql -u root -pSECRETpw",
+    "docker login -p hunter2 -u me",
+    "ssh-keygen -t ed25519 -N hunter2 -f k",
+]
+
+
+#: Ordinary commands the pattern must leave alone. A filter that eats these is
+#: worse than useless: it deletes history and says nothing.
+INNOCENT_SHAPES = [
+    "git status",
+    "ls -la",
+    "make -j8",
+    "ssh-keygen -t ed25519 -C me@host",
+    "ssh-keygen -lf ~/.ssh/id_ed25519.pub",
+    "ssh-keygen -R oldhost",
+    "git clone https://github.com/martinus/woswoar",
+    'curl -H "Accept: application/json" https://api.example.com',
+    "curl -sSL https://example.com/install.sh | bash",
+    "curl -fsSL -o out.json https://api.example.com/v1/items",
+    "docker run -p 8080:80 nginx",
+    "docker run -u 1000:1000 alpine",
+    "docker compose up -d --build",
+    "mysql --protocol=tcp -u root",
+    "mysql -u root -h db01 mydb",
+    "mysql < dump.sql",
+    "kubectl get secret",
+    "kubectl describe secrets",
+    "vault kv get secret/app",
+    "psql postgres://localhost/mydb",
+    "export EDITOR=vim",
+    "export MONKEY=banana",
+    "export KEYS=3",
+    "export KEYBOARD=us",
+    "export PASSAGE=x",
+    "export PATH=/usr/bin:$PATH",
+    "make KEYS=3",
+    "aws s3 ls",
+    "aws configure list",
+    "openssl req -new -x509",
+    "openssl x509 -in c.pem -text",
+    "grep -r password .",
+    "vim ~/.aws/credentials",
+    "cat /etc/passwd",
+    "git log --oneline -20",
+    "git commit -m 'add auth handler'",
+    "ssh -p 2222 user@host",
+    "npm install --save-dev typescript",
+    "touch a_key_file.txt",
+    "man curl",
+    # A long option that merely *starts* with a keyword. This is what the
+    # `([=[:space:]]|$)` boundary after each keyword is for: without it, `auth`
+    # matches inside `--auth-mode` and a real azure command disappears.
+    "az storage blob list --auth-mode login",
+]
+
+
+#: Shapes the pattern does **not** catch, each one a claim `docs/shell-integration.md`
+#: makes in prose. They are pinned here because an unbacked claim in a security
+#: document is worse than a known gap: a later broadening would falsify the
+#: document with CI green, and nobody would look.
+#:
+#: Not a wish list. Some of these genuinely carry a secret and are recorded
+#: anyway -- `redis-cli -a`, `aws configure set`, `vault kv put`. Chasing them
+#: means an unbounded list of tool names priced per character on every prompt,
+#: so the project documents them instead of pretending otherwise.
+DOCUMENTED_GAPS = [
+    # No secret is on these lines at all -- the tool prompts for it.
+    "mysql -p",
+    "docker login",
+    "gh auth login",
+    # A secret with no tell: nothing distinguishes it from any other argument.
+    "deploy.sh AKIAIOSFODNN7EXAMPLE",
+    # Lower-case assignment. Upper case is the convention and the pattern's cost
+    # is proportional to its length, so both cases are not spelled out.
+    "token=abc",
+    # A tool that takes a secret as a positional argument or a bare flag.
+    "aws configure set aws_secret_access_key wJalr",
+    "vault kv put secret/app value=hunter2",
+    "redis-cli -a hunter2",
+]

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,257 @@
+"""The importer's credential filter, and its contract with the bash hook.
+
+Two implementations of the same rules, in two languages, for two budgets. The
+hook is tested against the shared corpus by running a real bash
+(`tests/test_shell_hook.py`); this module runs the same corpus through Python.
+
+The contract is deliberately not "identical". The importer is allowed to be
+*stricter*, because it has no per-prompt budget and can afford token signatures
+the hook cannot. It is never allowed to be looser, and it must never eat an
+ordinary command that the hook keeps.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from woswoar import credentials
+
+from .credential_shapes import DOCUMENTED_GAPS, INNOCENT_SHAPES, SECRET_SHAPES
+
+#: Gaps in the *hook* that the importer is expected to close, because it can
+#: afford to look for the token itself rather than the shape around it.
+CLOSED_ON_IMPORT = {
+    "deploy.sh AKIAIOSFODNN7EXAMPLE",
+    "aws configure set aws_secret_access_key wJalr",
+    "vault kv put secret/app value=hunter2",
+    "redis-cli -a hunter2",
+}
+
+#: One command per rule in `_IMPORT_ONLY` and `_TOKENS`. Every entry here is a
+#: claim `docs/shell-integration.md` makes about what an import catches; without
+#: them, half those rules could be deleted with CI green while the document
+#: kept promising them.
+IMPORT_ONLY_SHAPES = [
+    "aws configure set aws_secret_access_key wJalrXUtnFEMI",
+    "aws configure set default.aws_session_token abc",
+    "vault kv put secret/app value=hunter2",
+    "vault write auth/approle/login secret_id=abc",
+    "redis-cli -a hunter2 ping",
+    "redis-cli -ahunter2",
+    "mongosh -p hunter2 mydb",
+    "mongo -phunter2",
+    "az login -u me -p hunter2",
+    "smbclient //host/share -U user%hunter2",
+    "pscp -pw hunter2 file host:/tmp",
+]
+
+TOKEN_SHAPES = [
+    "deploy.sh AKIAIOSFODNN7EXAMPLE",
+    "aws sts assume-role ASIAY34FZKBOKMUTVV7A",
+    "curl -H 'X-Api: ghp_" + "a" * 36 + "'",
+    "echo github_pat_" + "a" * 22,
+    "echo glpat-" + "a" * 20,
+    "slack post xoxb-1234567890-abcdef",
+    "stripe listen sk_live_" + "a" * 16,
+    "stripe listen sk_test_" + "a" * 16,
+    "openai --key sk-" + "a" * 32,
+    "curl 'https://maps.googleapis.com/x?key=AIza" + "a" * 35 + "'",
+    "echo '-----BEGIN OPENSSH PRIVATE KEY-----'",
+    "echo eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N",
+]
+
+
+class TestTheSharedRules(unittest.TestCase):
+    """Everything the hook catches, the importer must catch too."""
+
+    def test_every_credential_shape_is_caught(self) -> None:
+        missed = [c for c in SECRET_SHAPES if not credentials.looks_like_credential(c)]
+        self.assertEqual(missed, [], f"{len(missed)} shapes the bash hook drops would be imported")
+
+    def test_no_ordinary_command_is_caught(self) -> None:
+        """The direction that loses data silently, so it is the one to over-test."""
+        eaten = [c for c in INNOCENT_SHAPES if credentials.looks_like_credential(c)]
+        self.assertEqual(eaten, [], f"{len(eaten)} ordinary commands would be dropped on import")
+
+    def test_closed_on_import_names_real_documented_gaps(self) -> None:
+        """These are literals retyped from the shared corpus; keep them paired.
+
+        Rewording a gap example over there would otherwise silently unpair it,
+        and the failure would surface in a different test as a puzzle.
+        """
+        self.assertLessEqual(CLOSED_ON_IMPORT, set(DOCUMENTED_GAPS))
+
+    def test_the_corpus_is_not_empty(self) -> None:
+        """Guard the guard: an empty import makes both assertions above vacuous."""
+        self.assertGreater(len(SECRET_SHAPES), 20)
+        self.assertGreater(len(INNOCENT_SHAPES), 20)
+
+
+class TestWhereItGoesFurtherThanTheHook(unittest.TestCase):
+    def test_it_closes_the_gaps_it_can_afford_to(self) -> None:
+        """A secret with no tell is findable when you can pay for the lookup."""
+        for command in sorted(CLOSED_ON_IMPORT):
+            with self.subTest(command=command):
+                self.assertTrue(credentials.looks_like_credential(command))
+
+    def test_the_remaining_gaps_are_still_gaps_and_still_documented(self) -> None:
+        """Whatever import cannot close stays true of both implementations."""
+        for command in DOCUMENTED_GAPS:
+            if command in CLOSED_ON_IMPORT:
+                continue
+            with self.subTest(command=command):
+                self.assertFalse(
+                    credentials.looks_like_credential(command),
+                    "docs/shell-integration.md says this is recorded; update it in this commit",
+                )
+
+    def test_known_token_formats_are_recognised(self) -> None:
+        for token in TOKEN_SHAPES:
+            with self.subTest(token=token):
+                self.assertTrue(credentials.looks_like_credential(token))
+
+    def test_tools_that_take_a_secret_positionally_are_recognised(self) -> None:
+        for command in IMPORT_ONLY_SHAPES:
+            with self.subTest(command=command):
+                self.assertTrue(credentials.looks_like_credential(command))
+
+    def test_every_import_only_rule_earns_its_place(self) -> None:
+        """Drop each rule in turn; some corpus line must stop being caught.
+
+        A rule nothing exercises is one a refactor can delete with CI green,
+        while `docs/shell-integration.md` goes on promising it.
+        """
+        corpus = SECRET_SHAPES + IMPORT_ONLY_SHAPES + TOKEN_SHAPES
+        for group in (credentials._IMPORT_ONLY, credentials._TOKENS, credentials._SHARED):
+            for rule in group:
+                without = re.compile(
+                    "|".join(
+                        r
+                        for r in credentials._SHARED
+                        + credentials._IMPORT_ONLY
+                        + credentials._TOKENS
+                        if r != rule
+                    )
+                )
+                with self.subTest(rule=rule):
+                    self.assertTrue(
+                        any(
+                            credentials.looks_like_credential(c) and not without.search(c)
+                            for c in corpus
+                        ),
+                        "no corpus line depends on this rule",
+                    )
+
+    def test_high_entropy_strings_that_are_not_secrets_survive(self) -> None:
+        """Why there is no entropy heuristic: shell history is full of these.
+
+        Dropping one of these would be silent and unrecoverable, and a user
+        would have no way to tell it from a command they misremembered typing.
+        """
+        for command in (
+            "git checkout 3f2a1b9c8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a",
+            "git show 0163e08",
+            "sha256sum -c 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+            "docker pull ubuntu@sha256:82becede498899ec668628e7cb0ad87b"
+            "6e1c371cb8a1e597d83a47fac21d6af3",
+            "curl -o f https://example.com/pkg?token=abc",  # lower-case, and a URL query
+            "uuidgen 550e8400-e29b-41d4-a716-446655440000",
+            "base64 -d <<< aGVsbG8gd29ybGQgdGhpcyBpcyBub3QgYSBzZWNyZXQ=",
+        ):
+            with self.subTest(command=command):
+                self.assertFalse(
+                    credentials.looks_like_credential(command),
+                    "an entropy-shaped but innocent command would be dropped",
+                )
+
+
+class TestTheUsersOwnPattern(unittest.TestCase):
+    def test_an_extra_pattern_is_applied(self) -> None:
+        with mock.patch.dict(os.environ, {"WOSWOAR_IGNORE_EXTRA": "deploy-to-prod"}):
+            extra = credentials.user_pattern()
+        assert extra is not None
+        self.assertTrue(credentials.looks_like_credential("deploy-to-prod now", extra))
+        self.assertFalse(credentials.looks_like_credential("deploy-to-prod now"))
+
+    def test_no_extra_pattern_is_the_normal_case(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(credentials.user_pattern())
+
+    def test_woswoar_ignore_itself_is_never_read(self) -> None:
+        """It is a POSIX ERE. `re` cannot compile `[[:space:]]`, and reading it
+        would make every import complain about a variable nobody set."""
+        with mock.patch.dict(os.environ, {"WOSWOAR_IGNORE": "(x|y)[[:space:]]z"}, clear=True):
+            self.assertIsNone(credentials.user_pattern())
+
+    def test_an_uncompilable_extra_pattern_is_refused_not_ignored(self) -> None:
+        """Silently dropping it would leave the user believing it was applied."""
+        with (
+            mock.patch.dict(os.environ, {"WOSWOAR_IGNORE_EXTRA": "([unclosed"}),
+            self.assertRaises(credentials.BadExtraPattern),
+        ):
+            credentials.user_pattern()
+
+
+HOOK = Path(__file__).resolve().parent.parent / "woswoar" / "shell" / "woswoar.bash"
+
+
+def as_posix_ere(pattern: str) -> str:
+    r"""Rewrite one Python pattern into the POSIX ERE dialect bash `[[ =~ ]]` uses.
+
+    Only the two constructs `_SHARED` actually uses need translating: ERE has no
+    non-capturing group, and no `\s`. Inside a bracket expression the class is
+    spelled `[:space:]`; outside one it needs its own brackets.
+    """
+    pattern = pattern.replace("(?:", "(")
+    pattern = re.sub(r"\[([^]]*?)\\s([^]]*?)\]", r"[\1[:space:]\2]", pattern)
+    return pattern.replace(r"\s", "[[:space:]]")
+
+
+class TestParityWithTheHook(unittest.TestCase):
+    """The rules exist twice, so pin them to each other and not just to examples.
+
+    A corpus catches drift only where an example happens to cover it: add an
+    alternative to the hook for a user-reported command, give it its own test,
+    and the Python side stays silently behind -- on the path issue #52 argues
+    matters more. This compares the two sources directly, which is what
+    `TestEscapeParity` and `TestConstantParity` already do for the hook's other
+    duplicated logic.
+    """
+
+    def hook_pattern(self) -> str:
+        source = HOOK.read_text(encoding="utf-8")
+        match = re.search(r'^: "\$\{WOSWOAR_IGNORE=(.*)\}"$', source, re.MULTILINE)
+        assert match is not None, "the hook's default WOSWOAR_IGNORE was not found"
+        # `\$` is the bash escaping of the regex anchor, not part of the pattern.
+        return match.group(1).replace("\\$", "$")
+
+    def test_the_hook_ships_exactly_the_shared_rules(self) -> None:
+        self.assertEqual(
+            self.hook_pattern(),
+            "|".join(as_posix_ere(rule) for rule in credentials._SHARED),
+            "woswoar/shell/woswoar.bash and credentials._SHARED have diverged; "
+            "a rule added to one must be added to the other",
+        )
+
+    def test_the_import_only_rules_are_deliberately_not_in_the_hook(self) -> None:
+        """They are the ones the prompt path cannot afford; that is the design."""
+        hook = self.hook_pattern()
+        for rule in credentials._IMPORT_ONLY + credentials._TOKENS:
+            with self.subTest(rule=rule):
+                self.assertNotIn(as_posix_ere(rule), hook)
+
+
+class TestTheRulesAreReadable(unittest.TestCase):
+    def test_every_pattern_compiles(self) -> None:
+        """A typo in one alternative would otherwise disable it silently."""
+        for pattern in credentials._SHARED + credentials._IMPORT_ONLY + credentials._TOKENS:
+            with self.subTest(pattern=pattern):
+                re.compile(pattern)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import io
 import os
+import time
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 from woswoar import cache, importer
+from woswoar.__main__ import main
 
 from .support import WoswoarTestCase
 
@@ -68,7 +72,9 @@ class TestParseZsh(unittest.TestCase):
         self.assertEqual([p.cmd for p in parsed], ["earlier", "later"])
 
 
-class TestImportRun(WoswoarTestCase):
+class ImportTestCase(WoswoarTestCase):
+    """Fixture only. Subclassing a class that *has* tests would re-run them."""
+
     def _source(self, name: str, content: str) -> Path:
         path = self.root / name
         return self._rewrite(path, content)
@@ -81,6 +87,8 @@ class TestImportRun(WoswoarTestCase):
         os.utime(path, (MTIME, MTIME))
         return path
 
+
+class TestImportRun(ImportTestCase):
     def _commands(self) -> set[str]:
         return {e.cmd for e in cache.load_entries()}
 
@@ -154,6 +162,167 @@ class TestImportRun(WoswoarTestCase):
         source = self._source("hist", "#1753000000\nawk -F'\t' '{print $1}'\n")
         importer.run("bash", source)
         self.assertEqual(cache.load_entries()[0].cmd, "awk -F'\t' '{print $1}'")
+
+
+class TestImportDropsCredentials(ImportTestCase):
+    """Issue #52: import read years of history that no filter had ever seen.
+
+    The hook filters what you type from now on. Import brings in a
+    `~/.bash_history` recorded before woswoar existed -- which is the file most
+    likely to contain a secret, and it flows straight to logs/, into an
+    encrypted chunk, into git, and out to every machine. `docs/security.md`
+    says publication cannot be taken back.
+    """
+
+    HISTORY = (
+        "#1753000000\ngit status\n"
+        "#1753000100\nexport AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI\n"
+        "#1753000200\ncurl -u admin:hunter2 https://api.example.com\n"
+        "#1753000300\ndeploy.sh AKIAIOSFODNN7EXAMPLE\n"
+        "#1753000400\nninja -C build\n"
+    )
+
+    def test_a_credential_shaped_line_is_not_imported(self) -> None:
+        result = importer.run("bash", self._source("h", self.HISTORY))
+        self.assertEqual(
+            sorted(e.cmd for e in cache.load_entries()), ["git status", "ninja -C build"]
+        )
+        self.assertEqual(result.credentials, 3)
+        self.assertEqual(result.imported, 2)
+
+    def test_the_secret_never_reaches_the_log_file(self) -> None:
+        """The assertion that matters: not just absent from the API, absent from disk."""
+        importer.run("bash", self._source("h", self.HISTORY))
+        logs = (Path(os.environ["WOSWOAR_DIR"]) / "logs").rglob("*.tsv")
+        written = "".join(p.read_text(encoding="utf-8") for p in logs)
+        self.assertNotIn("wJalrXUtnFEMI", written)
+        self.assertNotIn("hunter2", written)
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", written)
+        self.assertIn("git status", written)
+
+    def test_a_dry_run_reports_what_it_would_drop(self) -> None:
+        result = importer.run("bash", self._source("h", self.HISTORY), dry_run=True)
+        self.assertEqual(result.credentials, 3)
+        self.assertEqual(cache.load_entries(), [])
+
+    def test_dropped_lines_do_not_come_back_on_a_second_import(self) -> None:
+        """Idempotency is by count and by (ts, cmd); a filtered line is in neither.
+
+        It must not be re-offered, and must not shift the watermark such that a
+        later real command is skipped instead.
+        """
+        source = self._source("h", self.HISTORY)
+        importer.run("bash", source)
+        again = importer.run("bash", source)
+        self.assertEqual(again.imported, 0)
+        self.assertEqual(
+            sorted(e.cmd for e in cache.load_entries()), ["git status", "ninja -C build"]
+        )
+
+    def test_a_repeated_secret_is_counted_as_a_secret_each_time(self) -> None:
+        """The filter runs before the duplicate bookkeeping, and the count says so.
+
+        If a filtered line were added to the seen-set first, the second copy
+        would be reported as a collapsed duplicate rather than as a credential.
+        Both were credential-shaped; the number the user is shown should say
+        that, because it is the number they will judge the filter by.
+        """
+        twice = "#1753000100\nexport AWS_SECRET_ACCESS_KEY=x\n" * 2
+        result = importer.run("bash", self._source("h", twice))
+        self.assertEqual(result.credentials, 2)
+        self.assertEqual(result.collapsed, 0)
+        self.assertEqual(result.imported, 0)
+
+    def test_a_huge_pasted_command_does_not_stall_the_import(self) -> None:
+        """The filter must see the truncated command, not the raw one.
+
+        Ten of the rules scan with `[^|;&]*`, which is quadratic in the length
+        of the line. A 97 KB pasted script measured 636ms on its own before
+        this was fixed, and a history can hold many. Those bytes can never be
+        published either -- `truncate` cuts the command at MAX_CMD_CHARS on the
+        way to disk -- so scanning them was pure waste.
+        """
+        paste = "curl -X POST https://api.example.com/v1/things " * 2000
+        source = self._source("h", f"#1753000000\n{paste}\n#1753000100\ngit status\n")
+        start = time.monotonic()
+        importer.run("bash", source)
+        elapsed = time.monotonic() - start
+
+        # 9ms healthy, 870ms scanning the raw command: two orders of magnitude
+        # of headroom either side of this bound.
+        self.assertLess(elapsed, 0.2, "the import filter is scanning untruncated commands")
+        self.assertIn("git status", [e.cmd for e in cache.load_entries()])
+
+    def test_the_users_own_extra_pattern_applies_to_imports_too(self) -> None:
+        os.environ["WOSWOAR_IGNORE_EXTRA"] = "ninja"
+        self.addCleanup(os.environ.pop, "WOSWOAR_IGNORE_EXTRA", None)
+        result = importer.run("bash", self._source("h", self.HISTORY))
+        self.assertEqual([e.cmd for e in cache.load_entries()], ["git status"])
+        self.assertEqual(result.credentials, 4)
+
+
+class TestImportReporting(ImportTestCase):
+    """What the user is told. A silent drop is its own bug: someone looking for
+    a command they know they ran needs to learn that the filter took it, not be
+    left thinking woswoar lost it."""
+
+    def run_main(self, *argv: str) -> tuple[int, str]:
+        """Both streams merged, and the exit code, which two of these need.
+
+        Named `run_main` rather than `run_cli`: `tests/test_sync.py` already has
+        a `run_cli` that returns stdout only, deliberately, so that "it warned"
+        assertions cannot pass on stderr. Two helpers with one name and
+        different contracts is worse than two names.
+        """
+        out = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(out):
+            code = main(list(argv))
+        return code, out.getvalue()
+
+    def test_the_dropped_count_is_reported(self) -> None:
+        source = self._source("h", TestImportDropsCredentials.HISTORY)
+        _, text = self.run_main("import", "bash", "--file", str(source))
+        self.assertIn("3 skipped as credential-shaped", text)
+
+    def test_nothing_is_said_when_nothing_was_dropped(self) -> None:
+        source = self._source("h", "#1753000000\ngit status\n")
+        _, text = self.run_main("import", "bash", "--file", str(source))
+        self.assertNotIn("credential-shaped", text)
+
+    def test_a_dry_run_lists_what_it_would_drop(self) -> None:
+        """A count alone is unauditable: 17 over a decade tells nobody which 17.
+
+        Dropping is irreversible, so there has to be one mode where a false
+        positive can be seen before it happens.
+        """
+        source = self._source("h", TestImportDropsCredentials.HISTORY)
+        _, text = self.run_main("import", "bash", "--file", str(source), "--dry-run")
+        self.assertIn("would skip as credential-shaped", text)
+        self.assertIn("AWS_SECRET_ACCESS_KEY", text)
+
+    def test_a_real_import_never_lists_them(self) -> None:
+        """The listing exists to be read once, not to be piped into a file."""
+        source = self._source("h", TestImportDropsCredentials.HISTORY)
+        _, text = self.run_main("import", "bash", "--file", str(source))
+        self.assertNotIn("would skip", text)
+        self.assertNotIn("wJalrXUtnFEMI", text)
+
+    def test_a_listed_command_cannot_drive_the_terminal(self) -> None:
+        """It is untrusted text from a history file, printed to a real tty."""
+        source = self._source("h", "#1753000000\nexport TOKEN=\x1b[31mred\x07\n")
+        _, text = self.run_main("import", "bash", "--file", str(source), "--dry-run")
+        self.assertIn("would skip as credential-shaped", text)
+        self.assertNotIn("\x1b", text)
+
+    def test_an_uncompilable_extra_pattern_stops_the_import(self) -> None:
+        """Importing unfiltered would be the opposite of what the user asked for."""
+        os.environ["WOSWOAR_IGNORE_EXTRA"] = "([unclosed"
+        self.addCleanup(os.environ.pop, "WOSWOAR_IGNORE_EXTRA", None)
+        source = self._source("h", TestImportDropsCredentials.HISTORY)
+        code, text = self.run_main("import", "bash", "--file", str(source))
+        self.assertEqual(code, 1)
+        self.assertIn("WOSWOAR_IGNORE_EXTRA", text)
+        self.assertEqual(cache.load_entries(), [], "history was imported unfiltered anyway")
 
 
 if __name__ == "__main__":

--- a/tests/test_importer_atuin.py
+++ b/tests/test_importer_atuin.py
@@ -456,5 +456,45 @@ class TestImportIsPrivate(AtuinTestCase):
             )
 
 
+class TestAtuinImportDropsCredentials(AtuinTestCase):
+    """The atuin path needs its own guard: it is a separate loop in `run_atuin`.
+
+    Worse than the bash file, in fact -- an atuin database holds every machine
+    the user ever synced, so one import can publish other machines' secrets too.
+    """
+
+    def rows(self, host: str = "box:someone") -> list[tuple[object, ...]]:
+        return [
+            (BASE, SECOND, 0, "git status", "/tmp", "s1", host),
+            (BASE + SECOND, SECOND, 0, "export GITHUB_TOKEN=ghp_secretvalue", "/tmp", "s1", host),
+            (BASE + 2 * SECOND, SECOND, 0, "psql postgres://u:pw@db/app", "/tmp", "s1", host),
+            (BASE + 3 * SECOND, SECOND, 0, "ninja -C build", "/tmp", "s1", host),
+        ]
+
+    def test_credential_shaped_rows_are_not_imported(self) -> None:
+        result = importer.run("atuin", self.atuin(self.rows()))
+        self.assertEqual(
+            sorted(e.cmd for e in cache.load_entries()), ["git status", "ninja -C build"]
+        )
+        self.assertEqual(result.credentials, 2)
+
+    def test_the_secret_never_reaches_the_log_file(self) -> None:
+        importer.run("atuin", self.atuin(self.rows()))
+        logs = (Path(os.environ["WOSWOAR_DIR"]) / "logs").rglob("*.tsv")
+        written = "".join(p.read_text(encoding="utf-8") for p in logs)
+        self.assertNotIn("ghp_secretvalue", written)
+        self.assertNotIn("u:pw@db", written)
+        self.assertIn("git status", written)
+
+    def test_a_second_import_does_not_resurrect_them(self) -> None:
+        db = self.atuin(self.rows())
+        importer.run("atuin", db)
+        again = importer.run("atuin", db)
+        self.assertEqual(again.imported, 0)
+        self.assertEqual(
+            sorted(e.cmd for e in cache.load_entries()), ["git status", "ninja -C build"]
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from woswoar import cache, store
 from woswoar.entry import MAX_CMD_CHARS, TRUNCATION_MARKER, Entry, escape, unescape
 
+from .credential_shapes import DOCUMENTED_GAPS, INNOCENT_SHAPES, SECRET_SHAPES
 from .support import MACHINE_ID, WoswoarTestCase
 
 HOOK = Path(__file__).resolve().parent.parent / "woswoar" / "shell" / "woswoar.bash"
@@ -500,121 +501,6 @@ class TestFiltering(ShellHookTestCase):
         assert match is not None, f"the shell did not report a timing:\n{out}"
         micros = int(match.group(1))
         self.assertLess(micros, 1_000_000, "the ignore pattern went superlinear again")
-
-
-#: Command shapes the default `WOSWOAR_IGNORE` must drop. Most come from #23,
-#: which listed them as *not* caught by the pattern this replaces.
-SECRET_SHAPES = [
-    "export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI",
-    "export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7",
-    "AWS_SESSION_TOKEN=abc aws s3 ls",
-    "export MY_SECRET_TOKEN=abc123",
-    "export GITHUB_TOKEN=ghp_xxx",
-    "API_KEY=abc",
-    "APIKEY=abc",
-    "PGPASSWORD=hunter2 psql",
-    "export PASSWORD=x",
-    "export SECRET_KEY_BASE=deadbeef",
-    "export DB_PASSWD=x",
-    "export DB_PASS=x",
-    "export MY_AUTH_TOKEN=x",
-    "export STRIPE_API_KEY=sk_live_x",
-    "mysql --password=hunter2",
-    "wget --password hunter2 http://x",
-    "curl --token abc https://x",
-    "gh auth login --with-token",
-    "kubectl create secret generic s --from-literal=password=x",
-    "aws --secret-key x",
-    "helm install --api-key=abc",
-    "s3cmd --access-key AKIAIOSFODNN7",
-    'curl -H "Authorization: Bearer eyJ0eXAi"',
-    'curl -H "authorization: Basic dXNlcg=="',
-    "curl -u user:pass https://api.example.com",
-    'psql "postgres://user:pass@host/db"',
-    "git clone https://user:token@github.com/o/r",
-    "sshpass -p hunter2 ssh host",
-    "htpasswd -b .htpasswd user pass",
-    "openssl passwd -6 hunter2",
-    "mysql -pSECRETpw -u root",
-    "mysql -u root -pSECRETpw",
-    "docker login -p hunter2 -u me",
-    "ssh-keygen -t ed25519 -N hunter2 -f k",
-]
-
-#: Ordinary commands the pattern must leave alone. A filter that eats these is
-#: worse than useless: it deletes history and says nothing.
-INNOCENT_SHAPES = [
-    "git status",
-    "ls -la",
-    "make -j8",
-    "ssh-keygen -t ed25519 -C me@host",
-    "ssh-keygen -lf ~/.ssh/id_ed25519.pub",
-    "ssh-keygen -R oldhost",
-    "git clone https://github.com/martinus/woswoar",
-    'curl -H "Accept: application/json" https://api.example.com',
-    "curl -sSL https://example.com/install.sh | bash",
-    "curl -fsSL -o out.json https://api.example.com/v1/items",
-    "docker run -p 8080:80 nginx",
-    "docker run -u 1000:1000 alpine",
-    "docker compose up -d --build",
-    "mysql --protocol=tcp -u root",
-    "mysql -u root -h db01 mydb",
-    "mysql < dump.sql",
-    "kubectl get secret",
-    "kubectl describe secrets",
-    "vault kv get secret/app",
-    "psql postgres://localhost/mydb",
-    "export EDITOR=vim",
-    "export MONKEY=banana",
-    "export KEYS=3",
-    "export KEYBOARD=us",
-    "export PASSAGE=x",
-    "export PATH=/usr/bin:$PATH",
-    "make KEYS=3",
-    "aws s3 ls",
-    "aws configure list",
-    "openssl req -new -x509",
-    "openssl x509 -in c.pem -text",
-    "grep -r password .",
-    "vim ~/.aws/credentials",
-    "cat /etc/passwd",
-    "git log --oneline -20",
-    "git commit -m 'add auth handler'",
-    "ssh -p 2222 user@host",
-    "npm install --save-dev typescript",
-    "touch a_key_file.txt",
-    "man curl",
-    # A long option that merely *starts* with a keyword. This is what the
-    # `([=[:space:]]|$)` boundary after each keyword is for: without it, `auth`
-    # matches inside `--auth-mode` and a real azure command disappears.
-    "az storage blob list --auth-mode login",
-]
-
-
-#: Shapes the pattern does **not** catch, each one a claim `docs/shell-integration.md`
-#: makes in prose. They are pinned here because an unbacked claim in a security
-#: document is worse than a known gap: a later broadening would falsify the
-#: document with CI green, and nobody would look.
-#:
-#: Not a wish list. Some of these genuinely carry a secret and are recorded
-#: anyway -- `redis-cli -a`, `aws configure set`, `vault kv put`. Chasing them
-#: means an unbounded list of tool names priced per character on every prompt,
-#: so the project documents them instead of pretending otherwise.
-DOCUMENTED_GAPS = [
-    # No secret is on these lines at all -- the tool prompts for it.
-    "mysql -p",
-    "docker login",
-    "gh auth login",
-    # A secret with no tell: nothing distinguishes it from any other argument.
-    "deploy.sh AKIAIOSFODNN7EXAMPLE",
-    # Lower-case assignment. Upper case is the convention and the pattern's cost
-    # is proportional to its length, so both cases are not spelled out.
-    "token=abc",
-    # A tool that takes a secret as a positional argument or a bare flag.
-    "aws configure set aws_secret_access_key wJalr",
-    "vault kv put secret/app value=hunter2",
-    "redis-cli -a hunter2",
-]
 
 
 @requires_bash5

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from . import __version__, cache, importer, search, store
+from .entry import make_inert
 from .errors import WoswoarError
 
 if TYPE_CHECKING:  # `sync` is imported lazily; only the annotation needs it.
@@ -136,15 +137,24 @@ def cmd_import(args: argparse.Namespace) -> int:
     except FileNotFoundError as exc:
         print(f"woswoar: {exc}", file=sys.stderr)
         return 1
-
     prefix = "would import" if args.dry_run else "imported"
     notes = []
     if result.skipped:
         notes.append(f"{result.skipped} already present")
     if result.collapsed:
         notes.append(f"{result.collapsed} same-second duplicates collapsed")
+    if result.credentials:
+        notes.append(f"{result.credentials} skipped as credential-shaped")
     print(f"{result.source}: {result.parsed} parsed, {prefix} {result.imported}", end="")
     print(f", {', '.join(notes)}" if notes else "")
+
+    if result.dropped:
+        # Only ever populated by --dry-run. Printed so a false positive can be
+        # spotted before it is dropped for real, and to stderr so that piping
+        # the summary somewhere does not write a secret to a file.
+        print("\nwould skip as credential-shaped:", file=sys.stderr)
+        for command in result.dropped:
+            print(f"  {make_inert(command)}", file=sys.stderr)
 
     if len(result.per_host) > 1:
         print("\nper machine:")

--- a/woswoar/credentials.py
+++ b/woswoar/credentials.py
@@ -1,0 +1,140 @@
+"""Recognise credential-shaped commands, for the paths that are not the hook.
+
+The bash hook carries its own copy of these rules, as one POSIX ERE in
+``woswoar/shell/woswoar.bash``. It has to: it runs on every prompt, must not
+fork, and cannot call Python. This module is for ``woswoar import``, which reads
+history recorded long before woswoar existed -- years of it, filtered by nothing
+at all.
+
+Two things are different here, both because an importer has no per-prompt
+budget to spend:
+
+- the rules are written as separate readable patterns with a comment each,
+  rather than as one dense line tuned for compile time. They are still joined
+  into a single compiled alternation, which measured no slower than trying
+  them one at a time and keeps the call site simple.
+- it also recognises **token formats**. `docs/shell-integration.md` lists "a
+  secret with no tell" as something the hook cannot catch, because
+  distinguishing `AKIAIOSFODNN7EXAMPLE` from any other argument costs more than
+  a prompt can pay. An importer can pay it, so on that path the well-known ones
+  stop being a gap.
+
+`tests/credential_shapes.py` is the corpus both implementations are held to, so
+the rules they share cannot drift apart.
+
+Deliberately *not* here: an entropy test. Shell history is full of high-entropy
+strings that are not secrets -- git SHAs, checksums, UUIDs, base64 payloads --
+and dropping a command is silent and unrecoverable. Precision matters more than
+recall for something that edits a user's history behind their back.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from .errors import WoswoarError
+
+#: Shapes the bash hook also catches. Kept in the same order as the alternatives
+#: in `WOSWOAR_IGNORE` so the two can be read side by side.
+_SHARED = (
+    # An assignment whose name reads like a credential. KEY, PASS and AUTH only
+    # after `_`, or MONKEY=, KEYS= and PASSAGE= would all be dropped.
+    r"(?:TOKEN|SECRET|PASSW|CREDENTIAL|APIKEY|_KEY|_PASS|_AUTH)[A-Za-z0-9_]*=",
+    # A long option that names one. The trailing boundary is what keeps
+    # `--auth-mode` (a real azure flag, not a secret) out of it.
+    r"--(?:[a-z]+-)*(?:(?:passw|token|secret|credential)[a-z-]*|api-?key|access-?key|auth)"
+    r"(?:[=\s]|$)",
+    r"--from-literal=",
+    # Credentials inside a URL.
+    r"://[^/\s]+:[^/@\s]+@",
+    r"[Aa]uthorization:\s*[A-Za-z]",
+    # The three tools that exist to take a password on the command line.
+    r"(?:sshpass|htpasswd|openssl passwd)\s",
+    # Short options that carry a secret value. `[^|;&]` bounds each to one
+    # pipeline stage; `mysql -p` with no value attached is a prompt, not a
+    # secret, which is why that one requires a following character.
+    r"curl[^|;&]*\s-u\s",
+    r"mysql[a-z]*[^|;&]*\s-p[^-\s]",
+    r"docker login[^|;&]*\s-p",
+    r"ssh-keygen[^|;&]*\s-N\s",
+)
+
+#: Secrets passed as a positional argument, or on a short flag of some specific
+#: program. `docs/shell-integration.md` lists these as things the hook does not
+#: catch, and they are the clearest example of why: matching them needs a list
+#: of program names, and the hook pays for every character of it on every
+#: prompt. An importer runs once, so it can carry the list.
+_IMPORT_ONLY = (
+    r"aws[^|;&]*\sconfigure\s+set\s+[a-z_.]*(?:secret|password|token|key)",
+    r"vault\s+(?:kv\s+)?(?:put|write)\b[^|;&]*\s\S+=",
+    r"redis-cli[^|;&]*\s-a\s*\S",
+    r"(?:mongo(?:sh)?|az\s+login)[^|;&]*\s-p\s*\S",
+    r"smbclient[^|;&]*\s-U\s*\S+%",
+    r"pscp[^|;&]*\s-pw\s*\S",
+)
+
+#: Token formats distinctive enough to name on sight. Each is anchored on a
+#: vendor prefix and a length, not on looking random, so a git SHA or a base64
+#: blob does not trip them.
+_TOKENS = (
+    r"\bA[KS]IA[0-9A-Z]{16}\b",  # AWS access key id, permanent (AKIA) and temporary (ASIA)
+    r"\bgh[pousr]_[A-Za-z0-9]{36,}",  # GitHub personal access token
+    r"\bgithub_pat_[A-Za-z0-9_]{20,}",
+    r"\bglpat-[A-Za-z0-9_-]{20,}",  # GitLab
+    r"\bxox[baprs]-[A-Za-z0-9-]{10,}",  # Slack
+    r"\b[sprk]k_(?:live|test)_[A-Za-z0-9]{16,}",  # Stripe
+    r"\bsk-[A-Za-z0-9]{32,}",  # OpenAI-style
+    r"\bAIza[A-Za-z0-9_-]{35}",  # Google API key
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----",
+    # A JWT: three dot-separated base64url segments starting with the encoding
+    # of `{"`. Two segments would match far too much.
+    r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+",
+)
+
+#: Compiled on first use, not at import. `woswoar list` is re-run by fzf on
+#: every scope switch and imports this module transitively through `importer`,
+#: and compiling the alternation measured ~0.6ms -- paid on a keystroke path by
+#: the one module whose docstring says it is not on one.
+_PATTERN: re.Pattern[str] | None = None
+
+
+def _pattern() -> re.Pattern[str]:
+    global _PATTERN
+    if _PATTERN is None:
+        _PATTERN = re.compile("|".join(_SHARED + _IMPORT_ONLY + _TOKENS))
+    return _PATTERN
+
+
+#: Set by the user, so it is theirs to get right. Read once per import run --
+#: `looks_like_credential` takes the compiled result rather than re-reading it.
+_EXTRA = "WOSWOAR_IGNORE_EXTRA"
+
+
+class BadExtraPattern(WoswoarError):
+    """`WOSWOAR_IGNORE_EXTRA` is set to something Python cannot compile."""
+
+
+def user_pattern() -> re.Pattern[str] | None:
+    """The user's own additions, or None if they set none.
+
+    Only `WOSWOAR_IGNORE_EXTRA` is read, never `WOSWOAR_IGNORE`. The default
+    value of `WOSWOAR_IGNORE` is a POSIX ERE using `[[:space:]]`, which Python's
+    `re` cannot compile at all -- so reading it would make every import warn
+    about a variable the user never touched. `_EXTRA` is unset unless someone
+    chose to set it.
+    """
+    raw = os.environ.get(_EXTRA)
+    if not raw:
+        return None
+    try:
+        return re.compile(raw)
+    except re.error as exc:
+        # Loudly. Silently ignoring it would leave the user believing their own
+        # rule was applied to the import when it was not.
+        raise BadExtraPattern(f"{_EXTRA} is not a valid Python regex: {exc}") from exc
+
+
+def looks_like_credential(command: str, extra: re.Pattern[str] | None = None) -> bool:
+    """Would publishing this command publish a secret with it?"""
+    return bool(_pattern().search(command) or (extra and extra.search(command)))

--- a/woswoar/importer.py
+++ b/woswoar/importer.py
@@ -13,7 +13,7 @@ from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Literal, NamedTuple
 
-from . import store
+from . import credentials, store
 from .entry import Entry, truncate
 
 Kind = Literal["bash", "zsh", "atuin"]
@@ -54,6 +54,17 @@ class Result(NamedTuple):
     #: on disk. Reporting them as one made a first-ever import into an empty
     #: store claim entries were "already present".
     collapsed: int = 0
+    #: Dropped because the command looks like it carries a secret. Reported
+    #: rather than silent: a user who expects a command to be there needs to
+    #: know why it is not, and "the filter ate it" is a different answer from
+    #: "your history file did not have it".
+    credentials: int = 0
+    #: The dropped commands themselves, populated only for a dry run. Dropping
+    #: is irreversible and a count alone is unauditable -- "17 skipped" over a
+    #: decade of history gives nobody a way to spot a false positive. Never
+    #: filled on a real import, so a secret cannot reach a caller that stores
+    #: its Result.
+    dropped: tuple[str, ...] = ()
     #: (display name, count) per machine, biggest first. Only atuin carries
     #: more than one host. A tuple rather than a dict because Result is a
     #: NamedTuple, and a mutable default would be shared across instances.
@@ -371,6 +382,9 @@ def run_atuin(
     entries_by_host: dict[str, list[Entry]] = {}
     skipped = 0
     collapsed = 0
+    secrets = 0
+    dropped: list[str] = []
+    extra = credentials.user_pattern()
 
     for host_id, rows in by_host.items():
         days = {store.day_for(r.ts) for r in rows}
@@ -388,6 +402,12 @@ def run_atuin(
                     skipped += 1
                 else:
                     collapsed += 1
+                continue
+            # key[1] is the truncated command -- see the note in `run`.
+            if credentials.looks_like_credential(key[1], extra):
+                secrets += 1
+                if dry_run:
+                    dropped.append(row.cmd)
                 continue
             known.add(key)
             fresh.append(
@@ -423,6 +443,8 @@ def run_atuin(
         imported=imported,
         skipped=skipped,
         collapsed=collapsed,
+        credentials=secrets,
+        dropped=tuple(dropped),
         source=source,
         per_host=tuple(
             sorted(
@@ -473,6 +495,9 @@ def run(
     entries: list[Entry] = []
     skipped = 0
     collapsed = 0
+    secrets = 0
+    dropped: list[str] = []
+    extra = credentials.user_pattern()
     for item in fresh:
         # Not `key`: that name already holds the per-source state key below.
         seen = _dedup_key(item.ts, item.cmd)
@@ -481,6 +506,21 @@ def run(
                 skipped += 1
             else:
                 collapsed += 1
+            continue
+        # Before the dedup bookkeeping is committed but after the cheap checks:
+        # a credential-shaped line must never become an Entry, because from
+        # there it goes to logs/, into an encrypted chunk, into git, and out to
+        # every machine -- and docs/security.md says publication is final.
+        #
+        # `seen[1]`, not `item.cmd`: the truncated text is what would be
+        # published, and several rules scan with `[^|;&]*`, which is quadratic
+        # in the length of the line. A 97 KB pasted script measured 636ms
+        # untruncated and 5ms truncated -- and `_dedup_key` computed the
+        # truncation on the line above regardless, so this is free.
+        if credentials.looks_like_credential(seen[1], extra):
+            secrets += 1
+            if dry_run:
+                dropped.append(item.cmd)
             continue
         known.add(seen)
         entries.append(
@@ -505,5 +545,7 @@ def run(
         imported=len(entries),
         skipped=skipped,
         collapsed=collapsed,
+        credentials=secrets,
+        dropped=tuple(dropped),
         source=source,
     )


### PR DESCRIPTION
Closes #52.

## The bug

`WOSWOAR_IGNORE` ran in the bash hook and nowhere else. `grep -c 'ignore' woswoar/importer.py` returned **0**.

That is the worse half of #23. The hook filters what you type *from now on*; `woswoar import` — a documented first-run step — reads a `~/.bash_history` or an atuin database recorded over years with no filter at all, and publishes the lot: `logs/` → encrypted chunk → git → every peer. `docs/security.md` already says publication cannot be taken back.

```sh
printf '#1753000000\nexport AWS_SECRET_ACCESS_KEY=wJalr\n' >> ~/.bash_history
woswoar import bash && woswoar list --scope host | grep wJalr    # there it is
```

## What it does

`woswoar/credentials.py` holds the rules in Python and both import paths apply them. Because an import runs **once** rather than on every prompt, it can afford what the hook cannot, so it also catches:

- **token formats** — `AKIA…`, `ghp_…`, `glpat-…`, `xox…`, `sk_live_…`, `AIza…`, JWTs, PEM private-key blocks
- **tools that take a secret positionally** — `aws configure set …secret…`, `vault kv put … value=`, `redis-cli -a`, `mongosh -p`, `az login -p`, `smbclient -U user%pass`, `pscp -pw`

Every one of those is a shape `docs/shell-integration.md` previously had to list as a gap.

**No entropy heuristic**, deliberately. Shell history is full of high-entropy strings that are not secrets — git SHAs, checksums, UUIDs, base64 payloads — and a drop is silent and unrecoverable, so precision beats recall. There's a test holding that line, and a mutation that adds an entropy check fails it.

## The parity problem, and the fix for it

The rules now exist twice: a POSIX ERE in the hook, Python here. My first version bound them only through a shared corpus — which catches drift **only where an example happens to cover it**. The altitude review pointed at the existing precedent (`TestEscapeParity` extracts `__woswoar_escape` from the real hook and compares outputs) and was right that I hadn't followed it.

So `TestParityWithTheHook` now translates the Python patterns into POSIX ERE and asserts the hook's shipped default is **exactly** that. Verified in both directions: adding a rule to Python only fails, adding one to bash only fails.

## Two things review caught that measurement confirmed

**The filter scanned the untruncated command.** Ten rules use `[^|;&]*`, quadratic in line length:

| pasted script | before | after |
|---|---|---|
| 97 KB | 870 ms | 6.4 ms |
| 100 KB | 2849 ms | 20 ms |

Those bytes can never be published — `truncate()` cuts at `MAX_CMD_CHARS` on the way to disk — and `_dedup_key` had already computed the truncation *on the line above*. So this was 135× for free. Guarded by a timing test.

**`credentials` was imported eagerly** by `__main__` via `importer`, so every Ctrl-R compiled a 900-character alternation it never used — in the one module whose docstring says it is not on the prompt path. Compiling on first use: **887 µs → 195 µs**.

## Auditability

A dry run now lists what it *would* drop, through `make_inert` and to stderr:

```console
$ woswoar import bash --dry-run
~/.bash_history: 8213 parsed, would import 8196, 17 skipped as credential-shaped

would skip as credential-shaped:
  export AWS_SECRET_ACCESS_KEY=…
```

Dropping is irreversible, and "17 skipped" over a decade of history gives nobody a way to spot a false positive. Never populated on a real import, so a secret cannot reach a caller that stores the `Result`.

## Verification

- **20 mutations, all killing their guarding test** — each import path, each rule group, the truncation, the parity check, the dry-run listing, and the terminal-escape sanitising.
- 5 clean full runs.
- One real bug found by writing the coverage tests: `mongosh?` means `mongos` + optional `h`, so plain `mongo -p` never matched.

## From `/simplify`

Applied: the truncation fix; lazy compile; `BadExtraPattern` reparented to `WoswoarError` (which deleted a duplicate handler *and* an import); a decorative `test_every_pattern_compiles`; corpus entries for **7 rules nothing exercised** while the docs promised them; test classes that subclassed a class with tests (45 tests where 27 were distinct); a `run_cli` that collided by name with `test_sync`'s but merged streams where that one deliberately doesn't; a stale doc pointer; a tool list that had already drifted between two paragraphs of the same file.

Also documented something the review found and I had stated wrongly: **`WOSWOAR_IGNORE` reaches the hook only.** It's a POSIX ERE that Python cannot compile, so a rule put there filters what you type and *not* what you import. `WOSWOAR_IGNORE_EXTRA` honours both.

Filed **#54** for the population this does not help: anyone who already imported before this lands.

### One thing to clean up

A review agent's benchmark created `~/.config/woswoar/` on this machine (`machine`, `imported.json` pointing at `/tmp/wbench/`). It tried to `rm -rf` it; the sandbox blocked that and I did not do it either — it is under your home and outside this repo. Safe to delete if you have no real woswoar install there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
