### PR TITLE
Record that nothing is deployed, so no change needs a migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,32 @@ single largest waste of a session so far, twice over.
 Not after. Undoing a commit that landed on `main` means branching at `HEAD` and
 then `git reset --hard origin/main` — the operation rule 6 is about.
 
+## 8. Write no migration code: nothing is deployed yet
+
+woswoar has no users. Nobody has installed it, so there is no history in the
+field and no repository built by an older version.
+
+Change the record format, the repo layout, `state.json`, the cache, the day-key
+scheme — outright. Do **not** write an upgrade path, a version field two code
+paths branch on, an "if this is the old shape" fallback, or a deprecation
+period. A clean cut is the norm here, not something to argue for.
+
+Two things this does not license:
+
+- **Say so in the PR body, with the rebuild command**, in case the maintainer's
+  own machine is on the old shape:
+  `rm -rf ~/.local/share/woswoar/history ~/.local/share/woswoar/state.json`,
+  then `woswoar init <url>` and `woswoar grant`.
+- `logs/` is the plaintext history and the primary copy; `history/` is derived
+  from it and can always be rebuilt. Discarding the derived tree is cheap;
+  discarding `logs/` loses data. That distinction outlives this rule.
+
+**This expires the moment woswoar is published and someone installs it.** Delete
+the rule then, rather than reasoning about who might be affected. Both errors
+cost: assuming a user base that does not exist wastes work — issue #54 was filed
+at P1 and closed for exactly that — and assuming forever that there is none
+corrupts somebody's history.
+
 ## Repository conventions worth matching
 
 - Comments explain **why**, especially why an obvious alternative was rejected.


### PR DESCRIPTION
Per your note: woswoar has no users, so there is no history in the field and no
repository built by an older version. Nothing needs preserving.

## What the rule says

Change the record format, the repo layout, `state.json`, the cache or the
day-key scheme **outright** — no upgrade path, no version field two code paths
branch on, no "if this is the old shape" fallback, no deprecation period.

That is already what happened twice, but each break was reasoned about from
first principles at the time. This makes it the default instead of an argument
to be won again.

## Two things I kept in

**The rebuild command belongs in the PR body.** Your own machine may be on the
old shape even when nobody else's is, and the recovery is two paths and two
commands. Cheap to state, annoying to rediscover.

**`logs/` versus `history/`.** `logs/` is the plaintext history and the primary
copy; `history/` is derived and can always be rebuilt from it. "No migration
needed" must not get read as "the local history is disposable" — and that
distinction stays true after this rule stops applying.

## The expiry

The rule says explicitly that it dies the moment woswoar is published and
someone installs it, and to delete it then rather than reason about who might be
affected.

That is there because I just made the mirror of this mistake in the other
direction: I filed **#54 at P1** on the strength of a user population inferred
from the README quick start rather than from anything real, and you closed it in
one sentence. Assuming a user base that does not exist wastes an afternoon;
assuming forever that there is none corrupts somebody's history. The second is
the expensive one, so the expiry is stated rather than left to judgement.

## On rule 1

`/simplify` was not run — markdown-only diff, so its four angles have nothing to
inspect. Same call and same reasoning as #47; flagging it rather than dropping
it silently. No code changed, so rule 3 does not apply either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)