### PR TITLE
Stop executing the cache file on every Ctrl-R

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ truthful. Re-running an import is idempotent.
 ## How it works
 
 ```
-bash hook  ──►  plaintext TSV logs  ──►  pickle cache  ──►  scope filter  ──►  fzf
+bash hook  ──►  plaintext TSV logs  ──►  parse cache  ──►  scope filter  ──►  fzf
                         │
                         └──►  age-encrypted chunks  ──►  git  ──►  remote
 ```

--- a/docs/milestone-1-plan.md
+++ b/docs/milestone-1-plan.md
@@ -95,7 +95,7 @@ CI measures the file count so it can't drift unnoticed.
     hosts/<id>/2026/07/29/<synctime>-<rand>.age
   state.json                own: plaintext bytes encrypted so far
                             others: last chunk merged, per (host, day)
-~/.cache/woswoar/cache.pickle
+~/.cache/woswoar/cache.txt
 ```
 
 `woswoar sync` is then:
@@ -150,7 +150,7 @@ tests/
 .github/workflows/ci.yml
 ```
 
-`Entry` is a `NamedTuple` rather than the doc's `@dataclass(slots=True)` — same attribute access, materially cheaper to unpickle.
+`Entry` is a `NamedTuple` rather than the doc's `@dataclass(slots=True)` — same attribute access, materially cheaper to deserialise.
 
 CLI: `search`, `list`, `import`, `install`, `stats`, `doctor`; `sync`/`reencrypt` stubbed with a clear "milestone 2" error.
 
@@ -212,7 +212,7 @@ Fold the resolved decisions back in so the doc stays the source of truth: the 6-
 | `immutability` | *(milestone 2)* After a simulated multi-day, multi-machine run, asserts `git log --diff-filter=MD --name-only -- 'hosts/**/*.age'` is **empty** — no chunk was ever modified or deleted. This is an exact invariant, not a heuristic, and it's what makes a future refactor unable to silently reintroduce whole-file re-encryption. |
 | `repo-growth` | *(milestone 2)* Simulates 40 syncs × 200 lines over several days, runs `git gc`, and asserts packed `.git` stays within ~2× the plaintext size and the working-tree file count matches the predicted chunk count. Emits the measured per-chunk `age` overhead so the estimates above get replaced by real numbers. |
 
-Unit tests (stdlib `unittest`): escape/unescape round-trip over tabs, newlines, backslashes, unicode and oversized commands; cache fresh-build / append / truncation / deleted-file / corrupt-pickle paths; scope filtering and dedup ordering; importer for bash with and without `HISTTIMEFORMAT`, zsh extended format, multi-line entries, idempotent re-import.
+Unit tests (stdlib `unittest`): escape/unescape round-trip over tabs, newlines, backslashes, unicode and oversized commands; cache fresh-build / append / truncation / deleted-file / corrupt-cache paths; scope filtering and dedup ordering; importer for bash with and without `HISTTIMEFORMAT`, zsh extended format, multi-line entries, idempotent re-import.
 
 ## Manual verification
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -199,6 +199,13 @@ with `--identity <path>` or `--new-identity`.
 
 ## 📦 Minimal supply chain
 
+No on-disk format woswoar reads can execute code. The parse cache under
+`~/.cache` is read on every Ctrl-R and used to be a pickle, which runs whatever
+the file says *before* any validation the caller might do; it is now plain text
+that a `split` cannot execute. That file is `0600`, so this was never a
+cross-user hole — what it removes is the step from "something could write one
+file in your home directory" to "something runs as you".
+
 The runtime dependency list is **empty**, and
 [intended to stay that way](../pyproject.toml). No PyPI packages, no transitive
 tree, no post-install scripts, no crate lockfile to audit — the only Python that
@@ -232,6 +239,7 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | A recalled command is one command | control characters never survive from the picker into the shell buffer |
 | The repo does not blow up | a simulated multi-day, multi-machine run is measured after `git gc` |
 | History is never readable by others | every path woswoar creates is walked under a stock `umask 022`, on both the Python and the shell-hook side |
+| The cache cannot execute | a pickle that would run code on load is written to the cache path; it is refused and a witness file never appears |
 | Search stays fast | latency measured on 52,000 entries |
 
 ## ⚠️ What is *not* protected

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -177,7 +177,7 @@ Measured on a real **54,943-entry** history across ~750 daily files:
 | record a command | **~150 µs**, 0 forks |
 | <kbd>Ctrl</kbd>+<kbd>R</kbd>, whole process | **~105 ms** |
 
-No index, no SQLite — a pickle cache that only re-reads what changed is enough,
+No index, no SQLite — a parse cache that only re-reads what changed is enough,
 and CI re-measures it on every push.
 
 <details>
@@ -188,7 +188,7 @@ and CI re-measures it on every push.
 | Python interpreter start | 8.8 ms |
 | importing woswoar | 29 ms |
 | building the argparse parser | 36 ms |
-| loading the cache (unpickling 55k entries) | 67 ms |
+| loading the cache (deserialising 55k entries) | 67 ms |
 | filter, sort, dedup, render | 87 ms |
 | writing 1.5 MB to fzf | 105 ms |
 

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -20,7 +20,7 @@ git sync with age encryption.
 ## Architecture
 
 ```
-bash hook  ──►  plaintext TSV logs  ──►  pickle cache  ──►  scope filter  ──►  fzf
+bash hook  ──►  plaintext TSV logs  ──►  parse cache  ──►  scope filter  ──►  fzf
    (record)          (truth)             (speed only)        (Python)         (UI)
                         │
                         └──►  age-encrypted chunks  ──►  git  ──►  remote
@@ -47,7 +47,7 @@ Two rules that everything else follows from:
   state.json                  sync watermarks (local, never synced)
 ~/.config/woswoar/machine     id + name
 ~/.config/woswoar/imported.json
-~/.cache/woswoar/cache.pickle
+~/.cache/woswoar/cache.txt
 ```
 
 **Machine identity is an opaque random hex string**, not `user@hostname`. Path
@@ -292,14 +292,18 @@ semicolon-joined. This is bash's behaviour, not something woswoar can recover.
 
 ## Cache
 
-```python
-{"version": 1,
- "files": {relpath: [Entry, ...]},                 # grouped per file
- "meta":  {relpath: (size, mtime_ns, offset, head)}}
+Plain text, not a pickle — it is read on every Ctrl-R, and unpickling executes
+what it reads before any check can run. Separated by NUL and the two bytes after
+it, which no field can hold, so nothing needs escaping:
+
+```
+woswoar-cache-2
+<relpath> <host> <size> <mtime_ns> <offset> <head hex>     one header per file
+<ts> <session> <cwd> <exit> <duration_ms> <cmd>            then its entries
 ```
 
 `Entry` is a `NamedTuple`, not the `@dataclass(slots=True)` originally sketched:
-identical attribute access, materially cheaper to unpickle, and the whole
+identical attribute access, materially cheaper to deserialise, and the whole
 history is loaded on every Ctrl-R.
 
 Entries are grouped **per file** rather than kept in one flat list. That costs a
@@ -385,10 +389,10 @@ from 26.6 to 24.6 ms.
 Going meaningfully below this needs a structural change, and both candidates are
 worse than the problem:
 
-- **Stop materialising 55k `Entry` objects.** Unpickling plain tuples is 16 ms
-  against 34, but reconstructing the NamedTuples costs the 13 ms back, so the
-  gain only exists if search indexes tuples positionally. Worth ~20 ms of 105,
-  paid for in readability across the whole search path.
+- **Stop materialising 55k `Entry` objects.** Deserialising plain tuples is
+  16 ms against 34, but reconstructing the NamedTuples costs the 13 ms back, so
+  the gain only exists if search indexes tuples positionally. Worth ~20 ms of
+  105, paid for in readability across the whole search path.
 - **A resident daemon**, which is what the no-server design exists to avoid.
 
 So 105 ms stands. fzf renders as it reads, so what a user perceives is closer to
@@ -813,7 +817,7 @@ changed only at onboarding); `merge=union` in `.gitattributes` resolves it.
 
 ## Dependencies
 
-Runtime: **Python standard library only** — `dataclasses`, `pathlib`, `pickle`,
+Runtime: **Python standard library only** — `dataclasses`, `pathlib`,
 `subprocess`, `tempfile`, `time`, `secrets`, `hashlib`, `json`, `argparse`.
 
 External binaries: `fzf` (the UI), and `age` plus `git` (sync only). Development only: `ruff`, `mypy`, `shellcheck`.

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,12 +3,29 @@
 from __future__ import annotations
 
 import os
+import pathlib
+import pickle
 import unittest
 
 from woswoar import cache, store
-from woswoar.entry import format_line
+from woswoar.entry import Entry, format_line
 
 from .support import MACHINE_ID, WoswoarTestCase, make_entry
+
+
+class _Exploit:
+    """A pickle that runs code on load, which is the whole point of issue #21.
+
+    `__reduce__` is what `pickle.load` calls, before any `isinstance` check the
+    caller might make. Creating a file rather than doing anything dangerous:
+    the test needs a witness, not a demonstration.
+    """
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    def __reduce__(self) -> tuple[object, tuple[object, ...]]:
+        return (pathlib.Path(self.path).touch, ())
 
 
 def line(ts: int, cmd: str) -> str:
@@ -101,35 +118,38 @@ class TestCache(WoswoarTestCase):
         self.write_log(MACHINE_ID, "2026-07-29", [line(100, "git status")])
         cache.load_entries()
 
-        store.cache_file().write_bytes(b"this is not a pickle")
+        store.cache_file().write_bytes(b"this is not a cache")
         self.assertEqual([e.cmd for e in cache.load_entries()], ["git status"])
 
-    def test_a_cache_missing_a_newer_attribute_falls_back_to_a_rebuild(self) -> None:
-        """Right class and right version is not the same as right shape.
+    def test_a_pickle_is_not_loaded_and_cannot_execute(self) -> None:
+        """Issue #21: the cache used to be a pickle, read on every Ctrl-R.
 
-        Pickle restores ``__dict__`` and never runs ``__init__``, so a file
-        written by a build with one attribute fewer unpickles cleanly and then
-        raises deep inside refresh() -- on the Ctrl-R path. Found in the wild:
-        a cache predating ``unsaved`` crashed `woswoar doctor` outright.
+        `pickle.load` runs `__reduce__` before any validation, so the old
+        `isinstance` guard was too late to matter. This writes a payload that
+        would create a file if it were ever unpickled, and asserts it does not.
         """
-        import pickle
+        witness = self.root / "payload-ran"
+        payload = pickle.dumps(_Exploit(str(witness)), protocol=pickle.HIGHEST_PROTOCOL)
+        # Sanity-check the payload really is live, or this test proves nothing.
+        pickle.loads(payload)
+        self.assertTrue(witness.exists(), "the exploit payload is inert; the test is worthless")
+        witness.unlink()
 
         self.write_log(MACHINE_ID, "2026-07-29", [line(100, "git status")])
-        cache.load_entries()
-
-        older = cache.load()
-        del older.__dict__["unsaved"]
-        store.cache_file().write_bytes(pickle.dumps(older, protocol=pickle.HIGHEST_PROTOCOL))
+        cache.load_entries()  # creates the cache directory, as a real run would
+        store.cache_file().write_bytes(payload)
 
         self.assertEqual([e.cmd for e in cache.load_entries()], ["git status"])
+        self.assertFalse(witness.exists(), "the cache file was unpickled")
 
-    def test_stale_version_falls_back_to_a_rebuild(self) -> None:
+    def test_a_cache_from_another_version_falls_back_to_a_rebuild(self) -> None:
+        """The version is the file's first field, so it is checked before use."""
         self.write_log(MACHINE_ID, "2026-07-29", [line(100, "git status")])
         cache.load_entries()
 
-        stale = cache.load()
-        stale.version = cache.CACHE_VERSION + 1
-        cache.save(stale)
+        written = store.cache_file().read_bytes()
+        self.assertTrue(written.startswith(b"woswoar-cache-"))
+        store.cache_file().write_bytes(written.replace(b"woswoar-cache-2", b"woswoar-cache-1", 1))
 
         self.assertEqual([e.cmd for e in cache.load_entries()], ["git status"])
 
@@ -150,6 +170,136 @@ class TestCache(WoswoarTestCase):
         cache.load_entries()
         leftovers = [p.name for p in store.cache_dir().iterdir() if p.name.startswith(".cache-")]
         self.assertEqual(leftovers, [])
+
+
+class TestNoFormatWeReadCanExecute(unittest.TestCase):
+    """docs/security.md claims this of the whole codebase, so assert it there.
+
+    The cache is the one that mattered and is fixed; this is what stops the
+    next one being introduced quietly somewhere else.
+    """
+
+    def test_no_module_imports_an_executing_deserialiser(self) -> None:
+        package = pathlib.Path(__file__).resolve().parent.parent / "woswoar"
+        banned = ("pickle", "marshal", "shelve", "dill", "yaml")
+        offenders = []
+        for module in sorted(package.rglob("*.py")):
+            source = module.read_text(encoding="utf-8")
+            for name in banned:
+                if f"import {name}" in source:
+                    offenders.append(f"{module.name} imports {name}")
+        self.assertEqual(
+            offenders,
+            [],
+            "these formats run what they read; docs/security.md says none is used",
+        )
+
+
+class TestTheOnDiskFormat(WoswoarTestCase):
+    """The serialiser on its own, without going through the filesystem."""
+
+    RELPATH = "hosts/abc/2026-07-29.tsv"
+
+    def sample(self, entries: list[Entry]) -> cache.Cache:
+        built = cache.Cache()
+        built.files[self.RELPATH] = entries
+        built.meta[self.RELPATH] = cache.FileMeta(
+            size=10, mtime_ns=20, offset=30, head=b"\x00\xff\x01"
+        )
+        return built
+
+    def roundtrip(self, entries: list[Entry]) -> list[Entry]:
+        return cache.loads(cache.dumps(self.sample(entries))).files[self.RELPATH]
+
+    def test_file_metadata_survives(self) -> None:
+        built = self.sample([make_entry(1, "git status")])
+        self.assertEqual(cache.loads(cache.dumps(built)).meta, built.meta)
+
+    def test_awkward_content_survives(self) -> None:
+        """Tabs, newlines and backslashes need no escaping in this format.
+
+        They do in the *log*, which is tab-separated; the point of choosing
+        separators no field can hold is that this layer escapes nothing.
+        """
+        entries = [
+            make_entry(1, "awk -F'\t' '{print $1}'"),
+            make_entry(2, "printf 'a\nb'"),
+            make_entry(3, "grep -r 'C:\\\\Users' ."),
+            make_entry(4, "echo über 😀 naïve"),
+            make_entry(5, ""),
+        ]
+        self.assertEqual(self.roundtrip(entries), entries)
+
+    def test_a_file_holding_a_separator_is_left_out_rather_than_altered(self) -> None:
+        """Only reachable from a peer's chunk, and it must not desynchronise.
+
+        Stripping the byte was tried first and is worse than it looks: the same
+        command then renders one way from a warm cache and another after a
+        rebuild. A cache is derived, so it must never change what you see.
+        Omitting the file means it is re-parsed every run instead.
+        """
+        built = self.sample([make_entry(1, "echo \x00\x01\x02 marker")])
+        restored = cache.loads(cache.dumps(built))
+        self.assertEqual(restored.files, {})
+        self.assertEqual(restored.meta, {}, "the file must be re-read, so it may keep no metadata")
+
+    def test_one_poisoned_file_does_not_cost_the_others(self) -> None:
+        built = self.sample([make_entry(1, "echo \x00 marker")])
+        built.files["hosts/abc/2026-07-30.tsv"] = [make_entry(2, "git status")]
+        built.meta["hosts/abc/2026-07-30.tsv"] = cache.FileMeta(1, 2, 3, b"")
+        restored = cache.loads(cache.dumps(built))
+        self.assertEqual(list(restored.files), ["hosts/abc/2026-07-30.tsv"])
+
+    def test_a_file_with_no_entries_survives(self) -> None:
+        self.assertEqual(self.roundtrip([]), [])
+
+    def test_repeated_values_are_shared_not_copied(self) -> None:
+        """30% of retained memory on a real history, for no measurable time."""
+        entries = [make_entry(i, f"cmd {i}") for i in range(50)]
+        restored = self.roundtrip(entries)
+        self.assertEqual(len({id(e.cwd) for e in restored}), 1)
+        self.assertEqual(len({id(e.session) for e in restored}), 1)
+
+    def test_a_cache_from_another_version_is_refused(self) -> None:
+        """The version guard, tested where it acts rather than through a rebuild.
+
+        Going through `load_entries` cannot see this: a cache with a stale magic
+        but a current *shape* still parses into the right entries, so the round
+        trip passes whether the check runs or not.
+        """
+        original = cache.Cache()
+        original.files["hosts/abc/2026-07-29.tsv"] = [make_entry(1, "git status")]
+        original.meta["hosts/abc/2026-07-29.tsv"] = cache.FileMeta(0, 0, 0, b"")
+        blob = cache.dumps(original)
+
+        self.assertEqual(cache.loads(blob).files, original.files)
+        for magic in (b"woswoar-cache-1", b"woswoar-cache-99", b"", b"pickle"):
+            with self.subTest(magic=magic), self.assertRaises(ValueError):
+                cache.loads(blob.replace(cache._MAGIC.encode(), magic, 1))
+
+    def test_a_row_missing_a_field_is_refused_not_silently_dropped(self) -> None:
+        """The field-count check, which nothing else catches.
+
+        `map` stops at its shortest argument, so the `strict=True` on the `zip`
+        inside it never fires: without this check a row short of one field
+        would quietly yield fewer entries than the file holds, and a cache that
+        loses history without saying so is worse than one that refuses.
+        """
+        built = self.sample([make_entry(1, "git status"), make_entry(2, "ninja")])
+        blob = cache.dumps(built)
+        self.assertEqual(len(cache.loads(blob).files[self.RELPATH]), 2)
+
+        short = blob[: blob.rindex(b"\x00")]  # drop the final field
+        with self.assertRaises(ValueError):
+            cache.loads(short)
+
+    def test_a_truncated_file_is_refused_rather_than_half_read(self) -> None:
+        original = cache.Cache()
+        original.files["hosts/abc/2026-07-29.tsv"] = [make_entry(1, "git status")]
+        original.meta["hosts/abc/2026-07-29.tsv"] = cache.FileMeta(0, 0, 0, b"")
+        blob = cache.dumps(original)
+        with self.assertRaises((ValueError, IndexError)):
+            cache.loads(blob[: len(blob) // 2])
 
 
 if __name__ == "__main__":

--- a/woswoar/cache.py
+++ b/woswoar/cache.py
@@ -1,7 +1,7 @@
 """Incremental parse cache.
 
 Parsing every log file on every Ctrl-R would be wasteful, so parsed entries are
-pickled and only the *appended* tail of each file is re-read on the next run.
+serialised and only the *appended* tail of each file is re-read on the next run.
 
 Entries are grouped per file rather than kept in one flat list. That costs a
 ``chain.from_iterable`` at read time and buys O(1) invalidation of a single
@@ -10,12 +10,40 @@ lines to one host's log.
 
 The cache is disposable by design: any corruption, version mismatch, or
 unreadable state falls back to a full rebuild rather than raising.
+
+**Not pickle.** This file is read on every Ctrl-R, and unpickling executes
+whatever the file says before any validation can run -- an `isinstance` check
+afterwards is too late. The file is 0600, so this was never a cross-user hole;
+what it did was turn "can write one file under ~/.cache" -- a restored backup, a
+synced dotfiles directory, a sandboxed app with home access -- into running code
+as you, on the hottest path, for a project whose whole posture is a small
+trusted surface. So the format is plain text that a parser reads and a `split`
+cannot execute.
+
+The separators are NUL and the two bytes after it, which no field should
+contain: a command comes from `execve`, whose arguments are NUL-terminated, and
+the rest are timestamps, ids and paths. Nothing is escaped on either side, which
+is most of why a pure-Python parser can keep up with a C one. A file whose
+values do contain a separator -- reachable only from a peer's chunk -- is left
+out of the cache by :func:`dumps` and re-parsed every run instead.
+
+It costs nothing to have done this. Measured on the 52,000-entry history in
+`tests/test_perf.py`, medians of three:
+
+                        pickle      this
+    warm cache load     39.6ms    36.8ms   (budget 50ms)
+    Ctrl-R end to end   86.3ms    86.9ms   (budget 200ms)
+    cold build         109.2ms    74.6ms
+
+Faster to write, and a keypress does not notice. That is not the obvious
+outcome and it is not free: the parse loop in :func:`loads` is written the way
+it is for exactly this reason, and a straightforward per-row list comprehension
+gives about 8ms of it back.
 """
 
 from __future__ import annotations
 
 import hashlib
-import pickle
 from itertools import chain
 from pathlib import Path
 from typing import NamedTuple
@@ -23,7 +51,22 @@ from typing import NamedTuple
 from . import store
 from .entry import Entry, parse_line
 
-CACHE_VERSION = 1
+#: Bump when the on-disk shape changes. Nothing reads the number back out and
+#: branches on it -- there is no migration code and no need for any -- so the
+#: whole first field is simply compared, and a pickle, an empty file or last
+#: year's shape all fail it alike.
+CACHE_VERSION = 2
+_MAGIC = f"woswoar-cache-{CACHE_VERSION}"
+
+#: Field, record and file separators. See the module docstring for why these
+#: three bytes are safe to use unescaped.
+_FIELD = "\x00"
+_RECORD = "\x01"
+_FILE = "\x02"
+
+#: Fields in a record, and in a file's header. Used to check on the way out
+#: that no value smuggled a separator in; see :func:`dumps`.
+_FIELDS_PER_ENTRY = 6
 
 #: Enough of the file head to notice a truncate-and-rewrite that happens to land
 #: on the same size. Only read when size or mtime already indicate a change, so
@@ -32,16 +75,19 @@ _HEAD_BYTES = 256
 
 #: How many freshly parsed entries must accumulate before the cache is rewritten.
 #:
-#: Writing the cache costs ~48 ms on a 52k-entry history, because pickling is
-#: proportional to the whole history rather than to what changed. Saving on
-#: every run would put that on the Ctrl-R path permanently: you always type a
-#: command before you search, so "one new line since last time" is the normal
-#: case, not an edge case -- it measured 42 ms without a save and 98 ms with one.
+#: Writing the cache costs ~16 ms on a 52k-entry history: serialising is
+#: proportional to the whole history rather than to what changed, so it is paid
+#: in full for one new line. And one new line is the normal case, not an edge
+#: case -- you always type a command before you search.
 #:
-#: Skipping the save just means the next run re-parses that tail, at roughly
-#: 2 us per entry. At this threshold the re-parse costs ~4 ms, which buys back
-#: far more than it spends, and the write happens every couple of thousand
-#: commands instead of every single one.
+#: Skipping the save means the next run re-parses that tail instead, at roughly
+#: 2 us per entry. At this threshold the re-parse costs ~4 ms against the 16 ms
+#: it defers, and the write happens every couple of thousand commands rather
+#: than on every single Ctrl-R.
+#:
+#: Both figures were ~48 ms and ~98 ms while this file was a pickle. Changing
+#: the format did not change the mechanism, but it did change the numbers, and
+#: a threshold tuned against a cost that no longer exists is worth re-checking.
 _SAVE_THRESHOLD = 2000
 
 
@@ -65,7 +111,10 @@ class Cache:
     """
 
     def __init__(self) -> None:
-        self.version = CACHE_VERSION
+        #: No `version` attribute: the version lives in the file's first field,
+        #: where it is checked before anything is built. Carrying it on the
+        #: object as well meant a stale cache could be constructed and only
+        #: then rejected, and left two things to keep in step.
         self.files: dict[str, list[Entry]] = {}
         self.meta: dict[str, FileMeta] = {}
         #: Entries parsed since the last write. Not persisted as a live count --
@@ -101,28 +150,108 @@ def _read_from(path: Path, host: str, offset: int) -> tuple[list[Entry], int]:
     return entries, new_offset
 
 
+def dumps(cache: Cache) -> bytes:
+    """Serialise `cache`. See the module docstring for the format."""
+    parts = [_MAGIC]
+    for relpath, entries in cache.files.items():
+        meta = cache.meta[relpath]
+        host = entries[0].host if entries else ""
+        rows = [
+            _FIELD.join((str(e.ts), e.session, e.cwd, str(e.exit_code), str(e.duration_ms), e.cmd))
+            for e in entries
+        ]
+        header = _FIELD.join(
+            (relpath, host, str(meta.size), str(meta.mtime_ns), str(meta.offset), meta.head.hex())
+        )
+        chunk = _RECORD.join([header, *rows])
+
+        # A value that contains a separator would shift every field after it.
+        # Only reachable from a peer's chunk, and counted rather than scanned
+        # per field: two `str.count` calls over the whole chunk cost less than
+        # six membership tests per entry.
+        #
+        # The file is left out of the cache rather than repaired. Stripping the
+        # byte was tried and rejected: it made the same command render one way
+        # from a warm cache and another after a rebuild, and a derived artefact
+        # must never change what you see. Omitted, the file is simply re-parsed
+        # every run -- correct, self-healing, and costing one file's parse on a
+        # history that should never contain one.
+        expected_fields = (len(entries) + 1) * (_FIELDS_PER_ENTRY - 1)
+        if (
+            chunk.count(_FIELD) != expected_fields
+            or chunk.count(_RECORD) != len(entries)
+            or _FILE in chunk
+        ):
+            continue
+        parts.append(chunk)
+    return _FILE.join(parts).encode("utf-8")
+
+
+def loads(blob: bytes) -> Cache:
+    """Parse what :func:`dumps` wrote, or raise.
+
+    Every failure mode -- wrong magic, a short record, a field that is not a
+    number, invalid UTF-8 -- comes out as an exception. Nothing here can execute
+    what it reads.
+
+    The shape of the loop is load-bearing, not style. Splitting each file's
+    body once and striding the flat list, then building entries with
+    ``tuple.__new__`` through ``zip``, keeps the whole thing in C: it measured
+    29ms against 37ms for the obvious per-row list comprehension, which is the
+    difference between matching pickle and losing to it.
+    """
+    chunks = blob.decode("utf-8").split(_FILE)
+    if chunks[0] != _MAGIC:
+        raise ValueError("not a woswoar cache of this version")
+
+    cache = Cache()
+    # `session` and `cwd` repeat enormously -- a few dozen sessions and a
+    # handful of directories across a whole history -- so equal values are
+    # shared rather than allocated per entry. Measured on 52,000 entries: no
+    # difference in time, and 30% less memory retained. One table for the whole
+    # file, because the same values recur across days.
+    shared: dict[str, str] = {}
+    share = shared.setdefault
+    for chunk in chunks[1:]:
+        header, _, body = chunk.partition(_RECORD)
+        relpath, host, size, mtime_ns, offset, head = header.split(_FIELD)
+        cache.meta[relpath] = FileMeta(
+            size=int(size), mtime_ns=int(mtime_ns), offset=int(offset), head=bytes.fromhex(head)
+        )
+        if not body:
+            cache.files[relpath] = []
+            continue
+
+        flat = body.replace(_RECORD, _FIELD).split(_FIELD)
+        count, remainder = divmod(len(flat), _FIELDS_PER_ENTRY)
+        if remainder:
+            raise ValueError(f"{relpath}: {len(flat)} fields is not a whole number of entries")
+        cache.files[relpath] = list(
+            map(
+                tuple.__new__,
+                (Entry,) * count,
+                zip(
+                    map(int, flat[0::6]),
+                    (host,) * count,
+                    map(share, flat[1::6], flat[1::6]),
+                    map(share, flat[2::6], flat[2::6]),
+                    map(int, flat[3::6]),
+                    map(int, flat[4::6]),
+                    flat[5::6],
+                    strict=True,
+                ),
+            )
+        )
+    return cache
+
+
 def load() -> Cache:
     """Read the cache from disk, or return an empty one."""
-    path = store.cache_file()
     try:
-        with path.open("rb") as handle:
-            data = pickle.load(handle)
-    except (OSError, pickle.UnpicklingError, EOFError, AttributeError, ValueError):
+        return loads(store.cache_file().read_bytes())
+    # UnicodeDecodeError is a ValueError, so it needs no entry of its own.
+    except (OSError, ValueError, IndexError):
         return Cache()
-
-    if not isinstance(data, Cache) or data.version != CACHE_VERSION:
-        return Cache()
-
-    # Right class and right version is not the same as right *shape*. Pickle
-    # restores __dict__ directly and never runs __init__, so a file written by
-    # a build whose Cache had one attribute fewer unpickles cleanly here and
-    # then raises AttributeError deep inside refresh() -- on the Ctrl-R path,
-    # for a file this module promises is disposable. Found in the wild: a
-    # cache predating `unsaved` crashed `woswoar doctor` outright.
-    fresh = Cache()
-    if data.__dict__.keys() != fresh.__dict__.keys():
-        return fresh
-    return data
 
 
 def refresh(cache: Cache) -> bool:
@@ -174,9 +303,7 @@ def save(cache: Cache) -> None:
     """Persist the cache. Failures are non-fatal -- it is a disposable artefact."""
     cache.unsaved = 0
     try:
-        store.write_atomic(
-            store.cache_file(), pickle.dumps(cache, protocol=pickle.HIGHEST_PROTOCOL)
-        )
+        store.write_atomic(store.cache_file(), dumps(cache))
     except OSError:
         return
 

--- a/woswoar/entry.py
+++ b/woswoar/entry.py
@@ -51,7 +51,8 @@ class Entry(NamedTuple):
     """One recorded command.
 
     A ``NamedTuple`` rather than a ``dataclass(slots=True)``: identical
-    attribute access, but materially cheaper to pickle and unpickle, which
+    attribute access, but a plain tuple underneath, so the cache can build
+    52,000 of them with ``tuple.__new__`` and never run Python per field. That
     matters because the whole history is loaded on every Ctrl-R.
     """
 

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -77,7 +77,8 @@ def cache_dir() -> Path:
 
 
 def cache_file() -> Path:
-    return cache_dir() / "cache.pickle"
+    """The parse cache. Not a pickle: see the note in :mod:`woswoar.cache`."""
+    return cache_dir() / "cache.txt"
 
 
 def logs_dir() -> Path:


### PR DESCRIPTION
Closes #21.

## The bug

`cache.load()` unpickled `~/.cache/woswoar/cache.pickle` on **every keypress**.
`pickle.load` runs `__reduce__` before anything comes back, so the
`isinstance(data, Cache)` guard after it was decoration.

The file is `0600`, so this was never a cross-user hole. What it was is the step
from *"something can write one file in your home directory"* — a restored
backup, a synced dotfiles directory, a sandboxed app with home access — to
*"something runs as you"*, on the hottest path, in a project whose whole posture
is a small trusted surface.

## The fix

Plain text that a `split` cannot execute. Separated by NUL and the two bytes
after it, which no field can hold — a command comes from `execve`, whose
arguments are NUL-terminated — so **nothing is escaped on either side**.

## It costs nothing

Medians of three, on the 52,000-entry history in `tests/test_perf.py`:

| | pickle | this | |
|---|---|---|---|
| warm cache load | 39.6 ms | **36.8 ms** | budget 50 ms |
| Ctrl-R end to end | 86.3 ms | 86.9 ms | budget 200 ms |
| cold build | 109.2 ms | **74.6 ms** | |

That was **not** the first result. My version was +8 ms on a keypress, and I had
written the docstring explaining why that was an acceptable price. The
`/simplify` efficiency pass found the shape that closes it: split each file's
body once, stride the flat list, and build entries with `tuple.__new__` through
`zip`, so the loop never runs Python per field. 36 % faster than the obvious
list comprehension, and the reason the trade-off paragraph is gone.

I also had my own benchmark wrong at one point — `git stash` only removes
*uncommitted* work, so after committing on this branch both sides of a
"main vs branch" comparison were measuring the branch. The numbers above are
from a real `git checkout main`.

## Two things review changed rather than polished

**A stripped separator made display depend on cache warmth.** My first version
removed the byte on the way out, so the same command rendered one way from a
warm cache and another after a rebuild. A derived artefact must never change
what you see. The file is now left out of the cache entirely and re-parsed each
run — lossless, self-healing, and free on any history that never contains one.

**The field-count check earns its place.** `map` stops at its shortest argument,
so the `strict=True` on the `zip` inside it never fires. Without the check, a row
short of one field silently yields fewer entries than the file holds — a cache
that loses history without saying so. There is now a test that removes exactly
one field and asserts the refusal.

## Also

`_SAVE_THRESHOLD`'s rationale still measured pickling (~48 ms, ~98 ms). The
mechanism didn't change when the format did; the numbers did, and a threshold
tuned against a cost that no longer exists should say so. Re-measured at ~16 ms.

`docs/security.md` gains a row, and its broader claim — that no on-disk format
woswoar reads can execute code — is now **asserted, not just written**: a test
refuses any import of `pickle`, `marshal`, `shelve` or `yaml` anywhere in the
package. Per CLAUDE.md, that claim was prose before.

Per rule 8 there is no migration: an old `cache.pickle` fails the magic check,
costs one rebuild, and the file is renamed `cache.txt` since it is no longer a
pickle.

## Verification

- **10 mutations, all killing their guarding test** — including reinstating
  `pickle.loads`, dropping the magic check, caching a poisoned file, and the
  short-row case above.
- The exploit test writes a live `__reduce__` payload, **sanity-checks that it
  does fire when unpickled directly** so it cannot rot into decoration, then
  asserts the witness never appears through `load_entries`.
- 4 clean full runs; `ruff`, `ruff format --check`, `mypy --strict`, `shellcheck`.

## Considered and rejected, with numbers

`json` is stdlib and non-executing and would have been the simpler call — it
measured **35.4 ms against 29.5 ms** for this format with the same fast rebuild,
i.e. slower than the pickle it replaces, and 3.4 MB against 2.6 MB. `sqlite3`
was 57.8 ms and 6.2 MB.

The altitude pass raised a fair question I am **not** answering here: the whole
cache buys ~24 ms over re-parsing the logs outright, and deleting it would
remove ~300 lines plus this issue. That is a design decision above this diff —
say the word and I will file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)