### PR TITLE
Keep the hook's scratch file out of any directory a stranger can write

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -239,6 +239,7 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | A recalled command is one command | control characters never survive from the picker into the shell buffer |
 | The repo does not blow up | a simulated multi-day, multi-machine run is measured after `git gc` |
 | History is never readable by others | every path woswoar creates is walked under a stock `umask 022`, on both the Python and the shell-hook side |
+| The hook's scratch file is never in a directory another user can write | `TMPDIR` and `/tmp` are never consulted; an `XDG_RUNTIME_DIR` this user cannot write falls back to woswoar's own `0700` tree instead of switching recording off |
 | The cache cannot execute | a pickle that would run code on load is written to the cache path; it is refused and a witness file never appears |
 | Search stays fast | latency measured on 52,000 entries |
 

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -18,6 +18,7 @@ import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from typing import ClassVar
 
 from woswoar import cache, store
 from woswoar.entry import MAX_CMD_CHARS, TRUNCATION_MARKER, Entry, escape, unescape
@@ -65,9 +66,13 @@ requires_bash5 = unittest.skipUnless(bash_major() >= 5, "bash 5.0+ required")
 
 
 class ShellHookTestCase(WoswoarTestCase):
+    def runtime_dir(self) -> Path:
+        """Where XDG_RUNTIME_DIR points for these runs."""
+        return self.root / "run"
+
     def shell_env(self, extra: dict[str, str] | None = None) -> dict[str, str]:
         """A minimal environment pointing the hook at this test's sandbox."""
-        runtime = self.root / "run"
+        runtime = self.runtime_dir()
         runtime.mkdir(exist_ok=True)
         env = {
             "HOME": str(self.root),
@@ -105,6 +110,13 @@ class ShellHookTestCase(WoswoarTestCase):
             timeout=60,
         )
         return result.stdout
+
+    def shell_value(self, expr: str, env_extra: dict[str, str] | None = None) -> str:
+        """Run the hook, then print one shell expression and read it back."""
+        out = self.run_shell(f'printf "VALUE %s\\n" {expr}\n', env_extra)
+        match = re.search(r"^VALUE (.*)$", out, re.MULTILINE)
+        assert match is not None, f"the shell printed no value:\n{out}"
+        return match.group(1)
 
     def recorded(self) -> list[Entry]:
         """Every entry the hook wrote, oldest first.
@@ -596,13 +608,13 @@ class TestConstantParity(unittest.TestCase):
 class TestForkFree(ShellHookTestCase):
     """Recording runs on every prompt, so its cost must not scale with usage."""
 
-    def clone_count(self, command_count: int) -> int:
+    def clone_count(self, command_count: int, env_extra: dict[str, str] | None = None) -> int:
         script = "".join(f"echo cmd{i}\n" for i in range(command_count))
         proc = subprocess.run(
             ["strace", "-f", "-c", "-e", "trace=clone,clone3,vfork,fork", "bash", "--norc", "-i"],
             input=f"source {HOOK}\n{script}",
             text=True,
-            env=self.shell_env(),
+            env=self.shell_env(env_extra),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
             check=False,
@@ -619,13 +631,18 @@ class TestForkFree(ShellHookTestCase):
         # Not "zero forks": startup legitimately runs mkdir and one `trap -p`
         # subshell. What matters is that the per-command path adds nothing, so
         # the count must be identical for 3 and for 30 commands.
-        few = self.clone_count(3)
-        many = self.clone_count(30)
-        self.assertEqual(
-            few,
-            many,
-            f"record path forks: {few} clones for 3 commands, {many} for 30",
-        )
+        #
+        # Both scratch-file branches, because they are chosen at startup and a
+        # fork added to either would be paid on every command of that shell.
+        for label, env in (("runtime dir", None), ("fallback", {"XDG_RUNTIME_DIR": ""})):
+            with self.subTest(scratch=label):
+                few = self.clone_count(3, env)
+                many = self.clone_count(30, env)
+                self.assertEqual(
+                    few,
+                    many,
+                    f"record path forks: {few} clones for 3 commands, {many} for 30",
+                )
 
 
 @requires_bash5
@@ -663,6 +680,79 @@ class TestRecordingIsPrivate(ShellHookTestCase):
         """
         out = self.run_shell("echo start\numask\n")
         self.assertIn("0022", out)
+
+
+@requires_bash5
+class TestTheScratchFileIsPrivate(ShellHookTestCase):
+    """Issue #24: the scratch file's directory decides who can touch it.
+
+    Its contents are read back and, at the first prompt, `eval`ed to chain onto
+    an existing DEBUG trap. That is only safe while nobody else can write it, so
+    what is pinned here is the *directory*, not the filename.
+    """
+
+    HOSTILE: ClassVar[dict[str, str]] = {
+        "XDG_RUNTIME_DIR": "",
+        "TMPDIR": "/nonexistent/hostile",
+    }
+
+    def scratch(self, env_extra: dict[str, str] | None = None) -> str:
+        return self.shell_value('"$__woswoar_scratch"', env_extra)
+
+    def test_it_lives_in_the_runtime_dir_when_there_is_one(self) -> None:
+        self.assertTrue(self.scratch().startswith(str(self.runtime_dir())))
+
+    def test_tmpdir_and_tmp_are_never_consulted(self) -> None:
+        """A predictable name in a world-writable directory is the whole bug.
+
+        The TMPDIR here is perfectly usable, which is the point: an unusable one
+        would prove nothing, because the fallback below would rescue it and the
+        scratch file would land in the right place for the wrong reason.
+        """
+        usable = self.root / "tmpdir"
+        usable.mkdir(exist_ok=True)
+        env = {"XDG_RUNTIME_DIR": "", "TMPDIR": str(usable)}
+
+        path = self.scratch(env)
+        self.assertFalse(path.startswith(str(usable)), f"TMPDIR was consulted: {path}")
+        self.assertTrue(path.startswith(os.environ["WOSWOAR_DIR"]))
+        self.assertEqual(list(usable.iterdir()), [], "the hook wrote into TMPDIR")
+
+        self.run_shell("echo still-recording\n", env_extra=env)
+        self.assertIn("echo still-recording", self.commands())
+
+    def test_an_unwritable_runtime_dir_falls_back_instead_of_giving_up(self) -> None:
+        """XDG_RUNTIME_DIR is inherited, not verified.
+
+        `su` hands over the calling user's, which this uid cannot write. Bailing
+        there switched recording off for the whole shell with no message -- the
+        same silent failure as a squatted /tmp path, reached from the other end.
+        """
+        unwritable = self.root / "unwritable"
+        unwritable.mkdir(exist_ok=True)
+        unwritable.chmod(0o500)
+        self.addCleanup(unwritable.chmod, 0o700)
+
+        env = {"XDG_RUNTIME_DIR": str(unwritable)}
+        self.assertTrue(self.scratch(env).startswith(os.environ["WOSWOAR_DIR"]))
+
+        self.run_shell("echo still-recording\n", env_extra=env)
+        self.assertIn("echo still-recording", self.commands())
+
+    def test_the_file_and_its_directory_are_owner_only(self) -> None:
+        """Stats from Python, not `stat -c`, which is GNU-only.
+
+        `before` gives the EXIT trap away, so the hook declines to claim it and
+        the file outlives the shell -- which is also the case that leaves one
+        behind, and the reason it lives in `run/` rather than the tree root.
+        """
+        self.run_shell("echo hello\n", env_extra=self.HOSTILE, before="trap ':' EXIT")
+
+        run_dir = Path(os.environ["WOSWOAR_DIR"]) / "run"
+        left = list(run_dir.glob("woswoar-hist.*"))
+        self.assertTrue(left, "no scratch file survived, so this asserts nothing")
+        self.assertEqual(left[0].stat().st_mode & 0o077, 0, "readable by others")
+        self.assertEqual(run_dir.stat().st_mode & 0o077, 0, "its directory is reachable")
 
 
 if __name__ == "__main__":

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -55,13 +55,38 @@ __woswoar_logdir=$__woswoar_dir/logs/hosts/$__woswoar_id
 # Only creation happens here. Re-tightening a tree from an older woswoar is
 # `woswoar install`'s job: a recursive chmod is proportional to the number of
 # days recorded, and this runs on every interactive shell.
-(umask 077 && mkdir -p "$__woswoar_logdir") 2>/dev/null || return 0
+#: Per-shell scratch, kept out of the data directory's root so that a file left
+#: behind by a shell whose EXIT trap was already taken is contained and obvious.
+__woswoar_run=$__woswoar_dir/run
+(umask 077 && mkdir -p "$__woswoar_logdir" "$__woswoar_run") 2>/dev/null || return 0
 
-# Scratch file for capturing `history 1`. Prefer XDG_RUNTIME_DIR: it is a
-# per-user tmpfs that systemd clears at logout, so a shell killed with -9 cannot
-# leave the last command lying around in /tmp.
-__woswoar_scratch=${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/woswoar-hist.$$
-(umask 077 && : >"$__woswoar_scratch") 2>/dev/null || return 0
+# Scratch file for capturing `history 1`, always in a directory only this user
+# can write. $TMPDIR and /tmp are never used: the name is just a pid, so in a
+# world-writable directory a stranger can pre-create it, and then either the
+# create below fails (recording silently off) or -- without
+# fs.protected_regular -- their mode-666 file survives our O_TRUNC, because
+# truncating changes neither owner nor mode, and they read every command. See
+# issue #24; both need a directory a stranger can write in.
+#
+# Not `mktemp`: it costs an exec in every interactive shell, and once the
+# directory is ours an unpredictable name buys nothing.
+#
+# XDG_RUNTIME_DIR is preferred but not trusted. It is a per-user 0700 tmpfs that
+# systemd clears at logout, so a shell killed with -9 leaves nothing at all --
+# and it is also just an inherited variable. `su` passes on the *calling* user's,
+# which this uid cannot write, and returning there would switch recording off
+# for the whole shell without a word: the very failure above, from the other
+# direction. So a failure falls back rather than gives up.
+#
+# The fallback is disk-backed where a runtime dir is tmpfs, and the capture step
+# reads and writes this file on every command. Measured on btrfs: 306us per
+# command with a runtime dir, 339us without. Accepted -- it only applies to
+# shells that have no XDG_RUNTIME_DIR at all, and 33us is not a keypress.
+__woswoar_scratch=${XDG_RUNTIME_DIR:-$__woswoar_run}/woswoar-hist.$$
+if ! (umask 077 && : >"$__woswoar_scratch") 2>/dev/null; then
+    __woswoar_scratch=$__woswoar_run/woswoar-hist.$$
+    (umask 077 && : >"$__woswoar_scratch") 2>/dev/null || return 0
+fi
 
 # Only claim the EXIT trap if nothing else owns it; clobbering a user's trap
 # would be a far worse bug than leaving one scratch file behind.


### PR DESCRIPTION
Closes #24.

## The bug

The scratch path was `${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/woswoar-hist.$$`, and
its contents are read back and `eval`'d at the first prompt to chain onto an
existing DEBUG trap.

With neither variable set — `su`, cron, some ssh and container setups — that is
`/tmp/woswoar-hist.<pid>`, keyed on a pid, in a world-writable directory:

- **Squat it** and our `: >` fails; the `|| return 0` after it switches recording
  off for that shell **with no message**.
- **On a kernel without `fs.protected_regular`**, pre-create it mode 666 and it
  survives our `O_TRUNC` — truncating changes neither owner nor mode — so every
  captured command is readable.

## The fix, and why not the one the issue suggested

Both attacks need a directory a stranger can write in. `mktemp` and `O_EXCL`
make the *name* harder to guess in a directory that is still shared; this removes
the shared directory instead — `XDG_RUNTIME_DIR`, else a `run/` directory under
woswoar's own `0700` tree, which already holds the entire plaintext history. It
also costs no exec at every interactive shell start.

## Review caught that my first version was half a fix

I hardened only the fallback. `XDG_RUNTIME_DIR` is an inherited variable, not a
fact — **`su` passes on the calling user's**, which this uid cannot write, and
the same `|| return 0` produced the same silent failure the issue is about. I
reproduced it in a real shell before fixing:

```
SCRATCH=[/tmp/dostest/badrun/woswoar-hist.579814]
NOTHING RECORDED — the DoS reproduces on the XDG_RUNTIME_DIR branch
```

A failed create now falls back rather than gives up, on **either** branch.

## And that moving the file has a cost I had not accounted for

`run/` rather than the tree root, because leaving `/tmp` also left the reach of
anything that reaps `/tmp`. A shell whose EXIT trap is already owned by a prompt
framework leaves its scratch file behind, and those now accumulate somewhere
permanent. Contained here, and **filed as #58**.

The fallback is also disk-backed where a runtime dir is tmpfs, and the capture
step touches this file on every command. Measured on btrfs, independently of the
review that raised it:

| | µs/command |
|---|---|
| with `XDG_RUNTIME_DIR` (tmpfs) | 306 |
| fallback (data dir, disk) | 339 |

Accepted — it only applies to shells with no runtime dir at all — and written
down next to the line rather than left for someone to rediscover.

## Verification

- **6 mutations, all killing their guarding test.** One survived the first round
  and was worth the round trip: my "hostile TMPDIR" test used an *unusable*
  TMPDIR, so the new fallback rescued it and the scratch file landed in the right
  place for the wrong reason. It now uses a perfectly writable TMPDIR and asserts
  nothing is written there.
- The fork-free CI guard now runs over **both** scratch-file branches — it only
  ever exercised the runtime-dir one, so a fork added to the fallback would not
  have been caught.
- `ruff`, `ruff format --check`, `mypy --strict`, `shellcheck`, 3 clean full runs.

## Scope

The `eval` is untouched. It was a hole because another user could write its
input; it no longer is. Retiring the file as its transport is a real improvement
— `trap -p DEBUG` works inside a command substitution in a `PROMPT_COMMAND`
string, verified during review — but it is a separate change to the boot
mechanism, and it is **#57**.

### One thing to clean up

A review agent's benchmark ran an interactive bash that inherited your real
`$HOME`, so about five lines of its scratch commands are now at the end of your
`~/.bash_history` (`: hello world`, `raw=${ HISTTIMEFORMAT='' history 1; }` and
similar). Nothing else outside `/tmp` was written. I have not edited your history
file — say the word and I will remove them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)