### PR TITLE
Refuse to publish to a day key whose sealed half has gone

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -228,6 +228,7 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | Forged history is refused | a chunk sealed to a host's published day key, but absent from that host's signed manifest, is rejected and reported |
 | The repo names no machine | every committed byte is searched for the username and hostname; a leaked archive says how many machines there are, not which |
 | Tampering is refused | flipping one byte of a real chunk fails authentication, not merely decryption |
+| A day whose sealed key is gone is refused, not written over | deleting one and syncing publishes nothing further for that day and says so, rather than adding chunks no machine could ever read |
 | A chunk cannot exhaust a peer | a chunk that unpacks past the cap is refused and reported, and the peak allocation is measured to stay bounded rather than the payload being materialised first |
 | A revoked machine cannot publish | it keeps its signing key and its old manifests, signs a chunk with them, pushes -- and a third machine accepts none of it |
 | Nor under another machine's name | the same, written into a peer's host directory, where that peer never looks |

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2254,5 +2254,220 @@ class TestRecipientsPublishNoNames(SyncTestCase):
         self.assertNotIn(sync._LABEL_SEP, written)
 
 
+class TestAnOrphanedDayKey(SyncTestCase):
+    """Issue #42: a public day key whose sealed half has gone.
+
+    `sync.orphaned_day_key` explains the state. What these pin is that it is
+    reachable by a stranger rather than only by bad luck, and that reaching it
+    costs the day's future history rather than passing unnoticed.
+    """
+
+    def test_a_peer_can_delete_another_machines_sealed_key(self) -> None:
+        """The reachability the priority rests on, through a real bare repo."""
+        alpha, beta = self.machine("alpha"), self.machine("beta")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "ours")
+            sync.run()
+        with beta.active():
+            sync.run()
+        self.accept_everyone(alpha)
+        self.accept_everyone(beta)
+
+        with beta.active():
+            sync.run()
+            victim = store.day_key(alpha.id, "2023-11-14")
+            self.assertTrue(victim.is_file(), "beta cannot even see the key; premise is wrong")
+            victim.unlink()
+            sync._commit()
+            sync._push()
+
+        with alpha.active():
+            sync.run()
+            self.assertFalse(store.day_key(alpha.id, "2023-11-14").is_file())
+            self.assertTrue(store.day_key_public(alpha.id, "2023-11-14").is_file())
+
+        # What was published before the deletion is still readable by a machine
+        # that had already merged it. That is what makes "copy the key back from
+        # another clone" real advice rather than wishful.
+        with beta.active():
+            sync.run()
+            self.assertIn("ours", beta.commands())
+
+    def test_nothing_more_is_written_for_a_day_whose_key_is_gone(self) -> None:
+        """The bug: sync used to mint over the top and report success."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "before")
+            sync.run()
+            before = {c.name for c in store.iter_chunks(alpha.id)}
+
+            store.day_key(alpha.id, "2023-11-14").unlink()
+            alpha.record("2023-11-14", 1_700_000_002, "after")
+            report = sync.run()
+
+            self.assertEqual(report.chunks_written, 0)
+            self.assertEqual(report.orphaned, {"2023-11-14"})
+            self.assertEqual({c.name for c in store.iter_chunks(alpha.id)}, before)
+
+    def test_the_lines_stay_pending_rather_than_being_lost(self) -> None:
+        """Refusing must not consume them: `logs/` is the only copy left."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "before")
+            sync.run()
+            sealed = store.day_key(alpha.id, "2023-11-14").read_bytes()
+            store.day_key(alpha.id, "2023-11-14").unlink()
+            alpha.record("2023-11-14", 1_700_000_002, "after")
+            sync.run()
+
+            # Put the sealed half back, which is what copying it from another
+            # clone amounts to, and the pending line publishes on the next
+            # ordinary sync.
+            store.write_atomic(store.day_key(alpha.id, "2023-11-14"), sealed)
+            report = sync.run()
+            self.assertEqual(report.orphaned, set())
+            self.assertGreater(report.chunks_written, 0)
+
+    def test_a_day_with_no_chunks_yet_simply_mints_a_new_key(self) -> None:
+        """Half-written pairs are ordinary; only chunks make them unrecoverable."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            # A real key, not a malformed one: a bad recipient would make age
+            # fail loudly and the test would pass for the wrong reason. This is
+            # the silent case -- a usable public half whose secret is gone.
+            stale = crypto.generate_identity()
+            pub = store.day_key_public(alpha.id, "2023-11-14")
+            pub.parent.mkdir(parents=True, exist_ok=True)
+            pub.write_text(stale.public + "\n", encoding="utf-8")
+
+            alpha.record("2023-11-14", 1_700_000_001, "first")
+            report = sync.run()
+
+            self.assertEqual(report.orphaned, set())
+            self.assertEqual(report.chunks_written, 1)
+            self.assertTrue(store.day_key(alpha.id, "2023-11-14").is_file())
+            self.assertNotEqual(
+                pub.read_text(encoding="utf-8").strip(),
+                stale.public,
+                "the stale public half was reused, so the chunk is already lost",
+            )
+
+    def test_an_interrupted_mint_leaves_the_recoverable_half(self) -> None:
+        """Ordering is the guarantee: sealed half first, public half second.
+
+        Written the other way round, a crash between the two produces exactly
+        the state this whole class is about, from woswoar's own hand rather than
+        a stranger's. This way the crash window leaves a sealed key with no
+        public half, which is simply re-minted.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "first")
+            real = store.write_atomic
+            calls: list[Path] = []
+
+            def die_after_first(path: Path, data: bytes) -> None:
+                calls.append(path)
+                if len(calls) > 1:
+                    raise OSError("interrupted between the two writes")
+                real(path, data)
+
+            with (
+                mock.patch.object(store, "write_atomic", die_after_first),
+                self.assertRaises(OSError),
+            ):
+                sync.day_public_key(store.machine(), "2023-11-14")
+
+            self.assertTrue(store.day_key(alpha.id, "2023-11-14").is_file(), "sealed half missing")
+            self.assertFalse(store.day_key_public(alpha.id, "2023-11-14").is_file())
+            self.assertFalse(
+                sync.orphaned_day_key(alpha.id, "2023-11-14"),
+                "an interrupted mint produced the destructive state",
+            )
+
+    def test_sync_says_which_day_it_refused(self) -> None:
+        """The refusal is only useful if the user is told. Through the CLI.
+
+        `Report.orphaned` is an internal field; what `docs/security.md` claims
+        is that woswoar *says so*, and only stderr proves that.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "before")
+            sync.run()
+            store.day_key(alpha.id, "2023-11-14").unlink()
+            alpha.record("2023-11-14", 1_700_000_002, "after")
+
+            errors = io.StringIO()
+            with redirect_stderr(errors), redirect_stdout(io.StringIO()):
+                main(["sync"])
+
+        said = errors.getvalue()
+        self.assertIn("2023-11-14", said)
+        self.assertIn("cannot be published", said)
+        # The recovery it offers has to be the one that works: the deleted key
+        # is still a blob in git, because woswoar never rewrites history.
+        self.assertIn("--diff-filter=D", said)
+
+    def test_doctor_is_quiet_about_a_half_written_pair_with_no_chunks(self) -> None:
+        """No chunks means nothing is lost, and the next sync mints over it.
+
+        Reporting it would be a hard red for a state that heals itself, and the
+        sentence doctor prints -- "chunks encrypted to them cannot be read" --
+        would be false. `export` and `orphaned_days` have to agree on that, and
+        they drifted apart once already.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "ours")
+            sync.run()
+
+            pub = store.day_key_public(alpha.id, "2099-01-01")
+            pub.parent.mkdir(parents=True, exist_ok=True)
+            pub.write_text(crypto.generate_identity().public + "\n", encoding="utf-8")
+
+            self.assertEqual(sync.orphaned_days(), [])
+            _, text = self.run_cli(alpha, "doctor")
+            self.assertIn("[ok] day keys", text)
+
+    def test_compact_skips_the_day_rather_than_aborting(self) -> None:
+        """One unreadable day used to leave every later day uncompacted."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            for day in ("2023-11-14", "2023-11-15"):
+                for i in range(2):
+                    alpha.record(day, 1_700_000_001 + i, f"{day}-{i}")
+                    sync.run()
+            store.day_key(alpha.id, "2023-11-14").unlink()
+
+            days, replaced = sync.compact(before="2023-12-01")
+
+            self.assertEqual(days, 1, "the healthy day was not compacted")
+            self.assertGreater(replaced, 0)
+            self.assertGreater(
+                len(list(store.chunk_dir(alpha.id, "2023-11-14").iterdir())),
+                1,
+                "the unreadable day was touched",
+            )
+
+    def test_doctor_finds_it_before_more_chunks_pile_up(self) -> None:
+        """Through the command, not the helper: the formatting is the fiddly part."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "ours")
+            sync.run()
+            self.assertEqual(sync.orphaned_days(), [])
+            code, healthy = self.run_cli(alpha, "doctor")
+            self.assertIn("[ok] day keys", healthy)
+
+            store.day_key(alpha.id, "2023-11-14").unlink()
+            self.assertEqual(sync.orphaned_days(), [(alpha.id, "2023-11-14")])
+
+            code, text = self.run_cli(alpha, "doctor")
+            self.assertEqual(code, 1, "doctor stayed green with an unreadable day")
+            self.assertIn("[FAIL] day keys", text)
+            self.assertIn("2023-11-14", text)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -288,6 +288,19 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
         trust = sync.trust_status(store.machine())
         check("trust", trust.ok, trust.detail)
+
+        # A listing, no decryption, so it is cheap enough to do every time --
+        # and the state is otherwise silent, which is the whole problem with it.
+        orphaned = sync.orphaned_days()
+        if orphaned:
+            host, day = orphaned[0]
+            detail = (
+                f"{len(orphaned)} sealed key(s) missing, e.g. {host[:8]}/{day}"
+                " - chunks encrypted to them cannot be read by any machine"
+            )
+        else:
+            detail = "all sealed"
+        check("day keys", not orphaned, detail)
     else:
         info("sync", "no history repo - run 'woswoar init <url>' to sync machines")
 
@@ -421,6 +434,26 @@ def cmd_sync(args: argparse.Namespace) -> int:
             "would disown everything it published earlier on those days.\n"
             "If this machine's signing key was replaced, that is why: days it signed\n"
             "with the old one stay as they are, and new days publish normally.",
+            file=sys.stderr,
+        )
+
+    if report.orphaned:
+        lost = ", ".join(sorted(report.orphaned))
+        print(
+            f"\nWARNING: {len(report.orphaned)} day(s) of this machine's own history\n"
+            f"cannot be published: {lost}\n"
+            "Their sealed key is missing from the repository while chunks encrypted to\n"
+            "it are still there. Those chunks are unreadable by every machine, and a\n"
+            "new key would not change that -- so nothing more is written for those\n"
+            "days rather than adding chunks nobody will ever read.\n"
+            "The commands themselves are still in this machine's own logs, and the\n"
+            "deleted key is still in git history -- woswoar never rewrites it, so\n"
+            "every clone has the blob. To put it back:\n"
+            "    git -C <history> log --diff-filter=D -- hosts/<id>/keys/<day>.age\n"
+            "    git -C <history> show <commit>^:hosts/<id>/keys/<day>.age > that path\n"
+            "'woswoar doctor' prints the host id and day. If it really is gone, delete\n"
+            "keys/<day>.pub to write the day off: the old chunks stay unreadable, but\n"
+            "this machine starts a new key and publishes again.",
             file=sys.stderr,
         )
 

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -27,6 +27,7 @@ _KEYS = "keys"
 _MANIFESTS = "manifests"
 _LOG_SUFFIX = ".tsv"
 _CHUNK_SUFFIX = ".age"
+_PUB_SUFFIX = ".pub"
 _NAME_FILE = ".name"
 
 RECIPIENTS = "recipients.txt"
@@ -495,7 +496,7 @@ def day_key_public(machine_id: str, day: str) -> Path:
     Public keys are not secret, and keeping this alongside means writing a chunk
     never has to open the sealed key first.
     """
-    return repo_host_dir(machine_id) / _KEYS / f"{day}.pub"
+    return repo_host_dir(machine_id) / _KEYS / f"{day}{_PUB_SUFFIX}"
 
 
 def chunk_dir(machine_id: str, day: str) -> Path:
@@ -570,6 +571,31 @@ def iter_day_keys(machine_id: str) -> Iterator[Path]:
     if not keys.is_dir():
         return
     yield from sorted(keys.glob(f"*{_CHUNK_SUFFIX}"))
+
+
+def day_key_days(machine_id: str) -> tuple[set[str], set[str]]:
+    """``(sealed, public)`` day strings for one host, from a single listing.
+
+    One readdir rather than a `glob` plus a stat per key: the caller asks this
+    for every host in the repo, so the cost grows with the archive forever --
+    measured on a two-year, five-machine tree, 1.9ms against 36ms.
+
+    Both sets from one pass because the only question worth asking is how they
+    differ, and pulling them apart is what let two callers drift over whether a
+    missing sealed half mattered.
+    """
+    sealed: set[str] = set()
+    public: set[str] = set()
+    try:
+        names = os.listdir(repo_host_dir(machine_id) / _KEYS)
+    except OSError:
+        return sealed, public
+    for name in names:
+        if name.endswith(_CHUNK_SUFFIX):
+            sealed.add(name.removesuffix(_CHUNK_SUFFIX))
+        elif name.endswith(_PUB_SUFFIX):
+            public.add(name.removesuffix(_PUB_SUFFIX))
+    return sealed, public
 
 
 def is_chunk_path(relpath: str) -> bool:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -90,6 +90,10 @@ class Report:
     #: them until the manifest is put right, which beats signing a replacement
     #: that silently disowns everything published earlier that day.
     unsignable: set[str] = field(default_factory=set)
+    #: Days of this machine's own history whose sealed day key has gone while
+    #: chunks sealed to its public half remain. Nothing further is written for
+    #: them, because a new key cannot rescue what the old one sealed.
+    orphaned: set[str] = field(default_factory=set)
     #: "<day>/<name>" chunks sitting under *this* machine's own id that it never
     #: published. Nothing else would ever look at them -- `merge` skips our own
     #: id -- and they are deliberately not swept into a manifest we sign.
@@ -574,18 +578,77 @@ def trust_status(known: Machine) -> IdentityStatus:
     return IdentityStatus(not waiting, detail)
 
 
+def orphaned_day_key(host_id: str, day: str) -> bool:
+    """A public half published with no sealed private half beside it.
+
+    Anything sealed to that public key is unreadable by every machine including
+    the one that wrote it, permanently -- the secret only ever existed inside
+    the `.age` file. So this is the state to notice before writing more, not
+    after.
+
+    It is reachable by a stranger: `keys/` is deliberately rewritable, because
+    `grant` and `revoke` re-seal every file in it, so anyone with push access can
+    delete one and the deletion arrives with the next fetch. `.age` is written
+    before `.pub` below, which keeps woswoar's own crash window on the harmless
+    side of this -- a sealed key with no public half is simply re-minted.
+    """
+    return (
+        store.day_key_public(host_id, day).is_file() and not store.day_key(host_id, day).is_file()
+    )
+
+
+def has_chunks(host_id: str, day: str) -> bool:
+    """Whether anything is already sealed to this host's key for ``day``.
+
+    What turns a half-written key pair from a nuisance into a loss: with no
+    chunks the next `export` simply mints a new pair over it and nothing is
+    ever noticed, so reporting that state would be a false alarm.
+    """
+    directory = store.chunk_dir(host_id, day)
+    return directory.is_dir() and any(directory.iterdir())
+
+
+def orphaned_days() -> list[tuple[str, str]]:
+    """``(host, day)`` for every day key in the repo whose sealed half is gone.
+
+    Cheap -- a listing of `keys/`, no decryption -- and worth doing on demand:
+    the state is silent otherwise, and every sync that passes over such a day
+    without noticing makes it look fine. Reported for *every* host, not just
+    this one, because a machine that can still open the key is the only place a
+    copy can come from.
+
+    Pairs rather than a formatted string, so the caller decides how to show
+    them and a test can assert on the day rather than search for it.
+    """
+    found = []
+    for host_id in store.repo_hosts():
+        sealed, public = store.day_key_days(host_id)
+        for day in sorted(public - sealed):
+            if has_chunks(host_id, day):
+                found.append((host_id, day))
+    return found
+
+
 def day_public_key(known: Machine, day: str) -> str:
     """The public half of this host's key for ``day``, creating it if needed.
 
     One key per host per day. Kept in the clear beside the sealed private half
     so writing a chunk never has to open the sealed key first.
+
+    Both halves are required to reuse a key. Checking only the public one meant
+    a day whose sealed half had gone kept handing out a public key nobody held
+    the secret for, and every chunk written afterwards was lost on the spot.
+    Minting over the top is safe only because `export` refuses first for any day
+    that already has chunks -- those are sealed to the old key, and a new one
+    cannot help them.
     """
     pub_path = store.day_key_public(known.id, day)
-    if pub_path.is_file():
+    if pub_path.is_file() and store.day_key(known.id, day).is_file():
         return pub_path.read_text(encoding="utf-8").strip()
 
     identity = crypto.generate_identity()
     sealed = crypto.encrypt_to_recipients(identity.secret.encode("utf-8"), recipients())
+    # Sealed half first: see `orphaned_day_key`.
     store.write_atomic(store.day_key(known.id, day), sealed)
     store.write_atomic(pub_path, (identity.public + "\n").encode("utf-8"))
     return identity.public
@@ -1021,6 +1084,21 @@ def export(known: Machine, state: State, report: Report, now: int) -> None:
         on_disk.setdefault(chunk.day, set()).add(chunk.name)
 
     for day, tails in sorted(fresh.items()):
+        # Before the manifest, not after. Refusing does not advance
+        # `state.exported`, so a refused day comes back on every sync -- and
+        # `read_manifest` forks `ssh-keygen -Y verify`. Checked afterwards, one
+        # orphaned day cost a fork a minute for as long as it stayed that way,
+        # on a path issue #50 is already about. `day in on_disk` first because
+        # it is a dict lookup and the other two are stats.
+        if day in on_disk and orphaned_day_key(known.id, day):
+            # See `orphaned_day_key` for what this state is. A fresh key would
+            # let this sync succeed and say nothing while the day's existing
+            # chunks stayed unreadable, so nothing is written. The lines stay
+            # pending -- `state.exported` is not advanced -- so they are still
+            # in `logs/` and publish once the sealed key is restored.
+            report.orphaned.add(day)
+            continue
+
         # What this machine has already put its name to for this day. Extended,
         # never rebuilt from the directory -- see the docstring.
         listed = read_manifest(known.id, day, verify_key)
@@ -1935,6 +2013,13 @@ def compact(before: str) -> tuple[int, int]:
         replaced = 0
         for day, chunks in sorted(by_day.items()):
             if len(chunks) < 2:
+                continue
+            if orphaned_day_key(known.id, day):
+                # Nothing here can be opened, and one such day used to abort the
+                # whole run -- so a single unreadable day left every later day
+                # uncompacted, reported as a bare path. Skipped instead: `sync`
+                # and `doctor` are where this state is explained, and compaction
+                # has no business being the messenger.
                 continue
             secret = open_day_key(known, known.id, day)
 


### PR DESCRIPTION
Closes #42.

## The bug

`sync` decided whether to mint a day key by looking at the **public** half
alone. With `keys/<day>.pub` present and `keys/<day>.age` gone, it handed out a
public key whose secret no longer existed anywhere — and every chunk written
afterwards was unreadable by every machine, including the one writing it.
Silently, because that machine still has its plaintext in `logs/`.

## I relabelled the issue P1 first

It said this "needs an interruption or a hand-edit, so nobody is hurt today".
That is the half the priority rested on, and it is wrong. `keys/` is
deliberately rewritable so `grant`/`revoke` can re-seal it, so **any machine with
push access can delete another machine's key**. Reproduced through a real bare
repo:

```
beta can see alpha's sealed key: True
beta pushed the deletion
after alpha syncs: .age missing=True  .pub present=True

chunks before 1, after 2
sync reported: chunks_written=1
day key opens: NO -- SyncError
```

## The fix

`day_public_key` requires both halves. `export` refuses a day whose sealed key is
gone **once chunks exist** — minting fresh would let the sync succeed and say
nothing while those chunks stayed lost. The lines stay pending in `logs/` and
publish once the key is back.

The sealed half is now written **first**, so woswoar's own crash window leaves a
sealed key with no public half — simply re-minted — rather than the destructive
state.

## What the reviews changed

**The refusal now runs before `read_manifest`, not after.** A refused day is not
drained from `state.exported`, so it returns on every sync — and `read_manifest`
forks `ssh-keygen -Y verify`. Checked afterwards, **one orphaned day cost a fork
a minute, forever**, on exactly the path #50 is about.

**My own simplify pass introduced a regression** and the altitude pass caught it:
inlining a stat left `orphaned_days` no longer asking whether the day had chunks,
so `doctor` hard-failed on a half-written pair that the next sync silently heals
— printing "chunks encrypted to them cannot be read" for a day with no chunks.
Both paths now ask the same question, and there is a test.

**The advice I wrote was wrong, and pessimistically so.** It told users their
history was gone unless another clone had the key. The deleted blob is reachable
in *every* clone, because woswoar never rewrites git history. `sync` now prints
the two commands that recover it — which I verified byte-for-byte — plus how to
write the day off if it really is lost.

**`doctor` is 19× cheaper**: one directory listing per host instead of a stat per
key (1.9 ms against 36 ms on a two-year, five-machine tree), and that cost grows
with the archive forever. Two `store` helpers I had added collapsed into one.

**`compact` used to abort entirely** on a single unreadable day, leaving every
later day uncompacted and reporting a bare absolute path. It skips now.

## Verification

- **10 mutations, all killing their guarding test.**
- Two of my tests were found to guard nothing: one **never deleted a key at all**
  (an existing test re-spelled, with a docstring claiming a guarantee it did not
  exercise), and the `doctor` block — the fiddliest new code — had no test
  reaching it. Both fixed.
- Idle sync unchanged: 47 stats, 11 git forks, before and after.
- `ruff`, `ruff format --check`, `mypy --strict`, `shellcheck`, 3 clean full runs.

## Filed rather than fixed here

**#63 (P1)** — `manifests/<day>` has the *same shape* and is unhandled: delete
one, and the next sync signs a fresh manifest that disowns every earlier chunk of
that day, reported only as `foreign` with the wrong diagnosis, or not at all on a
quiet day. That is a sibling bug in a different file with a different mechanism,
and the fix must not re-derive manifests from the directory — the thing #40
explicitly forbids.

Also considered and rejected as over-engineering: signing a day key's *presence*.
Deletion is not forgery, the secret is gone either way, and `grant`/`revoke` must
legitimately rewrite `keys/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)