### PR TITLE
Refuse to sign a manifest over one a peer deleted

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -228,6 +228,7 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | Forged history is refused | a chunk sealed to a host's published day key, but absent from that host's signed manifest, is rejected and reported |
 | The repo names no machine | every committed byte is searched for the username and hostname; a leaked archive says how many machines there are, not which |
 | Tampering is refused | flipping one byte of a real chunk fails authentication, not merely decryption |
+| A day whose signed list is gone is refused, not re-signed | deleting a manifest and syncing publishes nothing further for that day, rather than signing a replacement that names only the newest chunk and disowns every earlier one |
 | A day whose sealed key is gone is refused, not written over | deleting one and syncing publishes nothing further for that day and says so, rather than adding chunks no machine could ever read |
 | A chunk cannot exhaust a peer | a chunk that unpacks past the cap is refused and reported, and the peak allocation is measured to stay bounded rather than the payload being materialised first |
 | A revoked machine cannot publish | it keeps its signing key and its old manifests, signs a chunk with them, pushes -- and a third machine accepts none of it |

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2469,5 +2469,136 @@ class TestAnOrphanedDayKey(SyncTestCase):
             self.assertIn("2023-11-14", text)
 
 
+class TestADeletedManifest(SyncTestCase):
+    """Issue #63, the sibling of #42 in the other rewritable file.
+
+    `read_manifest` returns nothing for "absent" and for "will not verify"
+    alike, and only the second was guarded. So a deleted manifest looked exactly
+    like a day never published: the fresh one signed at the end of `export`
+    named only what that run wrote, and every chunk published earlier that day
+    stopped being one any peer would accept.
+    """
+
+    def published_day(self) -> Fake:
+        """One machine with one day published, which is all but one test needs.
+
+        A peer costs an `ssh-keygen` and a clone, so the one test that needs one
+        makes it itself rather than every test paying for it.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "first")
+            sync.run()
+        return alpha
+
+    def test_nothing_is_written_for_the_day(self) -> None:
+        alpha = self.published_day()
+        with alpha.active():
+            path = store.day_manifest(alpha.id, "2023-11-14")
+            before = {c.name for c in store.iter_chunks(alpha.id)}
+            self.assertTrue(any(name in path.read_text(encoding="utf-8") for name in before))
+
+            path.unlink()
+            alpha.record("2023-11-14", 1_700_000_002, "second")
+            report = sync.run()
+
+            self.assertEqual(report.chunks_written, 0)
+            self.assertEqual(report.manifest_missing, {"2023-11-14"})
+            self.assertEqual({c.name for c in store.iter_chunks(alpha.id)}, before)
+            # The disowning itself: a replacement would name only this run.
+            self.assertFalse(path.exists(), "a replacement manifest was signed")
+
+    def test_restoring_it_publishes_the_pending_line(self) -> None:
+        """The lines stay in `logs/`, so the day is recoverable, not lost."""
+        # Before alpha publishes, so beta is already a recipient when the day
+        # key is minted -- otherwise it would need a `grant` as well, which is
+        # a different mechanism and not what this test is about.
+        beta = self.machine("beta")
+        alpha = self.published_day()
+        with alpha.active():
+            path = store.day_manifest(alpha.id, "2023-11-14")
+            original = path.read_bytes()
+            path.unlink()
+            alpha.record("2023-11-14", 1_700_000_002, "second")
+            sync.run()
+
+            store.write_atomic(path, original)
+            report = sync.run()
+            self.assertEqual(report.manifest_missing, set())
+            self.assertEqual(report.chunks_written, 1)
+
+        with beta.active():
+            sync.run()
+        self.accept_everyone(alpha)
+        self.accept_everyone(beta)
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            sync.run()
+            self.assertEqual(sorted(beta.commands()), ["first", "second"])
+
+    def test_a_day_never_published_here_is_not_refused(self) -> None:
+        """A chunk under our id proves only that somebody wrote one.
+
+        Keying on chunks rather than on this machine's own watermark would let
+        anyone who can push plant one on a day we have not published and block
+        that day for good.
+        """
+        alpha = self.published_day()
+        with alpha.active():
+            planted = store.chunk_dir(alpha.id, "2023-11-20")
+            planted.mkdir(parents=True, exist_ok=True)
+            (planted / "9999999999-ffffff.age").write_bytes(b"whatever an attacker likes")
+
+            alpha.record("2023-11-20", 1_700_500_000, "mine")
+            report = sync.run()
+
+            self.assertEqual(report.manifest_missing, set())
+            self.assertEqual(report.chunks_written, 1)
+            self.assertTrue(store.day_manifest(alpha.id, "2023-11-20").exists())
+
+    def test_sync_says_which_day_and_how_to_get_it_back(self) -> None:
+        alpha = self.published_day()
+        with alpha.active():
+            store.day_manifest(alpha.id, "2023-11-14").unlink()
+            alpha.record("2023-11-14", 1_700_000_002, "second")
+            errors = io.StringIO()
+            with redirect_stderr(errors), redirect_stdout(io.StringIO()):
+                main(["sync"])
+
+        said = errors.getvalue()
+        self.assertIn("2023-11-14", said)
+        self.assertIn("--diff-filter=D", said)
+
+    def test_doctor_is_quiet_when_every_published_day_has_its_manifest(self) -> None:
+        """Keyed on what this machine published, not on log files on disk.
+
+        A day recorded but never exported has no manifest either, and reporting
+        it would be a hard red for the ordinary state of a day still being
+        written. The watermark is what tells the two apart.
+        """
+        alpha = self.published_day()
+        with alpha.active():
+            alpha.record("2023-11-20", 1_700_500_000, "not yet published")
+            self.assertEqual(sync.days_missing_a_manifest(), [])
+            _, text = self.run_cli(alpha, "doctor")
+            self.assertIn("[ok] manifests", text)
+
+    def test_doctor_finds_a_quiet_day_sync_never_looks_at(self) -> None:
+        """A day fully exported before the deletion never returns to `export`."""
+        alpha = self.published_day()
+        with alpha.active():
+            _, healthy = self.run_cli(alpha, "doctor")
+            self.assertIn("[ok] manifests", healthy)
+
+            store.day_manifest(alpha.id, "2023-11-14").unlink()
+            self.assertEqual(sync.days_missing_a_manifest(), ["2023-11-14"])
+
+            code, text = self.run_cli(alpha, "doctor")
+            self.assertEqual(code, 1)
+            self.assertIn("[FAIL] manifests", text)
+            self.assertIn("2023-11-14", text)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -126,6 +126,21 @@ def cmd_search(args: argparse.Namespace) -> int:
     return 0
 
 
+def _restore_remedy(path: str) -> str:
+    """How to recover a file a peer deleted from the history repo.
+
+    Deleting one is a commit like any other and woswoar never rewrites history,
+    so the blob is still reachable in every clone. Shared by the two files this
+    can happen to, so the recipe cannot drift between their messages.
+    """
+    return (
+        "It is still in git history -- woswoar never rewrites it, so every clone\n"
+        "has the blob. To put it back:\n"
+        f"    git -C <history> log --diff-filter=D -- {path}\n"
+        f"    git -C <history> show <commit>^:{path} > that path\n"
+    )
+
+
 def cmd_import(args: argparse.Namespace) -> int:
     try:
         result = importer.run(
@@ -289,6 +304,20 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         trust = sync.trust_status(store.machine())
         check("trust", trust.ok, trust.detail)
 
+        # One stat per day this machine has published. Worth doing every time
+        # because `export` only revisits a day that still has lines to publish,
+        # so a day finished before its manifest went is never looked at again.
+        unmanifested = sync.days_missing_a_manifest()
+        if unmanifested:
+            detail = (
+                f"{len(unmanifested)} published day(s) have no signed list, e.g."
+                f" {unmanifested[0]} - peers refuse every chunk this machine"
+                " published on them"
+            )
+        else:
+            detail = "all present"
+        check("manifests", not unmanifested, detail)
+
         # A listing, no decryption, so it is cheap enough to do every time --
         # and the state is otherwise silent, which is the whole problem with it.
         orphaned = sync.orphaned_days()
@@ -446,14 +475,25 @@ def cmd_sync(args: argparse.Namespace) -> int:
             "it are still there. Those chunks are unreadable by every machine, and a\n"
             "new key would not change that -- so nothing more is written for those\n"
             "days rather than adding chunks nobody will ever read.\n"
-            "The commands themselves are still in this machine's own logs, and the\n"
-            "deleted key is still in git history -- woswoar never rewrites it, so\n"
-            "every clone has the blob. To put it back:\n"
-            "    git -C <history> log --diff-filter=D -- hosts/<id>/keys/<day>.age\n"
-            "    git -C <history> show <commit>^:hosts/<id>/keys/<day>.age > that path\n"
+            "The commands themselves are still in this machine's own logs.\n"
+            f"{_restore_remedy('hosts/<id>/keys/<day>.age')}"
             "'woswoar doctor' prints the host id and day. If it really is gone, delete\n"
             "keys/<day>.pub to write the day off: the old chunks stay unreadable, but\n"
             "this machine starts a new key and publishes again.",
+            file=sys.stderr,
+        )
+
+    if report.manifest_missing:
+        lost = ", ".join(sorted(report.manifest_missing))
+        print(
+            f"\nWARNING: {len(report.manifest_missing)} day(s) of this machine's own\n"
+            f"history cannot be published: {lost}\n"
+            "The signed list this machine published for them is gone from the\n"
+            "repository. Signing a replacement would name only what is written now,\n"
+            "so every chunk published earlier that day would stop being one any peer\n"
+            "accepts. Nothing is written for those days instead.\n"
+            f"{_restore_remedy('hosts/<id>/manifests/<day>')}"
+            "'woswoar doctor' prints the days.",
             file=sys.stderr,
         )
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -94,6 +94,10 @@ class Report:
     #: chunks sealed to its public half remain. Nothing further is written for
     #: them, because a new key cannot rescue what the old one sealed.
     orphaned: set[str] = field(default_factory=set)
+    #: Days this machine has published before whose signed manifest has gone.
+    #: Signing a fresh one would list only what this run writes, disowning
+    #: everything published earlier -- so nothing is written for them either.
+    manifest_missing: set[str] = field(default_factory=set)
     #: "<day>/<name>" chunks sitting under *this* machine's own id that it never
     #: published. Nothing else would ever look at them -- `merge` skips our own
     #: id -- and they are deliberately not swept into a manifest we sign.
@@ -629,6 +633,39 @@ def orphaned_days() -> list[tuple[str, str]]:
     return found
 
 
+def manifest_gone(host_id: str, day: str) -> bool:
+    """No signed list for a day, said once so both callers ask it the same way.
+
+    Meaningless on its own -- a day never published has no manifest either --
+    so every caller pairs it with "did this machine publish this day", which is
+    its own export watermark.
+    """
+    return not store.day_manifest(host_id, day).exists()
+
+
+def days_missing_a_manifest() -> list[str]:
+    """Days this machine published and whose signed manifest is no longer there.
+
+    `export` reports the same state, but only for a day that still has lines to
+    publish -- a day that was fully exported before the manifest went is never
+    looked at again, and stays silently unusable by every peer that had not
+    already merged it.
+
+    Keyed on this machine's own export watermark rather than on the presence of
+    chunks, for the reason `export` gives: a chunk under our id proves only that
+    somebody wrote one.
+    """
+    known = store.machine()
+    # Every key here is a day this machine exported: the watermark is written
+    # only after a chunk was sealed for it, so its presence is the claim and
+    # there is no zero to filter out.
+    return [
+        day
+        for day in sorted(store.day_of_log(relpath) for relpath in State.load().exported)
+        if manifest_gone(known.id, day)
+    ]
+
+
 def day_public_key(known: Machine, day: str) -> str:
     """The public half of this host's key for ``day``, creating it if needed.
 
@@ -1099,10 +1136,30 @@ def export(known: Machine, state: State, report: Report, now: int) -> None:
             report.orphaned.add(day)
             continue
 
+        # A manifest this machine wrote before and that is no longer there.
+        # `read_manifest` returns nothing for "absent" and for "will not verify"
+        # alike, and the branch below only covers the second -- so a deletion
+        # looked exactly like a day never published, and the fresh manifest
+        # signed at the end of this loop listed only what this run wrote.
+        # Everything published earlier that day was dropped out of it, and a
+        # peer refuses a chunk no signed manifest names. The machine that did it
+        # keeps its own copy in `logs/`, and the only thing said out loud was
+        # `foreign`, whose message blames a planted chunk.
+        #
+        # The signal is this machine's own export watermark, not the presence of
+        # chunks: a chunk under our id proves only that *someone* wrote one, so
+        # keying on that would let anyone who can push plant one on a day we
+        # have not published yet and block that day for good.
+        published_before = any(relpath in state.exported for relpath, _, _ in tails)
+        has_manifest = not manifest_gone(known.id, day)
+        if published_before and not has_manifest:
+            report.manifest_missing.add(day)
+            continue
+
         # What this machine has already put its name to for this day. Extended,
         # never rebuilt from the directory -- see the docstring.
         listed = read_manifest(known.id, day, verify_key)
-        if not listed and store.day_manifest(known.id, day).exists():
+        if not listed and has_manifest:
             # There is a manifest for this day and this machine cannot verify
             # it, so it cannot tell what it has already published. Signing a
             # fresh one would silently drop every earlier chunk of that day from


### PR DESCRIPTION
Closes #63 — the sibling of #42 in the other rewritable file.

## The bug

`read_manifest` returns nothing for "absent" and for "will not verify" alike,
and only the second was guarded. So a deleted manifest looked exactly like a day
never published: the fresh one signed at the end of `export` named only what
that run wrote, and **every chunk published earlier that day stopped being one
any peer accepts**.

Reproduced with two machines through a bare repo:

```
alpha sync: chunks_written=1  unsignable=set()  foreign=1
earlier chunk still named in the manifest: False
beta sees: ['second']          <- 'first' is gone for good
```

The machine that published both still sees both in its own `logs/`, so nothing
looks wrong from that end. The only thing said out loud was `foreign`, whose
message blames a planted chunk — the wrong diagnosis.

Reachable the same way as #42: `manifests/` must be writable because `export`
re-signs it, so anyone who can push can delete one.

## The signal, and why not the obvious one

`export` refuses such a day and reports it. The test is **this machine's own
export watermark**, not the presence of chunks — a chunk under our id proves
only that *somebody* wrote one, so keying on that would let anyone who can push
plant one on a day we have not published yet and block that day permanently.
There is a test for exactly that.

## The trap from #42, avoided by construction

A refused day is never drained from `state.exported`, so it comes back on **every
sync**. #42's review found that anything expensive after the refusal is then paid
every minute. So this guard sits before `read_manifest`, which forks
`ssh-keygen -Y verify`. Measured:

| | ssh-keygen | git |
|---|---|---|
| healthy idle sync | 0 | 10 |
| every sync with a refused day | **0** | **10** |

`doctor` scans too, because `export` only revisits a day that still has lines to
publish — a day finished before its manifest went is never looked at again.

Recovery shares one recipe with #42's message now: the deleted list is still a
blob in every clone, and restoring it publishes the pending line (verified
byte-for-byte).

## Verification

- **6 mutations, all killing their guarding test**, including the planted-chunk
  denial and the "refusing must not consume the pending lines" case.
- Review caught a test of mine that passed trivially — it asserted something true
  with or without the fix — and a docstring that described a guard the code does
  not contain. Both replaced.
- 3 clean full runs; `ruff`, `ruff format --check`, `mypy --strict`, `shellcheck`.

## A caveat on this PR's review

**Two of the four `/simplify` angles did not complete** — the efficiency and
altitude agents both died on a session limit. What is applied here is the reuse
and simplification passes only. I ran the efficiency question I most wanted
answered myself (the fork table above), but no altitude pass looked at this, so
the "is this the right depth" question is less examined than on the last few PRs.
Worth knowing when reading it.

The one altitude question I can answer myself: two files now each have a bespoke
missing-file guard. A single "nothing under `hosts/` is ever deleted" check via
`git log --diff-filter=D` would subsume both and the repo already asserts exactly
that shape for chunks. I did **not** do it here — it is a different mechanism
with its own cost (O(history)) and it belongs in one change that replaces both,
not bolted onto the second of them. Say the word and I will file it.

### One naming call

`Report.manifest_missing` breaks the single-adjective shape of its siblings
(`orphaned`, `unsignable`, `foreign`). I kept it: `unlisted` reads as "not in the
manifest", which is what `foreign` already means, and the confusion costs more
than the inconsistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)