### PR TITLE
Rebuild a rewritten day from all of it, not from what is new

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -222,6 +222,7 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | The hook forks nothing | recording runs under `strace`; the clone/fork/execve count must be **0** |
 | Shell and Python escaping agree | a command containing a literal tab and newline must round-trip byte-for-byte |
 | History is never rewritten | `git log --diff-filter=MD` over chunk files must be **empty** |
+| A compacted day survives gaining more history | a chunk written for a day after it was compacted leaves every peer holding that day's earlier commands as well, not only the new one |
 | Compaction does not duplicate history | a peer that already merged a day, and one that merged only part of it, both end up holding each command exactly once |
 | A failed chunk is retried, not dropped | an earlier chunk that fails while a later one succeeds is merged once it is repaired |
 | age is never given a file path | every age invocation is inspected; no argument may be an existing path outside `/dev/fd` |

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2754,5 +2754,113 @@ class TestSplitForExport(unittest.TestCase):
         self.assertLess(sync.MAX_EXPORT_BYTES, sync.MAX_CHUNK_BYTES)
 
 
+class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
+    """Issue #67: a rewrite must rebuild the day from everything, not what is new.
+
+    A compacted chunk keeps its `subsumes` list in the manifest for good, so
+    `_Day.open` sees a rewrite on every later pass too. Skipping the chunks
+    already in `state.merged` first meant the day was rebuilt from only the
+    chunks that happened to be new -- and everything before them was gone from
+    the peer's log, silently.
+
+    Reached by `compact` and then `import`, which writes into past days by
+    construction.
+    """
+
+    def merged_pair(self) -> tuple[Fake, Fake]:
+        """alpha with one day of four chunks, and a beta that has merged them."""
+        alpha, beta = self.history_across_days(days=1, per_day=4)
+        with beta.active():
+            sync.run()
+            self.assertEqual(len(beta.commands()), 4)
+        return alpha, beta
+
+    def test_a_later_chunk_does_not_discard_the_day(self) -> None:
+        alpha, beta = self.merged_pair()
+        with alpha.active():
+            days, _, _ = sync.compact(before="2023-12-01")
+            self.assertEqual(days, 1)
+            sync.run()
+        with beta.active():
+            sync.run()
+            self.assertEqual(len(beta.commands()), 4, "compaction alone lost history")
+
+        # The trigger: one more line on a day already compacted and merged.
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_100, "later")
+            sync.run()
+        with beta.active():
+            sync.run()
+            self.assertEqual(
+                sorted(beta.commands()),
+                [f"day 0 command {i}" for i in range(4)] + ["later"],
+                "the rewrite dropped what had already been merged",
+            )
+
+    def test_a_re_read_chunk_is_not_counted_as_newly_merged(self) -> None:
+        """Two passes, so the second genuinely re-reads the compacted chunk."""
+        alpha, beta = self.merged_pair()
+        with alpha.active():
+            sync.compact(before="2023-12-01")
+            sync.run()
+        with beta.active():
+            sync.run()  # merges the compacted chunk
+
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_100, "later")
+            sync.run()
+        with beta.active():
+            report = sync.run()
+            # The compacted chunk is read again to rebuild the day, but only
+            # `later` is new. Counting the re-read would tell the user history
+            # arrived that they already had.
+            self.assertEqual(report.chunks_merged, 1, "a re-read chunk was counted as new")
+            self.assertEqual(len(set(beta.commands())), 5)
+
+    def test_an_ordinary_day_stays_incremental(self) -> None:
+        """Only a rewrite re-reads. Otherwise every sync would redo the day.
+
+        A day with no compacted chunk gains a line: exactly one chunk should be
+        decrypted, not every chunk the day holds.
+        """
+        alpha, beta = self.merged_pair()
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_100, "later")
+            sync.run()
+
+        with beta.active():
+            opened: list[str] = []
+            real = sync.open_chunk
+
+            def counted(path: Path, digest: str) -> bytes:
+                opened.append(path.name)
+                return real(path, digest)
+
+            with mock.patch.object(sync, "open_chunk", counted):
+                sync.run()
+            self.assertEqual(len(opened), 1, f"the whole day was re-read: {opened}")
+            self.assertEqual(len(beta.commands()), 5)
+
+    def test_a_day_with_nothing_new_reads_no_manifest(self) -> None:
+        """The laziness that makes signatures affordable, kept.
+
+        A manifest costs an `ssh-keygen -Y verify`, and sync runs on a
+        one-minute timer. Grouping by day must not turn that into one fork per
+        day of history per run.
+        """
+        _, beta = self.merged_pair()
+        with beta.active():
+            reads: list[str] = []
+            real = sync.read_manifest
+
+            def counted(host_id: str, day: str, verify_key: str) -> dict[str, sync.Entry]:
+                reads.append(day)
+                return real(host_id, day, verify_key)
+
+            with mock.patch.object(sync, "read_manifest", counted):
+                sync.run()
+            self.assertEqual(reads, [], "a day with nothing new still read its manifest")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -545,7 +545,13 @@ class Chunk(NamedTuple):
 
 
 def iter_chunks(machine_id: str) -> Iterator[Chunk]:
-    """Every sealed chunk belonging to one host, oldest first."""
+    """Every sealed chunk belonging to one host, oldest first.
+
+    A day's chunks are contiguous, and days come in order: the outer loop walks
+    one day directory at a time. `sync._merge_host` groups on that -- it holds
+    one day at a time to bound memory, and a day appearing twice would make the
+    second group overwrite the log file the first had just written.
+    """
     root = repo_host_dir(machine_id)
     if not root.is_dir():
         return

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -33,6 +33,7 @@ from collections import Counter
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from itertools import groupby
 from pathlib import Path
 from typing import NamedTuple
 
@@ -1325,76 +1326,90 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
     #: chunk rather than once per day -- tens of thousands of subprocess spawns
     #: instead of hundreds, on precisely the first sync a new machine runs.
     day_keys: dict[str, str | None] = {}
-    day = _Day(host_id, "")
 
-    # `iter_chunks` walks day directory by day directory, in order, so a day is
-    # finished the moment the day changes. That is what bounds memory: at most
-    # one day is ever held, rather than a whole host's worth. Holding everything
-    # until the loop ended was the other half of #20, and flushing "whichever
-    # days are safe to write" instead left the compacted ones -- which is every
-    # day of a fully compacted archive -- held anyway.
-    for chunk in store.iter_chunks(host_id):
-        if chunk.day != day.day:
-            day.flush(report)
-            day = _Day(host_id, chunk.day)
-
-        key = f"{host_id}/{chunk.day}"
+    # Grouped by day rather than streamed chunk by chunk, because whether a day
+    # is being *rewritten* has to be known before deciding which of its chunks
+    # to read -- and that answer is in the manifest. `iter_chunks` yields a
+    # day's chunks contiguously, which is what makes one group one day.
+    #
+    # A rewrite replaces the day's log file outright, so it has to be rebuilt
+    # from every chunk the manifest lists, not from the ones this run happens to
+    # find new. Skipping the already-merged ones first, as this used to, meant a
+    # single chunk appended after a compaction rewrote the day down to just that
+    # chunk and discarded everything before it, on every peer, silently. That is
+    # reachable by `compact` and then `import`, which writes into past days.
+    #
+    # Laziness is kept where it pays: a day with nothing new never reads its
+    # manifest, and a manifest costs a subprocess. Over a year of three machines
+    # that is the difference between ~3.6s and nearly two minutes.
+    for chunk_day, group in groupby(store.iter_chunks(host_id), key=lambda c: c.day):
+        chunks = list(group)
+        key = f"{host_id}/{chunk_day}"
         # `get`, not `setdefault`: a day this machine only ever *looks* at --
         # never granted, or a manifest it cannot verify -- must not gain an
         # empty record that is then written out on every sync forever.
-        if chunk.name in state.merged.get(key, ()):
+        # A copy, not the live set: `state.merged` is updated as each chunk is
+        # merged below, and aliasing it made "was this already merged" answer
+        # yes for a chunk this very run had just added.
+        already = frozenset(state.merged.get(key, ()))
+        fresh = [chunk for chunk in chunks if chunk.name not in already]
+        if not fresh:
             continue
 
-        if not day.opened:
-            # Manifests cost a subprocess each. One per day rather than one per
-            # chunk is the whole reason signatures are affordable here: over a
-            # year of three machines that is ~3.6 s against nearly two minutes.
-            day.open(read_manifest(host_id, chunk.day, verify_key))
-        if chunk.name not in day.listed:
-            # No signed statement that this host wrote this. Covers a missing,
-            # unsigned, mis-signed or mis-addressed manifest as well as a chunk
-            # simply absent from a good one -- see `Report.unauthenticated`.
-            report.unauthenticated.add(key)
-            continue
+        day = _Day(host_id, chunk_day, read_manifest(host_id, chunk_day, verify_key))
+        pending = chunks if day.rewrite else fresh
 
-        if chunk.day not in day_keys:
+        for chunk in pending:
+            if chunk.name not in day.listed:
+                # No signed statement that this host wrote this. Covers a
+                # missing, unsigned, mis-signed or mis-addressed manifest as
+                # well as a chunk simply absent from a good one -- see
+                # `Report.unauthenticated`.
+                report.unauthenticated.add(key)
+                continue
+
+            if chunk_day not in day_keys:
+                try:
+                    day_keys[chunk_day] = open_day_key(known, host_id, chunk_day)
+                except (crypto.AgeError, SyncError):
+                    # Sealed before this machine was enrolled, and no one has
+                    # run `grant` yet. Skip it without recording it as merged,
+                    # so a later sync picks it up -- and above all without
+                    # aborting, or one unreadable day would block this machine's
+                    # own export too.
+                    day_keys[chunk_day] = None
+            secret = day_keys[chunk_day]
+            if secret is None:
+                report.unreadable.add(key)
+                continue
+
+            # Authenticated before it is decrypted or decompressed, so age, zlib
+            # and the parser only ever see bytes one of this user's own machines
+            # wrote.
             try:
-                day_keys[chunk.day] = open_day_key(known, host_id, chunk.day)
-            except (crypto.AgeError, SyncError):
-                # Sealed before this machine was enrolled, and no one has run
-                # `grant` yet. Skip it without recording it as merged, so a
-                # later sync picks it up -- and above all without aborting, or
-                # one unreadable day would block this machine's own export too.
-                day_keys[chunk.day] = None
-        secret = day_keys[chunk.day]
-        if secret is None:
-            report.unreadable.add(key)
-            continue
+                blob = open_chunk(chunk.path, day.listed[chunk.name].digest)
+            except (OSError, ValueError):
+                report.unauthenticated.add(key)
+                continue
 
-        # Authenticated before it is decrypted or decompressed, so age, zlib and
-        # the parser only ever see bytes one of this user's own machines wrote.
-        try:
-            blob = open_chunk(chunk.path, day.listed[chunk.name].digest)
-        except (OSError, ValueError):
-            report.unauthenticated.add(key)
-            continue
+            try:
+                plaintext = unpack(crypto.decrypt_with_secret(blob, secret))
+            except (crypto.AgeError, zlib.error, OSError):
+                # Same judgement as an unopenable day key above: a chunk we
+                # cannot consume -- damaged, written by a woswoar that packs it
+                # some other way, or expanding past `MAX_CHUNK_BYTES` -- must not
+                # abort the sync. Aborting would block this machine's own export
+                # and every other host's readable chunks, on this run and every
+                # run after it.
+                report.unreadable.add(key)
+                continue
 
-        try:
-            plaintext = unpack(crypto.decrypt_with_secret(blob, secret))
-        except (crypto.AgeError, zlib.error, OSError):
-            # Same judgement as an unopenable day key above: a chunk we cannot
-            # consume -- damaged, written by a woswoar that packs it some other
-            # way, or expanding past `MAX_CHUNK_BYTES` -- must not abort the
-            # sync. Aborting would block this machine's own export and every
-            # other host's readable chunks, on this run and every run after it.
-            report.unreadable.add(key)
-            continue
+            day.add(plaintext, report)
+            state.merged.setdefault(key, set()).add(chunk.name)
+            if chunk.name not in already:
+                report.chunks_merged += 1
 
-        day.add(plaintext, report)
-        state.merged.setdefault(key, set()).add(chunk.name)
-        report.chunks_merged += 1
-
-    day.flush(report)
+        day.flush(report)
 
 
 class _Day:
@@ -1412,22 +1427,16 @@ class _Day:
     would drop them.
     """
 
-    def __init__(self, host_id: str, day: str) -> None:
+    def __init__(self, host_id: str, day: str, listed: dict[str, Entry]) -> None:
         self.host_id = host_id
         self.day = day
-        self.listed: dict[str, Entry] = {}
-        self.opened = False
-        self.rewrite = False
-        self._blocks: list[bytes] = []
-        self._bytes = 0
-
-    def open(self, listed: dict[str, Entry]) -> None:
         self.listed = listed
-        self.opened = True
         # A compacted chunk is a complete statement of the chunks it names, so
         # the day is replaced rather than added to -- which is the only answer
         # right whether the peer had merged all of them, some, or none.
         self.rewrite = any(entry.subsumes for entry in listed.values())
+        self._blocks: list[bytes] = []
+        self._bytes = 0
 
     def add(self, plaintext: bytes, report: Report) -> None:
         self._blocks.append(plaintext)
@@ -2180,12 +2189,14 @@ def compact(before: str) -> tuple[int, int, int]:
             # unlink the smaller ones that were fine -- leaving a day no peer
             # can read and no way to re-export it.
             #
-            # Skipped rather than merged in batches. Batching was tried and
-            # backed out: it leaves some of a day's chunks unmerged, and a peer
-            # rebuilding a compacted day drops every chunk it had already
-            # merged (issue #67), so partial compaction turns a space
-            # optimisation into history loss. A day this large stays as the
-            # small chunks it already is, which is correct if untidy.
+            # Skipped rather than merged in batches. Batching was backed out
+            # when a peer rebuilding a compacted day still dropped every chunk
+            # it had already merged; that was #67 and is fixed, so batching is
+            # safe again and would compact these days properly -- see #70. It
+            # is not done here because the batch budget then bounds peak merge
+            # memory, which wants measuring rather than assuming. A day this
+            # large stays as the small chunks it already is, which is correct
+            # if untidy.
             plain = b"".join(plaintexts)
             if len(plain) > MAX_EXPORT_BYTES:
                 skipped += 1


### PR DESCRIPTION
Closes #67 — the P1 I found while writing tests for #45.

## The bug

A compacted chunk keeps its `subsumes` list in the manifest **for good**, so
`_Day` saw a rewrite on every later pass, not just the one where the compacted
chunk arrived. But `_merge_host` skipped chunks already in `state.merged`
*before* it read the manifest — so on those passes the day was rebuilt from only
the chunks that happened to be new, and everything before them vanished from the
peer's log.

Silently: the machine that published it still has its own copy in `logs/` and
looks fine. Reproduced on `origin/main`:

```
beta before compaction: 4
beta after compaction (1 day): 4
beta after a later chunk: 1 -> ['later']
```

Reached by `compact` and then `import`, which writes into past days by
construction.

## The fix

The merge loop groups by day, so whether the day is a rewrite is known from the
manifest **before** deciding which chunks to read. A rewrite reads every chunk
the manifest lists; anything else still reads only what is new.

Laziness is kept where it pays — a day with nothing new reads no manifest, and a
manifest costs a subprocess. Review measured a year of three machines fully
compacted: idle sync **0 manifests, 10 forks, unchanged**; cold merge peak memory
1.74 → 1.75 MiB. The cost of the fix is exactly **+1 `age` fork per day actually
rewritten**.

## Found while writing the test

`already` aliased the live `state.merged` set, so a chunk merged by this very run
answered "already merged" and the run reported having merged nothing. The test
that caught it asserts the reported count, not just the contents.

## Verification

- **6 mutations, all killing their guarding test** — including "every day is a
  rewrite" (pinned by a test counting chunks opened) and "no day is a rewrite"
  (pinned by the pre-existing compaction test).
- Review found one of my five tests **passed unchanged on `origin/main` and
  survived every injected mutation** — deleted; the path it claimed was already
  covered with more state by `TestCompactionDoesNotDuplicateOnPeers`.
- `_Day.opened` was dead after the restructure and `open()` was vestigial; the
  manifest now goes in the constructor. My helper also rebuilt the existing
  `history_across_days` plus a no-op trust ceremony — it uses the real one now.
- 3 clean full runs; `ruff`, `ruff format --check`, `mypy --strict`, `shellcheck`.

## Two follow-ups filed

**#69 (P2)** — `rewrite` is keyed on the day's *shape*, not on whether it
changed, so it is sticky: every later sync that finds anything new for a
compacted day re-reads all of it. Measured quadratic over a day that keeps
growing (14 → 25 subprocesses over 11 passes). The common path costs 13 ms once,
which is why this landed as it did; the cheap half of the fix is refusing a
`--before` in the future, which is the only trigger that repeats indefinitely.

**#70 (P3)** — #45 deliberately did *not* compact large days in batches, because
of this bug. Review re-tested batching on top of this fix: a peer goes from
124,000 lines to the full 155,000, no duplicates. The blocker is gone, so the
comment there is updated, but re-enabling it wants its own measurement — with
batching, the batch budget becomes what bounds peak merge memory.

### One note

A review agent's `cp -a` of the worktree copied the gitfile, so a `git checkout`
inside its `/tmp` copy staged a blob into this repo's shared index. I verified
worktree == HEAD by hash before touching it and reset only the index entry; no
content was at risk and no commit changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)