### PR TITLE
sync: halve the git forks on the one-minute timer

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -18,6 +18,7 @@ import zlib
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
+from typing import Any
 from unittest import mock
 
 from woswoar import cache, crypto, search, store, sync
@@ -2864,3 +2865,139 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
+    """`sync` runs from a one-minute timer, so each fork is a recurring cost.
+
+    The numbers are a ceiling, not a description: they exist so that adding a
+    git call to this path is a decision somebody makes rather than one that
+    happens. Raise them deliberately when a call earns its place.
+    """
+
+    def git_calls(self) -> list[str]:
+        real = subprocess.run
+        seen: list[str] = []
+
+        def spy(argv: list[str], *args: Any, **kwargs: Any) -> Any:
+            if argv and Path(argv[0]).name == "git":
+                seen.append(" ".join(argv[1:3]))
+            return real(argv, *args, **kwargs)
+
+        with mock.patch.object(subprocess, "run", spy):
+            sync.run()
+        return seen
+
+    def test_an_idle_sync_forks_git_five_times(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            calls = self.git_calls()
+        self.assertLessEqual(len(calls), 5, calls)
+        # The identity and the remote come from one config read, not three.
+        self.assertEqual([c for c in calls if c.startswith("config")], ["config --list"])
+        self.assertEqual([c for c in calls if c.startswith("remote")], [])
+        # Level with the remote, so neither replaying nor sending is any work.
+        self.assertEqual([c for c in calls if c.startswith(("rebase", "push"))], [])
+        # The branch cannot change mid-run, so it is asked for once.
+        self.assertEqual([c for c in calls if c.startswith("branch")], ["branch --show-current"])
+
+    def test_a_sync_with_something_to_say_still_pushes(self) -> None:
+        """The half that would silently stop publishing if the skip overreached.
+
+        `_fetch_and_rebase` decides "level with the remote" *before* this run's
+        chunk is committed, so a skip keyed on that alone strands every machine
+        that was up to date a moment ago -- which is every machine, every time.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            sync.run()  # idle: leaves alpha level with the remote
+            alpha.record("2023-11-14", 1_700_000_002, "make -j8")
+            calls = self.git_calls()
+        self.assertIn("push --quiet", calls)
+
+        beta = self.machine("beta")
+        with beta.active():
+            sync.run()
+        with alpha.active():
+            sync.grant()
+        with beta.active():
+            sync.run()
+            self.assertEqual(beta.commands(), {"git status", "make -j8"})
+
+    def test_a_sync_behind_the_remote_still_rebases(self) -> None:
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            sync.grant()
+        with beta.active():
+            sync.run()  # picks up alpha's chunk, so it cannot be level first
+            beta.record("2023-11-14", 1_700_000_002, "make -j8")
+            sync.run()
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_003, "cargo build")
+            calls = self.git_calls()
+            self.assertTrue(any(c.startswith("rebase") for c in calls), calls)
+            # Asserted at the git level rather than through `commands()`: alpha
+            # cloned before beta existed and has not been told beta is real, so
+            # it holds the chunk without yet being willing to read it.
+            self.assertTrue(list(store.chunk_dir(beta.id, "2023-11-14").glob("*.age")))
+        # And once it is told, the history the rebase brought in is readable.
+        self.accept_everyone(alpha)
+        with alpha.active():
+            sync.run()
+            self.assertIn("make -j8", alpha.commands())
+
+
+class TestResolvingSeveralRefsInOneFork(SyncTestCase):
+    def test_a_ref_that_does_not_exist_comes_back_empty(self) -> None:
+        """`rev-parse` echoes an argument it cannot resolve instead of dropping it.
+
+        Taking that echo for an object id would make an unborn branch look like
+        it matched the remote, and skip both the rebase and the push for good.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            head, missing = sync._resolve("HEAD", "refs/remotes/origin/no-such-branch")
+            self.assertEqual(len(head), 40)
+            self.assertEqual(missing, "")
+
+    def test_an_unborn_head_resolves_to_nothing(self) -> None:
+        """The state `init` is in while enrolling the very first machine."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.git("update-ref", "-d", "HEAD")
+            self.assertEqual(sync._resolve("HEAD", "refs/remotes/origin/main"), ["", ""])
+
+
+class TestTheCommitIdentityIsStillPinned(SyncTestCase):
+    def test_a_repo_missing_the_identity_gets_it_back(self) -> None:
+        """Reading the config in one fork must not stop it being *written*.
+
+        Without an identity, `commit` fails on a machine with no gitconfig --
+        which is the machine woswoar is most likely to be installed on.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.git("config", "--unset", "user.name", check=False)
+            sync.git("config", "--unset", "user.email", check=False)
+            self.assertEqual(sync._repo_config().name, "")
+
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            self.assertEqual(sync._repo_config().name, sync.COMMIT_NAME)
+            self.assertEqual(sync._repo_config().email, sync.COMMIT_EMAIL)
+            self.assertIn(sync.COMMIT_NAME, sync.git("log", "-1", "--format=%an"))
+
+    def test_the_remote_is_read_from_the_same_config(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            self.assertEqual(sync._repo_config().has_remote, sync.has_remote())
+            sync.git("remote", "remove", "origin")
+            self.assertFalse(sync._repo_config().has_remote)
+            self.assertEqual(sync._repo_config().has_remote, sync.has_remote())

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2968,10 +2968,12 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
             sync.git("commit", "-qam", "unpushed")
             calls = self.git_calls()
             self.assertIn("push --quiet", calls)
-            self.assertEqual(
-                sync._resolve("HEAD", "refs/remotes/origin/main")[0],
-                sync._resolve("HEAD", "refs/remotes/origin/main")[1],
-            )
+            # The branch is read rather than assumed: the harness's bare remote
+            # is created with no `-b`, so it is whatever `init.defaultBranch`
+            # says on the machine running the suite.
+            branch = sync.read_repo().branch
+            head, upstream = sync._resolve("HEAD", f"refs/remotes/origin/{branch}")
+            self.assertEqual(head, upstream)
 
     def test_a_sync_behind_the_remote_still_rebases(self) -> None:
         alpha = self.machine("alpha")
@@ -3016,8 +3018,9 @@ class TestResolvingSeveralRefsInOneFork(SyncTestCase):
         """The state `init` is in while enrolling the very first machine."""
         alpha = self.machine("alpha")
         with alpha.active():
+            branch = sync.read_repo().branch
             sync.git("update-ref", "-d", "HEAD")
-            self.assertEqual(sync._resolve("HEAD", "refs/remotes/origin/main"), ["", ""])
+            self.assertEqual(sync._resolve("HEAD", f"refs/remotes/origin/{branch}"), ["", ""])
 
 
 class TestTheCommitIdentityIsStillPinned(SyncTestCase):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -18,7 +18,6 @@ import zlib
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
-from typing import Any
 from unittest import mock
 
 from woswoar import cache, crypto, search, store, sync
@@ -898,10 +897,10 @@ class TestARevokedMachineCannotPublish(SyncTestCase):
             beta.record(day, ts, cmd)
             known = store.machine()
             with sync.lock():
-                sync._fetch_and_rebase()
+                sync._fetch_and_rebase(sync.read_repo())
                 sync.export(known, sync.State.load(), sync.Report(), ts)
                 sync._commit()
-                sync._push()
+                sync._push(sync.read_repo())
 
     def revoke_beta(self, alpha: Fake, beta: Fake) -> None:
         with beta.active():
@@ -939,7 +938,7 @@ class TestARevokedMachineCannotPublish(SyncTestCase):
         with beta.active():
             day = "2023-11-14"
             with sync.lock():
-                sync._fetch_and_rebase()
+                sync._fetch_and_rebase(sync.read_repo())
                 pub = store.day_key_public(alpha.id, day)
                 entry = Entry(1_700_000_900, alpha.id, "s1", "~", 0, 5, "planted-under-alpha")
                 sealed = crypto.encrypt_to(
@@ -950,7 +949,7 @@ class TestARevokedMachineCannotPublish(SyncTestCase):
                 target.parent.mkdir(parents=True, exist_ok=True)
                 target.write_bytes(sealed)
                 sync._commit()
-                sync._push()
+                sync._push(sync.read_repo())
 
         with gamma.active():
             sync.run()
@@ -2065,7 +2064,7 @@ class TestADecompressionBomb(SyncTestCase):
             listed[path.name] = sync.Entry(sync.digest_of(sealed))
             sync.write_manifest(store.machine(), day, listed)
             sync._commit()
-            sync._push()
+            sync._push(sync.read_repo())
 
         with beta.active():
             report = sync.run()
@@ -2280,7 +2279,7 @@ class TestAnOrphanedDayKey(SyncTestCase):
             self.assertTrue(victim.is_file(), "beta cannot even see the key; premise is wrong")
             victim.unlink()
             sync._commit()
-            sync._push()
+            sync._push(sync.read_repo())
 
         with alpha.active():
             sync.run()
@@ -2863,10 +2862,6 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
             self.assertEqual(reads, [], "a day with nothing new still read its manifest")
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
     """`sync` runs from a one-minute timer, so each fork is a recurring cost.
 
@@ -2876,15 +2871,20 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
     """
 
     def git_calls(self) -> list[str]:
-        real = subprocess.run
+        """Every git subcommand one `sync.run()` spawns, in order.
+
+        Counted at `sync.git`, which is the only place in the package that
+        spawns git -- the same seam the chunk-read counters in this file use,
+        and it needs no argv sniffing to tell git from `age`.
+        """
+        real = sync.git
         seen: list[str] = []
 
-        def spy(argv: list[str], *args: Any, **kwargs: Any) -> Any:
-            if argv and Path(argv[0]).name == "git":
-                seen.append(" ".join(argv[1:3]))
-            return real(argv, *args, **kwargs)
+        def spy(*args: str, **kwargs: object) -> str:
+            seen.append(" ".join(args[:2]))
+            return real(*args, **kwargs)  # type: ignore[arg-type]
 
-        with mock.patch.object(subprocess, "run", spy):
+        with mock.patch.object(sync, "git", spy):
             sync.run()
         return seen
 
@@ -2986,18 +2986,31 @@ class TestTheCommitIdentityIsStillPinned(SyncTestCase):
         with alpha.active():
             sync.git("config", "--unset", "user.name", check=False)
             sync.git("config", "--unset", "user.email", check=False)
-            self.assertEqual(sync._repo_config().name, "")
+            self.assertEqual(sync.read_repo().name, "")
 
             alpha.record("2023-11-14", 1_700_000_001, "git status")
             sync.run()
-            self.assertEqual(sync._repo_config().name, sync.COMMIT_NAME)
-            self.assertEqual(sync._repo_config().email, sync.COMMIT_EMAIL)
+            self.assertEqual(sync.read_repo().name, sync.COMMIT_NAME)
+            self.assertEqual(sync.read_repo().email, sync.COMMIT_EMAIL)
             self.assertIn(sync.COMMIT_NAME, sync.git("log", "-1", "--format=%an"))
 
-    def test_the_remote_is_read_from_the_same_config(self) -> None:
+    def test_a_repo_with_no_remote_is_seen_to_have_none(self) -> None:
+        """The remote is now inferred from config keys rather than `git remote`.
+
+        Getting that wrong in the optimistic direction would make a local-only
+        repo try to push on every timer tick, and fail every time.
+        """
         alpha = self.machine("alpha")
         with alpha.active():
-            self.assertEqual(sync._repo_config().has_remote, sync.has_remote())
+            self.assertTrue(sync.read_repo().has_remote)
             sync.git("remote", "remove", "origin")
-            self.assertFalse(sync._repo_config().has_remote)
-            self.assertEqual(sync._repo_config().has_remote, sync.has_remote())
+            self.assertFalse(sync.read_repo().has_remote)
+
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            report = sync.run()
+            self.assertEqual(report.chunks_written, 1)
+            self.assertFalse(report.pushed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2928,6 +2928,51 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
             sync.run()
             self.assertEqual(beta.commands(), {"git status", "make -j8"})
 
+    def test_a_sync_that_only_receives_does_not_push(self) -> None:
+        """Adopting a peer's commit leaves nothing of our own to send.
+
+        `push` opens a connection to the remote whether or not it has anything
+        to say, and this fires on every machine every time any peer records a
+        command -- so it is the most frequent needless round trip there is.
+        """
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            sync.grant()
+        with beta.active():
+            calls = self.git_calls()
+            self.assertIn("rebase --autostash", calls)
+            self.assertNotIn("push --quiet", calls)
+            self.assertEqual(beta.commands(), {"git status"})
+
+    def test_a_machine_ahead_of_the_remote_still_pushes(self) -> None:
+        """The trap in deciding "level" from anything but where HEAD lands.
+
+        A commit the remote has not seen makes `origin/<branch>` an *ancestor*
+        of HEAD. Every cheap test for "up to date" -- `merge --ff-only`, "the
+        rebase replayed nothing", "the fetch changed no ref" -- passes in that
+        state, and a machine that believes it would stop publishing silently and
+        for good, because the condition never clears by itself.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            # A commit that never reached the remote -- what a compaction, or a
+            # run that died between committing and pushing, leaves behind.
+            store.recipients_file().write_text(
+                store.recipients_file().read_text(encoding="utf-8") + "\n", "utf-8"
+            )
+            sync.git("commit", "-qam", "unpushed")
+            calls = self.git_calls()
+            self.assertIn("push --quiet", calls)
+            self.assertEqual(
+                sync._resolve("HEAD", "refs/remotes/origin/main")[0],
+                sync._resolve("HEAD", "refs/remotes/origin/main")[1],
+            )
+
     def test_a_sync_behind_the_remote_still_rebases(self) -> None:
         alpha = self.machine("alpha")
         beta = self.machine("beta")

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -416,7 +416,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
         f"across {len(report.hosts_seen)} other host(s)"
     )
     if report.pushed:
-        print("pushed to remote")
+        print("in sync with the remote")
     elif not sync.has_remote():
         print("no remote configured - history is local only")
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1600,13 +1600,18 @@ def _fetch_and_rebase(repo: Repo) -> bool:
     with one code path.
 
     HEAD is resolved in the same fork, and a HEAD already equal to the fetched
-    ref skips the rebase -- git would replay nothing, and this is the shape of
-    every idle run of the one-minute timer. Returning that fact also lets the
-    caller skip a push that would contact the remote to send nothing.
+    ref needs no replaying at all -- the shape of every idle run of the
+    one-minute timer. Returning that fact lets the caller skip a push that would
+    contact the remote to send nothing.
 
     The rebase cannot conflict over chunks -- every machine only ever adds files
     below its own host id. ``recipients.txt`` is the single shared file, and
     ``.gitattributes`` marks it ``merge=union`` so both sides' keys survive.
+
+    Do not answer the question with ``merge --ff-only`` succeeding. Merging a ref
+    that is already an *ancestor* of HEAD succeeds too -- it is a no-op -- so a
+    machine holding commits nobody else has would read as level and never
+    publish them. Only where HEAD lands says anything.
     """
     git("fetch", "--quiet", "origin")
     local, upstream = _resolve("HEAD", f"refs/remotes/origin/{repo.branch}")
@@ -1619,7 +1624,12 @@ def _fetch_and_rebase(repo: Repo) -> bool:
     except SyncError:
         git("rebase", "--abort", check=False)
         raise
-    return False
+    # A rebase with nothing of its own to replay lands exactly on the fetched
+    # ref: this machine only received. Worth one fork on the path that just
+    # rebased -- never on the idle path -- because it saves opening a connection
+    # to the remote to send it nothing, on every machine every time any peer
+    # records a command.
+    return _resolve("HEAD")[0] == upstream
 
 
 def _push(repo: Repo) -> None:
@@ -1664,14 +1674,19 @@ def read_repo() -> Repo:
     for line in git("config", "--list", "--local", check=False).splitlines():
         key, _, value = line.partition("=")
         values[key] = value
+    has_remote = any(key.startswith("remote.") and key.endswith(".url") for key in values)
     return Repo(
-        has_remote=any(key.startswith("remote.") and key.endswith(".url") for key in values),
+        has_remote=has_remote,
         name=values.get("user.name", ""),
         email=values.get("user.email", ""),
+        # Only asked for when there is a remote to name it to: every reader of
+        # this field is inside an `if has_remote`, and a local-only install
+        # would otherwise fork once a minute for a string nothing reads.
+        #
         # `branch --show-current` rather than `rev-parse --abbrev-ref HEAD`,
         # which cannot answer on an unborn HEAD -- exactly the state `init` is
         # in when it enrols the first machine.
-        branch=git("branch", "--show-current"),
+        branch=git("branch", "--show-current") if has_remote else "",
     )
 
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -60,6 +60,9 @@ class Report:
     lines_exported: int = 0
     chunks_merged: int = 0
     lines_imported: int = 0
+    #: This machine's history is on the remote. A state, not an event: a run
+    #: that was already level with the remote and committed nothing sets it
+    #: without sending anything, because there was nothing to send.
     pushed: bool = False
     hosts_seen: set[str] = field(default_factory=set)
     #: "<host>/<day>" entries sealed before this machine was enrolled. Not an

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -140,7 +140,8 @@ def git(*args: str, cwd: Path | None = None, check: bool = True) -> str:
 
 
 def has_remote() -> bool:
-    return bool(git("remote", check=False))
+    """For the callers that want only this. The definition lives in `Repo`."""
+    return read_repo().has_remote
 
 
 def remote_summary() -> str:
@@ -808,8 +809,9 @@ def trust_candidates() -> list[Candidate]:
     machine that appeared since this one last looked.
     """
     with lock():
-        if has_remote():
-            _fetch_and_rebase()
+        repo = read_repo()
+        if repo.has_remote:
+            _fetch_and_rebase(repo)
 
         known = store.machine()
         state = State.load()
@@ -1522,10 +1524,10 @@ def run(push: bool = True, now: int | None = None) -> Report:
     if not store.recipients_file().is_file():
         raise SyncError("no recipients.txt in the history repo; run 'woswoar init'")
 
-    config = _repo_config()
-    _ensure_repo_config(config)
+    repo = read_repo()
+    _ensure_repo_config(repo)
     report = Report()
-    remote = push and config.has_remote
+    remote = push and repo.has_remote
 
     with lock():
         state = State.load()
@@ -1535,10 +1537,7 @@ def run(push: bool = True, now: int | None = None) -> Report:
         # stale list would produce a key that machines enrolled since the last
         # sync can never open -- silently, and permanently, because the repo is
         # append-only.
-        # One `branch --show-current` for the run: nothing here checks a branch
-        # out, so it cannot change under us, and it was being asked twice.
-        branch = _branch() if remote else ""
-        in_sync = _fetch_and_rebase(branch) if remote else False
+        in_sync = _fetch_and_rebase(repo) if remote else False
 
         # Before anything is trusted, and only ever subtracting -- see
         # `apply_withdrawals`.
@@ -1563,22 +1562,13 @@ def run(push: bool = True, now: int | None = None) -> Report:
             # to send -- and `pushed` still holds, since it means this machine's
             # history is on the remote, not that bytes moved.
             if committed or not in_sync:
-                _push(branch)
+                _push(repo)
             report.pushed = True
 
         merge(known, state, report)
         state.save()
 
     return report
-
-
-def _branch() -> str:
-    """The current branch, including before the first commit exists.
-
-    `rev-parse --abbrev-ref HEAD` cannot answer on an unborn HEAD, which is
-    exactly the state `init` is in when it enrols the first machine.
-    """
-    return git("branch", "--show-current")
 
 
 #: Object ids as `rev-parse` prints them. Both lengths, because a repo may be
@@ -1600,7 +1590,7 @@ def _resolve(*refs: str) -> list[str]:
     return [line if len(line) in (40, 64) and _HEX.issuperset(line) else "" for line in printed]
 
 
-def _fetch_and_rebase(branch: str | None = None) -> bool:
+def _fetch_and_rebase(repo: Repo) -> bool:
     """Adopt the remote's history under ours; say whether we now match it.
 
     Fetch-then-rebase rather than ``git pull --rebase`` because the tracking ref
@@ -1618,31 +1608,27 @@ def _fetch_and_rebase(branch: str | None = None) -> bool:
     below its own host id. ``recipients.txt`` is the single shared file, and
     ``.gitattributes`` marks it ``merge=union`` so both sides' keys survive.
     """
-    if branch is None:
-        branch = _branch()
     git("fetch", "--quiet", "origin")
-    local, upstream = _resolve("HEAD", f"refs/remotes/origin/{branch}")
+    local, upstream = _resolve("HEAD", f"refs/remotes/origin/{repo.branch}")
     if not upstream:
         return False
     if local == upstream:
         return True
     try:
-        git("rebase", "--autostash", f"origin/{branch}")
+        git("rebase", "--autostash", f"origin/{repo.branch}")
     except SyncError:
         git("rebase", "--abort", check=False)
         raise
     return False
 
 
-def _push(branch: str | None = None) -> None:
+def _push(repo: Repo) -> None:
     """Publish, retrying once if someone else pushed while we worked."""
-    if branch is None:
-        branch = _branch()
     try:
-        git("push", "--quiet", "-u", "origin", branch)
+        git("push", "--quiet", "-u", "origin", repo.branch)
     except SyncError:
-        _fetch_and_rebase(branch)
-        git("push", "--quiet", "-u", "origin", branch)
+        _fetch_and_rebase(repo)
+        git("push", "--quiet", "-u", "origin", repo.branch)
 
 
 #: Commit metadata is one of the few things in the repo that is *not* encrypted,
@@ -1653,44 +1639,47 @@ COMMIT_NAME = "woswoar"
 COMMIT_EMAIL = "woswoar@localhost"
 
 
-class RepoConfig(NamedTuple):
-    """What a run needs to know about the repo, from one `git config` read.
+class Repo(NamedTuple):
+    """What a command needs to know about the git repo, read once up front.
 
-    Three separate forks before -- `user.name`, `user.email`, and `git remote` --
-    on a timer that fires every minute, to learn things that change about once in
-    the life of a clone. `git remote` reads the same local config file: it prints
-    the names in the `remote.<name>.url` keys that are already in hand here.
+    Every field was its own `git` fork before, repeated by each helper that
+    wanted it: `user.name` and `user.email` read every run to be written
+    approximately never, `git remote`, and `branch --show-current` twice per
+    sync. None of it can change under a command -- woswoar never checks a branch
+    out, and the identity is written at `init` -- so reading it once and passing
+    it down is the whole saving, on a timer that fires every minute.
+
+    `git remote` needs no fork of its own: it prints the names in the
+    `remote.<name>.url` keys of the same local config read here.
     """
 
     has_remote: bool
     name: str
     email: str
+    branch: str
 
 
-def _repo_config() -> RepoConfig:
+def read_repo() -> Repo:
     values: dict[str, str] = {}
     for line in git("config", "--list", "--local", check=False).splitlines():
         key, _, value = line.partition("=")
         values[key] = value
-    return RepoConfig(
+    return Repo(
         has_remote=any(key.startswith("remote.") and key.endswith(".url") for key in values),
         name=values.get("user.name", ""),
         email=values.get("user.email", ""),
+        # `branch --show-current` rather than `rev-parse --abbrev-ref HEAD`,
+        # which cannot answer on an unborn HEAD -- exactly the state `init` is
+        # in when it enrols the first machine.
+        branch=git("branch", "--show-current"),
     )
 
 
-def _ensure_repo_config(config: RepoConfig | None = None) -> None:
-    """Pin the commit identity, writing only what is actually wrong.
-
-    Takes an already-read config from the callers that have one -- those are the
-    ones on the timer; the rest are one-shot commands where a fork does not
-    matter.
-    """
-    if config is None:
-        config = _repo_config()
-    if config.name != COMMIT_NAME:
+def _ensure_repo_config(repo: Repo) -> None:
+    """Pin the commit identity, writing only what is actually wrong."""
+    if repo.name != COMMIT_NAME:
         git("config", "user.name", COMMIT_NAME)
-    if config.email != COMMIT_EMAIL:
+    if repo.email != COMMIT_EMAIL:
         git("config", "user.email", COMMIT_EMAIL)
 
 
@@ -1781,13 +1770,15 @@ def initialise(
     if remote and not has_remote():
         git("remote", "add", "origin", remote)
 
-    _ensure_repo_config()
+    # After the remote is added, not before: that is what decides `has_remote`.
+    repo = read_repo()
+    _ensure_repo_config(repo)
 
     # Adopt the remote's state before enrolling, so we append to the real
     # recipients.txt rather than creating a competing one.
-    publishing = has_remote()
+    publishing = repo.has_remote
     if publishing:
-        _fetch_and_rebase()
+        _fetch_and_rebase(repo)
 
     if _write_repo_metadata(known, chosen):
         _commit()
@@ -1812,7 +1803,7 @@ def initialise(
     # `grant` run elsewhere cannot include it, so onboarding would appear to
     # succeed and then silently fail to grant access to any older history.
     if publishing:
-        _push()
+        _push(repo)
 
     return known, chosen, pinned
 
@@ -1907,8 +1898,9 @@ def readers() -> list[Reader]:
     parses either side of the prompt, so they could describe different sets.
     """
     with lock():
-        if has_remote():
-            _fetch_and_rebase()
+        repo = read_repo()
+        if repo.has_remote:
+            _fetch_and_rebase(repo)
         granted = set(State.load().granted)
         enrolled = recipients()
         owners = _host_owners()
@@ -1966,19 +1958,19 @@ def _access_change() -> Iterator[_AccessChange]:
 
     known = store.machine()
     identity = identity_path(known)
-    config = _repo_config()
-    _ensure_repo_config(config)
-    remote = config.has_remote
+    repo = read_repo()
+    _ensure_repo_config(repo)
+    remote = repo.has_remote
 
     # The same lock sync takes: this rewrites files in the working tree, and a
     # timer-driven sync must not be reading them halfway through.
     with lock():
         if remote:
-            _fetch_and_rebase()
+            _fetch_and_rebase(repo)
         yield _AccessChange(identity, known, remote)
         _commit()
         if remote:
-            _push()
+            _push(repo)
 
 
 def _reseal(identity: Path, keys: list[str]) -> tuple[int, int]:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1519,9 +1519,10 @@ def run(push: bool = True, now: int | None = None) -> Report:
     if not store.recipients_file().is_file():
         raise SyncError("no recipients.txt in the history repo; run 'woswoar init'")
 
-    _ensure_repo_config()
+    config = _repo_config()
+    _ensure_repo_config(config)
     report = Report()
-    remote = push and has_remote()
+    remote = push and config.has_remote
 
     with lock():
         state = State.load()
@@ -1531,8 +1532,10 @@ def run(push: bool = True, now: int | None = None) -> Report:
         # stale list would produce a key that machines enrolled since the last
         # sync can never open -- silently, and permanently, because the repo is
         # append-only.
-        if remote:
-            _fetch_and_rebase()
+        # One `branch --show-current` for the run: nothing here checks a branch
+        # out, so it cannot change under us, and it was being asked twice.
+        branch = _branch() if remote else ""
+        in_sync = _fetch_and_rebase(branch) if remote else False
 
         # Before anything is trusted, and only ever subtracting -- see
         # `apply_withdrawals`.
@@ -1548,10 +1551,16 @@ def run(push: bool = True, now: int | None = None) -> Report:
             publish_signer(known)
             export(known, state, report, int(time.time()) if now is None else now)
 
-        _commit()
+        committed = _commit()
 
         if remote:
-            _push()
+            # `push` contacts the remote even with nothing to send, which is the
+            # slowest thing an idle run does. If the fetch above found us level
+            # with the remote and nothing was committed since, there is nothing
+            # to send -- and `pushed` still holds, since it means this machine's
+            # history is on the remote, not that bytes moved.
+            if committed or not in_sync:
+                _push(branch)
             report.pushed = True
 
         merge(known, state, report)
@@ -1569,8 +1578,27 @@ def _branch() -> str:
     return git("branch", "--show-current")
 
 
-def _fetch_and_rebase() -> None:
-    """Adopt the remote's history under ours.
+#: Object ids as `rev-parse` prints them. Both lengths, because a repo may be
+#: SHA-256 rather than SHA-1 -- woswoar never creates one, but it is handed the
+#: repo the user cloned.
+_HEX = frozenset("0123456789abcdef")
+
+
+def _resolve(*refs: str) -> list[str]:
+    """Resolve several refs in one fork; an unresolvable one comes back empty.
+
+    `rev-parse --verify` takes a single ref, so asking about two costs two forks.
+    Plain `rev-parse` takes any number, but *echoes* an argument it could not
+    resolve instead of failing that line, hence the shape check.
+    """
+    printed = git("rev-parse", *refs, check=False).splitlines()
+    if len(printed) != len(refs):
+        return [""] * len(refs)
+    return [line if len(line) in (40, 64) and _HEX.issuperset(line) else "" for line in printed]
+
+
+def _fetch_and_rebase(branch: str | None = None) -> bool:
+    """Adopt the remote's history under ours; say whether we now match it.
 
     Fetch-then-rebase rather than ``git pull --rebase`` because the tracking ref
     may legitimately not exist: cloning an *empty* remote configures a branch
@@ -1578,28 +1606,39 @@ def _fetch_and_rebase() -> None:
     enrol. Checking the fetched ref directly handles that and the ordinary case
     with one code path.
 
+    HEAD is resolved in the same fork, and a HEAD already equal to the fetched
+    ref skips the rebase -- git would replay nothing, and this is the shape of
+    every idle run of the one-minute timer. Returning that fact also lets the
+    caller skip a push that would contact the remote to send nothing.
+
     The rebase cannot conflict over chunks -- every machine only ever adds files
     below its own host id. ``recipients.txt`` is the single shared file, and
     ``.gitattributes`` marks it ``merge=union`` so both sides' keys survive.
     """
-    branch = _branch()
+    if branch is None:
+        branch = _branch()
     git("fetch", "--quiet", "origin")
-    if not git("rev-parse", "--verify", "--quiet", f"refs/remotes/origin/{branch}", check=False):
-        return
+    local, upstream = _resolve("HEAD", f"refs/remotes/origin/{branch}")
+    if not upstream:
+        return False
+    if local == upstream:
+        return True
     try:
         git("rebase", "--autostash", f"origin/{branch}")
     except SyncError:
         git("rebase", "--abort", check=False)
         raise
+    return False
 
 
-def _push() -> None:
+def _push(branch: str | None = None) -> None:
     """Publish, retrying once if someone else pushed while we worked."""
-    branch = _branch()
+    if branch is None:
+        branch = _branch()
     try:
         git("push", "--quiet", "-u", "origin", branch)
     except SyncError:
-        _fetch_and_rebase()
+        _fetch_and_rebase(branch)
         git("push", "--quiet", "-u", "origin", branch)
 
 
@@ -1611,14 +1650,48 @@ COMMIT_NAME = "woswoar"
 COMMIT_EMAIL = "woswoar@localhost"
 
 
-def _ensure_repo_config() -> None:
-    if git("config", "user.name", check=False) != COMMIT_NAME:
+class RepoConfig(NamedTuple):
+    """What a run needs to know about the repo, from one `git config` read.
+
+    Three separate forks before -- `user.name`, `user.email`, and `git remote` --
+    on a timer that fires every minute, to learn things that change about once in
+    the life of a clone. `git remote` reads the same local config file: it prints
+    the names in the `remote.<name>.url` keys that are already in hand here.
+    """
+
+    has_remote: bool
+    name: str
+    email: str
+
+
+def _repo_config() -> RepoConfig:
+    values: dict[str, str] = {}
+    for line in git("config", "--list", "--local", check=False).splitlines():
+        key, _, value = line.partition("=")
+        values[key] = value
+    return RepoConfig(
+        has_remote=any(key.startswith("remote.") and key.endswith(".url") for key in values),
+        name=values.get("user.name", ""),
+        email=values.get("user.email", ""),
+    )
+
+
+def _ensure_repo_config(config: RepoConfig | None = None) -> None:
+    """Pin the commit identity, writing only what is actually wrong.
+
+    Takes an already-read config from the callers that have one -- those are the
+    ones on the timer; the rest are one-shot commands where a fork does not
+    matter.
+    """
+    if config is None:
+        config = _repo_config()
+    if config.name != COMMIT_NAME:
         git("config", "user.name", COMMIT_NAME)
-    if git("config", "user.email", check=False) != COMMIT_EMAIL:
+    if config.email != COMMIT_EMAIL:
         git("config", "user.email", COMMIT_EMAIL)
 
 
-def _commit() -> None:
+def _commit() -> bool:
     # `--verbose` prints one "add '<path>'"/"remove '<path>'" line per staged
     # path and nothing at all when the index already matches, so the same
     # command that stages also answers "is there anything to commit". The
@@ -1626,8 +1699,9 @@ def _commit() -> None:
     # working tree that is tens of thousands of chunks after a couple of years,
     # on a timer that now fires every minute.
     if not git("add", "-A", "--verbose"):
-        return
+        return False
     git("commit", "-q", "-m", COMMIT_MESSAGE)
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -1889,8 +1963,9 @@ def _access_change() -> Iterator[_AccessChange]:
 
     known = store.machine()
     identity = identity_path(known)
-    _ensure_repo_config()
-    remote = has_remote()
+    config = _repo_config()
+    _ensure_repo_config(config)
+    remote = config.has_remote
 
     # The same lock sync takes: this rewrites files in the working tree, and a
     # timer-driven sync must not be reading them halfway through.


### PR DESCRIPTION
Closes #50.

`woswoar sync` runs from a one-minute timer. An idle run — nothing recorded here,
nothing new from any peer — forked `git` ten times to discover that. This gets it
to five, and skips two more forks on the receive path.

| | before | after |
|---|---|---|
| idle run, git forks | 10 | **5** |
| idle run, wall | 18.5 ms | **10.7 ms** |
| one new line, forks | 14 | **10** |
| one new line, wall | 38.9 ms | **34.9 ms** |
| receive a peer's commit | rebase + push | **rebase, no push** |
| `python -m unittest tests.test_sync` | 25.2 s | **23.5 s** |

The suite is faster despite seven new tests: #50 noted that this path is also
what makes it slow.

## What changed

**One read of the repo instead of five forks.** `user.name`, `user.email` and
`git remote` were three separate forks asking one local config file, every run,
to learn things written once at `init`. `git config --list --local` answers all
three — `git remote` just prints the names in the `remote.<name>.url` keys — and
`branch --show-current` was being asked twice per sync for a value that cannot
change under a command. They are now one `Repo` NamedTuple, read once and passed
down as a required argument. `_branch()` and the second `has_remote` implement­ation
are gone.

**No rebase when there is nothing to replay.** `rev-parse` resolves `HEAD` and
the fetched ref in one fork, and an idle run — where they are equal — skips the
rebase entirely.

**No push when there is nothing to send.** `push` opens a connection to the
remote whether or not it has anything to say, and it was the slowest thing an
idle run did. It is skipped when the machine is level with the remote and
committed nothing. `report.pushed` now means "this machine's history is on the
remote", a state rather than an event, and `cmd_sync` says "in sync with the
remote" instead of "pushed to remote".

That also fixes a case the issue did not mention: a machine that only *received*
a peer's commit had nothing of its own to publish, and pushed anyway. It now
re-resolves HEAD after the rebase — one fork, never on the idle path — and skips
the round trip. This fires on every machine every time any peer records a
command.

## The trap, since it cost a debugging round

`merge --ff-only` looks like a cheaper way to answer "am I level with the
remote": it costs 14.3 ms against 28.2 ms for `rebase --autostash` on a
20k-chunk tree. It is wrong. Merging a ref that is already an **ancestor** of
HEAD also succeeds — it is a no-op — so a machine holding unpushed commits reads
as level, skips the push, and never publishes again, because being ahead does not
clear by itself. It surfaced as `compact` silently failing to reach any peer.
Only where HEAD actually lands answers the question, and a test now pins that.
The fast-forward idea is filed as #75 with the constraint written down.

## Tests

Nine mutations, each reverting one part of the change, each caught:

```
caught  config read: back to a fork per question
caught  rebase: never short-circuit
caught  push: always push
caught  push skip overreaches: ignore what we just committed
caught  rebase skip overreaches: claim level with the remote always
caught  receive-only: go back to assuming a rebase leaves work to push
caught  level decided by the merge succeeding, which an ancestor also does
caught  _resolve: trust rev-parse's echo of an unresolvable ref
caught  identity: read it but never write it
caught  has_remote: not actually read from the config
```

The fork counts are asserted as a ceiling, at `sync.git`, so adding a call to
this path is a decision somebody makes rather than one that happens.

## `/simplify`

Run before opening, as CLAUDE.md rule 1 requires; four findings applied:

- the three new test classes had been appended **below** `if __name__ ==
  "__main__"`, so a direct `python -m tests.test_sync` never ran them. CI is
  discovery-based and was green regardless.
- `has_remote()` and `RepoConfig.has_remote` were two definitions of the same
  fact, kept in step by a test whose only job was to police the duplication.
  `has_remote()` now delegates; the test asserts behaviour instead.
- three functions had grown `X | None = None` "or go find it yourself"
  parameters, giving each a fast path and a slow one. All required now, which is
  what collapsed `RepoConfig` and `_branch` into one `Repo`.
- the fork counter spied on global `subprocess.run` and sniffed argv; it patches
  `sync.git` instead, the one place in the package that spawns git.

Four findings were out of scope and are filed rather than fixed: #72 (`merge`
walks every peer's whole chunk tree every run — 64.3 ms per 20k chunks, the
largest remaining cost), #73 (`git add -A` stats the whole tree to stage
nothing — 9.8 ms at 20k files), #74 (the branch name from `.git/HEAD`, 170x
cheaper), #75 (the fast-forward above).

One `/simplify` finding is deliberately **not** taken: `_repo_config`'s
`key, _, value = line.partition("=")` is a third copy of a parse that
`store._read_kv` and `deps._os_release` also have. Neither is a drop-in — both
take a `Path` and read the file themselves — and splitting one open to share
three lines is more churn than it saves.

## No migration needed

Per CLAUDE.md rule 8, and it does not arise here anyway: no format, no on-disk
layout and no `state.json` field changed. Only the git commands issued.

## One CI-only failure, fixed

`test_a_machine_ahead_of_the_remote_still_pushes` passed locally and failed on
every runner. The harness creates its bare remote with `git init --bare` and no
`-b`, so the branch is whatever `init.defaultBranch` says — `main` here,
`master` on the runners — and the test had `refs/remotes/origin/main` written
into it. It reads `read_repo().branch` now, and the suite passes under both
(`GIT_CONFIG_KEY_0=init.defaultBranch GIT_CONFIG_VALUE_0=master`).
