### PR TITLE
hook: pass the trap spec as an argument, not through a file

### DIFF
--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -183,7 +183,8 @@ rolls.
 
 The result is verified rather than asserted: CI runs the hook under `strace` with
 3 commands and with 30, and requires the clone count to be *identical*. Not zero
-— startup legitimately forks for `mkdir` and one `trap -p` subshell — but flat,
+— startup legitimately forks for `mkdir` and two `trap -p` subshells, one to see
+whether the EXIT trap is free and one to read any prior DEBUG trap — but flat,
 which is the property that actually matters.
 
 ### Sharing the shell with everything else

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -289,6 +289,34 @@ class TestCoexistence(ShellHookTestCase):
         self.assertIn("PREEXEC[echo hello]", out)
         self.assertEqual(self.commands(), [], "the scratch file survived the sabotage")
 
+    def test_the_boot_entry_removes_itself_from_every_shape(self) -> None:
+        """It has done its job after the first prompt, and it is not free.
+
+        `__woswoar_unboot` matches the boot text exactly, once per branch of the
+        PROMPT_COMMAND assembly, so each branch can miss on its own. What a miss
+        costs is measured in the comment above `__woswoar_unboot` -- ~12us of
+        re-testing a flag on every command -- and until #57 that was the whole
+        price. It is now also the difference between forking once at the first
+        prompt and forking at every one, which is why the shapes are enumerated
+        rather than represented by the bare shell.
+        """
+        shapes = {
+            "bare": "",
+            "string": "_other() { :; }\nPROMPT_COMMAND=_other",
+            "array": "_other() { :; }\nPROMPT_COMMAND=(_other)",
+        }
+        for label, before in shapes.items():
+            with self.subTest(shape=label):
+                out = self.run_shell(
+                    'echo one\nprintf "PC:%s\\n" "${PROMPT_COMMAND[*]}"\n', before=before
+                )
+                # Searched over the whole output rather than one captured line:
+                # the string form joins its entries with newlines, so the value
+                # is not a line. Nothing else the shell prints or echoes back
+                # contains this name, and `PC:` proves the printf itself ran.
+                self.assertIn("PC:", out)
+                self.assertNotIn("__woswoar_wire", out)
+
     def test_a_trap_that_could_not_be_read_installs_nothing(self) -> None:
         """An unreadable prior trap must not be mistaken for an absent one.
 

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -689,11 +689,16 @@ class TestConstantParity(unittest.TestCase):
 class TestForkFree(ShellHookTestCase):
     """Recording runs on every prompt, so its cost must not scale with usage."""
 
-    def clone_count(self, command_count: int, env_extra: dict[str, str] | None = None) -> int:
+    def clone_count(
+        self,
+        command_count: int,
+        env_extra: dict[str, str] | None = None,
+        before: str = "",
+    ) -> int:
         script = "".join(f"echo cmd{i}\n" for i in range(command_count))
         proc = subprocess.run(
             ["strace", "-f", "-c", "-e", "trace=clone,clone3,vfork,fork", "bash", "--norc", "-i"],
-            input=f"source {HOOK}\n{script}",
+            input=f"{textwrap.dedent(before)}\nsource {HOOK}\n{script}",
             text=True,
             env=self.shell_env(env_extra),
             stdout=subprocess.DEVNULL,
@@ -727,6 +732,33 @@ class TestForkFree(ShellHookTestCase):
                     many,
                     f"record path forks: {few} clones for 3 commands, {many} for 30",
                 )
+
+    #: Each takes a different branch of the PROMPT_COMMAND assembly, and the
+    #: last two are shapes where `__woswoar_unboot`'s exact-match removal can
+    #: miss -- which is when a boot entry stays and forks at every prompt.
+    SHAPES: ClassVar[dict[str, str]] = {
+        "array": "PROMPT_COMMAND=(_other)\n_other() { :; }",
+        "a prior string entry": "_other() { :; }\nPROMPT_COMMAND=_other",
+        "an entry rewritten after us": (
+            "_other() { PROMPT_COMMAND=${PROMPT_COMMAND//$'\\n'/$'\\n'}; }\nPROMPT_COMMAND=_other"
+        ),
+        "ble.sh": "BLE_VERSION=0.4.0-stub\nblehook() { :; }",
+    }
+
+    def test_no_prompt_command_shape_forks_per_prompt(self) -> None:
+        """The one fork the hook has is at the first prompt; it must stay there.
+
+        `__woswoar_boot` forks since #57, and it removes itself by matching its
+        own text in `PROMPT_COMMAND` -- a variable prompt frameworks rewrite
+        freely. A miss used to cost a redirect; now it would cost a fork on every
+        prompt for the life of the shell. The bare-shell case above never
+        exercises a miss, because there is nothing else in the variable.
+        """
+        for label, before in self.SHAPES.items():
+            with self.subTest(shape=label):
+                few = self.clone_count(3, before=before)
+                many = self.clone_count(30, before=before)
+                self.assertEqual(few, many, f"{label}: {few} clones for 3 commands, {many} for 30")
 
 
 @requires_bash5

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -240,12 +240,14 @@ class TestCoexistence(ShellHookTestCase):
     #: The shape of a common .bashrc: a title hook owning both. `_title_prompt`
     #: prints `$?` because that is what a real prompt does with it, and it is
     #: the only way to notice woswoar handing everyone downstream a 0.
-    PRIOR = """
+    PRIOR_TRAP = """
         _title_preexec() { printf 'PREEXEC[%s]\\n' "$BASH_COMMAND"; }
         _title_prompt() { printf 'PROMPT[%s]\\n' "$?"; }
         trap '_title_preexec' DEBUG
-        PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }_title_prompt"
     """
+    PRIOR = (
+        PRIOR_TRAP + '        PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }_title_prompt"\n'
+    )
 
     def test_an_existing_debug_trap_still_fires(self) -> None:
         # A bare `trap ... DEBUG` in the hook silently replaced it, so the other
@@ -253,17 +255,6 @@ class TestCoexistence(ShellHookTestCase):
         out = self.run_shell("echo hello\n", before=self.PRIOR)
         self.assertIn("PREEXEC[echo hello]", out)
         self.assertEqual(self.commands(), ["echo hello"])
-
-    #: Runs as an ordinary PROMPT_COMMAND entry, which woswoar orders *ahead*
-    #: of its own boot string -- so it breaks the scratch file in the window
-    #: where the boot string used to write the trap spec into it.
-    SABOTAGE = """
-        _sabotage() {
-            [[ -n ${__woswoar_scratch-} ]] || return 0
-            rm -f -- "$__woswoar_scratch" && mkdir -p -- "$__woswoar_scratch"
-        }
-        PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }_sabotage"
-    """
 
     def test_a_prior_trap_survives_a_scratch_file_that_cannot_be_written(self) -> None:
         """Issue #57: chaining must not depend on a file round trip.
@@ -278,25 +269,63 @@ class TestCoexistence(ShellHookTestCase):
         the file it captures `history 1` into is gone. What must not also be lost
         is somebody else's DEBUG trap.
         """
-        out = self.run_shell("echo hello\n", before=self.PRIOR + self.SABOTAGE)
+        # An ordinary PROMPT_COMMAND entry, which woswoar orders *ahead* of its
+        # own boot string -- so it breaks the file in the window where the boot
+        # string used to write the trap spec into it. It announces itself
+        # because its guard makes silence ambiguous: were `__woswoar_scratch`
+        # ever renamed, `_sabotage` would return 0 having sabotaged nothing and
+        # this test would pass while asserting what its sibling above already
+        # asserts.
+        sabotage = """
+            _sabotage() {
+                [[ -n ${__woswoar_scratch-} ]] || return 0
+                rm -f -- "$__woswoar_scratch" && mkdir -p -- "$__woswoar_scratch"
+                printf 'SABOTAGED\\n'
+            }
+            PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }_sabotage"
+        """
+        out = self.run_shell("echo hello\n", before=self.PRIOR + sabotage)
+        self.assertIn("SABOTAGED", out)
+        self.assertIn("PREEXEC[echo hello]", out)
+        self.assertEqual(self.commands(), [], "the scratch file survived the sabotage")
+
+    def test_a_trap_that_could_not_be_read_installs_nothing(self) -> None:
+        """An unreadable prior trap must not be mistaken for an absent one.
+
+        The spec reaches `__woswoar_wire` through a command substitution, and a
+        substitution that cannot fork yields an empty string -- which read as
+        "nobody owns DEBUG" would clobber the owner. That is the same silent
+        failure the scratch file used to cause, reached by the other route, so
+        the empty case has to mean "I could not look" and install nothing.
+
+        Driven by calling `__woswoar_wire` with an empty spec directly: the real
+        trigger is `fork` failing under `RLIMIT_NPROC`, which a test cannot ask
+        for without deciding how the rest of the shell behaves once it is there.
+        """
+        out = self.run_shell(
+            "__woswoar_wired=\n"
+            "trap '_title_preexec' DEBUG\n"
+            "__woswoar_wire ''\n"
+            "printf 'TRAP[%s]\\n' \"$(trap -p DEBUG)\"\n"
+            "echo hello\n",
+            before=self.PRIOR_TRAP,
+        )
+        # The trap is read back in the same shell: a second `run_shell` would be
+        # a fresh one, where nothing had gone wrong and woswoar wired normally.
+        self.assertIn("TRAP[trap -- '_title_preexec' DEBUG]", out)
         self.assertIn("PREEXEC[echo hello]", out)
 
     def test_a_prior_trap_survives_an_array_prompt_command(self) -> None:
         """bash 5.1's array form is a separate branch, and it was untested.
 
-        `__woswoar_boot` is an array *element* there rather than part of a
-        newline-joined string, and #57 moved the trap spec into a command
-        substitution inside it. If an element were evaluated somewhere that
-        cannot see the parent's DEBUG trap, chaining would break for every user
-        of a prompt framework that sets the array -- silently, since every part
-        would still look installed.
+        Coverage, not a regression test for #57: it passes with #57 reverted
+        too. It is here because `__woswoar_boot` is an array *element* on this
+        branch rather than part of a newline-joined string, and #57 put a command
+        substitution inside it -- which made it worth establishing that an
+        element is evaluated somewhere that can see the parent's DEBUG trap.
+        Nothing covered that before, for either shape of the boot string.
         """
-        array = """
-            _title_preexec() { printf 'PREEXEC[%s]\\n' "$BASH_COMMAND"; }
-            _title_prompt() { printf 'PROMPT[%s]\\n' "$?"; }
-            trap '_title_preexec' DEBUG
-            PROMPT_COMMAND=(_title_prompt)
-        """
+        array = self.PRIOR_TRAP + "        PROMPT_COMMAND=(_title_prompt)\n"
         out = self.run_shell("sleep 0.2\n", before=array)
         self.assertIn("PREEXEC[sleep 0.2]", out)
         self.assertIn("PROMPT[0]", out)
@@ -680,9 +709,12 @@ class TestForkFree(ShellHookTestCase):
         return total
 
     def test_clone_count_does_not_scale_with_commands(self) -> None:
-        # Not "zero forks": startup legitimately runs mkdir and one `trap -p`
-        # subshell. What matters is that the per-command path adds nothing, so
-        # the count must be identical for 3 and for 30 commands.
+        # Not "zero forks": startup legitimately runs mkdir and two `trap -p`
+        # subshells -- one to see whether the EXIT trap is free, one at the first
+        # prompt to read any prior DEBUG trap. What matters is that the
+        # per-command path adds nothing, so the count must be identical for 3 and
+        # for 30 commands. That also pins the boot string removing itself: were
+        # it left in PROMPT_COMMAND, its substitution would fork every time.
         #
         # Both scratch-file branches, because they are chosen at startup and a
         # fork added to either would be paid on every command of that shell.

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -281,6 +281,31 @@ class TestCoexistence(ShellHookTestCase):
         out = self.run_shell("echo hello\n", before=self.PRIOR + self.SABOTAGE)
         self.assertIn("PREEXEC[echo hello]", out)
 
+    def test_a_prior_trap_survives_an_array_prompt_command(self) -> None:
+        """bash 5.1's array form is a separate branch, and it was untested.
+
+        `__woswoar_boot` is an array *element* there rather than part of a
+        newline-joined string, and #57 moved the trap spec into a command
+        substitution inside it. If an element were evaluated somewhere that
+        cannot see the parent's DEBUG trap, chaining would break for every user
+        of a prompt framework that sets the array -- silently, since every part
+        would still look installed.
+        """
+        array = """
+            _title_preexec() { printf 'PREEXEC[%s]\\n' "$BASH_COMMAND"; }
+            _title_prompt() { printf 'PROMPT[%s]\\n' "$?"; }
+            trap '_title_preexec' DEBUG
+            PROMPT_COMMAND=(_title_prompt)
+        """
+        out = self.run_shell("sleep 0.2\n", before=array)
+        self.assertIn("PREEXEC[sleep 0.2]", out)
+        self.assertIn("PROMPT[0]", out)
+        # A duration, not merely a recorded command: `__woswoar_precmd` captures
+        # from `history 1` and would record the command even if nothing had ever
+        # wired the trap. Only a start time proves `__woswoar_preexec` fired,
+        # which is the half this branch is responsible for installing.
+        self.assertGreaterEqual(self.by_cmd()["sleep 0.2"].duration_ms, 100)
+
     def test_durations_survive_chaining(self) -> None:
         self.run_shell("sleep 0.2\n", before=self.PRIOR)
         by_cmd = self.by_cmd()

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -254,6 +254,33 @@ class TestCoexistence(ShellHookTestCase):
         self.assertIn("PREEXEC[echo hello]", out)
         self.assertEqual(self.commands(), ["echo hello"])
 
+    #: Runs as an ordinary PROMPT_COMMAND entry, which woswoar orders *ahead*
+    #: of its own boot string -- so it breaks the scratch file in the window
+    #: where the boot string used to write the trap spec into it.
+    SABOTAGE = """
+        _sabotage() {
+            [[ -n ${__woswoar_scratch-} ]] || return 0
+            rm -f -- "$__woswoar_scratch" && mkdir -p -- "$__woswoar_scratch"
+        }
+        PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }_sabotage"
+    """
+
+    def test_a_prior_trap_survives_a_scratch_file_that_cannot_be_written(self) -> None:
+        """Issue #57: chaining must not depend on a file round trip.
+
+        The prior handler's spec used to travel from the boot string to
+        `__woswoar_wire` through the scratch file. A shell where that file could
+        not be written therefore read an *empty* spec, concluded there was no
+        prior trap, and replaced whoever owned it -- so the other tool stopped
+        working, silently, for the life of the shell.
+
+        Recording is genuinely off in this shell, which is the honest outcome:
+        the file it captures `history 1` into is gone. What must not also be lost
+        is somebody else's DEBUG trap.
+        """
+        out = self.run_shell("echo hello\n", before=self.PRIOR + self.SABOTAGE)
+        self.assertIn("PREEXEC[echo hello]", out)
+
     def test_durations_survive_chaining(self) -> None:
         self.run_shell("sleep 0.2\n", before=self.PRIOR)
         by_cmd = self.by_cmd()
@@ -686,9 +713,11 @@ class TestRecordingIsPrivate(ShellHookTestCase):
 class TestTheScratchFileIsPrivate(ShellHookTestCase):
     """Issue #24: the scratch file's directory decides who can touch it.
 
-    Its contents are read back and, at the first prompt, `eval`ed to chain onto
-    an existing DEBUG trap. That is only safe while nobody else can write it, so
-    what is pinned here is the *directory*, not the filename.
+    Its contents are read back on every command, so what is pinned here is the
+    *directory*, not the filename -- the name is only a pid. Until #57 the file
+    also carried the trap spec that `__woswoar_wire` evaluates; it does not any
+    more, which is one fewer reason to care what is in it, not a reason to stop
+    caring who can write it.
     """
 
     HOSTILE: ClassVar[dict[str, str]] = {

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -360,8 +360,12 @@ __woswoar_wire() {
         return 0
     fi
 
-    local spec=
-    [[ -s $__woswoar_scratch ]] && IFS= read -r -d '' spec <"$__woswoar_scratch"
+    # The spec arrives as an argument, from a command substitution in the
+    # PROMPT_COMMAND string. It used to be written to the scratch file and read
+    # back here, which put the `eval` below's input on disk for no reason --
+    # defence in depth after #24 made the directory unreachable by anyone else,
+    # and it leaves the scratch file with the one job it is named for.
+    local spec=${1-}
 
     # `trap -p` prints a command that would restore the trap, with the handler
     # requoted -- `trap -- 'handler' DEBUG`. Re-splitting that as an array
@@ -410,12 +414,12 @@ __woswoar_unboot() {
 
 #: Runs at the first prompt and then deletes itself. A string, not a function,
 #: because only a string element is evaluated at top level, and `trap -p DEBUG`
-#: reports nothing from inside a function or a sourced file. Ordered before
-#: __woswoar_precmd so both can use the scratch file.
+#: reports nothing from inside a function or a sourced file. A command
+#: substitution is not a function: it forks, but it reads the parent's trap, and
+#: it runs here at top level where there is a trap to read.
 # shellcheck disable=SC2016  # single quotes are the point: this expands later
 __woswoar_boot='{
-    builtin trap -p DEBUG >"$__woswoar_scratch" 2>/dev/null
-    __woswoar_wire
+    __woswoar_wire "$(builtin trap -p DEBUG 2>/dev/null)"
     __woswoar_unboot
 }'
 

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -436,15 +436,28 @@ __woswoar_unboot() {
 #: substitution is not a function: it forks, but it reads the parent's trap, and
 #: it runs here at top level where there is a trap to read.
 #:
-#: That fork is the one exception to the builtins-only rule above, and it is
-#: only safe because `__woswoar_unboot` removes this entry immediately. Which is
-#: why it must stay ordered *before* `__woswoar_precmd` rather than last: the
+#: That fork is the one exception to the builtins-only rule above, so it is
+#: guarded twice over. `__woswoar_unboot` removes this entry after the first
+#: prompt -- and the `__woswoar_wired` test in front of the substitution means
+#: that even where removal fails, the fork is paid once rather than on every
+#: prompt. Removal *can* fail: it is an exact match on a variable other prompt
+#: frameworks rewrite freely, and it was harmless when this string only wrote a
+#: file. Measured with removal broken: 6 clones for 3 commands and for 30 with
+#: the guard, 9 and 36 without.
+#:
+#: The guard also pays for itself under ble.sh, where `__woswoar_wire` has
+#: already run at source time and the substitution would fork only to have its
+#: argument discarded.
+#:
+#: Ordered before `__woswoar_precmd` rather than last for a related reason: the
 #: string branch removes this text plus the newline after it, so a boot with
-#: nothing following it is never removed and the fork is paid on every command
-#: instead of once. `TestForkFree` catches exactly that.
+#: nothing following it is never removed at all.
+#:
+#: One cost, once per shell: under `set -T` a prior DEBUG handler sees the
+#: substitution as a command it did not run.
 # shellcheck disable=SC2016  # single quotes are the point: this expands later
 __woswoar_boot='{
-    __woswoar_wire "$(builtin trap -p DEBUG 2>/dev/null; printf .)"
+    [[ -n $__woswoar_wired ]] || __woswoar_wire "$(builtin trap -p DEBUG 2>/dev/null; printf .)"
     __woswoar_unboot
 }'
 

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -162,6 +162,12 @@ __woswoar_today=
 
 # ---------------------------------------------------------------------------
 # Hot path. Builtins only below this line.
+#
+# Two sections below are deliberately outside that rule and say so at their own
+# headers: the Ctrl-R widget, which runs on a keypress, and the boot string,
+# which runs once at the first prompt and then removes itself. Everything on the
+# per-command path is builtins, and CI proves it by counting clones for 3
+# commands and for 30.
 # ---------------------------------------------------------------------------
 
 # Escapes $1 into __woswoar_escaped. Mirrors escape() in woswoar/entry.py --
@@ -361,11 +367,23 @@ __woswoar_wire() {
     fi
 
     # The spec arrives as an argument, from a command substitution in the
-    # PROMPT_COMMAND string. It used to be written to the scratch file and read
-    # back here, which put the `eval` below's input on disk for no reason --
-    # defence in depth after #24 made the directory unreachable by anyone else,
-    # and it leaves the scratch file with the one job it is named for.
+    # PROMPT_COMMAND string. It used to travel through the scratch file, which
+    # meant a file that could not be written produced an *empty* spec -- and an
+    # empty spec is indistinguishable from "there was no prior trap", so the
+    # hook replaced whoever owned it and that tool silently stopped working for
+    # the life of the shell. A missing file must not be able to look like an
+    # absent trap. Taking the `eval` below's input off disk is the second
+    # reason, and after #24 only defence in depth.
+    # The only caller that legitimately passes nothing is the ble.sh branch
+    # above, which has already returned. So an empty argument here means the
+    # command substitution in the boot string failed to fork -- and empty is
+    # otherwise indistinguishable from "there is no prior trap", which would
+    # clobber another tool's handler: the same silent failure by a different
+    # route. `printf .` gives "I could not look" an answer of its own, and the
+    # answer to that is to install nothing rather than to guess.
     local spec=${1-}
+    [[ -n $spec ]] || return 0
+    spec=${spec%.}
 
     # `trap -p` prints a command that would restore the trap, with the handler
     # requoted -- `trap -- 'handler' DEBUG`. Re-splitting that as an array
@@ -417,9 +435,16 @@ __woswoar_unboot() {
 #: reports nothing from inside a function or a sourced file. A command
 #: substitution is not a function: it forks, but it reads the parent's trap, and
 #: it runs here at top level where there is a trap to read.
+#:
+#: That fork is the one exception to the builtins-only rule above, and it is
+#: only safe because `__woswoar_unboot` removes this entry immediately. Which is
+#: why it must stay ordered *before* `__woswoar_precmd` rather than last: the
+#: string branch removes this text plus the newline after it, so a boot with
+#: nothing following it is never removed and the fork is paid on every command
+#: instead of once. `TestForkFree` catches exactly that.
 # shellcheck disable=SC2016  # single quotes are the point: this expands later
 __woswoar_boot='{
-    __woswoar_wire "$(builtin trap -p DEBUG 2>/dev/null)"
+    __woswoar_wire "$(builtin trap -p DEBUG 2>/dev/null; printf .)"
     __woswoar_unboot
 }'
 


### PR DESCRIPTION
Closes #57.

The DEBUG-trap spec that `__woswoar_wire` evaluates used to travel from
`__woswoar_boot` to `__woswoar_wire` through the scratch file. It is now an
argument:

```sh
__woswoar_boot='{
    [[ -n $__woswoar_wired ]] || __woswoar_wire "$(builtin trap -p DEBUG 2>/dev/null; printf .)"
    __woswoar_unboot
}'
```

## The issue undersold itself

It filed this as defence in depth — "after #24 the file is in a directory only
this user can write, so this is no longer a security hole". It is also a bug
fix. A scratch file that could not be written produced an **empty** spec, and an
empty spec is indistinguishable from *there was no prior trap*: the hook then
replaced whoever owned DEBUG, so a title hook or bash-preexec stopped working
silently for the life of that shell.

`test_a_prior_trap_survives_a_scratch_file_that_cannot_be_written` fails against
the pre-#57 hook.

## And the same hole by the new route

`$( )` yields an empty string when it cannot fork, so moving the spec off disk
would have moved the defect rather than fixed it. Hence `printf .`: an empty
argument now means *I could not look*, and the answer to that is to install
nothing rather than to guess that DEBUG is free.

## Cost, measured

The substitution forks. It is the only fork below the "Builtins only below this
line" banner, which the header now says.

| shell | before | after |
|---|---|---|
| plain | 5 clones | 6 |
| prior string `PROMPT_COMMAND` | 5 | 6 |
| array `PROMPT_COMMAND` | 6 | 7 |
| **ble.sh** | 5 | **5** |

Flat for 3 commands and for 30 in every shape — the per-command path is
untouched. Startup 5.21 ms → 5.64 ms.

The `[[ -n $__woswoar_wired ]] ||` guard is doing real work. Under ble.sh
`__woswoar_wire` has already run at source time, so the substitution would fork
only to have its argument discarded. And `__woswoar_unboot` removes the boot
entry by matching its own text in a variable other prompt frameworks rewrite
freely — a miss used to cost ~12 µs per command, and would now cost a fork per
prompt. With the guard, a miss costs one fork total: measured 6 clones for 3
commands and for 30 with it, **9 and 36 without**.

## Tests

Ten mutations, each caught:

```
caught  the spec never arrives
caught  boot stops passing it
caught  spec taken off disk again
caught  no guard for an unreadable trap
caught  no sentinel to tell empty from absent
caught  array branch loses boot
caught  boot ordered last, never removed
caught  array branch never removes boot
caught  string branch never removes boot
caught  array unboot broken + guard removed (forks per prompt)
```

Three pre-existing coverage gaps this opened up and closed:

- **`TestForkFree` only ever exercised the bare shell.** Its two scratch-file
  variants share one `PROMPT_COMMAND` branch, so a per-prompt fork reachable only
  through the array branch shipped green. Verified: breaking removal in the array
  branch alone is invisible to the old test and caught by the new one.
- **Nothing asserted the boot entry removes itself**, in any branch — the thing
  the ~12 µs comment above `__woswoar_unboot` is about.
- **The array `PROMPT_COMMAND` branch had no trap-chaining coverage at all.**
  That test is coverage, not a #57 regression test: it passes with #57 reverted.
  It asserts a *duration*, because `__woswoar_precmd` records the command from
  `history 1` whether or not anything ever wired the trap — asserting the command
  was recorded would have proved nothing.

## `/simplify`

Run before opening, per rule 1. Applied: the WHY comment led with tidiness
instead of the defect; the builtins-only banner had gained a silent exception;
`SABOTAGE`'s guard let it no-op silently, so it now announces itself and the test
pins `commands() == []`; the array fixture duplicated `PRIOR`, now sharing
`PRIOR_TRAP`; stale fork counts in `tests/test_shell_hook.py` and
`docs/woswoar_design_summary.md`; and the ble.sh/unboot guard above.

Not taken, and noted rather than argued: `[[ -n $spec ]] && eval "parts=($spec)"`
keeps its guard. It is pre-existing, and it now reads as the pair of the
`return 0` above it rather than as redundancy.

## Ordering

The issue asked to retire the comment "Ordered before `__woswoar_precmd` so both
can use the scratch file". The sentence is gone but the ordering is not: I moved
boot last to check, and `TestForkFree` failed. The string branch removes the boot
text *plus the newline after it*, so a boot with nothing following it is never
removed. That is now what the comment says, and a test pins it.

## No migration needed

Per rule 8, and nothing on disk changed shape regardless — only what the hook
passes to itself.
