### PR TITLE
sync: stop re-reading a compacted day on every sync

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -12,6 +12,7 @@ import os
 import secrets
 import subprocess
 import tempfile
+import time
 import tracemalloc
 import unittest
 import zlib
@@ -1290,6 +1291,30 @@ class TestCompact(SyncTestCase):
             # A finished day is still fine, so the guard is on the future and
             # not on the flag.
             self.assertEqual(sync.compact(before="2023-12-01")[0], 1)
+
+    def test_the_default_leaves_today_alone(self) -> None:
+        """`compact()` with no argument means "days that are finished".
+
+        Today is still being written, so compacting it produces exactly the day
+        whose local copy every peer rebuilds each time it grows -- the case #69
+        is about, reached without passing any flag at all.
+        """
+        alpha = self.machine("alpha")
+        today = store.day_for(int(time.time()))
+        with alpha.active():
+            for i in range(2):
+                alpha.record(today, 1_700_000_001 + i, f"today {i}")
+                sync.run()
+                alpha.record("2023-11-14", 1_700_000_001 + i, f"finished {i}")
+                sync.run()
+            live = {c.name for c in store.iter_chunks(alpha.id) if c.day == today}
+
+            self.assertEqual(sync.compact()[0], 1, "the finished day was not compacted")
+            self.assertEqual(
+                {c.name for c in store.iter_chunks(alpha.id) if c.day == today},
+                live,
+                "the default compacted a day still being written",
+            )
 
     def test_compacted_chunk_still_reaches_another_machine(self) -> None:
         alpha = self.machine("alpha")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2845,19 +2845,22 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
             self.assertEqual(report.chunks_merged, 1, "a re-read chunk was counted as new")
             self.assertEqual(len(set(beta.commands())), 5)
 
-    def chunks_read(self, machine: Fake) -> int:
-        """How many chunks one sync on ``machine`` actually decrypts."""
-        reads = 0
+    def chunks_read(self, machine: Fake) -> list[str]:
+        """The chunks one sync on ``machine`` actually decrypts, in order.
+
+        Names rather than a count, because a re-read is far easier to read about
+        when the assertion can say which chunks came back.
+        """
+        opened: list[str] = []
         real = sync.open_chunk
 
-        def counted(path: Path, expected: str) -> bytes:
-            nonlocal reads
-            reads += 1
-            return real(path, expected)
+        def counted(path: Path, digest: str) -> bytes:
+            opened.append(path.name)
+            return real(path, digest)
 
         with machine.active(), mock.patch.object(sync, "open_chunk", counted):
             sync.run()
-        return reads
+        return opened
 
     def merged_lines(self, machine: Fake, host: Fake, day: str = "2023-11-14") -> int:
         """Lines in the local copy of a day, *not* deduplicated.
@@ -2891,7 +2894,8 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
                 sync.run()
             # One: the chunk that is actually new. Before #69 this was 2, 3,
             # 4 ... as the day's own chunks were re-read alongside it.
-            self.assertEqual(self.chunks_read(beta), 1, f"pass {i} re-read the day")
+            opened = self.chunks_read(beta)
+            self.assertEqual(len(opened), 1, f"pass {i} re-read the day: {opened}")
 
         with beta.active():
             self.assertEqual(len(beta.commands()), 10)
@@ -2966,17 +2970,9 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
             alpha.record("2023-11-14", 1_700_000_100, "later")
             sync.run()
 
+        opened = self.chunks_read(beta)
+        self.assertEqual(len(opened), 1, f"the whole day was re-read: {opened}")
         with beta.active():
-            opened: list[str] = []
-            real = sync.open_chunk
-
-            def counted(path: Path, digest: str) -> bytes:
-                opened.append(path.name)
-                return real(path, digest)
-
-            with mock.patch.object(sync, "open_chunk", counted):
-                sync.run()
-            self.assertEqual(len(opened), 1, f"the whole day was re-read: {opened}")
             self.assertEqual(len(beta.commands()), 5)
 
     def test_a_day_with_nothing_new_reads_no_manifest(self) -> None:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -95,6 +95,15 @@ class Fake:
     def commands(self) -> set[str]:
         return {e.cmd for e in cache.load_entries()}
 
+    def entries(self) -> list[Entry]:
+        """Everything merged here, *not* deduplicated.
+
+        `commands()` is a set, and a set is exactly what hides a day written
+        twice over -- which is what a rewrite that should have happened and did
+        not leaves behind.
+        """
+        return cache.load_entries()
+
     def append_recipient(self, name: str = "") -> str:
         """Enrol a machine behind woswoar's back, and return its recipient.
 
@@ -1265,23 +1274,22 @@ class TestCompact(SyncTestCase):
         """
         alpha = self.machine("alpha")
         with alpha.active():
-            alpha.record("2023-11-14", 1_700_000_001, "git status")
-            sync.run()
+            # Two syncs, so the day has two chunks: compacting a day that holds
+            # one is a no-op, and would prove nothing about the guard.
+            for i, cmd in enumerate(("git status", "make -j8")):
+                alpha.record("2023-11-14", 1_700_000_001 + i, cmd)
+                sync.run()
             before = {c.name for c in store.iter_chunks(alpha.id)}
 
-        # stderr, captured here rather than by `run_cli`, which is stdout only.
-        errors = io.StringIO()
-        with redirect_stderr(errors):
-            code, _ = self.run_cli(alpha, "compact", "--before", "2099-01-01")
-        self.assertEqual(code, 1)
-        self.assertIn("in the future", errors.getvalue())
         with alpha.active():
+            with self.assertRaises(sync.SyncError) as refused:
+                sync.compact(before="2099-01-01")
+            self.assertIn("in the future", str(refused.exception))
             self.assertEqual({c.name for c in store.iter_chunks(alpha.id)}, before)
 
-        # A finished day is still fine, so the guard is on the future and not on
-        # the flag.
-        code, _ = self.run_cli(alpha, "compact", "--before", "2023-12-01")
-        self.assertEqual(code, 0)
+            # A finished day is still fine, so the guard is on the future and
+            # not on the flag.
+            self.assertEqual(sync.compact(before="2023-12-01")[0], 1)
 
     def test_compacted_chunk_still_reaches_another_machine(self) -> None:
         alpha = self.machine("alpha")
@@ -1870,7 +1878,7 @@ class TestCompactionDoesNotDuplicateOnPeers(SyncTestCase):
     def merged_entries(self, beta: Fake) -> int:
         with beta.active():
             sync.run()
-            return len(cache.load_entries())
+            return len(beta.entries())
 
     def test_a_peer_that_already_merged_the_day_gains_nothing(self) -> None:
         # Counted as *entries*, not unique commands: `commands()` is a set, and
@@ -2862,17 +2870,6 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
             sync.run()
         return opened
 
-    def merged_lines(self, machine: Fake, host: Fake, day: str = "2023-11-14") -> int:
-        """Lines in the local copy of a day, *not* deduplicated.
-
-        `commands()` is a set, so it cannot see a day written twice over -- which
-        is the shape a rewrite that should have happened and did not leaves
-        behind.
-        """
-        with machine.active():
-            text = store.log_file(host.id, day).read_text(encoding="utf-8")
-        return len(text.splitlines())
-
     def test_a_compacted_day_that_keeps_growing_re_reads_only_what_is_new(self) -> None:
         """Issue #69: `subsumes` stays in the manifest, so it cannot mean "rebuild".
 
@@ -2899,7 +2896,7 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
 
         with beta.active():
             self.assertEqual(len(beta.commands()), 10)
-        self.assertEqual(self.merged_lines(beta, alpha), 10)
+            self.assertEqual(len(beta.entries()), 10)
 
     def test_compacting_a_second_time_does_rebuild(self) -> None:
         """The record is the *set* of compacted chunks, not a flag or a count.
@@ -2920,14 +2917,15 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
                 alpha.record("2023-11-14", 1_700_000_600 + i, f"later {i}")
                 sync.run()
         self.chunks_read(beta)
-        self.assertEqual(self.merged_lines(beta, alpha), 6)
+        with beta.active():
+            self.assertEqual(len(beta.entries()), 6)
 
         with alpha.active():
             self.assertEqual(sync.compact(before="2023-12-01")[0], 1)
             sync.run()
         self.chunks_read(beta)
-        self.assertEqual(self.merged_lines(beta, alpha), 6, "the day was written twice over")
         with beta.active():
+            self.assertEqual(len(beta.entries()), 6, "the day was written twice over")
             self.assertEqual(len(beta.commands()), 6)
 
     def test_a_rewrite_that_lost_a_chunk_is_tried_again(self) -> None:
@@ -2955,8 +2953,8 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
         # as done, this appends the compacted chunk to a day that still holds
         # every line it replaces.
         self.chunks_read(beta)
-        self.assertEqual(self.merged_lines(beta, alpha), 4, "the day was written twice over")
         with beta.active():
+            self.assertEqual(len(beta.entries()), 4, "the day was written twice over")
             self.assertEqual(len(beta.commands()), 4)
 
     def test_an_ordinary_day_stays_incremental(self) -> None:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1255,6 +1255,34 @@ class TestCompact(SyncTestCase):
             self.assertEqual((days, replaced), (1, 5))
             self.assertEqual(len(list(store.iter_chunks(alpha.id))), 1)
 
+    def test_a_before_in_the_future_is_refused(self) -> None:
+        """Issue #69: the only trigger that repeats indefinitely.
+
+        `--before 2099-01-01` takes in today and every day after it, and those
+        days keep gaining chunks -- so each is a day whose local copy peers must
+        rebuild every time it grows. A day compacted while still being written
+        reaches ~1440 chunks. There is no case where asking for it is the intent.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            before = {c.name for c in store.iter_chunks(alpha.id)}
+
+        # stderr, captured here rather than by `run_cli`, which is stdout only.
+        errors = io.StringIO()
+        with redirect_stderr(errors):
+            code, _ = self.run_cli(alpha, "compact", "--before", "2099-01-01")
+        self.assertEqual(code, 1)
+        self.assertIn("in the future", errors.getvalue())
+        with alpha.active():
+            self.assertEqual({c.name for c in store.iter_chunks(alpha.id)}, before)
+
+        # A finished day is still fine, so the guard is on the future and not on
+        # the flag.
+        code, _ = self.run_cli(alpha, "compact", "--before", "2023-12-01")
+        self.assertEqual(code, 0)
+
     def test_compacted_chunk_still_reaches_another_machine(self) -> None:
         alpha = self.machine("alpha")
         beta = self.machine("beta")
@@ -2816,6 +2844,116 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
             # arrived that they already had.
             self.assertEqual(report.chunks_merged, 1, "a re-read chunk was counted as new")
             self.assertEqual(len(set(beta.commands())), 5)
+
+    def chunks_read(self, machine: Fake) -> int:
+        """How many chunks one sync on ``machine`` actually decrypts."""
+        reads = 0
+        real = sync.open_chunk
+
+        def counted(path: Path, expected: str) -> bytes:
+            nonlocal reads
+            reads += 1
+            return real(path, expected)
+
+        with machine.active(), mock.patch.object(sync, "open_chunk", counted):
+            sync.run()
+        return reads
+
+    def merged_lines(self, machine: Fake, host: Fake, day: str = "2023-11-14") -> int:
+        """Lines in the local copy of a day, *not* deduplicated.
+
+        `commands()` is a set, so it cannot see a day written twice over -- which
+        is the shape a rewrite that should have happened and did not leaves
+        behind.
+        """
+        with machine.active():
+            text = store.log_file(host.id, day).read_text(encoding="utf-8")
+        return len(text.splitlines())
+
+    def test_a_compacted_day_that_keeps_growing_re_reads_only_what_is_new(self) -> None:
+        """Issue #69: `subsumes` stays in the manifest, so it cannot mean "rebuild".
+
+        A rewrite re-reads every chunk the manifest lists, which is right on the
+        pass the compacted chunk arrives and wrong on every pass after it. Keyed
+        on the day merely *having* one, a day that gains a chunk per sync re-read
+        one more chunk each time -- linear per sync, quadratic over the day, and
+        a day compacted while still being written reaches ~1440 chunks.
+        """
+        alpha, beta = self.merged_pair()
+        with alpha.active():
+            self.assertEqual(sync.compact(before="2023-12-01")[0], 1)
+            sync.run()
+        self.chunks_read(beta)  # the pass that adopts the compaction
+
+        for i in range(6):
+            with alpha.active():
+                alpha.record("2023-11-14", 1_700_000_600 + i, f"later {i}")
+                sync.run()
+            # One: the chunk that is actually new. Before #69 this was 2, 3,
+            # 4 ... as the day's own chunks were re-read alongside it.
+            self.assertEqual(self.chunks_read(beta), 1, f"pass {i} re-read the day")
+
+        with beta.active():
+            self.assertEqual(len(beta.commands()), 10)
+        self.assertEqual(self.merged_lines(beta, alpha), 10)
+
+    def test_compacting_a_second_time_does_rebuild(self) -> None:
+        """The record is the *set* of compacted chunks, not a flag or a count.
+
+        A second compaction replaces one compacted chunk with another, so a flag
+        would not change and neither would a count. The peer would then treat the
+        new compacted chunk -- a complete statement of the whole day -- as one
+        more chunk to append, and write the day twice over.
+        """
+        alpha, beta = self.merged_pair()
+        with alpha.active():
+            sync.compact(before="2023-12-01")
+            sync.run()
+        self.chunks_read(beta)
+
+        with alpha.active():
+            for i in range(2):
+                alpha.record("2023-11-14", 1_700_000_600 + i, f"later {i}")
+                sync.run()
+        self.chunks_read(beta)
+        self.assertEqual(self.merged_lines(beta, alpha), 6)
+
+        with alpha.active():
+            self.assertEqual(sync.compact(before="2023-12-01")[0], 1)
+            sync.run()
+        self.chunks_read(beta)
+        self.assertEqual(self.merged_lines(beta, alpha), 6, "the day was written twice over")
+        with beta.active():
+            self.assertEqual(len(beta.commands()), 6)
+
+    def test_a_rewrite_that_lost_a_chunk_is_tried_again(self) -> None:
+        """Recording the rebuild before it succeeded would make the day short.
+
+        The record says "this day was rebuilt from these compacted chunks". If a
+        chunk fails on the pass that rewrites -- an unopenable day key, a chunk
+        that does not match its digest -- the day on disk does not have it, and
+        writing the record anyway means the day is never rebuilt again: the peer
+        appends whatever arrives next to a copy that was never rebuilt at all.
+        """
+        alpha, beta = self.merged_pair()
+        with alpha.active():
+            sync.compact(before="2023-12-01")
+            sync.run()
+
+        def refuse(path: Path, expected: str) -> bytes:
+            raise ValueError(f"{path.name} is not the chunk its manifest names")
+
+        with beta.active(), mock.patch.object(sync, "open_chunk", refuse):
+            report = sync.run()
+        self.assertIn(f"{alpha.id}/2023-11-14", report.unauthenticated)
+
+        # The next pass must still owe a rewrite. If the failed one was recorded
+        # as done, this appends the compacted chunk to a day that still holds
+        # every line it replaces.
+        self.chunks_read(beta)
+        self.assertEqual(self.merged_lines(beta, alpha), 4, "the day was written twice over")
+        with beta.active():
+            self.assertEqual(len(beta.commands()), 4)
 
     def test_an_ordinary_day_stays_incremental(self) -> None:
         """Only a rewrite re-reads. Otherwise every sync would redo the day.

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -736,22 +736,7 @@ def cmd_trust(args: argparse.Namespace) -> int:
 def cmd_compact(args: argparse.Namespace) -> int:
     from . import sync
 
-    # Through `store.day_for`, so the CLI's "today" is the bucket the shell hook
-    # records into rather than a second definition of it.
-    today = store.day_for(int(time.time()))
-    before = args.before or today
-    # Compaction is for days that are finished. A `--before` in the future takes
-    # in today and every day after it, and those days keep gaining chunks -- so
-    # each one is a day whose local copy has to be rebuilt on peers every time
-    # it grows. There is no case where asking for it is what was meant.
-    if before > today:
-        print(
-            f"--before {before} is in the future; compaction is for days that are finished",
-            file=sys.stderr,
-        )
-        return 1
-
-    days, replaced, skipped = sync.compact(before=before)
+    days, replaced, skipped = sync.compact(before=args.before)
     if not days:
         print("nothing to compact")
     else:

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -736,7 +736,21 @@ def cmd_trust(args: argparse.Namespace) -> int:
 def cmd_compact(args: argparse.Namespace) -> int:
     from . import sync
 
-    days, replaced, skipped = sync.compact(before=args.before or time.strftime("%Y-%m-%d"))
+    today = time.strftime("%Y-%m-%d")
+    before = args.before or today
+    # Compaction is for days that are finished. A `--before` in the future takes
+    # in today and every day after it, and those days keep gaining chunks -- so
+    # each one is a day whose local copy has to be rebuilt on peers every time
+    # it grows. There is no case where asking for it is what was meant.
+    if before > today:
+        print(
+            f"woswoar: --before {before} is in the future; compaction is for days "
+            "that are finished",
+            file=sys.stderr,
+        )
+        return 1
+
+    days, replaced, skipped = sync.compact(before=before)
     if not days:
         print("nothing to compact")
     else:

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -736,7 +736,9 @@ def cmd_trust(args: argparse.Namespace) -> int:
 def cmd_compact(args: argparse.Namespace) -> int:
     from . import sync
 
-    today = time.strftime("%Y-%m-%d")
+    # Through `store.day_for`, so the CLI's "today" is the bucket the shell hook
+    # records into rather than a second definition of it.
+    today = store.day_for(int(time.time()))
     before = args.before or today
     # Compaction is for days that are finished. A `--before` in the future takes
     # in today and every day after it, and those days keep gaining chunks -- so
@@ -744,8 +746,7 @@ def cmd_compact(args: argparse.Namespace) -> int:
     # it grows. There is no case where asking for it is what was meant.
     if before > today:
         print(
-            f"woswoar: --before {before} is in the future; compaction is for days "
-            "that are finished",
+            f"--before {before} is in the future; compaction is for days that are finished",
             file=sys.stderr,
         )
         return 1

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -373,6 +373,28 @@ def is_repo() -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _names_by_day(raw: object) -> dict[str, set[str]]:
+    """A ``"<host>/<day>" -> chunk names`` map out of whatever the file holds.
+
+    Guarded per value, not just on the whole thing being a dict. A state file
+    from before `merged` became a set holds one *string* per day, and a string
+    is iterable: without this, every day's record turns into its own characters,
+    every chunk looks unmerged, and the first sync after upgrading duplicates
+    every peer's history wholesale.
+
+    Shared by `merged` and `rebuilt` because they are the same shape and want
+    the same answer when malformed: forget that day and read it again, which
+    repeats work rather than dropping history.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(key): {str(name) for name in value}
+        for key, value in raw.items()
+        if isinstance(value, list)
+    }
+
+
 @dataclass
 class State:
     """Per-machine progress. Deliberately *not* in the repo: it describes what
@@ -415,7 +437,7 @@ class State:
     #: cannot mean "rebuild it". Keyed on the *set* rather than a count or a
     #: flag: compacting twice replaces one compacted chunk with another, and
     #: neither the count nor a flag would change.
-    rebuilt: dict[str, list[str]] = field(default_factory=dict)
+    rebuilt: dict[str, set[str]] = field(default_factory=dict)
     #: What was on disk when this was loaded, so `save` can tell whether there
     #: is anything to write. Not part of the state itself.
     _loaded: dict[str, object] = field(default_factory=dict, repr=False, compare=False)
@@ -432,15 +454,7 @@ class State:
             return cls()
         state = cls(
             exported={str(k): int(v) for k, v in exported.items()},
-            # Guarded per value, not just on `merged` being a dict. A state
-            # file from before this became a set holds one *string* per day, and
-            # a string is iterable: without this, every day's record turns into
-            # its own characters, every chunk looks unmerged, and the first sync
-            # after upgrading duplicates every peer's history wholesale -- which
-            # is the bug this change exists to fix.
-            merged={
-                str(k): {str(name) for name in v} for k, v in merged.items() if isinstance(v, list)
-            },
+            merged=_names_by_day(merged),
             # A malformed list costs the prompt its memory, which shows every
             # machine as new -- the safe direction to be wrong in.
             granted=[str(k) for k in granted] if isinstance(granted, list) else [],
@@ -450,14 +464,7 @@ class State:
             signers={str(k): str(v) for k, v in signers.items()}
             if isinstance(signers, dict)
             else {},
-            # A malformed record costs one rebuild of that day, which re-reads
-            # chunks it already had. Wrong in the direction that repeats work
-            # rather than the one that drops history.
-            rebuilt={
-                str(k): [str(name) for name in v] for k, v in rebuilt.items() if isinstance(v, list)
-            }
-            if isinstance(rebuilt, dict)
-            else {},
+            rebuilt=_names_by_day(rebuilt),
         )
         state._loaded = state.as_json()
         return state
@@ -474,7 +481,7 @@ class State:
             "merged": {key: sorted(names) for key, names in self.merged.items()},
             "granted": list(self.granted),
             "signers": dict(self.signers),
-            "rebuilt": {key: list(names) for key, names in self.rebuilt.items()},
+            "rebuilt": {key: sorted(names) for key, names in self.rebuilt.items()},
         }
 
     def save(self) -> None:
@@ -1388,8 +1395,8 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         # rebuilt the whole day every time it gained anything: linear per sync,
         # quadratic over a day still being written, and a day compacted while
         # live reaches ~1440 chunks.
-        compacted = sorted(name for name, entry in listed.items() if entry.subsumes)
-        day = _Day(host_id, chunk_day, listed, compacted != state.rebuilt.get(key, []))
+        compacted = {name for name, entry in listed.items() if entry.subsumes}
+        day = _Day(host_id, chunk_day, listed, compacted != state.rebuilt.get(key, set()))
         pending = chunks if day.rewrite else fresh
 
         # Whether every chunk the manifest lists reached the file this pass. A

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -407,6 +407,15 @@ class State:
     #: `hosts/<id>/signer.pub` included, so the key a host is held to has to be
     #: remembered somewhere the remote cannot reach.
     signers: dict[str, str] = field(default_factory=dict)
+    #: "<host>/<day>" -> the compacted chunks the local copy of that day was last
+    #: rebuilt from, sorted.
+    #:
+    #: A compacted chunk keeps its `subsumes` list in the signed manifest for
+    #: good, so "does this day contain a compacted chunk" stays true forever and
+    #: cannot mean "rebuild it". Keyed on the *set* rather than a count or a
+    #: flag: compacting twice replaces one compacted chunk with another, and
+    #: neither the count nor a flag would change.
+    rebuilt: dict[str, list[str]] = field(default_factory=dict)
     #: What was on disk when this was loaded, so `save` can tell whether there
     #: is anything to write. Not part of the state itself.
     _loaded: dict[str, object] = field(default_factory=dict, repr=False, compare=False)
@@ -418,6 +427,7 @@ class State:
         merged = raw.get("merged", {})
         granted = raw.get("granted", [])
         signers = raw.get("signers", {})
+        rebuilt = raw.get("rebuilt", {})
         if not isinstance(exported, dict) or not isinstance(merged, dict):
             return cls()
         state = cls(
@@ -440,6 +450,14 @@ class State:
             signers={str(k): str(v) for k, v in signers.items()}
             if isinstance(signers, dict)
             else {},
+            # A malformed record costs one rebuild of that day, which re-reads
+            # chunks it already had. Wrong in the direction that repeats work
+            # rather than the one that drops history.
+            rebuilt={
+                str(k): [str(name) for name in v] for k, v in rebuilt.items() if isinstance(v, list)
+            }
+            if isinstance(rebuilt, dict)
+            else {},
         )
         state._loaded = state.as_json()
         return state
@@ -456,6 +474,7 @@ class State:
             "merged": {key: sorted(names) for key, names in self.merged.items()},
             "granted": list(self.granted),
             "signers": dict(self.signers),
+            "rebuilt": {key: list(names) for key, names in self.rebuilt.items()},
         }
 
     def save(self) -> None:
@@ -1361,8 +1380,22 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         if not fresh:
             continue
 
-        day = _Day(host_id, chunk_day, read_manifest(host_id, chunk_day, verify_key))
+        listed = read_manifest(host_id, chunk_day, verify_key)
+        # A rewrite is owed when the day's *compacted* chunks are not the ones
+        # the local copy was last rebuilt from -- not merely when it has some.
+        # A compacted chunk keeps its `subsumes` list in the manifest forever,
+        # so "has one" stays true for the life of the day, and keying on it
+        # rebuilt the whole day every time it gained anything: linear per sync,
+        # quadratic over a day still being written, and a day compacted while
+        # live reaches ~1440 chunks.
+        compacted = sorted(name for name, entry in listed.items() if entry.subsumes)
+        day = _Day(host_id, chunk_day, listed, compacted != state.rebuilt.get(key, []))
         pending = chunks if day.rewrite else fresh
+
+        # Whether every chunk the manifest lists reached the file this pass. A
+        # rewrite that lost one to an unopenable key must not be recorded as
+        # done, or the day is never rebuilt again and stays short for good.
+        complete = True
 
         for chunk in pending:
             if chunk.name not in day.listed:
@@ -1386,6 +1419,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             secret = day_keys[chunk_day]
             if secret is None:
                 report.unreadable.add(key)
+                complete = False
                 continue
 
             # Authenticated before it is decrypted or decompressed, so age, zlib
@@ -1395,6 +1429,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 blob = open_chunk(chunk.path, day.listed[chunk.name].digest)
             except (OSError, ValueError):
                 report.unauthenticated.add(key)
+                complete = False
                 continue
 
             try:
@@ -1407,6 +1442,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 # and every other host's readable chunks, on this run and every
                 # run after it.
                 report.unreadable.add(key)
+                complete = False
                 continue
 
             day.add(plaintext, report)
@@ -1415,6 +1451,8 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 report.chunks_merged += 1
 
         day.flush(report)
+        if compacted and complete:
+            state.rebuilt[key] = compacted
 
 
 class _Day:
@@ -1425,21 +1463,22 @@ class _Day:
     decryption, and so "this day is being rewritten" is settled once, from the
     manifest, instead of discovered part way through.
 
-    That last part is not tidiness. A day holding a compacted chunk has to be
-    written in a single atomic replacement, so it must never be flushed early;
-    working that out when the subsuming chunk turns up is too late, because
-    chunks before it may already have gone to the file and the replacement
-    would drop them.
+    That last part is not tidiness. A day being rewritten has to be written in a
+    single atomic replacement, so it must never be flushed early; working that
+    out when the subsuming chunk turns up is too late, because chunks before it
+    may already have gone to the file and the replacement would drop them.
     """
 
-    def __init__(self, host_id: str, day: str, listed: dict[str, Entry]) -> None:
+    def __init__(self, host_id: str, day: str, listed: dict[str, Entry], rewrite: bool) -> None:
         self.host_id = host_id
         self.day = day
         self.listed = listed
-        # A compacted chunk is a complete statement of the chunks it names, so
-        # the day is replaced rather than added to -- which is the only answer
-        # right whether the peer had merged all of them, some, or none.
-        self.rewrite = any(entry.subsumes for entry in listed.values())
+        # Decided by the caller, which is the only place that knows what this
+        # machine last rebuilt the day from. A compacted chunk is a complete
+        # statement of the chunks it names, so a day that has gained one is
+        # replaced rather than added to -- the only answer right whether the
+        # peer had merged all of them, some, or none.
+        self.rewrite = rewrite
         self._blocks: list[bytes] = []
         self._bytes = 0
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -2206,7 +2206,7 @@ def revoke(reader: Reader) -> RevokeReport:
     return RevokeReport(resealed, skipped, pushed=change.remote, still_readable=still_readable)
 
 
-def compact(before: str) -> tuple[int, int, int]:
+def compact(before: str | None = None) -> tuple[int, int, int]:
     """Merge a host's own chunks for completed days into one chunk per day.
 
     Write-once chunks trade bytes for inodes: a 5-minute timer produces roughly
@@ -2220,11 +2220,26 @@ def compact(before: str) -> tuple[int, int, int]:
     `store.new_chunk`'s uniqueness check sound, since that check assumes no
     other process is creating chunks for this host concurrently.
 
+    ``before`` defaults to today, and may not be later than it: compaction is
+    for days that are *finished*. A future one takes in today and every day
+    after it, and those days keep gaining chunks -- so each becomes a day whose
+    local copy every peer rebuilds each time it grows (#69). There is no case
+    where asking for it is what was meant.
+
     Returns (days compacted, chunks replaced, days left alone because merging
     them would exceed `MAX_EXPORT_BYTES`).
     """
     crypto.require()
     crypto.require_signing()
+    # `store.day_for`, so "today" here is the bucket the shell hook records
+    # into rather than a second definition of it.
+    today = store.day_for(int(time.time()))
+    if before is None:
+        before = today
+    elif before > today:
+        raise SyncError(
+            f"--before {before} is in the future; compaction is for days that are finished"
+        )
     known = store.machine()
 
     with lock():

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -373,28 +373,6 @@ def is_repo() -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _names_by_day(raw: object) -> dict[str, set[str]]:
-    """A ``"<host>/<day>" -> chunk names`` map out of whatever the file holds.
-
-    Guarded per value, not just on the whole thing being a dict. A state file
-    from before `merged` became a set holds one *string* per day, and a string
-    is iterable: without this, every day's record turns into its own characters,
-    every chunk looks unmerged, and the first sync after upgrading duplicates
-    every peer's history wholesale.
-
-    Shared by `merged` and `rebuilt` because they are the same shape and want
-    the same answer when malformed: forget that day and read it again, which
-    repeats work rather than dropping history.
-    """
-    if not isinstance(raw, dict):
-        return {}
-    return {
-        str(key): {str(name) for name in value}
-        for key, value in raw.items()
-        if isinstance(value, list)
-    }
-
-
 @dataclass
 class State:
     """Per-machine progress. Deliberately *not* in the repo: it describes what
@@ -429,15 +407,6 @@ class State:
     #: `hosts/<id>/signer.pub` included, so the key a host is held to has to be
     #: remembered somewhere the remote cannot reach.
     signers: dict[str, str] = field(default_factory=dict)
-    #: "<host>/<day>" -> the compacted chunks the local copy of that day was last
-    #: rebuilt from, sorted.
-    #:
-    #: A compacted chunk keeps its `subsumes` list in the signed manifest for
-    #: good, so "does this day contain a compacted chunk" stays true forever and
-    #: cannot mean "rebuild it". Keyed on the *set* rather than a count or a
-    #: flag: compacting twice replaces one compacted chunk with another, and
-    #: neither the count nor a flag would change.
-    rebuilt: dict[str, set[str]] = field(default_factory=dict)
     #: What was on disk when this was loaded, so `save` can tell whether there
     #: is anything to write. Not part of the state itself.
     _loaded: dict[str, object] = field(default_factory=dict, repr=False, compare=False)
@@ -449,12 +418,19 @@ class State:
         merged = raw.get("merged", {})
         granted = raw.get("granted", [])
         signers = raw.get("signers", {})
-        rebuilt = raw.get("rebuilt", {})
         if not isinstance(exported, dict) or not isinstance(merged, dict):
             return cls()
         state = cls(
             exported={str(k): int(v) for k, v in exported.items()},
-            merged=_names_by_day(merged),
+            # Guarded per value, not just on `merged` being a dict. A value
+            # that is a bare *string* rather than a list is iterable, so without
+            # this every day's record turns into its own characters, every chunk
+            # looks unmerged, and the next sync duplicates every peer's history
+            # wholesale. Forgetting a malformed day and reading it again is the
+            # direction that repeats work rather than dropping history.
+            merged={
+                str(k): {str(name) for name in v} for k, v in merged.items() if isinstance(v, list)
+            },
             # A malformed list costs the prompt its memory, which shows every
             # machine as new -- the safe direction to be wrong in.
             granted=[str(k) for k in granted] if isinstance(granted, list) else [],
@@ -464,7 +440,6 @@ class State:
             signers={str(k): str(v) for k, v in signers.items()}
             if isinstance(signers, dict)
             else {},
-            rebuilt=_names_by_day(rebuilt),
         )
         state._loaded = state.as_json()
         return state
@@ -481,7 +456,6 @@ class State:
             "merged": {key: sorted(names) for key, names in self.merged.items()},
             "granted": list(self.granted),
             "signers": dict(self.signers),
-            "rebuilt": {key: sorted(names) for key, names in self.rebuilt.items()},
         }
 
     def save(self) -> None:
@@ -1388,21 +1362,8 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             continue
 
         listed = read_manifest(host_id, chunk_day, verify_key)
-        # A rewrite is owed when the day's *compacted* chunks are not the ones
-        # the local copy was last rebuilt from -- not merely when it has some.
-        # A compacted chunk keeps its `subsumes` list in the manifest forever,
-        # so "has one" stays true for the life of the day, and keying on it
-        # rebuilt the whole day every time it gained anything: linear per sync,
-        # quadratic over a day still being written, and a day compacted while
-        # live reaches ~1440 chunks.
-        compacted = {name for name, entry in listed.items() if entry.subsumes}
-        day = _Day(host_id, chunk_day, listed, compacted != state.rebuilt.get(key, set()))
+        day = _Day(host_id, chunk_day, listed, already)
         pending = chunks if day.rewrite else fresh
-
-        # Whether every chunk the manifest lists reached the file this pass. A
-        # rewrite that lost one to an unopenable key must not be recorded as
-        # done, or the day is never rebuilt again and stays short for good.
-        complete = True
 
         for chunk in pending:
             if chunk.name not in day.listed:
@@ -1426,7 +1387,6 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             secret = day_keys[chunk_day]
             if secret is None:
                 report.unreadable.add(key)
-                complete = False
                 continue
 
             # Authenticated before it is decrypted or decompressed, so age, zlib
@@ -1436,7 +1396,6 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 blob = open_chunk(chunk.path, day.listed[chunk.name].digest)
             except (OSError, ValueError):
                 report.unauthenticated.add(key)
-                complete = False
                 continue
 
             try:
@@ -1449,7 +1408,6 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 # and every other host's readable chunks, on this run and every
                 # run after it.
                 report.unreadable.add(key)
-                complete = False
                 continue
 
             day.add(plaintext, report)
@@ -1458,8 +1416,6 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 report.chunks_merged += 1
 
         day.flush(report)
-        if compacted and complete:
-            state.rebuilt[key] = compacted
 
 
 class _Day:
@@ -1467,8 +1423,8 @@ class _Day:
 
     Exists so the two things that decide *when* bytes are written -- the day
     boundary and `FLUSH_BYTES` -- are in one place rather than interleaved with
-    decryption, and so "this day is being rewritten" is settled once, from the
-    manifest, instead of discovered part way through.
+    decryption, and so "this day is being rewritten" is settled once, instead of
+    discovered part way through.
 
     That last part is not tidiness. A day being rewritten has to be written in a
     single atomic replacement, so it must never be flushed early; working that
@@ -1476,16 +1432,29 @@ class _Day:
     may already have gone to the file and the replacement would drop them.
     """
 
-    def __init__(self, host_id: str, day: str, listed: dict[str, Entry], rewrite: bool) -> None:
+    def __init__(
+        self, host_id: str, day: str, listed: dict[str, Entry], already: frozenset[str]
+    ) -> None:
         self.host_id = host_id
         self.day = day
         self.listed = listed
-        # Decided by the caller, which is the only place that knows what this
-        # machine last rebuilt the day from. A compacted chunk is a complete
-        # statement of the chunks it names, so a day that has gained one is
-        # replaced rather than added to -- the only answer right whether the
-        # peer had merged all of them, some, or none.
-        self.rewrite = rewrite
+        self.compacted = {name for name, entry in listed.items() if entry.subsumes}
+        # A compacted chunk is a complete statement of the chunks it names, so a
+        # day that gains one is replaced rather than added to -- the only answer
+        # right whether the peer had merged all of them, some, or none.
+        #
+        # "One this machine has not taken in yet", not "the day has one at all".
+        # A compacted chunk keeps its `subsumes` list in the signed manifest for
+        # good, so the second reading stays true for the life of the day, and it
+        # rebuilt the whole day every time that day gained anything: linear per
+        # sync, quadratic over a day, and a day compacted while still being
+        # written reaches ~1440 chunks.
+        #
+        # `already` can answer this because a compacted chunk only ever enters
+        # `state.merged` on a pass that rewrote the file. So a rewrite cut short
+        # by an unopenable day key is still owed on the next pass, with no
+        # second record of what was rebuilt to keep in step with this one.
+        self.rewrite = bool(self.compacted - already)
         self._blocks: list[bytes] = []
         self._bytes = 0
 


### PR DESCRIPTION
Closes #69.

A compacted chunk keeps its `subsumes` list in the signed manifest for good, so
`any(entry.subsumes ...)` stays true for the life of that day — and it was what
decided whether to rebuild. Every later sync that found anything new for the day
re-read all of it.

Measured, a compacted day gaining one chunk per sync (the issue's own table,
reproduced):

| pass | 0 | 3 | 6 | 9 | 11 |
|---|---|---|---|---|---|
| **main**, chunks re-read | 2 | 5 | 8 | 11 | 13 |
| **branch** | 1 | 1 | 1 | 1 | 1 |
| main, wall | 29 ms | 36 ms | 41 ms | 46 ms | 52 ms |
| branch, wall | 25 ms | 26 ms | 27 ms | 26 ms | 25 ms |

Linear per sync, so quadratic over a day. A day compacted while still being
written reaches ~1440 chunks on a one-minute timer.

## Both halves

**`rewrite` now means "the day's shape changed since I last merged it."**
`State` gains `rebuilt`, a `"<host>/<day>" -> chunk names` map of the compacted
chunks each day was last rebuilt from. Keyed on the *set*, not a flag or a count:
compacting twice replaces one compacted chunk with another, and neither a flag
nor a count would change — the peer would then treat a complete statement of the
whole day as one more chunk to append and write the day twice over.

Recorded only when every listed chunk actually reached the file. A rewrite that
lost one to an unopenable day key must be owed again, or the day stays short for
good.

**`compact --before` in the future is refused.** It was passed through
unvalidated, so `--before 2099-01-01` took in today and every day after it — the
only trigger that repeats indefinitely, and never what was meant.

## Two false starts worth recording

**My first benchmark showed no growth on `main` either**, which would have meant
there was nothing to fix. It was wrong: a sync batches a day's commands into one
chunk, so compacting a four-command day was a no-op and no compacted chunk ever
existed. It needs a sync per record.

**Three of my first tests asserted the wrong thing.** I assumed a rewrite re-reads
several chunks — but after compaction the day *is* one chunk, so "rewrote" and
"appended" both read exactly 1. The observable that separates them is the raw
line count of the peer's log file: a rewrite that should have happened and did
not writes the day twice over, which `commands()` hides because it is a set.

## Tests

Seven mutations, each caught:

```
caught  rewrite keyed on the shape again, as before #69
caught  never rewrite at all
caught  record a rebuild that lost a chunk
caught  record that it was compacted, not from what
caught  rebuilt never persisted
caught  rebuilt never loaded back
caught  a future --before is allowed through
```

## `/simplify`

Re-run in full after the first attempt was cut short — all four agents this
time. Two of them independently found the same thing, each verified it in a
scratch copy, and it removed most of what I had written:

**`State.rebuilt` and the `complete` flag were both redundant.** `state.merged`
already records which chunks this machine has taken in, and a compacted chunk
only ever enters it on a pass that rewrote the file. So the whole decision is:

```python
self.compacted = {name for name, entry in listed.items() if entry.subsumes}
self.rewrite = bool(self.compacted - already)
```

No new persisted state, no flag threaded through three failure branches, and the
"is a rewrite still owed after one failed?" question stops being a question — it
is answered by the same record. That deleted the `state.json` field, its loader
and dump, the `_names_by_day` helper extracted to serve it, and ~35 lines.

It is also *better* on partial failure. With a compacted day plus two later
chunks where the last is refused on the rewrite pass, the version I had written
re-read the whole day next pass (3 chunks) because `complete` is all-or-nothing;
the derived form re-reads only the chunk that was missing (1). That was the one
path where #69's bound did not hold.

**The future-`--before` guard was one layer too high.** It sat in `cmd_compact`,
so `sync.compact(before="2099-01-01")` still compacted today — and every test in
`tests/test_sync.py` calls the library directly. It now raises `SyncError` in
`compact`, beside compaction's other two refusals, and `main` already turns that
into exit 1 plus a stderr line. `--before` also defaults inside the library now,
via `store.day_for`, which is the bucket the shell hook records into.

Also applied: `Fake.entries()` — the non-deduplicated view — beside
`Fake.commands()`, replacing three spellings of the same measurement; `_Day`
computes `compacted` itself rather than having `subsumes` knowledge leak into
`_merge_host`; and a docstring that still said the rewrite is settled "from the
manifest" alone.

Not taken, noted rather than argued: `as_json`'s two `{key: sorted(names)}`
comprehensions were not factored into a twin of the load side — with `rebuilt`
gone there is only one left.

## A flake, measured rather than assumed

Two of ~19 suite runs failed with `git clone ... failed to copy file to
.../objects/99/...: No such file or directory`, in `initialise`, which this
branch does not touch. Both happened while four review agents were running their
own syncs and benchmarks in `/tmp`. Measured after they finished: **0 failures in
20 runs on this branch and 30 on `main`.** An environmental race under heavy
parallel load, not a defect here — filed as #79 rather than left in a commit
message.

## No migration needed

Per rule 8 — and after the simplification nothing on disk changed shape at all.
`state.json` gains no field; only the merge decision changed.
