### PR TITLE
sync: stop stating the whole working tree to stage nothing

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3065,13 +3065,13 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
             sync.run()
         return seen
 
-    def test_an_idle_sync_forks_git_five_times(self) -> None:
+    def test_an_idle_sync_forks_git_four_times(self) -> None:
         alpha = self.machine("alpha")
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "git status")
             sync.run()
             calls = self.git_calls()
-        self.assertLessEqual(len(calls), 5, calls)
+        self.assertLessEqual(len(calls), 4, calls)
         # The identity and the remote come from one config read, not three.
         self.assertEqual([c for c in calls if c.startswith("config")], ["config --list"])
         self.assertEqual([c for c in calls if c.startswith("remote")], [])
@@ -3079,6 +3079,57 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
         self.assertEqual([c for c in calls if c.startswith(("rebase", "push"))], [])
         # The branch cannot change mid-run, so it is asked for once.
         self.assertEqual([c for c in calls if c.startswith("branch")], ["branch --show-current"])
+        # Nothing wrote, so there is nothing to stage -- and `add -A` is a full
+        # stat of every chunk this machine ever published. Measured at 20k
+        # chunks, asking cost 10.3 ms of a 20.6 ms idle sync.
+        self.assertEqual([c for c in calls if c.startswith("add")], [])
+
+    def test_a_sync_that_wrote_something_still_commits_it(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            alpha.record("2023-11-14", 1_700_000_002, "make -j8")
+            calls = self.git_calls()
+            self.assertIn("add -A", calls)
+            self.assertIn("commit -q", calls)
+
+        beta = self.machine("beta")
+        with beta.active():
+            sync.run()
+        with alpha.active():
+            sync.grant()
+        with beta.active():
+            sync.run()
+            self.assertEqual(beta.commands(), {"git status", "make -j8"})
+
+    def test_files_left_by_a_run_that_died_are_committed_by_the_next_one(self) -> None:
+        """The catch-up that makes skipping the `add` safe.
+
+        A run that died between writing a chunk and committing it leaves files
+        nothing staged. They are not stranded: the watermark was never saved
+        either, so the next run with anything to export writes again -- and that
+        run's `add -A` stages the leftovers alongside the new files.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+
+            # What a run that died after `write_atomic` and before `commit`
+            # leaves behind.
+            stray = store.chunk_dir(alpha.id, "2023-11-14") / "1700000009-abcdef.age"
+            stray.parent.mkdir(parents=True, exist_ok=True)
+            stray.write_bytes(b"debris from a run that did not finish")
+
+            # An idle sync leaves it alone, which is the whole point.
+            sync.run()
+            self.assertNotIn(stray.name, sync.git("show", "--name-only", "--format=", "HEAD"))
+
+            # The next run with something of its own to write picks it up.
+            alpha.record("2023-11-14", 1_700_000_002, "make -j8")
+            sync.run()
+            self.assertIn(stray.name, sync.git("log", "--name-only", "--format=", "-3"))
 
     def test_a_sync_with_something_to_say_still_pushes(self) -> None:
         """The half that would silently stop publishing if the skip overreached.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1844,17 +1844,16 @@ class TestTheMergeWatermark(SyncTestCase):
             sync.grant()
         return alpha, beta, chunks
 
-    def publish_repo_edit(self, machine: Fake, message: str) -> None:
+    def publish_repo_edit(self, message: str) -> None:
         """Commit and push a change made to the repo behind `sync`'s back.
 
-        `sync` commits only when it has written something itself, so a test that
-        edits the repo directly has to publish the edit itself rather than wait
-        for the next sync to stage it.
+        `sync` commits only when it wrote something itself, so a test that edits
+        the repo directly has to publish the edit rather than wait for the next
+        sync to stage it. Call from inside the editing machine's `active()`.
         """
-        with machine.active():
-            sync.git("add", "-A")
-            sync.git("commit", "-q", "-m", message)
-            sync._push(sync.read_repo())
+        sync.git("add", "-A")
+        sync.git("commit", "-q", "-m", message)
+        sync._push(sync.read_repo())
 
     def test_a_chunk_that_failed_once_is_retried_rather_than_skipped(self) -> None:
         """The silent half, and the worse one.
@@ -1871,15 +1870,8 @@ class TestTheMergeWatermark(SyncTestCase):
         with alpha.active():
             # Damaged in place: its digest no longer matches the signed
             # manifest, so beta refuses it -- while the later chunk is fine.
-            #
-            # Staged and committed here rather than left for `sync` to notice.
-            # `sync` only commits when it has itself written something, so a
-            # chunk changed behind its back is not published -- which is the
-            # right answer for real corruption and would make this test about
-            # that instead of about the watermark.
             first.path.write_bytes(b"corrupted" + original)
-            self.publish_repo_edit(alpha, "corrupt the first chunk")
-            sync.run(now=1_700_000_700)
+            self.publish_repo_edit("corrupt the first chunk")
 
         with beta.active():
             report = sync.run()
@@ -1890,8 +1882,7 @@ class TestTheMergeWatermark(SyncTestCase):
         # Repaired at the source, as a transient failure would be.
         with alpha.active():
             first.path.write_bytes(original)
-            self.publish_repo_edit(alpha, "repair the first chunk")
-            sync.run(now=1_700_000_800)
+            self.publish_repo_edit("repair the first chunk")
 
         with beta.active():
             sync.run()
@@ -3081,7 +3072,7 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
         self.assertEqual([c for c in calls if c.startswith("branch")], ["branch --show-current"])
         # Nothing wrote, so there is nothing to stage -- and `add -A` is a full
         # stat of every chunk this machine ever published. Measured at 20k
-        # chunks, asking cost 10.3 ms of a 20.6 ms idle sync.
+        # chunks: an idle sync drops from 20.6 ms to 10.3 ms by not asking.
         self.assertEqual([c for c in calls if c.startswith("add")], [])
 
     def test_a_sync_that_wrote_something_still_commits_it(self) -> None:
@@ -3093,15 +3084,7 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
             calls = self.git_calls()
             self.assertIn("add -A", calls)
             self.assertIn("commit -q", calls)
-
-        beta = self.machine("beta")
-        with beta.active():
-            sync.run()
-        with alpha.active():
-            sync.grant()
-        with beta.active():
-            sync.run()
-            self.assertEqual(beta.commands(), {"git status", "make -j8"})
+            self.assertIn("push --quiet", calls)
 
     def test_a_republished_signer_is_committed_even_with_nothing_to_export(self) -> None:
         """The other writer on this path, and the one with no chunk beside it.
@@ -3142,10 +3125,10 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
     def test_files_left_by_a_run_that_died_are_committed_by_the_next_one(self) -> None:
         """The catch-up that makes skipping the `add` safe.
 
-        A run that died between writing a chunk and committing it leaves files
-        nothing staged. They are not stranded: the watermark was never saved
-        either, so the next run with anything to export writes again -- and that
-        run's `add -A` stages the leftovers alongside the new files.
+        A run that died between writing a chunk and committing it leaves that
+        chunk unstaged. It is not stranded: the watermark was not saved either,
+        so the next run with anything to export writes again -- and that run's
+        `add -A` stages the leftovers alongside the new files.
         """
         alpha = self.machine("alpha")
         with alpha.active():
@@ -3154,8 +3137,9 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
 
             # What a run that died after `write_atomic` and before `commit`
             # leaves behind.
+            # Into the day directory the sync above already made, because that
+            # is where a run that died after `write_atomic` would have left it.
             stray = store.chunk_dir(alpha.id, "2023-11-14") / "1700000009-abcdef.age"
-            stray.parent.mkdir(parents=True, exist_ok=True)
             stray.write_bytes(b"debris from a run that did not finish")
 
             # An idle sync leaves it alone, which is the whole point.
@@ -3165,7 +3149,9 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
             # The next run with something of its own to write picks it up.
             alpha.record("2023-11-14", 1_700_000_002, "make -j8")
             sync.run()
-            self.assertIn(stray.name, sync.git("log", "--name-only", "--format=", "-3"))
+            # HEAD, not the last few commits: the catch-up has to happen on
+            # the run that wrote, not eventually.
+            self.assertIn(stray.name, sync.git("show", "--name-only", "--format=", "HEAD"))
 
     def test_a_sync_with_something_to_say_still_pushes(self) -> None:
         """The half that would silently stop publishing if the skip overreached.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3103,6 +3103,42 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
             sync.run()
             self.assertEqual(beta.commands(), {"git status", "make -j8"})
 
+    def test_a_republished_signer_is_committed_even_with_nothing_to_export(self) -> None:
+        """The other writer on this path, and the one with no chunk beside it.
+
+        `publish_signer` writes about once in a machine's life -- but when it
+        does, it may well be the *only* thing that run wrote. Dropping its answer
+        leaves this machine's verify key uncommitted, and a peer that cannot read
+        it refuses every chunk this host has ever signed.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+
+            # A *changed* key, not a deleted file: rewriting the same bytes
+            # leaves the worktree matching HEAD, so there would be nothing to
+            # commit and the assertion below would hold either way.
+            key = store.signing_key_file()
+            key.unlink()
+            crypto.public_half(key).unlink()
+            fresh = crypto.generate_signing_key(key)
+
+            published = store.signer_public(alpha.id)
+            sync.run()  # nothing new to export: the signer is all there is
+
+            self.assertIn(fresh, published.read_text(encoding="utf-8"))
+            self.assertEqual(
+                sync.git("status", "--porcelain", "--", str(published)),
+                "",
+                "the republished signer was left uncommitted",
+            )
+
+        # And it reached the remote, which is the point of publishing it.
+        beta = self.machine("beta")
+        with beta.active():
+            self.assertIn(fresh, store.signer_public(alpha.id).read_text(encoding="utf-8"))
+
     def test_files_left_by_a_run_that_died_are_committed_by_the_next_one(self) -> None:
         """The catch-up that makes skipping the `add` safe.
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1844,15 +1844,14 @@ class TestTheMergeWatermark(SyncTestCase):
             sync.grant()
         return alpha, beta, chunks
 
-    def publish_repo_edit(self, message: str) -> None:
+    def publish_repo_edit(self) -> None:
         """Commit and push a change made to the repo behind `sync`'s back.
 
         `sync` commits only when it wrote something itself, so a test that edits
         the repo directly has to publish the edit rather than wait for the next
         sync to stage it. Call from inside the editing machine's `active()`.
         """
-        sync.git("add", "-A")
-        sync.git("commit", "-q", "-m", message)
+        sync._commit()
         sync._push(sync.read_repo())
 
     def test_a_chunk_that_failed_once_is_retried_rather_than_skipped(self) -> None:
@@ -1871,7 +1870,7 @@ class TestTheMergeWatermark(SyncTestCase):
             # Damaged in place: its digest no longer matches the signed
             # manifest, so beta refuses it -- while the later chunk is fine.
             first.path.write_bytes(b"corrupted" + original)
-            self.publish_repo_edit("corrupt the first chunk")
+            self.publish_repo_edit()
 
         with beta.active():
             report = sync.run()
@@ -1882,7 +1881,7 @@ class TestTheMergeWatermark(SyncTestCase):
         # Repaired at the source, as a transient failure would be.
         with alpha.active():
             first.path.write_bytes(original)
-            self.publish_repo_edit("repair the first chunk")
+            self.publish_repo_edit()
 
         with beta.active():
             sync.run()
@@ -3121,6 +3120,33 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
         beta = self.machine("beta")
         with beta.active():
             self.assertIn(fresh, store.signer_public(alpha.id).read_text(encoding="utf-8"))
+
+    def test_a_day_that_can_never_be_exported_does_not_cost_a_stat_every_run(self) -> None:
+        """The state where answering "probably wrote" would undo the whole fix.
+
+        A day refused for a missing key never advances `state.exported`, so its
+        tail is fresh again on every run for the life of the machine. An `export`
+        that reported "wrote something" merely for having looked would then stat
+        the entire working tree once a minute, forever, in exactly the stuck
+        state this is meant to relieve.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+
+            # The sealed half gone: `export` refuses the day rather than
+            # re-minting a key peers could never open. See `orphaned_day_key`.
+            store.day_key(alpha.id, "2023-11-14").unlink()
+            alpha.record("2023-11-14", 1_700_000_002, "make -j8")
+
+            first = self.git_calls()
+            self.assertIn("2023-11-14", sync.run().orphaned)
+            for _ in range(3):
+                calls = self.git_calls()
+                self.assertEqual(
+                    [c for c in calls if c.startswith("add")], [], f"first run was {first}"
+                )
 
     def test_files_left_by_a_run_that_died_are_committed_by_the_next_one(self) -> None:
         """The catch-up that makes skipping the `add` safe.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1844,6 +1844,18 @@ class TestTheMergeWatermark(SyncTestCase):
             sync.grant()
         return alpha, beta, chunks
 
+    def publish_repo_edit(self, machine: Fake, message: str) -> None:
+        """Commit and push a change made to the repo behind `sync`'s back.
+
+        `sync` commits only when it has written something itself, so a test that
+        edits the repo directly has to publish the edit itself rather than wait
+        for the next sync to stage it.
+        """
+        with machine.active():
+            sync.git("add", "-A")
+            sync.git("commit", "-q", "-m", message)
+            sync._push(sync.read_repo())
+
     def test_a_chunk_that_failed_once_is_retried_rather_than_skipped(self) -> None:
         """The silent half, and the worse one.
 
@@ -1859,7 +1871,14 @@ class TestTheMergeWatermark(SyncTestCase):
         with alpha.active():
             # Damaged in place: its digest no longer matches the signed
             # manifest, so beta refuses it -- while the later chunk is fine.
+            #
+            # Staged and committed here rather than left for `sync` to notice.
+            # `sync` only commits when it has itself written something, so a
+            # chunk changed behind its back is not published -- which is the
+            # right answer for real corruption and would make this test about
+            # that instead of about the watermark.
             first.path.write_bytes(b"corrupted" + original)
+            self.publish_repo_edit(alpha, "corrupt the first chunk")
             sync.run(now=1_700_000_700)
 
         with beta.active():
@@ -1871,6 +1890,7 @@ class TestTheMergeWatermark(SyncTestCase):
         # Repaired at the source, as a transient failure would be.
         with alpha.active():
             first.path.write_bytes(original)
+            self.publish_repo_edit(alpha, "repair the first chunk")
             sync.run(now=1_700_000_800)
 
         with beta.active():

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1128,7 +1128,7 @@ def unpack(blob: bytes, limit: int = MAX_CHUNK_BYTES) -> bytes:
     return out
 
 
-def export(known: Machine, state: State, report: Report, now: int) -> None:
+def export(known: Machine, state: State, report: Report, now: int) -> bool:
     """Seal each log file's new lines into a fresh chunk, and sign the day's list.
 
     The manifest is built by **extending the one this machine last signed**,
@@ -1163,8 +1163,10 @@ def export(known: Machine, state: State, report: Report, now: int) -> None:
                 (log.relpath, data, new_offset)
             )
 
+    # The one exit that has provably written nothing, which is what lets `run`
+    # skip the `git add` that would stat the whole working tree to find that out.
     if not fresh:
-        return
+        return False
 
     # One pass for the whole host, not one per day.
     on_disk: dict[str, set[str]] = {}
@@ -1256,6 +1258,11 @@ def export(known: Machine, state: State, report: Report, now: int) -> None:
         # chunk on a quiet day is refused by peers either way, because it is in
         # no manifest -- this is a report, not the defence.
         report.foreign |= {f"{day}/{name}" for name in on_disk.get(day, set()) - set(listed)}
+
+    # True even where a day was skipped for size or refused for a missing key:
+    # by here a chunk, a day key or a manifest has all but certainly been
+    # written, and being wrong costs one `git add` rather than a lost commit.
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -1564,11 +1571,25 @@ def run(push: bool = True, now: int | None = None) -> Report:
         # a machine nobody had granted access to could not tag a chunk either,
         # so its own history piled up locally until someone else acted.
         report.revoked = _this_machine_revoked(known)
+        wrote = False
         if not report.revoked:
-            publish_signer(known)
-            export(known, state, report, int(time.time()) if now is None else now)
+            # `or` the other way round would short-circuit the export.
+            wrote = publish_signer(known)
+            wrote = export(known, state, report, int(time.time()) if now is None else now) or wrote
 
-        committed = _commit()
+        # `git add -A` is a full stat of the working tree -- every chunk this
+        # machine has ever published, 9.8 ms at 20k files -- and this runs once
+        # a minute. On an idle run there is provably nothing to stage: the only
+        # two things that write into the repo here have just said they wrote
+        # nothing.
+        #
+        # A run that died between writing and committing leaves files nothing
+        # staged, and this does not strand them. Its watermark was never saved
+        # either, so the next run with anything to export writes again -- and
+        # `add -A` on *that* run stages the leftovers alongside the new files.
+        # The same catch-up covers a `recipients.txt` edited by hand, which no
+        # amount of asking woswoar's own writers would ever notice.
+        committed = _commit() if wrote else False
 
         if remote:
             # `push` contacts the remote even with nothing to send, which is the

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1259,9 +1259,11 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
         # no manifest -- this is a report, not the defence.
         report.foreign |= {f"{day}/{name}" for name in on_disk.get(day, set()) - set(listed)}
 
-    # True even where a day was skipped for size or refused for a missing key:
-    # by here a chunk, a day key or a manifest has all but certainly been
-    # written, and being wrong costs one `git add` rather than a lost commit.
+    # True even on the passes that refused every day they looked at -- an
+    # orphaned day key, a manifest gone missing, one that will not verify. By
+    # here a chunk, a day key or a manifest has all but certainly been written,
+    # and over-reporting costs one `git add` where under-reporting would cost a
+    # commit.
     return True
 
 
@@ -1571,25 +1573,26 @@ def run(push: bool = True, now: int | None = None) -> Report:
         # a machine nobody had granted access to could not tag a chunk either,
         # so its own history piled up locally until someone else acted.
         report.revoked = _this_machine_revoked(known)
-        wrote = False
+        published = False
+        exported = False
         if not report.revoked:
-            # `or` the other way round would short-circuit the export.
-            wrote = publish_signer(known)
-            wrote = export(known, state, report, int(time.time()) if now is None else now) or wrote
+            published = publish_signer(known)
+            exported = export(known, state, report, int(time.time()) if now is None else now)
 
         # `git add -A` is a full stat of the working tree -- every chunk this
-        # machine has ever published, 9.8 ms at 20k files -- and this runs once
-        # a minute. On an idle run there is provably nothing to stage: the only
-        # two things that write into the repo here have just said they wrote
-        # nothing.
+        # machine has ever published -- and this runs once a minute. On an idle
+        # run there is provably nothing to stage, because the only two things
+        # that write into the repo here have just said they wrote nothing.
+        # Measured at 20k chunks: an idle sync drops from 20.6 ms to 10.3 ms,
+        # and stops growing with the size of the history.
         #
-        # A run that died between writing and committing leaves files nothing
-        # staged, and this does not strand them. Its watermark was never saved
-        # either, so the next run with anything to export writes again -- and
-        # `add -A` on *that* run stages the leftovers alongside the new files.
-        # The same catch-up covers a `recipients.txt` edited by hand, which no
-        # amount of asking woswoar's own writers would ever notice.
-        committed = _commit() if wrote else False
+        # A run that died between writing a file and committing it leaves that
+        # file unstaged, and this does not strand it. The watermark was not
+        # saved either, so the next run with anything to export writes again --
+        # and `add -A` on *that* run stages the leftovers alongside the new
+        # files. The same catch-up covers a `recipients.txt` edited by hand,
+        # which no amount of asking woswoar's own writers would ever notice.
+        committed = _commit() if published or exported else False
 
         if remote:
             # `push` contacts the remote even with nothing to send, which is the
@@ -1739,8 +1742,12 @@ def _commit() -> bool:
     # path and nothing at all when the index already matches, so the same
     # command that stages also answers "is there anything to commit". The
     # obvious `status --porcelain` afterwards costs a second full stat of a
-    # working tree that is tens of thousands of chunks after a couple of years,
-    # on a timer that now fires every minute.
+    # working tree that is tens of thousands of chunks after a couple of years.
+    #
+    # `run` no longer reaches here on an idle sync -- it asks its writers first
+    # -- so this is now paid only by runs that did write, and by `grant`,
+    # `revoke` and `init`. That makes it cheaper, not unnecessary: those runs
+    # still have a whole tree to stat, and doing it once beats doing it twice.
     if not git("add", "-A", "--verbose"):
         return False
     git("commit", "-q", "-m", COMMIT_MESSAGE)

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1163,10 +1163,12 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
                 (log.relpath, data, new_offset)
             )
 
-    # The one exit that has provably written nothing, which is what lets `run`
-    # skip the `git add` that would stat the whole working tree to find that out.
+    # Whether anything reached the repo. What lets `run` skip the `git add` that
+    # would otherwise stat the whole working tree to find that out.
+    wrote = False
+
     if not fresh:
-        return False
+        return wrote
 
     # One pass for the whole host, not one per day.
     on_disk: dict[str, set[str]] = {}
@@ -1246,6 +1248,7 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
             state.exported[relpath] = new_offset
 
         write_manifest(known, day, listed)
+        wrote = True
 
         # A chunk under this host's own id that this host never wrote. `merge`
         # skips our own id, so nothing else would ever look at it, and peers
@@ -1259,12 +1262,18 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
         # no manifest -- this is a report, not the defence.
         report.foreign |= {f"{day}/{name}" for name in on_disk.get(day, set()) - set(listed)}
 
-    # True even on the passes that refused every day they looked at -- an
-    # orphaned day key, a manifest gone missing, one that will not verify. By
-    # here a chunk, a day key or a manifest has all but certainly been written,
-    # and over-reporting costs one `git add` where under-reporting would cost a
-    # commit.
-    return True
+    # Set at the manifest rather than approximated by "we got past the guards".
+    # A day can be refused for an orphaned key, a missing manifest or one that
+    # will not verify, and a refused day never advances `state.exported` -- so
+    # its tail is fresh again next run, and every run after that. Answering
+    # "probably wrote" there would mean a full stat of the working tree once a
+    # minute for the life of that machine, in precisely the stuck state this
+    # exists to relieve.
+    #
+    # The manifest is the right place to set it: every repo write in the loop
+    # above -- minting a day key, sealing a chunk -- happens in the same
+    # iteration, ahead of it.
+    return wrote
 
 
 # ---------------------------------------------------------------------------
@@ -1586,12 +1595,20 @@ def run(push: bool = True, now: int | None = None) -> Report:
         # Measured at 20k chunks: an idle sync drops from 20.6 ms to 10.3 ms,
         # and stops growing with the size of the history.
         #
-        # A run that died between writing a file and committing it leaves that
-        # file unstaged, and this does not strand it. The watermark was not
-        # saved either, so the next run with anything to export writes again --
-        # and `add -A` on *that* run stages the leftovers alongside the new
-        # files. The same catch-up covers a `recipients.txt` edited by hand,
-        # which no amount of asking woswoar's own writers would ever notice.
+        # A run that died between writing a chunk and committing it leaves that
+        # chunk unstaged, and this does not strand it: the watermark was not
+        # saved either, so the next run with anything to export writes the same
+        # lines again, and `add -A` on *that* run stages the leftovers too.
+        #
+        # That argument is about `export`, whose write and whose watermark are
+        # one all-or-nothing unit. It does not carry to `publish_signer`, whose
+        # write *is* its own watermark: the file survives the crash, so the next
+        # run reads it back, agrees with it, and reports writing nothing. The
+        # file then waits for an unrelated export. Benign -- a machine in that
+        # state publishes nothing, so peers keep seeing the old key beside the
+        # old chunks it signed -- and `grant`, `revoke` and `init` still sweep
+        # the tree unconditionally, which is also what catches a
+        # `recipients.txt` edited by hand.
         committed = _commit() if published or exported else False
 
         if remote:


### PR DESCRIPTION
Closes #73.

`_commit` ran `git add -A --verbose` on every sync — a full stat of the working
tree, which is every chunk this machine has ever published — to discover that an
idle run had staged nothing. `run` now asks its writers first, and only commits
when one of them says it wrote.

| | before | after |
|---|---|---|
| idle sync, 20k chunks | 20.6 ms | **10.0 ms** |
| idle sync, git forks | 5 | **4** |
| grows with history? | yes | **no** |

The two writers were already able to answer: `publish_signer` returned a bool
already, and `export` now does too.

## Why not a flag in `state.json`

The issue suggested one, for the run that dies between writing a chunk and
committing it. It is not needed, and would be worse: `export`'s write and its
watermark are already one all-or-nothing unit, so a crashed run saved neither —
the next run with anything to export writes the same lines again, and *that*
run's `add -A` stages the leftovers alongside the new files. A flag would have to
be written *before* the export to be crash-safe, i.e. on the path being
optimised.

Two things that argument does **not** cover, both now stated in the code rather
than assumed:

- **`publish_signer`'s write is its own watermark.** It survives a crash, so the
  next run agrees with the file and reports writing nothing; the file then waits
  for an unrelated export. Benign — a machine in that state publishes nothing, so
  peers keep seeing the old key beside the old chunks it signed.
- **A `recipients.txt` edited by hand** is never reported by any of woswoar's
  writers. `grant`, `revoke` and `init` still sweep the tree unconditionally,
  which is what catches it.

The issue also lists `apply_withdrawals` as a third writer that would need to
report. It is not one: it only deletes from `state.signers` and fills
`report.unpinned`. `recipients.txt` is written solely by `_append_recipient_line`,
whose callers both commit for themselves.

## What `/simplify` caught, and it was the important half

Two agents independently measured the same defect in my first version. I had
`export` return `True` at its end for anything that got past the guards, arguing
that over-reporting "costs one `git add`". It costs one **per minute, forever**: a
day refused for an orphaned key never advances `state.exported`, so its tail is
fresh again on every run for the life of that machine — and deleting a sealed day
key is something a stranger with push access can do. Measured, with a deleted key:
`add -A` on every one of three following idle syncs.

The flag is now set where a write actually happens, at `write_manifest`, and a
test pins that a permanently stuck day costs no `add` at all.

Also applied: named booleans instead of `wrote = export(...) or wrote` and the
comment about operand order it needed; `_commit`'s "why not `status --porcelain`"
comment, which still argued from the one-minute timer it no longer sees; a
comment claiming a size-based skip that exists in `compact`, not `export`; a
garbled sentence carrying the whole safety argument, in both copies; a test
helper re-implementing `sync._commit()`; a duplicated three-machine handshake;
and a dead `mkdir` that made the crash scenario it simulates incoherent.

## A test broke, and it was right to

`test_a_chunk_that_failed_once_is_retried_rather_than_skipped` corrupted a chunk
in the working tree and relied on the next sync committing and pushing it. That
was only ever incidental: `sync` now commits when *it* wrote, so a chunk changed
behind its back is not published — which is the better answer for real
corruption, since it no longer propagates the damage to peers. The test publishes
its own edit now, and is about the watermark again rather than about that.

## Tests

Six mutations, each caught:

```
caught  add -A unconditional again, as before #73
caught  never commit at all
caught  export always says it wrote
caught  export never says it wrote
caught  publish_signer's answer dropped
caught  the export's answer dropped
```

One of my own tests asserted nothing until mutation testing said so: deleting
`signer.pub` and letting `publish_signer` rewrite it leaves the worktree matching
HEAD, so `git status` is clean whether or not the commit happened. It needed a
genuinely changed verify key.

## Filed rather than fixed

**#80** — `export`'s early exit still reads every log file to learn nothing
changed: 3.34 ms at one host x 365 days, 5.61 ms at three, against a ~10 ms idle
sync. Now the next-largest term on this path, with two measured fixes.

## No migration needed

Per rule 8, and nothing on disk changed shape: only when a commit is made.
