### PR TITLE
sync: stop reading every log file to learn nothing changed

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3114,6 +3114,21 @@ class TestExportDoesNotReadWhatCannotHaveChanged(SyncTestCase):
             everyone = {log.host_id for log in store.iter_log_files()}
             self.assertEqual(everyone, {alpha.id, beta.id})
 
+            listed: list[str] = []
+            real = store.iter_log_files
+
+            def counted(host_id: str | None = None) -> Iterator[store.LogFile]:
+                for log in real(host_id):
+                    listed.append(log.host_id)
+                    yield log
+
+            with mock.patch.object(store, "iter_log_files", counted):
+                sync.export(store.machine(), sync.State.load(), sync.Report(), 1_700_000_900)
+            # Peers' directories are not walked at all, rather than walked and
+            # then discarded: at three machines that was two thirds of the
+            # listing done to be thrown away, once a minute.
+            self.assertEqual(set(listed), {alpha.id}, "another host's logs were listed")
+
             ours = list(store.iter_log_files(alpha.id))
             self.assertEqual({log.host_id for log in ours}, {alpha.id})
             # The same files the caller would have kept after filtering, so

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3029,6 +3029,101 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
             self.assertEqual(reads, [], "a day with nothing new still read its manifest")
 
 
+class TestExportDoesNotReadWhatCannotHaveChanged(SyncTestCase):
+    """Issue #80: the early exit is the shape of every idle sync.
+
+    Getting to it used to cost work proportional to the whole history -- every
+    host's log directory listed, and every one of this machine's own day files
+    opened, seeked, read and closed to discover it had not grown.
+    """
+
+    def read_tails(self, machine: Fake) -> list[str]:
+        """Which log files one `export` actually opens."""
+        opened: list[str] = []
+        real = store.read_tail
+
+        def counted(path: Path, offset: int) -> tuple[bytes, int]:
+            opened.append(path.name)
+            return real(path, offset)
+
+        with machine.active(), mock.patch.object(store, "read_tail", counted):
+            sync.export(store.machine(), sync.State.load(), sync.Report(), 1_700_000_900)
+        return opened
+
+    def test_a_log_that_cannot_have_grown_is_not_opened(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            for day in ("2023-11-14", "2023-11-15", "2023-11-16"):
+                alpha.record(day, 1_700_000_001, f"on {day}")
+                sync.run()
+
+        self.assertEqual(self.read_tails(alpha), [], "an unchanged log was read")
+
+        with alpha.active():
+            alpha.record("2023-11-15", 1_700_000_002, "a later line")
+        # Only the day that grew, not the three that exist.
+        self.assertEqual(self.read_tails(alpha), ["2023-11-15.tsv"])
+
+    def test_a_growing_log_is_still_exported(self) -> None:
+        """The half a wrong comparison would break, and break silently."""
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            alpha.record("2023-11-14", 1_700_000_002, "make -j8")
+            self.assertEqual(sync.run().lines_exported, 1)
+            sync.grant()
+        with beta.active():
+            sync.run()
+            self.assertEqual(beta.commands(), {"git status", "make -j8"})
+
+    def test_a_log_that_shrank_is_not_read_either(self) -> None:
+        """A truncated log reads as nothing new, exactly as it did before.
+
+        `read_tail` seeking past the end returns no data, so skipping the open
+        gives the same answer -- which is what makes the comparison `<=` and not
+        `==`. Pinned because it is the one case where the two differ in reads
+        but must not differ in outcome.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            store.log_file(alpha.id, "2023-11-14").write_text("", encoding="utf-8")
+
+        self.assertEqual(self.read_tails(alpha), [])
+        with alpha.active():
+            self.assertEqual(sync.run().lines_exported, 0)
+
+    def test_only_our_own_host_directory_is_listed(self) -> None:
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            sync.grant()
+        with beta.active():
+            beta.record("2023-11-14", 1_700_000_002, "make -j8")
+            sync.run()
+        # alpha cloned before beta existed, so it has to be told beta is real.
+        self.accept_everyone(alpha)
+        with alpha.active():
+            sync.run()  # alpha now holds a decrypted copy of beta's log
+
+            everyone = {log.host_id for log in store.iter_log_files()}
+            self.assertEqual(everyone, {alpha.id, beta.id})
+
+            ours = list(store.iter_log_files(alpha.id))
+            self.assertEqual({log.host_id for log in ours}, {alpha.id})
+            # The same files the caller would have kept after filtering, so
+            # narrowing the listing cannot change what is exported.
+            self.assertEqual(
+                [log.relpath for log in ours],
+                [log.relpath for log in store.iter_log_files() if log.host_id == alpha.id],
+            )
+
+
 class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
     """`sync` runs from a one-minute timer, so each fork is a recurring cost.
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3047,8 +3047,12 @@ class TestExportDoesNotReadWhatCannotHaveChanged(SyncTestCase):
             return real(path, offset)
 
         with machine.active(), mock.patch.object(store, "read_tail", counted):
-            sync.export(store.machine(), sync.State.load(), sync.Report(), 1_700_000_900)
+            self.export_once()
         return opened
+
+    def export_once(self) -> None:
+        """One `export` as `run` would call it. Caller holds `active()`."""
+        sync.export(store.machine(), sync.State.load(), sync.Report(), 1_700_000_900)
 
     def test_a_log_that_cannot_have_grown_is_not_opened(self) -> None:
         alpha = self.machine("alpha")
@@ -3063,20 +3067,6 @@ class TestExportDoesNotReadWhatCannotHaveChanged(SyncTestCase):
             alpha.record("2023-11-15", 1_700_000_002, "a later line")
         # Only the day that grew, not the three that exist.
         self.assertEqual(self.read_tails(alpha), ["2023-11-15.tsv"])
-
-    def test_a_growing_log_is_still_exported(self) -> None:
-        """The half a wrong comparison would break, and break silently."""
-        alpha = self.machine("alpha")
-        beta = self.machine("beta")
-        with alpha.active():
-            alpha.record("2023-11-14", 1_700_000_001, "git status")
-            sync.run()
-            alpha.record("2023-11-14", 1_700_000_002, "make -j8")
-            self.assertEqual(sync.run().lines_exported, 1)
-            sync.grant()
-        with beta.active():
-            sync.run()
-            self.assertEqual(beta.commands(), {"git status", "make -j8"})
 
     def test_a_log_that_shrank_is_not_read_either(self) -> None:
         """A truncated log reads as nothing new, exactly as it did before.
@@ -3123,18 +3113,13 @@ class TestExportDoesNotReadWhatCannotHaveChanged(SyncTestCase):
                     yield log
 
             with mock.patch.object(store, "iter_log_files", counted):
-                sync.export(store.machine(), sync.State.load(), sync.Report(), 1_700_000_900)
-            # Peers' directories are not walked at all, rather than walked and
-            # then discarded: at three machines that was two thirds of the
-            # listing done to be thrown away, once a minute.
+                self.export_once()
             self.assertEqual(set(listed), {alpha.id}, "another host's logs were listed")
 
-            ours = list(store.iter_log_files(alpha.id))
-            self.assertEqual({log.host_id for log in ours}, {alpha.id})
-            # The same files the caller would have kept after filtering, so
-            # narrowing the listing cannot change what is exported.
+            # And narrowing cannot change *what* is exported: the same files the
+            # caller would have kept after filtering, in the same order.
             self.assertEqual(
-                [log.relpath for log in ours],
+                [log.relpath for log in store.iter_log_files(alpha.id)],
                 [log.relpath for log in store.iter_log_files() if log.host_id == alpha.id],
             )
 

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -398,10 +398,7 @@ class LogFile(NamedTuple):
 def iter_log_files(host_id: str | None = None) -> Iterator[LogFile]:
     """Yield plaintext log files, sorted for reproducible cache builds.
 
-    ``host_id`` narrows it to one host's directory instead of listing every
-    host's and letting the caller throw the rest away. `export` wants only this
-    machine's own logs and runs once a minute, so at three machines that was two
-    thirds of the listing done to be discarded.
+    ``host_id`` lists that host's directory alone; without it, every host's.
     """
     root = logs_dir() / _HOSTS
     if not root.is_dir():

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -261,6 +261,11 @@ def read_tail(path: Path, offset: int) -> tuple[bytes, int]:
     cache, and sync's export. They must agree on where a file "ends", and for
     sync the stakes are higher -- a half-sealed record would be committed to an
     append-only repo where it could never be fixed.
+
+    An ``offset`` at or past the end returns ``(b"", offset)``, and `export`
+    leans on that: it stats first and skips this call entirely when the file
+    cannot have grown. Anything that made reading past the end mean something
+    else -- returning the partial final line, say -- has to change that too.
     """
     try:
         with path.open("rb") as handle:

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -395,13 +395,20 @@ class LogFile(NamedTuple):
     path: Path
 
 
-def iter_log_files() -> Iterator[LogFile]:
-    """Yield every plaintext log file, sorted for reproducible cache builds."""
+def iter_log_files(host_id: str | None = None) -> Iterator[LogFile]:
+    """Yield plaintext log files, sorted for reproducible cache builds.
+
+    ``host_id`` narrows it to one host's directory instead of listing every
+    host's and letting the caller throw the rest away. `export` wants only this
+    machine's own logs and runs once a minute, so at three machines that was two
+    thirds of the listing done to be discarded.
+    """
     root = logs_dir() / _HOSTS
     if not root.is_dir():
         return
 
-    for host in sorted(root.iterdir()):
+    hosts = [root / host_id] if host_id is not None else sorted(root.iterdir())
+    for host in hosts:
         if not host.is_dir():
             continue
         for path in sorted(host.glob(f"*{_LOG_SUFFIX}")):

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1154,10 +1154,24 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
     # that turned a no-op sync from 0.04 s into nearly 3 s and grew with the
     # archive forever.
     fresh: dict[str, list[tuple[str, bytes, int]]] = {}
-    for log in store.iter_log_files():
-        if log.host_id != known.id:
-            continue  # other hosts' logs arrived decrypted; never re-export them
-        data, new_offset = store.read_tail(log.path, state.exported.get(log.relpath, 0))
+    # Only this machine's own logs: other hosts' arrived decrypted and are never
+    # re-exported. Asked for by host rather than filtered afterwards, so peers'
+    # directories are not listed at all.
+    for log in store.iter_log_files(known.id):
+        exported = state.exported.get(log.relpath, 0)
+        try:
+            size = log.path.stat().st_size
+        except OSError:
+            continue
+        # One stat instead of an open, a seek, a read and a close, on a file
+        # that is almost always exactly as long as it was a minute ago. Reading
+        # from at or past the end returns nothing anyway, so this is the same
+        # answer for a fraction of the syscalls -- measured over 365 own-day
+        # files, 2.05 ms down to 0.66 ms.
+        if size <= exported:
+            continue
+
+        data, new_offset = store.read_tail(log.path, exported)
         if data:
             fresh.setdefault(store.day_of_log(log.relpath), []).append(
                 (log.relpath, data, new_offset)
@@ -2191,9 +2205,7 @@ def find_reader(fingerprint: str) -> Reader:
 def _still_readable(host_id: str) -> list[str]:
     """Days this host has both a key for and a log it may still append to."""
     keyed = {store.day_of_key(path) for path in store.iter_day_keys(host_id)}
-    logged = {
-        store.day_of_log(log.relpath) for log in store.iter_log_files() if log.host_id == host_id
-    }
+    logged = {store.day_of_log(log.relpath) for log in store.iter_log_files(host_id)}
     return sorted(keyed & logged)
 
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1155,19 +1155,26 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
     # archive forever.
     fresh: dict[str, list[tuple[str, bytes, int]]] = {}
     # Only this machine's own logs: other hosts' arrived decrypted and are never
-    # re-exported. Asked for by host rather than filtered afterwards, so peers'
-    # directories are not listed at all.
+    # re-exported. Asked for by host rather than listed and then filtered, which
+    # at three machines walked two thirds of a tree to throw it away.
     for log in store.iter_log_files(known.id):
         exported = state.exported.get(log.relpath, 0)
-        try:
-            size = log.path.stat().st_size
-        except OSError:
-            continue
+
         # One stat instead of an open, a seek, a read and a close, on a file
         # that is almost always exactly as long as it was a minute ago. Reading
         # from at or past the end returns nothing anyway, so this is the same
-        # answer for a fraction of the syscalls -- measured over 365 own-day
-        # files, 2.05 ms down to 0.66 ms.
+        # answer for a fraction of the syscalls -- which is why the comparison
+        # is `<=` and not `==`: a *truncated* log also has no tail to take.
+        #
+        # Together with the line above, `export`'s early exit -- the shape of
+        # every idle sync -- goes from 5.50 ms to 1.85 ms at three years of
+        # three machines, and stops growing with how many machines there are.
+        try:
+            size = log.path.stat().st_size
+        except OSError:
+            # As `read_tail` treats one: a file that went away between being
+            # listed and being looked at has no tail to export.
+            continue
         if size <= exported:
             continue
 


### PR DESCRIPTION
Closes #80.

`export` returns early when no log file has new bytes — the shape of every idle
sync. Getting to that early exit cost work proportional to the whole history:
every host's log directory was listed and then filtered, and each of this
machine's own day files was opened, seeked, read and closed to discover it had
not grown.

| `export`'s early exit | before | after |
|---|---|---|
| 1 host x 365 days | 3.22 ms | **2.00 ms** |
| 3 hosts x 365 days | 5.50 ms | **1.85 ms** |

It no longer grows with how many machines you have.

## What changed

- `store.iter_log_files(host_id=None)` lists one host's directory when asked.
  `export` and `_still_readable` were both listing everything and discarding the
  rest; at three machines that was two thirds of the walk done to be thrown away.
- `export` stats each own log file and skips `read_tail` when it cannot have
  grown. `read_tail` seeking at or past the end returns nothing anyway, so this
  is the same answer for a fraction of the syscalls — which is why the comparison
  is `<=` and not `==`: a *truncated* log also has no tail to take. That
  guarantee is now stated in `read_tail`'s own docstring, since `export` leans on
  it from another module.

`cache.refresh` and `doctor` still list every host, correctly — they have no one
host to narrow to.

## I nearly concluded there was nothing to fix

My first measurements showed no improvement at all, and no difference between one
and three hosts on `main` either. The reason was mine: I had not committed, so
`git checkout main` carried the working-tree edits across and both "branches"
were the same modified code. The component timings — listing 3.50 → 1.22 ms,
`read_tail` 1.96 → 0.64 ms — were what showed the end-to-end figure had to be
wrong. Committing first gave the numbers above.

## Tests

Five mutations, each caught:

```
caught  no stat: open every log again
caught  skip when equal only, so a shrunk log is reopened
caught  skip too eagerly: a grown log is passed over
caught  list every host again
caught  host filter ignored
```

One initially survived: nothing pinned that `export` *uses* the narrowed listing,
because the behaviour is identical either way — only the cost differs. That now
has its own assertion, in the same style as the git-fork ceilings.

## `/simplify`

Applied: the same rationale and measurement had been written into three places;
a peer round-trip test that duplicated four existing tests; an unexplained
`except OSError` on a path where everything else says why; a redundant assertion
and a duplicated `export` invocation.

## Found while measuring, filed not fixed

**#82 (P1)** — `store.iter_chunks` is **88.4 ms against 3.3 ms** for the
`os.listdir` equivalent on a 20k-chunk peer, with byte-identical output, and
`merge` walks it in full on every sync. That is several times everything the
recent sync work has removed put together, and it grows without bound. I ranked
it above the remaining P2s and said so in the issue — it touches the subsystem
#72 was closed on, but it is a three-line swap rather than #72's design change,
so the ranking is worth a second opinion.

## No migration needed

Per rule 8, and nothing on disk changed shape: only which files are read.
