### PR TITLE
sync: walk chunk names, not Path objects

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -19,6 +19,7 @@ import zlib
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
+from typing import ClassVar
 from unittest import mock
 
 from woswoar import cache, crypto, search, store, sync
@@ -3037,24 +3038,24 @@ class TestWalkingAPeersChunks(SyncTestCase):
     8.5 ms for one peer with 20k chunks, once a minute, growing with the archive.
     """
 
+    #: Recorded newest-day-first, deliberately. Two days cannot tell a sorted
+    #: walk from a reversed one, and creation order is not incidental: on btrfs
+    #: -- the filesystem this is developed on -- `readdir` returns entries in
+    #: the order they were made, so an unsorted walk comes back wrong here and
+    #: would pass on the tmpfs the suite's temporary directories land in.
+    DAYS: ClassVar[tuple[str, ...]] = ("2023-11-16", "2023-11-14", "2023-11-15")
+
     def stocked(self) -> tuple[Fake, Fake]:
-        """alpha, and a beta whose history alpha has merged."""
+        """alpha with three days of two chunks each, and a beta that merged them."""
         alpha = self.machine("alpha")
         beta = self.machine("beta")
         with alpha.active():
-            alpha.record("2023-11-14", 1_700_000_001, "on alpha")
-            sync.run()
+            for day in self.DAYS:
+                for i in range(2):
+                    alpha.record(day, 1_700_000_100 + i, f"{day} number {i}")
+                    sync.run()
             sync.grant()
         with beta.active():
-            # Three days, recorded newest first: two cannot tell a sorted walk
-            # from a reversed one, and readdir order is not the creation order
-            # in any case.
-            for day in ("2023-11-16", "2023-11-14", "2023-11-15"):
-                for i in range(2):
-                    beta.record(day, 1_700_000_100 + i, f"{day} number {i}")
-                    sync.run()
-        self.accept_everyone(alpha)
-        with alpha.active():
             sync.run()
         return alpha, beta
 
@@ -3065,17 +3066,20 @@ class TestWalkingAPeersChunks(SyncTestCase):
         chunk still goes through it -- so a difference here would mean `merge`
         and `compact` disagreeing about what a host published.
         """
-        _alpha, beta = self.stocked()
-        with beta.active():
-            by_day = list(store.iter_chunk_days(beta.id))
-            flat = [(chunk.day, chunk.name) for chunk in store.iter_chunks(beta.id)]
+        alpha, _beta = self.stocked()
+        with alpha.active():
+            by_day = list(store.iter_chunk_days(alpha.id))
+            flat = [(chunk.day, chunk.name) for chunk in store.iter_chunks(alpha.id)]
 
         self.assertEqual(
             [(day, name) for day, names in by_day for name in names],
             flat,
             "the name walk and the chunk walk disagree",
         )
-        self.assertEqual([day for day, _ in by_day], ["2023-11-14", "2023-11-15", "2023-11-16"])
+        # Sorted, and each day exactly once. `_Day` *replaces* the log file it
+        # writes, so a day arriving in two pieces would have the second
+        # overwrite what the first had just written.
+        self.assertEqual([day for day, _ in by_day], sorted(self.DAYS))
         for _day, names in by_day:
             self.assertEqual(names, sorted(names))
             self.assertTrue(names, "an empty day was yielded")
@@ -3087,35 +3091,23 @@ class TestWalkingAPeersChunks(SyncTestCase):
         walk names what it is looking for rather than taking whatever is there,
         because everything downstream treats a name as a chunk to authenticate.
         """
-        _alpha, beta = self.stocked()
-        with beta.active():
-            directory = store.chunk_dir(beta.id, "2023-11-14")
+        alpha, _beta = self.stocked()
+        with alpha.active():
+            directory = store.chunk_dir(alpha.id, "2023-11-14")
             (directory / "1700000000-abcdef.age.tmp").write_bytes(b"half a chunk")
             (directory / "notes.txt").write_text("not a chunk", encoding="utf-8")
 
-            names = dict(store.iter_chunk_days(beta.id))["2023-11-14"]
+            names = dict(store.iter_chunk_days(alpha.id))["2023-11-14"]
         self.assertTrue(all(name.endswith(".age") for name in names), names)
         self.assertEqual(len(names), 2)
 
-    def test_a_day_is_never_split_across_two_groups(self) -> None:
-        """The contract `_merge_host` leans on, and the one that loses history.
-
-        `_Day` replaces the log file it writes, so a day appearing twice would
-        have the second group overwrite what the first had just written.
-        """
-        _alpha, beta = self.stocked()
-        with beta.active():
-            days = [day for day, _ in store.iter_chunk_days(beta.id)]
-        self.assertEqual(len(days), len(set(days)), f"a day was yielded twice: {days}")
-
     def test_keys_and_manifests_are_not_mistaken_for_days(self) -> None:
         """They sit in the same host directory, and neither holds chunks."""
-        _alpha, beta = self.stocked()
-        with beta.active():
-            siblings = {p.name for p in store.repo_host_dir(beta.id).iterdir() if p.is_dir()}
+        alpha, _beta = self.stocked()
+        with alpha.active():
+            siblings = {p.name for p in store.repo_host_dir(alpha.id).iterdir() if p.is_dir()}
             self.assertTrue({"keys", "manifests"} <= siblings, siblings)
-            days = {day for day, _ in store.iter_chunk_days(beta.id)}
-        self.assertEqual(days, {"2023-11-14", "2023-11-15", "2023-11-16"})
+            self.assertEqual({day for day, _ in store.iter_chunk_days(alpha.id)}, set(self.DAYS))
 
     def test_an_idle_merge_builds_nothing_per_chunk(self) -> None:
         """The saving itself, asserted where a future change would undo it.
@@ -3124,7 +3116,7 @@ class TestWalkingAPeersChunks(SyncTestCase):
         constructing one per file is what made this walk cost 8x what reading
         the names does.
         """
-        alpha, _beta = self.stocked()
+        _alpha, beta = self.stocked()
         real = store.iter_chunks
         used = []
 
@@ -3132,7 +3124,7 @@ class TestWalkingAPeersChunks(SyncTestCase):
             used.append(machine_id)
             return real(machine_id)
 
-        with alpha.active(), mock.patch.object(store, "iter_chunks", spy):
+        with beta.active(), mock.patch.object(store, "iter_chunks", spy):
             report = sync.run()
         self.assertEqual(report.chunks_merged, 0)
         self.assertEqual(used, [], "merge built Chunk objects for an idle sync")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3101,6 +3101,32 @@ class TestWalkingAPeersChunks(SyncTestCase):
         self.assertTrue(all(name.endswith(".age") for name in names), names)
         self.assertEqual(len(names), 2)
 
+    def test_a_directory_holding_no_chunk_is_not_a_day(self) -> None:
+        """Empty and "nothing new" are different answers, told apart here.
+
+        A day directory can exist with nothing in it -- a `compact` that removed
+        the last chunk, a partial write cleaned up -- and every caller would
+        otherwise have to ask. `has_chunks` in particular decides whether an
+        orphaned day key is a loss or a harmless nuisance, so a directory with
+        only a stray file in it must read as empty there too.
+        """
+        alpha, _beta = self.stocked()
+        with alpha.active():
+            hollow = store.chunk_dir(alpha.id, "2023-11-20")
+            hollow.mkdir(parents=True, exist_ok=True)
+
+            self.assertNotIn("2023-11-20", dict(store.iter_chunk_days(alpha.id)))
+            self.assertFalse(sync.has_chunks(alpha.id, "2023-11-20"))
+
+            (hollow / "1700000000-abcdef.age.tmp").write_bytes(b"half a chunk")
+            self.assertNotIn("2023-11-20", dict(store.iter_chunk_days(alpha.id)))
+            self.assertFalse(
+                sync.has_chunks(alpha.id, "2023-11-20"), "a stray file counted as a chunk"
+            )
+
+            # And a day that does hold one still says so.
+            self.assertTrue(sync.has_chunks(alpha.id, "2023-11-14"))
+
     def test_keys_and_manifests_are_not_mistaken_for_days(self) -> None:
         """They sit in the same host directory, and neither holds chunks."""
         alpha, _beta = self.stocked()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3029,6 +3029,95 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
             self.assertEqual(reads, [], "a day with nothing new still read its manifest")
 
 
+class TestWalkingAPeersChunks(SyncTestCase):
+    """Issue #82: `merge` walks every peer's whole tree on every sync.
+
+    Its idle answer is "nothing new", decided from chunk *names*, so building a
+    `Path` and a `Chunk` per file first was the entire cost: 71.5 ms against
+    8.5 ms for one peer with 20k chunks, once a minute, growing with the archive.
+    """
+
+    def stocked(self) -> tuple[Fake, Fake]:
+        """alpha, and a beta whose history alpha has merged."""
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "on alpha")
+            sync.run()
+            sync.grant()
+        with beta.active():
+            for day in ("2023-11-14", "2023-11-15"):
+                for i in range(2):
+                    beta.record(day, 1_700_000_100 + i, f"{day} number {i}")
+                    sync.run()
+        self.accept_everyone(alpha)
+        with alpha.active():
+            sync.run()
+        return alpha, beta
+
+    def test_the_names_are_the_ones_the_chunk_walk_yields(self) -> None:
+        """The two views of the same tree must not drift.
+
+        `iter_chunks` is built on `iter_chunk_days`, and everything that reads a
+        chunk still goes through it -- so a difference here would mean `merge`
+        and `compact` disagreeing about what a host published.
+        """
+        _alpha, beta = self.stocked()
+        with beta.active():
+            by_day = list(store.iter_chunk_days(beta.id))
+            flat = [(chunk.day, chunk.name) for chunk in store.iter_chunks(beta.id)]
+
+        self.assertEqual(
+            [(day, name) for day, names in by_day for name in names],
+            flat,
+            "the name walk and the chunk walk disagree",
+        )
+        self.assertEqual([day for day, _ in by_day], sorted(day for day, _ in by_day))
+        for _day, names in by_day:
+            self.assertEqual(names, sorted(names))
+            self.assertTrue(names, "an empty day was yielded")
+
+    def test_a_day_is_never_split_across_two_groups(self) -> None:
+        """The contract `_merge_host` leans on, and the one that loses history.
+
+        `_Day` replaces the log file it writes, so a day appearing twice would
+        have the second group overwrite what the first had just written.
+        """
+        _alpha, beta = self.stocked()
+        with beta.active():
+            days = [day for day, _ in store.iter_chunk_days(beta.id)]
+        self.assertEqual(len(days), len(set(days)), f"a day was yielded twice: {days}")
+
+    def test_keys_and_manifests_are_not_mistaken_for_days(self) -> None:
+        """They sit in the same host directory, and neither holds chunks."""
+        _alpha, beta = self.stocked()
+        with beta.active():
+            siblings = {p.name for p in store.repo_host_dir(beta.id).iterdir() if p.is_dir()}
+            self.assertTrue({"keys", "manifests"} <= siblings, siblings)
+            days = {day for day, _ in store.iter_chunk_days(beta.id)}
+        self.assertEqual(days, {"2023-11-14", "2023-11-15"})
+
+    def test_an_idle_merge_builds_nothing_per_chunk(self) -> None:
+        """The saving itself, asserted where a future change would undo it.
+
+        Nothing is new, so `merge` has no reason to construct a `Chunk` -- and
+        constructing one per file is what made this walk cost 8x what reading
+        the names does.
+        """
+        alpha, _beta = self.stocked()
+        real = store.iter_chunks
+        used = []
+
+        def spy(machine_id: str) -> Iterator[store.Chunk]:
+            used.append(machine_id)
+            return real(machine_id)
+
+        with alpha.active(), mock.patch.object(store, "iter_chunks", spy):
+            report = sync.run()
+        self.assertEqual(report.chunks_merged, 0)
+        self.assertEqual(used, [], "merge built Chunk objects for an idle sync")
+
+
 class TestExportDoesNotReadWhatCannotHaveChanged(SyncTestCase):
     """Issue #80: the early exit is the shape of every idle sync.
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3046,7 +3046,10 @@ class TestWalkingAPeersChunks(SyncTestCase):
             sync.run()
             sync.grant()
         with beta.active():
-            for day in ("2023-11-14", "2023-11-15"):
+            # Three days, recorded newest first: two cannot tell a sorted walk
+            # from a reversed one, and readdir order is not the creation order
+            # in any case.
+            for day in ("2023-11-16", "2023-11-14", "2023-11-15"):
                 for i in range(2):
                     beta.record(day, 1_700_000_100 + i, f"{day} number {i}")
                     sync.run()
@@ -3072,10 +3075,27 @@ class TestWalkingAPeersChunks(SyncTestCase):
             flat,
             "the name walk and the chunk walk disagree",
         )
-        self.assertEqual([day for day, _ in by_day], sorted(day for day, _ in by_day))
+        self.assertEqual([day for day, _ in by_day], ["2023-11-14", "2023-11-15", "2023-11-16"])
         for _day, names in by_day:
             self.assertEqual(names, sorted(names))
             self.assertTrue(names, "an empty day was yielded")
+
+    def test_only_chunks_are_yielded(self) -> None:
+        """A day directory is not guaranteed to hold nothing else.
+
+        A partial write, an editor's backup, a `.orig` left by a merge tool: the
+        walk names what it is looking for rather than taking whatever is there,
+        because everything downstream treats a name as a chunk to authenticate.
+        """
+        _alpha, beta = self.stocked()
+        with beta.active():
+            directory = store.chunk_dir(beta.id, "2023-11-14")
+            (directory / "1700000000-abcdef.age.tmp").write_bytes(b"half a chunk")
+            (directory / "notes.txt").write_text("not a chunk", encoding="utf-8")
+
+            names = dict(store.iter_chunk_days(beta.id))["2023-11-14"]
+        self.assertTrue(all(name.endswith(".age") for name in names), names)
+        self.assertEqual(len(names), 2)
 
     def test_a_day_is_never_split_across_two_groups(self) -> None:
         """The contract `_merge_host` leans on, and the one that loses history.
@@ -3095,7 +3115,7 @@ class TestWalkingAPeersChunks(SyncTestCase):
             siblings = {p.name for p in store.repo_host_dir(beta.id).iterdir() if p.is_dir()}
             self.assertTrue({"keys", "manifests"} <= siblings, siblings)
             days = {day for day, _ in store.iter_chunk_days(beta.id)}
-        self.assertEqual(days, {"2023-11-14", "2023-11-15"})
+        self.assertEqual(days, {"2023-11-14", "2023-11-15", "2023-11-16"})
 
     def test_an_idle_merge_builds_nothing_per_chunk(self) -> None:
         """The saving itself, asserted where a future change would undo it.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3127,6 +3127,34 @@ class TestWalkingAPeersChunks(SyncTestCase):
             # And a day that does hold one still says so.
             self.assertTrue(sync.has_chunks(alpha.id, "2023-11-14"))
 
+    def test_one_day_is_not_answered_by_walking_the_host(self) -> None:
+        """`orphaned_days` asks once per orphaned day, so the cost compounds.
+
+        Answering from a whole-host walk made a 0.12 ms question 5 ms, and
+        `orphaned_days` 5 ms to 184 ms with 40 orphaned days over 20k chunks --
+        quadratic in the archive, in exactly the state `doctor` exists to find
+        and that a stranger with push access can create.
+        """
+        alpha, _beta = self.stocked()
+        walked: list[str] = []
+        real = store.iter_chunk_days
+
+        def spy(machine_id: str) -> Iterator[tuple[str, list[str]]]:
+            walked.append(machine_id)
+            return real(machine_id)
+
+        with alpha.active(), mock.patch.object(store, "iter_chunk_days", spy):
+            self.assertTrue(sync.has_chunks(alpha.id, "2023-11-14"))
+            sync.orphaned_days()
+
+            # `export` asks the same question, per day it is sealing, on every
+            # sync that records anything.
+            alpha.record("2023-11-14", 1_700_000_900, "one more")
+            self.assertTrue(
+                sync.export(store.machine(), sync.State.load(), sync.Report(), 1_700_000_901)
+            )
+        self.assertEqual(walked, [], "a one-day question walked the whole host")
+
     def test_keys_and_manifests_are_not_mistaken_for_days(self) -> None:
         """They sit in the same host directory, and neither holds chunks."""
         alpha, _beta = self.stocked()

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -553,6 +553,39 @@ class Chunk(NamedTuple):
     path: Path
 
 
+def iter_chunk_days(machine_id: str) -> Iterator[tuple[str, list[str]]]:
+    """``(day, chunk filenames)`` for one host, days in order, names sorted.
+
+    Names, not `Chunk` objects, because the caller that runs every minute --
+    `sync._merge_host` -- decides from the *name* alone whether it has already
+    merged a chunk, and on an idle sync the answer is always yes. Building a
+    `Path` and a `Chunk` per file first is the whole cost of that walk: at 20k
+    chunks it is 88 ms against 3 ms for the names, once a minute, per peer,
+    growing with the archive forever.
+
+    `os.scandir` rather than `Path.glob` for the same reason, and it is free:
+    scandir already knows whether an entry is a directory, so `_is_day` decides
+    on a name that has been read once. The order is identical -- chunk names are
+    fixed-width, so sorting them as strings sorts them as `Path`s did.
+    """
+    root = repo_host_dir(machine_id)
+    try:
+        with os.scandir(root) as entries:
+            days = sorted(e.name for e in entries if e.is_dir() and _is_day(e.name))
+    except OSError:
+        return
+
+    for day in days:
+        try:
+            with os.scandir(root / day) as entries:
+                names = sorted(
+                    e.name for e in entries if e.is_file() and e.name.endswith(_CHUNK_SUFFIX)
+                )
+        except OSError:
+            continue
+        yield day, names
+
+
 def iter_chunks(machine_id: str) -> Iterator[Chunk]:
     """Every sealed chunk belonging to one host, oldest first.
 
@@ -562,11 +595,9 @@ def iter_chunks(machine_id: str) -> Iterator[Chunk]:
     second group overwrite the log file the first had just written.
     """
     root = repo_host_dir(machine_id)
-    if not root.is_dir():
-        return
-    for day_dir in sorted(p for p in root.iterdir() if p.is_dir() and _is_day(p.name)):
-        for path in sorted(day_dir.glob(f"*{_CHUNK_SUFFIX}")):
-            yield Chunk(day=day_dir.name, name=path.name, path=path)
+    for day, names in iter_chunk_days(machine_id):
+        for name in names:
+            yield Chunk(day=day, name=name, path=root / day / name)
 
 
 def _is_day(name: str) -> bool:

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -553,6 +553,25 @@ class Chunk(NamedTuple):
     path: Path
 
 
+def chunk_names(machine_id: str, day: str) -> list[str]:
+    """The chunk filenames in one host-day, sorted. Empty if there are none.
+
+    The unit the layout is actually asked about: what counts as a chunk is
+    decided here, so a partial write or an editor's leftover in a day directory
+    is not one. Callers that want a single day must not reach it by walking the
+    host -- `has_chunks` did, and turned a 0.09 ms question into a 4.6 ms one on
+    an archive of 20k chunks, once per orphaned day.
+
+    `os.scandir` swallows the same errors `Path.glob` did: a day directory that
+    has gone away, or that cannot be read, has no chunks to offer.
+    """
+    try:
+        with os.scandir(chunk_dir(machine_id, day)) as entries:
+            return sorted(e.name for e in entries if e.is_file() and e.name.endswith(_CHUNK_SUFFIX))
+    except OSError:
+        return []
+
+
 def iter_chunk_days(machine_id: str) -> Iterator[tuple[str, list[str]]]:
     """``(day, chunk filenames)`` for one host: days in order, names sorted.
 
@@ -565,7 +584,7 @@ def iter_chunk_days(machine_id: str) -> Iterator[tuple[str, list[str]]]:
     decides from the *name* alone whether it has already merged a chunk, and on
     an idle sync the answer is yes for every one of them. Building a `Path` and
     a `Chunk` per file first was the whole cost of that walk: one peer with 20k
-    chunks took 88 ms to list against 3 ms to name, once a minute, growing with
+    chunks took 88 ms to list against 5 ms to name, once a minute, growing with
     the archive forever.
 
     `os.scandir` rather than `Path.glob` for the same reason, and it is free:
@@ -573,25 +592,17 @@ def iter_chunk_days(machine_id: str) -> Iterator[tuple[str, list[str]]]:
     on a name that has been read once. The order is unchanged -- chunk names are
     fixed-width, so sorting them as strings sorts them as `Path`s did.
     """
-    root = repo_host_dir(machine_id)
     try:
-        with os.scandir(root) as entries:
+        with os.scandir(repo_host_dir(machine_id)) as entries:
             days = sorted(e.name for e in entries if e.is_dir() and _is_day(e.name))
     except OSError:
         return
 
     for day in days:
-        try:
-            with os.scandir(root / day) as entries:
-                names = sorted(
-                    e.name for e in entries if e.is_file() and e.name.endswith(_CHUNK_SUFFIX)
-                )
-        except OSError:
-            continue
         # A day directory with nothing in it is not a day with no new chunks --
         # it is not a day at all, and saying so keeps every caller from having
         # to ask.
-        if names:
+        if names := chunk_names(machine_id, day):
             yield day, names
 
 

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -554,18 +554,23 @@ class Chunk(NamedTuple):
 
 
 def iter_chunk_days(machine_id: str) -> Iterator[tuple[str, list[str]]]:
-    """``(day, chunk filenames)`` for one host, days in order, names sorted.
+    """``(day, chunk filenames)`` for one host: days in order, names sorted.
 
-    Names, not `Chunk` objects, because the caller that runs every minute --
-    `sync._merge_host` -- decides from the *name* alone whether it has already
-    merged a chunk, and on an idle sync the answer is always yes. Building a
-    `Path` and a `Chunk` per file first is the whole cost of that walk: at 20k
-    chunks it is 88 ms against 3 ms for the names, once a minute, per peer,
-    growing with the archive forever.
+    Each day appears exactly once, with all of its chunks. `sync._merge_host`
+    relies on that: it holds one day at a time to bound memory, and `_Day`
+    *replaces* the log file it writes, so a day arriving in two pieces would
+    have the second overwrite what the first had just written.
+
+    Names, not `Chunk` objects, because the caller that runs every minute
+    decides from the *name* alone whether it has already merged a chunk, and on
+    an idle sync the answer is yes for every one of them. Building a `Path` and
+    a `Chunk` per file first was the whole cost of that walk: one peer with 20k
+    chunks took 88 ms to list against 3 ms to name, once a minute, growing with
+    the archive forever.
 
     `os.scandir` rather than `Path.glob` for the same reason, and it is free:
     scandir already knows whether an entry is a directory, so `_is_day` decides
-    on a name that has been read once. The order is identical -- chunk names are
+    on a name that has been read once. The order is unchanged -- chunk names are
     fixed-width, so sorting them as strings sorts them as `Path`s did.
     """
     root = repo_host_dir(machine_id)
@@ -583,16 +588,17 @@ def iter_chunk_days(machine_id: str) -> Iterator[tuple[str, list[str]]]:
                 )
         except OSError:
             continue
-        yield day, names
+        # A day directory with nothing in it is not a day with no new chunks --
+        # it is not a day at all, and saying so keeps every caller from having
+        # to ask.
+        if names:
+            yield day, names
 
 
 def iter_chunks(machine_id: str) -> Iterator[Chunk]:
     """Every sealed chunk belonging to one host, oldest first.
 
-    A day's chunks are contiguous, and days come in order: the outer loop walks
-    one day directory at a time. `sync._merge_host` groups on that -- it holds
-    one day at a time to bound memory, and a day appearing twice would make the
-    second group overwrite the log file the first had just written.
+    The flat view of `iter_chunk_days`, for the callers that want the paths.
     """
     root = repo_host_dir(machine_id)
     for day, names in iter_chunk_days(machine_id):

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -611,9 +611,13 @@ def has_chunks(host_id: str, day: str) -> bool:
     What turns a half-written key pair from a nuisance into a loss: with no
     chunks the next `export` simply mints a new pair over it and nothing is
     ever noticed, so reporting that state would be a false alarm.
+
+    Through the same walk that decides what a chunk *is*, so a day directory
+    holding only a partial write or an editor's leftover reads as empty here
+    too. "Anything at all is in the directory" said the opposite, which would
+    have turned a stray file into a reported loss.
     """
-    directory = store.chunk_dir(host_id, day)
-    return directory.is_dir() and any(directory.iterdir())
+    return bool(dict(store.iter_chunk_days(host_id)).get(day))
 
 
 def orphaned_days() -> list[tuple[str, str]]:
@@ -1191,9 +1195,7 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
         return wrote
 
     # One pass for the whole host, not one per day.
-    on_disk: dict[str, set[str]] = {}
-    for chunk in store.iter_chunks(known.id):
-        on_disk.setdefault(chunk.day, set()).add(chunk.name)
+    on_disk = {day: set(names) for day, names in store.iter_chunk_days(known.id)}
 
     for day, tails in sorted(fresh.items()):
         # Before the manifest, not after. Refusing does not advance
@@ -1372,9 +1374,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
 
     # A day at a time rather than a chunk at a time, because whether a day is
     # being *rewritten* has to be known before deciding which of its chunks to
-    # read -- and that answer is in the manifest. `iter_chunk_days` hands over
-    # one day's names together, which used to be a `groupby` over a flat stream
-    # relying on that stream keeping a day contiguous.
+    # read -- and that answer is in the manifest.
     #
     # A rewrite replaces the day's log file outright, so it has to be rebuilt
     # from every chunk the manifest lists, not from the ones this run happens to
@@ -1386,11 +1386,8 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
     # Laziness is kept where it pays: a day with nothing new never reads its
     # manifest, and a manifest costs a subprocess. Over a year of three machines
     # that is the difference between ~3.6s and nearly two minutes.
-    # Names, not `Chunk` objects: the decision below is made from the name
-    # alone, and on an idle sync it is "already merged" for every one of them.
-    # Building a `Path` and a `Chunk` per file first is what made this walk cost
-    # 88 ms per peer at 20k chunks rather than 3 -- once a minute, growing with
-    # the archive. Objects are built only for the chunks actually read.
+    # Names rather than `Chunk` objects, and paths built only for the chunks
+    # actually read -- see `store.iter_chunk_days` for what that is worth here.
     for chunk_day, names in store.iter_chunk_days(host_id):
         key = f"{host_id}/{chunk_day}"
         # `get`, not `setdefault`: a day this machine only ever *looks* at --

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -33,7 +33,6 @@ from collections import Counter
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from itertools import groupby
 from pathlib import Path
 from typing import NamedTuple
 
@@ -1371,10 +1370,11 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
     #: instead of hundreds, on precisely the first sync a new machine runs.
     day_keys: dict[str, str | None] = {}
 
-    # Grouped by day rather than streamed chunk by chunk, because whether a day
-    # is being *rewritten* has to be known before deciding which of its chunks
-    # to read -- and that answer is in the manifest. `iter_chunks` yields a
-    # day's chunks contiguously, which is what makes one group one day.
+    # A day at a time rather than a chunk at a time, because whether a day is
+    # being *rewritten* has to be known before deciding which of its chunks to
+    # read -- and that answer is in the manifest. `iter_chunk_days` hands over
+    # one day's names together, which used to be a `groupby` over a flat stream
+    # relying on that stream keeping a day contiguous.
     #
     # A rewrite replaces the day's log file outright, so it has to be rebuilt
     # from every chunk the manifest lists, not from the ones this run happens to
@@ -1386,8 +1386,12 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
     # Laziness is kept where it pays: a day with nothing new never reads its
     # manifest, and a manifest costs a subprocess. Over a year of three machines
     # that is the difference between ~3.6s and nearly two minutes.
-    for chunk_day, group in groupby(store.iter_chunks(host_id), key=lambda c: c.day):
-        chunks = list(group)
+    # Names, not `Chunk` objects: the decision below is made from the name
+    # alone, and on an idle sync it is "already merged" for every one of them.
+    # Building a `Path` and a `Chunk` per file first is what made this walk cost
+    # 88 ms per peer at 20k chunks rather than 3 -- once a minute, growing with
+    # the archive. Objects are built only for the chunks actually read.
+    for chunk_day, names in store.iter_chunk_days(host_id):
         key = f"{host_id}/{chunk_day}"
         # `get`, not `setdefault`: a day this machine only ever *looks* at --
         # never granted, or a manifest it cannot verify -- must not gain an
@@ -1396,16 +1400,17 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         # merged below, and aliasing it made "was this already merged" answer
         # yes for a chunk this very run had just added.
         already = frozenset(state.merged.get(key, ()))
-        fresh = [chunk for chunk in chunks if chunk.name not in already]
+        fresh = [name for name in names if name not in already]
         if not fresh:
             continue
 
         listed = read_manifest(host_id, chunk_day, verify_key)
         day = _Day(host_id, chunk_day, listed, already)
-        pending = chunks if day.rewrite else fresh
+        pending = names if day.rewrite else fresh
+        directory = store.chunk_dir(host_id, chunk_day)
 
-        for chunk in pending:
-            if chunk.name not in day.listed:
+        for name in pending:
+            if name not in day.listed:
                 # No signed statement that this host wrote this. Covers a
                 # missing, unsigned, mis-signed or mis-addressed manifest as
                 # well as a chunk simply absent from a good one -- see
@@ -1432,7 +1437,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             # and the parser only ever see bytes one of this user's own machines
             # wrote.
             try:
-                blob = open_chunk(chunk.path, day.listed[chunk.name].digest)
+                blob = open_chunk(directory / name, day.listed[name].digest)
             except (OSError, ValueError):
                 report.unauthenticated.add(key)
                 continue
@@ -1450,8 +1455,8 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 continue
 
             day.add(plaintext, report)
-            state.merged.setdefault(key, set()).add(chunk.name)
-            if chunk.name not in already:
+            state.merged.setdefault(key, set()).add(name)
+            if name not in already:
                 report.chunks_merged += 1
 
         day.flush(report)

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -612,12 +612,17 @@ def has_chunks(host_id: str, day: str) -> bool:
     chunks the next `export` simply mints a new pair over it and nothing is
     ever noticed, so reporting that state would be a false alarm.
 
-    Through the same walk that decides what a chunk *is*, so a day directory
+    Through the same listing that decides what a chunk *is*, so a day directory
     holding only a partial write or an editor's leftover reads as empty here
     too. "Anything at all is in the directory" said the opposite, which would
     have turned a stray file into a reported loss.
+
+    One day, asked directly: `orphaned_days` calls this once per orphaned day,
+    so answering by walking the whole host would be quadratic in the archive --
+    186 ms rather than 3.8 ms for 40 orphaned days at 20k chunks, in exactly the
+    state `doctor` exists to find.
     """
-    return bool(dict(store.iter_chunk_days(host_id)).get(day))
+    return bool(store.chunk_names(host_id, day))
 
 
 def orphaned_days() -> list[tuple[str, str]]:
@@ -1195,7 +1200,6 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
         return wrote
 
     # One pass for the whole host, not one per day.
-    on_disk = {day: set(names) for day, names in store.iter_chunk_days(known.id)}
 
     for day, tails in sorted(fresh.items()):
         # Before the manifest, not after. Refusing does not advance
@@ -1204,7 +1208,8 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
         # orphaned day cost a fork a minute for as long as it stayed that way,
         # on a path issue #50 is already about. `day in on_disk` first because
         # it is a dict lookup and the other two are stats.
-        if day in on_disk and orphaned_day_key(known.id, day):
+        on_disk = set(store.chunk_names(known.id, day))
+        if on_disk and orphaned_day_key(known.id, day):
             # See `orphaned_day_key` for what this state is. A fresh key would
             # let this sync succeed and say nothing while the day's existing
             # chunks stayed unreadable, so nothing is written. The lines stay
@@ -1282,7 +1287,7 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
         # every manifest, which is the cost this loop exists to avoid. A planted
         # chunk on a quiet day is refused by peers either way, because it is in
         # no manifest -- this is a report, not the defence.
-        report.foreign |= {f"{day}/{name}" for name in on_disk.get(day, set()) - set(listed)}
+        report.foreign |= {f"{day}/{name}" for name in on_disk - set(listed)}
 
     # Set at the manifest rather than approximated by "we got past the guards".
     # A day can be refused for an orphaned key, a missing manifest or one that


### PR DESCRIPTION
Closes #82.

`merge` walks every peer's whole chunk tree on every sync, and its idle answer —
"nothing new" — is decided from chunk *names*. It was building a `Path` and a
`Chunk` per file first, via `Path.glob`, to reach that conclusion.

Measured with one peer holding 20,000 chunks, all already merged:

| | before | after |
|---|---|---|
| `merge()` | 70.9 ms | **9.0 ms** |
| full idle `sync.run()` | 85.7 ms | **21.8 ms** |

A 4x faster idle sync at that scale — more than #50, #73 and #80 removed
together — and it no longer grows with the archive the way it did.

## What changed

`store.iter_chunk_days(machine_id)` yields `(day, sorted names)` over
`os.scandir`. `iter_chunks` is the flat view of it and yields exactly what it did
before, so `export` and `compact` are unaffected. `_merge_host` consumes names
and builds a path only for the chunks it actually reads.

`os.scandir` is free here beyond being faster: it already knows whether an entry
is a directory, so `_is_day` decides on a name that has been read once. The order
is unchanged — chunk names are fixed-width, so sorting them as strings sorts them
as `Path`s did, and a test pins that the two walks agree.

## A regression the review caught, in my own `/simplify` pass

The first round of review suggested routing `has_chunks` through the new walk so
that "what counts as a chunk" is decided in one place. I did — and answered a
one-day question by listing every day of the host. `orphaned_days` calls it once
per orphaned day, so it became quadratic in the archive. Measured, 40 orphaned
days over 20k chunks:

| | before this PR | after the `/simplify` edit | now |
|---|---|---|---|
| `has_chunks` | 0.09 ms | **5.03 ms** | 0.12 ms |
| `orphaned_days` | 3.8 ms | **183.5 ms** | 5.0 ms |

It degraded exactly the state `doctor` exists to find, and one the
`orphaned_day_key` docstring says a stranger with push access can create.

The fix is `store.chunk_names(machine_id, day)` — one `scandir`, the unit the
layout is actually asked about. `iter_chunk_days` is built on it, and so are
`has_chunks` and `export`. A test now pins that a one-day question never walks
the host, for all three.

## Two adjacent things this made visible

- **`export` asked the same question for the whole host.** Its `on_disk` map was
  built from `chunk.day` and `chunk.name`, never touching `chunk.path`, and was
  then read for one day at a time. It is a `chunk_names` call per day it is
  sealing now: 30 ms to 0.13 ms at 20k own chunks. Not the idle path — it sits
  below the early exit — but every sync that records a command paid it.
- **`has_chunks` counted a stray file as a chunk.** It asked "is anything at all
  in this directory", so a partial write or an editor's leftover would make a day
  with no chunks report as populated — and that answer decides whether an
  orphaned day key is a real loss or a false alarm. It goes through the same walk
  now, so "what counts as a chunk" is decided in one place.

## Tests

Eight mutations, each caught:

```
caught  merge builds a Chunk per file again
caught  days no longer sorted
caught  names no longer sorted
caught  keys/ and manifests/ counted as days
caught  the suffix filter dropped
caught  iter_chunks builds the wrong path
caught  empty days yielded again
caught  has_chunks counts a stray file again
caught  has_chunks walks the host again
caught  export walks the host for one day again
```

Five of those initially survived, and each was a fixture too weak to tell the
difference:

- with two day directories, "reversed" and "sorted" can coincide. The fixture
  records three days newest-first now — and that is not arbitrary: on **btrfs**
  `readdir` returns entries in creation order, so an unsorted walk comes back
  wrong there and would pass on the tmpfs the suite's temporary directories
  actually land in. The old comment claimed the opposite; it was wrong.
- with only `.age` files present, dropping the suffix filter changes nothing. A
  `.tmp` and a `.txt` are planted now.
- the two behaviours added during review — skipping empty day directories, and
  `has_chunks` — had no test at all until the sweep said so.

## `/simplify`

Applied: the contiguous-days contract moved onto `iter_chunk_days`, where it is
now enforced, and off `iter_chunks`, whose remaining callers cannot break it; a
call-site comment that restated the docstring measurement word for word; a
comment that narrated the edit instead of the reason; a test subsumed by an
assertion in its neighbour; a duplicate day-set assertion; and `stocked()`, which
re-implemented `history_across_days` plus a trust ceremony the shape did not
need.

## On #72

This touches the subsystem #72 was closed on. It is not #72's ask — that was
"stop walking the tree, ask git what the last fetch brought in", a design change
with new state. This keeps the walk and every contract it has, and makes it cost
what listing a directory costs. If closing #72 meant leaving this walk alone
rather than declining that particular redesign, say so and I will drop it.

## No migration needed

Per rule 8, and nothing on disk changed shape: only how it is read.
