### PR TITLE
sync: skip a peer day whose directory has not changed

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3047,6 +3047,9 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
     once a minute, per peer.
     """
 
+    #: The days `history_across_days` writes.
+    DAYS: ClassVar[tuple[str, ...]] = ("2023-11-14", "2023-11-15")
+
     def listed(self, machine: Fake) -> list[str]:
         """The days one sync actually lists the chunks of."""
         days: list[str] = []
@@ -3060,12 +3063,29 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
             sync.run()
         return days
 
+    def settle(self, machine: Fake, host: Fake, *days: str) -> None:
+        """Age a day directory past `RACY_WINDOW_NS`, as a minute of real time does.
+
+        A day written moments ago is deliberately not stamped: its mtime cannot
+        yet rule out another write landing in the same filesystem tick. Every
+        real day reaches that state within seconds; a test would otherwise have
+        to sleep through it.
+        """
+        aged = time.time() - sync.RACY_WINDOW_NS / 1e9 - 60
+        with machine.active():
+            for day in days:
+                os.utime(store.chunk_dir(host.id, day), (aged, aged))
+
     def pair(self) -> tuple[Fake, Fake]:
         """alpha with two days of one chunk, and a beta that has merged both."""
         alpha, beta = self.history_across_days(days=2, per_day=1)
         with beta.active():
             sync.run()
             self.assertEqual(len(beta.commands()), 2)
+        # Settled, then one more pass so the stamps are recorded.
+        self.settle(beta, alpha, *self.DAYS)
+        with beta.active():
+            sync.run()
         return alpha, beta
 
     def test_a_merged_day_is_not_listed_again(self) -> None:
@@ -3086,7 +3106,12 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
         with beta.active():
             self.assertIn("a later line", beta.commands())
 
-        # And it settles again rather than re-listing for ever.
+        # And once the day has been still long enough to be trusted, it settles
+        # rather than re-listing for ever. Until then it is looked at again --
+        # deliberately, since its mtime cannot yet rule out another write.
+        self.assertEqual(self.listed(beta), ["2023-11-15"])
+        self.settle(beta, alpha, "2023-11-15")
+        self.assertEqual(self.listed(beta), ["2023-11-15"])
         self.assertEqual(self.listed(beta), [])
 
     def test_a_day_left_short_is_looked_at_again(self) -> None:
@@ -3125,7 +3150,52 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
             stray = store.chunk_dir(alpha.id, "2023-11-14") / "not-a-chunk"
             stray.write_bytes(b"something landed in the directory")
         self.assertEqual(self.listed(beta), ["2023-11-14"])
+        self.settle(beta, alpha, "2023-11-14")
+        self.assertEqual(self.listed(beta), ["2023-11-14"])
         self.assertEqual(self.listed(beta), [], "a stray file re-listed the day for ever")
+
+    def test_a_chunk_arriving_mid_listing_is_not_stamped_over(self) -> None:
+        """Why the stamp is read *before* the listing, not after.
+
+        Read after, a chunk that lands between the two is missing from the names
+        but covered by the stamp -- so the day looks finished, is skipped from
+        then on, and those commands are never merged. Read before, the same
+        chunk is either in the listing or under a stamp that no longer matches.
+
+        The arrival is forced here rather than raced for: `chunk_names` drops a
+        real chunk into the directory the instant after it has listed it, which
+        is the one interleaving that matters.
+        """
+        alpha, beta = self.pair()
+        with alpha.active():
+            alpha.record("2023-11-15", 1_700_100_002, "arrived mid-listing")
+            sync.run()
+            source = store.chunk_dir(alpha.id, "2023-11-15")
+            late = max(store.chunk_names(alpha.id, "2023-11-15"))
+            payload = (source / late).read_bytes()
+
+        real = store.chunk_names
+        dropped = False
+
+        def racing(machine_id: str, day: str) -> list[str]:
+            nonlocal dropped
+            names = real(machine_id, day)
+            if day == "2023-11-15" and not dropped:
+                dropped = True
+                names = [name for name in names if name != late]
+                (store.chunk_dir(machine_id, day) / late).write_bytes(payload)
+            return names
+
+        with beta.active(), mock.patch.object(store, "chunk_names", racing):
+            sync.run()
+        self.assertTrue(dropped, "the race was never reached")
+
+        # The chunk was invisible to that pass. It must not have been stamped
+        # over: the next sync has to look again and take it.
+        self.settle(beta, alpha, "2023-11-15")
+        with beta.active():
+            sync.run()
+            self.assertIn("arrived mid-listing", beta.commands())
 
     def test_a_day_shaped_directory_holding_nothing_is_not_stamped(self) -> None:
         """`state.json` is read and compared every sync, so what goes in it lasts.
@@ -3139,9 +3209,9 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
             hollow = store.chunk_dir(alpha.id, "2023-11-20")
             hollow.mkdir(parents=True, exist_ok=True)
             sync.run()
-            self.assertNotIn(f"{alpha.id}/2023-11-20", sync.State.load().scanned)
+            self.assertNotIn(f"{alpha.id}/2023-11-20", sync.State.load().merged_at)
             # The days that *are* days still are.
-            self.assertIn(f"{alpha.id}/2023-11-14", sync.State.load().scanned)
+            self.assertIn(f"{alpha.id}/2023-11-14", sync.State.load().merged_at)
 
 
 class TestWalkingAPeersChunks(SyncTestCase):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3127,6 +3127,22 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
         self.assertEqual(self.listed(beta), ["2023-11-14"])
         self.assertEqual(self.listed(beta), [], "a stray file re-listed the day for ever")
 
+    def test_a_day_shaped_directory_holding_nothing_is_not_stamped(self) -> None:
+        """`state.json` is read and compared every sync, so what goes in it lasts.
+
+        A directory named like a day but holding no chunk is not a day (see
+        `store.iter_chunk_days`). Stamping one would leave a permanent entry for
+        something that was never there -- and this file already only grows.
+        """
+        alpha, beta = self.pair()
+        with beta.active():
+            hollow = store.chunk_dir(alpha.id, "2023-11-20")
+            hollow.mkdir(parents=True, exist_ok=True)
+            sync.run()
+            self.assertNotIn(f"{alpha.id}/2023-11-20", sync.State.load().scanned)
+            # The days that *are* days still are.
+            self.assertIn(f"{alpha.id}/2023-11-14", sync.State.load().scanned)
+
 
 class TestWalkingAPeersChunks(SyncTestCase):
     """Issue #82: `merge` walks every peer's whole tree on every sync.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3030,6 +3030,96 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
             self.assertEqual(reads, [], "a day with nothing new still read its manifest")
 
 
+class TestSkippingAnUnchangedDay(SyncTestCase):
+    """Issue #85: listing a peer's archive is what an idle merge costs.
+
+    A day directory's mtime moves when a chunk lands in it, so a day whose stamp
+    is unchanged since it was merged has nothing new -- and needs no listing. At
+    20k chunks over 40 days that is 0.18 ms of stats against 4.96 ms of listing,
+    once a minute, per peer.
+    """
+
+    def listed(self, machine: Fake) -> list[str]:
+        """The days one sync actually lists the chunks of."""
+        days: list[str] = []
+        real = store.chunk_names
+
+        def counted(machine_id: str, day: str) -> list[str]:
+            days.append(day)
+            return real(machine_id, day)
+
+        with machine.active(), mock.patch.object(store, "chunk_names", counted):
+            sync.run()
+        return days
+
+    def pair(self) -> tuple[Fake, Fake]:
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        with alpha.active():
+            for day in ("2023-11-14", "2023-11-15"):
+                alpha.record(day, 1_700_000_001, f"on {day}")
+                sync.run()
+            sync.grant()
+        with beta.active():
+            sync.run()
+            self.assertEqual(len(beta.commands()), 2)
+        return alpha, beta
+
+    def test_a_merged_day_is_not_listed_again(self) -> None:
+        alpha, beta = self.pair()
+        self.assertEqual(self.listed(beta), [], "an unchanged day was listed")
+        # ...and the history is still there, which is the point of not looking.
+        with beta.active():
+            self.assertEqual(len(beta.commands()), 2)
+        del alpha
+
+    def test_a_day_that_gains_a_chunk_is_listed_and_merged(self) -> None:
+        """The half that would silently stop merging if the skip overreached."""
+        alpha, beta = self.pair()
+        with alpha.active():
+            alpha.record("2023-11-15", 1_700_000_002, "a later line")
+            sync.run()
+
+        self.assertEqual(self.listed(beta), ["2023-11-15"])
+        with beta.active():
+            self.assertIn("a later line", beta.commands())
+
+        # And it settles again rather than re-listing for ever.
+        self.assertEqual(self.listed(beta), [])
+
+    def test_a_day_left_short_is_looked_at_again(self) -> None:
+        """A stamp must mean "merged", not "looked at".
+
+        A chunk that would not open leaves the day incomplete. Stamping it would
+        say the day is finished, and nothing would ever read that chunk again --
+        the same trap #69 hit by recording a rebuild that had failed.
+        """
+        alpha, beta = self.pair()
+        with alpha.active():
+            alpha.record("2023-11-15", 1_700_000_002, "a later line")
+            sync.run()
+
+        def refuse(path: Path, expected: str) -> bytes:
+            raise ValueError(f"{path.name} is not the chunk its manifest names")
+
+        with beta.active(), mock.patch.object(sync, "open_chunk", refuse):
+            report = sync.run()
+        self.assertIn(f"{alpha.id}/2023-11-15", report.unauthenticated)
+
+        # Nothing changed on disk, so only an unstamped day gets a second look.
+        self.assertEqual(self.listed(beta), ["2023-11-15"])
+        with beta.active():
+            self.assertIn("a later line", beta.commands())
+
+    def test_a_day_whose_directory_changed_is_listed_again(self) -> None:
+        """The stamp is the whole test, so a moved stamp must be believed."""
+        alpha, beta = self.pair()
+        with beta.active():
+            stray = store.chunk_dir(alpha.id, "2023-11-14") / "not-a-chunk"
+            stray.write_bytes(b"something landed in the directory")
+        self.assertEqual(self.listed(beta), ["2023-11-14"])
+
+
 class TestWalkingAPeersChunks(SyncTestCase):
     """Issue #82: `merge` walks every peer's whole tree on every sync.
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3129,6 +3129,14 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
         def refuse(path: Path, expected: str) -> bytes:
             raise ValueError(f"{path.name} is not the chunk its manifest names")
 
+        # Twice, with a settle between. The first pass is what *fetches* the
+        # chunk, so it leaves the directory freshly written and the racy window
+        # would keep the day being read again whatever the completeness rule
+        # said. The second runs against a day that is settled and still short --
+        # the only state in which the rule is the thing being tested.
+        with beta.active(), mock.patch.object(sync, "open_chunk", refuse):
+            sync.run()
+        self.settle(beta, alpha, "2023-11-15")
         with beta.active(), mock.patch.object(sync, "open_chunk", refuse):
             report = sync.run()
         self.assertIn(f"{alpha.id}/2023-11-15", report.unauthenticated)
@@ -3208,6 +3216,9 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
         with beta.active():
             hollow = store.chunk_dir(alpha.id, "2023-11-20")
             hollow.mkdir(parents=True, exist_ok=True)
+        # Old enough that the racy window is not what is keeping it unstamped.
+        self.settle(beta, alpha, "2023-11-20")
+        with beta.active():
             sync.run()
             self.assertNotIn(f"{alpha.id}/2023-11-20", sync.State.load().merged_at)
             # The days that *are* days still are.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3015,9 +3015,17 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
         A manifest costs an `ssh-keygen -Y verify`, and sync runs on a
         one-minute timer. Grouping by day must not turn that into one fork per
         day of history per run.
+
+        The day's directory is disturbed first, so the mtime stamp of #85 does
+        not skip it before `read_manifest` is ever reached. Without that this
+        test passes whether or not the laziness it is named for still exists.
         """
-        _, beta = self.merged_pair()
+        alpha, beta = self.merged_pair()
         with beta.active():
+            stray = store.chunk_dir(alpha.id, "2023-11-14") / "not-a-chunk"
+            stray.write_bytes(b"disturb the day's stamp")
+            stray.unlink()
+
             reads: list[str] = []
             real = sync.read_manifest
 
@@ -3053,25 +3061,19 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
         return days
 
     def pair(self) -> tuple[Fake, Fake]:
-        alpha = self.machine("alpha")
-        beta = self.machine("beta")
-        with alpha.active():
-            for day in ("2023-11-14", "2023-11-15"):
-                alpha.record(day, 1_700_000_001, f"on {day}")
-                sync.run()
-            sync.grant()
+        """alpha with two days of one chunk, and a beta that has merged both."""
+        alpha, beta = self.history_across_days(days=2, per_day=1)
         with beta.active():
             sync.run()
             self.assertEqual(len(beta.commands()), 2)
         return alpha, beta
 
     def test_a_merged_day_is_not_listed_again(self) -> None:
-        alpha, beta = self.pair()
+        _alpha, beta = self.pair()
         self.assertEqual(self.listed(beta), [], "an unchanged day was listed")
         # ...and the history is still there, which is the point of not looking.
         with beta.active():
             self.assertEqual(len(beta.commands()), 2)
-        del alpha
 
     def test_a_day_that_gains_a_chunk_is_listed_and_merged(self) -> None:
         """The half that would silently stop merging if the skip overreached."""
@@ -3112,12 +3114,18 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
             self.assertIn("a later line", beta.commands())
 
     def test_a_day_whose_directory_changed_is_listed_again(self) -> None:
-        """The stamp is the whole test, so a moved stamp must be believed."""
+        """The stamp is the whole test, so a moved stamp must be believed.
+
+        And then re-recorded. A day that is looked at, found to hold nothing
+        new, and left unstamped would be listed again on every sync for ever --
+        which is what a single stray file in a peer's directory would cost.
+        """
         alpha, beta = self.pair()
         with beta.active():
             stray = store.chunk_dir(alpha.id, "2023-11-14") / "not-a-chunk"
             stray.write_bytes(b"something landed in the directory")
         self.assertEqual(self.listed(beta), ["2023-11-14"])
+        self.assertEqual(self.listed(beta), [], "a stray file re-listed the day for ever")
 
 
 class TestWalkingAPeersChunks(SyncTestCase):

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -572,6 +572,38 @@ def chunk_names(machine_id: str, day: str) -> list[str]:
         return []
 
 
+def chunk_days(machine_id: str) -> list[str]:
+    """The day directories one host publishes into, in order.
+
+    One `scandir` of the host, and no listing of the days themselves -- which is
+    what lets a caller decide *per day* whether it needs the names at all.
+    """
+    try:
+        with os.scandir(repo_host_dir(machine_id)) as entries:
+            return sorted(e.name for e in entries if e.is_dir() and _is_day(e.name))
+    except OSError:
+        return []
+
+
+def day_stamp(machine_id: str, day: str) -> int | None:
+    """When this day directory last gained or lost a file. ``None`` if absent.
+
+    A directory's mtime moves when an entry is added to or removed from it,
+    which is exactly what a fetch bringing in a chunk does -- so a day whose
+    stamp is unchanged since it was last merged has nothing new in it, without
+    listing it. At 20k chunks over 40 days, stamping is 0.18 ms against 4.96 ms
+    to list.
+
+    Nanoseconds, and compared for equality rather than order: a directory
+    restored from a backup can be older than the stamp that was recorded, and
+    "older" still means "different, look again".
+    """
+    try:
+        return os.stat(chunk_dir(machine_id, day)).st_mtime_ns
+    except OSError:
+        return None
+
+
 def iter_chunk_days(machine_id: str) -> Iterator[tuple[str, list[str]]]:
     """``(day, chunk filenames)`` for one host: days in order, names sorted.
 
@@ -592,13 +624,7 @@ def iter_chunk_days(machine_id: str) -> Iterator[tuple[str, list[str]]]:
     on a name that has been read once. The order is unchanged -- chunk names are
     fixed-width, so sorting them as strings sorts them as `Path`s did.
     """
-    try:
-        with os.scandir(repo_host_dir(machine_id)) as entries:
-            days = sorted(e.name for e in entries if e.is_dir() and _is_day(e.name))
-    except OSError:
-        return
-
-    for day in days:
+    for day in chunk_days(machine_id):
         # A day directory with nothing in it is not a day with no new chunks --
         # it is not a day at all, and saying so keeps every caller from having
         # to ask.

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -562,6 +562,10 @@ def chunk_names(machine_id: str, day: str) -> list[str]:
     host -- `has_chunks` did, and turned a 0.09 ms question into a 4.6 ms one on
     an archive of 20k chunks, once per orphaned day.
 
+    Listing is what walking an archive costs now that nothing builds a `Path`
+    per file: 4.96 ms for one peer's 20k chunks, against 0.18 ms to stat its 40
+    day directories, which is why `day_stamp` exists.
+
     `os.scandir` swallows the same errors `Path.glob` did: a day directory that
     has gone away, or that cannot be read, has no chunks to offer.
     """
@@ -591,8 +595,7 @@ def day_stamp(machine_id: str, day: str) -> int | None:
     A directory's mtime moves when an entry is added to or removed from it,
     which is exactly what a fetch bringing in a chunk does -- so a day whose
     stamp is unchanged since it was last merged has nothing new in it, without
-    listing it. At 20k chunks over 40 days, stamping is 0.18 ms against 4.96 ms
-    to list.
+    listing it -- see `chunk_names` for what that saves.
 
     Nanoseconds, and compared for equality rather than order: a directory
     restored from a backup can be older than the stamp that was recorded, and
@@ -607,22 +610,10 @@ def day_stamp(machine_id: str, day: str) -> int | None:
 def iter_chunk_days(machine_id: str) -> Iterator[tuple[str, list[str]]]:
     """``(day, chunk filenames)`` for one host: days in order, names sorted.
 
-    Each day appears exactly once, with all of its chunks. `sync._merge_host`
-    relies on that: it holds one day at a time to bound memory, and `_Day`
-    *replaces* the log file it writes, so a day arriving in two pieces would
-    have the second overwrite what the first had just written.
-
-    Names, not `Chunk` objects, because the caller that runs every minute
-    decides from the *name* alone whether it has already merged a chunk, and on
-    an idle sync the answer is yes for every one of them. Building a `Path` and
-    a `Chunk` per file first was the whole cost of that walk: one peer with 20k
-    chunks took 88 ms to list against 5 ms to name, once a minute, growing with
-    the archive forever.
-
-    `os.scandir` rather than `Path.glob` for the same reason, and it is free:
-    scandir already knows whether an entry is a directory, so `_is_day` decides
-    on a name that has been read once. The order is unchanged -- chunk names are
-    fixed-width, so sorting them as strings sorts them as `Path`s did.
+    Each day appears exactly once, with all of its chunks, and days with none at
+    all are not days. `sync._merge_host` reaches the same two halves separately
+    -- `chunk_days` then, per day it has to look at, `chunk_names` -- because it
+    can decide from the day alone that it needs no names.
     """
     for day in chunk_days(machine_id):
         # A day directory with nothing in it is not a day with no new chunks --

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -409,7 +409,7 @@ class State:
     #: "<host>/<day>" -> the day directory's mtime when every chunk it held had
     #: been merged. A day whose stamp still matches has gained nothing since, so
     #: it needs no listing at all -- and listing is what a peer's whole archive
-    #: costs on a timer that fires every minute.
+    #: costs on a timer that fires every minute. See `store.day_stamp`.
     #:
     #: Recorded only for a day merged *completely*. One left short by an
     #: unopenable key or a chunk that would not authenticate has to be looked at
@@ -1408,7 +1408,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
     # manifest, and a manifest costs a subprocess. Over a year of three machines
     # that is the difference between ~3.6s and nearly two minutes.
     # Names rather than `Chunk` objects, and paths built only for the chunks
-    # actually read -- see `store.iter_chunk_days` for what that is worth here.
+    # actually read -- see `store.chunk_names` for what that is worth here.
     for chunk_day in store.chunk_days(host_id):
         key = f"{host_id}/{chunk_day}"
 
@@ -1430,8 +1430,15 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         fresh = [name for name in names if name not in already]
         if not fresh:
             # Nothing new, but the stamp moved -- a chunk added and removed
-            # again, or a first sight of a day already merged from elsewhere.
-            # Recording it here is what stops the next run listing it too.
+            # again, a stray file dropped in, or a first sight of a day already
+            # merged from elsewhere. Recording it here is what stops the next
+            # run listing that day too, and for ever.
+            #
+            # The same condition as the write below the merge, reached earlier:
+            # `not fresh` means every name is in `already`, which *is*
+            # `state.merged[key]`. `names` because an empty directory is not a
+            # day (see `store.iter_chunk_days`), and stamping one would put a
+            # permanent entry in `state.json` for something that is not there.
             if stamp is not None and names:
                 state.scanned[key] = stamp
             continue

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -411,10 +411,10 @@ class State:
     #: it needs no listing at all -- and listing is what a peer's whole archive
     #: costs on a timer that fires every minute. See `store.day_stamp`.
     #:
-    #: Recorded only for a day merged *completely*. One left short by an
-    #: unopenable key or a chunk that would not authenticate has to be looked at
-    #: again, and a stamp would say it did not.
-    scanned: dict[str, int] = field(default_factory=dict)
+    #: Named for what it means: a day merged *completely*, not one looked at.
+    #: One left short by an unopenable key or a chunk that would not
+    #: authenticate has to be read again, and a stamp would say it need not be.
+    merged_at: dict[str, int] = field(default_factory=dict)
     #: What was on disk when this was loaded, so `save` can tell whether there
     #: is anything to write. Not part of the state itself.
     _loaded: dict[str, object] = field(default_factory=dict, repr=False, compare=False)
@@ -426,7 +426,7 @@ class State:
         merged = raw.get("merged", {})
         granted = raw.get("granted", [])
         signers = raw.get("signers", {})
-        scanned = raw.get("scanned", {})
+        merged_at = raw.get("merged_at", {})
         if not isinstance(exported, dict) or not isinstance(merged, dict):
             return cls()
         state = cls(
@@ -451,8 +451,8 @@ class State:
             else {},
             # A malformed stamp costs one listing of that day, which is what
             # every run did before it existed.
-            scanned={str(k): int(v) for k, v in scanned.items() if isinstance(v, int)}
-            if isinstance(scanned, dict)
+            merged_at={str(k): int(v) for k, v in merged_at.items() if isinstance(v, int)}
+            if isinstance(merged_at, dict)
             else {},
         )
         state._loaded = state.as_json()
@@ -470,7 +470,7 @@ class State:
             "merged": {key: sorted(names) for key, names in self.merged.items()},
             "granted": list(self.granted),
             "signers": dict(self.signers),
-            "scanned": dict(self.scanned),
+            "merged_at": dict(self.merged_at),
         }
 
     def save(self) -> None:
@@ -1381,6 +1381,30 @@ def _trusted_signer(host_id: str, state: State, report: Report) -> str | None:
     return pinned
 
 
+#: How long a day directory must have been still before its mtime is trusted as
+#: a statement about its contents.
+#:
+#: mtime is not a serial number. Where the filesystem stores it to the second --
+#: ext3, ext4 formatted with 128-byte inodes, HFS+, NFSv3, and two seconds on
+#: exFAT -- a chunk written into a day *after* this listing but within the same
+#: tick would land under a stamp already recorded, and would never be read.
+#: Inside woswoar that cannot happen: every writer of `history/` takes the same
+#: lock and `merge` runs after them. But a hand-run `git pull` in the repo, or a
+#: restore with `rsync -a`, is a writer woswoar does not know about.
+#:
+#: So a day is stamped only once it has been still for longer than any of those
+#: granularities. Git's index does the same for the same reason and calls such
+#: an entry racily clean. The cost is that a day being written *right now* is
+#: listed again next run -- and that is a day gaining chunks anyway.
+RACY_WINDOW_NS = 2_000_000_000
+
+
+def _stamp(state: State, key: str, stamp: int | None, settled: bool) -> None:
+    """Record that ``key`` is merged as of ``stamp``, where that can be trusted."""
+    if stamp is not None and settled and time.time_ns() - stamp > RACY_WINDOW_NS:
+        state.merged_at[key] = stamp
+
+
 def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> None:
     verify_key = _trusted_signer(host_id, state, report)
     if verify_key is None:
@@ -1416,7 +1440,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         # would otherwise be covered by a stamp taken after it landed, and not
         # looked at until something else changed the directory.
         stamp = store.day_stamp(host_id, chunk_day)
-        if stamp is not None and state.scanned.get(key) == stamp:
+        if stamp is not None and state.merged_at.get(key) == stamp:
             continue
 
         names = store.chunk_names(host_id, chunk_day)
@@ -1439,8 +1463,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             # `state.merged[key]`. `names` because an empty directory is not a
             # day (see `store.iter_chunk_days`), and stamping one would put a
             # permanent entry in `state.json` for something that is not there.
-            if stamp is not None and names:
-                state.scanned[key] = stamp
+            _stamp(state, key, stamp, settled=bool(names))
             continue
 
         listed = read_manifest(host_id, chunk_day, verify_key)
@@ -1502,9 +1525,8 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
 
         # Only a day with nothing left over. A chunk that failed to open, or one
         # in no signed manifest, is not in `merged` -- so the day is unfinished
-        # and must be looked at again, stamp or no stamp.
-        if stamp is not None and not set(names) - state.merged.get(key, set()):
-            state.scanned[key] = stamp
+        # and must be read again, stamp or no stamp.
+        _stamp(state, key, stamp, settled=not set(names) - state.merged.get(key, set()))
 
 
 class _Day:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -406,6 +406,15 @@ class State:
     #: `hosts/<id>/signer.pub` included, so the key a host is held to has to be
     #: remembered somewhere the remote cannot reach.
     signers: dict[str, str] = field(default_factory=dict)
+    #: "<host>/<day>" -> the day directory's mtime when every chunk it held had
+    #: been merged. A day whose stamp still matches has gained nothing since, so
+    #: it needs no listing at all -- and listing is what a peer's whole archive
+    #: costs on a timer that fires every minute.
+    #:
+    #: Recorded only for a day merged *completely*. One left short by an
+    #: unopenable key or a chunk that would not authenticate has to be looked at
+    #: again, and a stamp would say it did not.
+    scanned: dict[str, int] = field(default_factory=dict)
     #: What was on disk when this was loaded, so `save` can tell whether there
     #: is anything to write. Not part of the state itself.
     _loaded: dict[str, object] = field(default_factory=dict, repr=False, compare=False)
@@ -417,6 +426,7 @@ class State:
         merged = raw.get("merged", {})
         granted = raw.get("granted", [])
         signers = raw.get("signers", {})
+        scanned = raw.get("scanned", {})
         if not isinstance(exported, dict) or not isinstance(merged, dict):
             return cls()
         state = cls(
@@ -439,6 +449,11 @@ class State:
             signers={str(k): str(v) for k, v in signers.items()}
             if isinstance(signers, dict)
             else {},
+            # A malformed stamp costs one listing of that day, which is what
+            # every run did before it existed.
+            scanned={str(k): int(v) for k, v in scanned.items() if isinstance(v, int)}
+            if isinstance(scanned, dict)
+            else {},
         )
         state._loaded = state.as_json()
         return state
@@ -455,6 +470,7 @@ class State:
             "merged": {key: sorted(names) for key, names in self.merged.items()},
             "granted": list(self.granted),
             "signers": dict(self.signers),
+            "scanned": dict(self.scanned),
         }
 
     def save(self) -> None:
@@ -1393,8 +1409,17 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
     # that is the difference between ~3.6s and nearly two minutes.
     # Names rather than `Chunk` objects, and paths built only for the chunks
     # actually read -- see `store.iter_chunk_days` for what that is worth here.
-    for chunk_day, names in store.iter_chunk_days(host_id):
+    for chunk_day in store.chunk_days(host_id):
         key = f"{host_id}/{chunk_day}"
+
+        # Read before the listing, not after: a chunk arriving between the two
+        # would otherwise be covered by a stamp taken after it landed, and not
+        # looked at until something else changed the directory.
+        stamp = store.day_stamp(host_id, chunk_day)
+        if stamp is not None and state.scanned.get(key) == stamp:
+            continue
+
+        names = store.chunk_names(host_id, chunk_day)
         # `get`, not `setdefault`: a day this machine only ever *looks* at --
         # never granted, or a manifest it cannot verify -- must not gain an
         # empty record that is then written out on every sync forever.
@@ -1404,6 +1429,11 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         already = frozenset(state.merged.get(key, ()))
         fresh = [name for name in names if name not in already]
         if not fresh:
+            # Nothing new, but the stamp moved -- a chunk added and removed
+            # again, or a first sight of a day already merged from elsewhere.
+            # Recording it here is what stops the next run listing it too.
+            if stamp is not None and names:
+                state.scanned[key] = stamp
             continue
 
         listed = read_manifest(host_id, chunk_day, verify_key)
@@ -1462,6 +1492,12 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 report.chunks_merged += 1
 
         day.flush(report)
+
+        # Only a day with nothing left over. A chunk that failed to open, or one
+        # in no signed manifest, is not in `merged` -- so the day is unfinished
+        # and must be looked at again, stamp or no stamp.
+        if stamp is not None and not set(names) - state.merged.get(key, set()):
+            state.scanned[key] = stamp
 
 
 class _Day:


### PR DESCRIPTION
Closes #85.

`merge` re-listed every peer's day directories on every sync to learn that
nothing had changed. A day directory's mtime moves when a chunk lands in it, so
a day whose stamp is unchanged since it merged has nothing new — and needs no
listing.

Measured with one peer holding 20,000 chunks across 40 days, all merged:

| | before | after |
|---|---|---|
| `merge()` | 7.9 ms | **3.2 ms** |
| full idle `sync.run()` | 20.4 ms | **14.2 ms** |

`State.merged_at` records the stamp; `store.chunk_days` lists day names without
listing their contents; `store.day_stamp` reads the mtime.

## The stamp is only trusted once the day has been still

mtime is not a serial number. Where a filesystem stores it to the second — ext3,
ext4 with 128-byte inodes, HFS+, NFSv3, two seconds on exFAT — a chunk written
*after* a listing but within the same tick would land under a stamp already
recorded, and would never be read. Silently, permanently, with no report line.

Inside woswoar that cannot happen: every writer of `history/` takes the same lock
and `merge` runs after them. But a hand-run `git pull` in the repo, or a restore
with `rsync -a`, is a writer woswoar does not know about — and the review
demonstrated the loss by forcing a directory's mtime back after a chunk landed.

So a day is stamped only once it has been quiet for longer than any of those
granularities (`RACY_WINDOW_NS`, 2 s). Git's index does the same thing for the
same reason and calls such an entry racily clean. The cost is that a day being
written right now is listed again next run — which is a day gaining chunks
anyway.

The stamp is also read **before** the listing, not after: read after, a chunk
arriving between the two is missing from the names but covered by the stamp. A
test forces exactly that interleaving.

## Recorded only for a day merged completely

A day left short by an unopenable key, or by a chunk that would not
authenticate, must be read again — the trap #69 hit by recording a rebuild that
had failed. The field is named `merged_at` rather than `scanned` for the same
reason: it means merged, not looked at.

## Tests

Nine mutations, each caught:

```
caught  never skip: list every day again
caught  skip once stamped, however stale
caught  stamp a day left short
caught  stamp a hollow directory
caught  stamp read after the listing
caught  no racy window: trust a stamp taken this instant
caught  merged_at never persisted
caught  merged_at never loaded back
caught  the stamp never changes
```

Three of those survived at first, and all three were the racy window *masking*
the rule under test: a fixture that writes a day and immediately syncs is never
stamped anyway, so `settled=True` changes nothing. The fixtures now age the
directory the way sixty seconds of real time does — and for the "day left short"
case, the two refusal passes are separated by that ageing, because the pass that
fetches the chunk is itself what makes the directory fresh.

`/simplify` also caught a rule 3 violation of mine: one of the two places that
record a stamp had no test at all — deleting it left the suite green. Without it,
a single stray file in a peer's directory would re-list that day for ever. It is
pinned now, and the sibling `test_a_day_with_nothing_new_reads_no_manifest` — which
this change had quietly turned into decoration, since the stamp now skips the day
before `read_manifest` is reached — disturbs the directory first so it still
tests what it is named for.

## Found while reviewing, filed not fixed

**#87 (P2)** — one stray `*.age` file in a peer's day directory leaves that day
permanently incomplete, so it is re-listed *and* re-verifies its manifest, one
`ssh-keygen` fork per sync, for ever. Pre-existing, but #85's premise is that an
idle sync costs nothing, and that is the hole in it. A stranger with push access
can turn it on with one byte.

## No migration needed

Per rule 8, and it does not arise: a `state.json` with no `merged_at` key does
one listing pass and then settles.
