### PR TITLE
sync: a day is what its manifest says, not what its directory holds

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3096,6 +3096,10 @@ class TestADayIsWhatItsManifestSays(SyncTestCase):
         self.assertEqual([self.verifications(beta) for _ in range(3)], [0, 0, 0])
         with beta.active():
             self.assertEqual(len(beta.commands()), 2, "the day's own history was lost")
+        # And the stray is not recorded as merged. It never was -- and a name
+        # remembered as merged is one that would be skipped if a manifest ever
+        # did list it, taking its lines with it.
+        self.assertNotIn("1700000000-dead.age", self.remembered(beta, alpha))
 
     def test_compaction_shrinks_what_is_remembered(self) -> None:
         """#86: `state.json` is read and compared every sync, and only grew."""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -200,6 +200,19 @@ class SyncTestCase(unittest.TestCase):
         with fake.active():
             sync.trust(sync.trust_candidates())
 
+    def settle(self, machine: Fake, host: Fake, *days: str) -> None:
+        """Age a day directory past `RACY_WINDOW_NS`, as a minute of real time does.
+
+        A day written moments ago is deliberately not stamped: its mtime cannot
+        yet rule out another write landing in the same filesystem tick. Every
+        real day reaches that state within seconds; a test would otherwise have
+        to sleep through it.
+        """
+        aged = time.time() - sync.RACY_WINDOW_NS / 1e9 - 60
+        with machine.active():
+            for day in days:
+                os.utime(store.chunk_dir(host.id, day), (aged, aged))
+
     def run_cli(self, fake: Fake, *argv: str) -> tuple[int, str]:
         """Drive the real CLI as ``fake``, returning ``(exit code, stdout)``.
 
@@ -3050,12 +3063,6 @@ class TestADayIsWhatItsManifestSays(SyncTestCase):
 
     DAY = "2023-11-14"
 
-    def settle(self, machine: Fake, host: Fake) -> None:
-        """Age the day past `RACY_WINDOW_NS`, as a minute of real time does."""
-        aged = time.time() - sync.RACY_WINDOW_NS / 1e9 - 60
-        with machine.active():
-            os.utime(store.chunk_dir(host.id, self.DAY), (aged, aged))
-
     def verifications(self, machine: Fake) -> int:
         """Manifest signature checks one sync makes -- an `ssh-keygen` fork each."""
         seen = 0
@@ -3085,7 +3092,7 @@ class TestADayIsWhatItsManifestSays(SyncTestCase):
         with beta.active():
             sync.run()
             (store.chunk_dir(alpha.id, self.DAY) / "1700000000-dead.age").write_bytes(b"x")
-        self.settle(beta, alpha)
+        self.settle(beta, alpha, self.DAY)
 
         # Said once, because the day did change -- and that pass is the one
         # that pays for the manifest.
@@ -3149,7 +3156,7 @@ class TestADayIsWhatItsManifestSays(SyncTestCase):
         with beta.active():
             sync.run()
             self.assertEqual(
-                set(sync.State.load().merged.get(f"{alpha.id}/{self.DAY}", set())),
+                self.remembered(beta, alpha),
                 before,
                 "an unverifiable manifest emptied the day's record",
             )
@@ -3189,19 +3196,6 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
         with machine.active(), mock.patch.object(store, "chunk_names", counted):
             sync.run()
         return days
-
-    def settle(self, machine: Fake, host: Fake, *days: str) -> None:
-        """Age a day directory past `RACY_WINDOW_NS`, as a minute of real time does.
-
-        A day written moments ago is deliberately not stamped: its mtime cannot
-        yet rule out another write landing in the same filesystem tick. Every
-        real day reaches that state within seconds; a test would otherwise have
-        to sleep through it.
-        """
-        aged = time.time() - sync.RACY_WINDOW_NS / 1e9 - 60
-        with machine.active():
-            for day in days:
-                os.utime(store.chunk_dir(host.id, day), (aged, aged))
 
     def pair(self) -> tuple[Fake, Fake]:
         """alpha with two days of one chunk, and a beta that has merged both."""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3038,6 +3038,129 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
             self.assertEqual(reads, [], "a day with nothing new still read its manifest")
 
 
+class TestADayIsWhatItsManifestSays(SyncTestCase):
+    """Issues #86 and #87: the signed manifest is the statement of a day.
+
+    Judging a day by what is *in its directory* gets both wrong. A name the
+    manifest does not list is not part of the day, so waiting for it to be
+    merged waits for ever; and a name the manifest no longer lists is a chunk
+    compaction replaced, so remembering it for ever makes `state.json` grow
+    while the archive it describes shrinks.
+    """
+
+    DAY = "2023-11-14"
+
+    def settle(self, machine: Fake, host: Fake) -> None:
+        """Age the day past `RACY_WINDOW_NS`, as a minute of real time does."""
+        aged = time.time() - sync.RACY_WINDOW_NS / 1e9 - 60
+        with machine.active():
+            os.utime(store.chunk_dir(host.id, self.DAY), (aged, aged))
+
+    def verifications(self, machine: Fake) -> int:
+        """Manifest signature checks one sync makes -- an `ssh-keygen` fork each."""
+        seen = 0
+        real = crypto.verify
+
+        def counted(*args: object, **kwargs: object) -> bool:
+            nonlocal seen
+            seen += 1
+            return real(*args, **kwargs)  # type: ignore[arg-type]
+
+        with machine.active(), mock.patch.object(crypto, "verify", counted):
+            sync.run()
+        return seen
+
+    def remembered(self, machine: Fake, host: Fake) -> set[str]:
+        with machine.active():
+            return set(sync.State.load().merged.get(f"{host.id}/{self.DAY}", set()))
+
+    def test_a_stray_file_is_reported_once_and_then_settles(self) -> None:
+        """#87: an unlistable name must not hold the day open for ever.
+
+        Before, the day was never complete, so every sync re-listed it *and*
+        re-verified its manifest -- a fork a minute, which anyone with push
+        access could turn on with one byte.
+        """
+        alpha, beta = self.history_across_days(days=1, per_day=2)
+        with beta.active():
+            sync.run()
+            (store.chunk_dir(alpha.id, self.DAY) / "1700000000-dead.age").write_bytes(b"x")
+        self.settle(beta, alpha)
+
+        # Said once, because the day did change -- and that pass is the one
+        # that pays for the manifest.
+        with beta.active():
+            self.assertIn(f"{alpha.id}/{self.DAY}", sync.run().unauthenticated)
+        # Then never again while the directory is untouched. Settling here would
+        # move the mtime and legitimately earn another look.
+        self.assertEqual([self.verifications(beta) for _ in range(3)], [0, 0, 0])
+        with beta.active():
+            self.assertEqual(len(beta.commands()), 2, "the day's own history was lost")
+
+    def test_compaction_shrinks_what_is_remembered(self) -> None:
+        """#86: `state.json` is read and compared every sync, and only grew."""
+        alpha, beta = self.history_across_days(days=1, per_day=6)
+        with beta.active():
+            sync.run()
+        self.assertEqual(len(self.remembered(beta, alpha)), 6)
+
+        with alpha.active():
+            self.assertEqual(sync.compact(before="2023-12-01")[0], 1)
+            sync.run()
+        with beta.active():
+            sync.run()
+
+        with alpha.active():
+            live = set(store.chunk_names(alpha.id, self.DAY))
+        self.assertEqual(self.remembered(beta, alpha), live, "names of chunks that are gone")
+        with beta.active():
+            self.assertEqual(len(beta.commands()), 6, "compaction lost history")
+
+    def test_a_manifest_that_will_not_verify_settles_nothing(self) -> None:
+        """The hazard both halves share, and the one that loses history.
+
+        `read_manifest` answers with *nothing* for a manifest that is missing,
+        unsigned or mis-signed -- not because the day is empty. Treating that as
+        "every signed chunk is merged" would stamp a day whose chunks are all
+        still being refused, and would prune the day's record to nothing. The
+        day would then be merged again from scratch, and `_Day` appends: every
+        line twice.
+        """
+        alpha, beta = self.history_across_days(days=1, per_day=2)
+        with beta.active():
+            sync.run()
+        before = self.remembered(beta, alpha)
+        self.assertEqual(len(before), 2)
+
+        # A chunk arrives *and* the manifest stops verifying, so the day has to
+        # be looked at and then cannot be trusted. Wrecking it alone would leave
+        # the day settled and never consulted, which is its own right answer.
+        with alpha.active():
+            alpha.record(self.DAY, 1_700_000_003, "a third line")
+            sync.run()
+            store.day_manifest(alpha.id, self.DAY).write_text("wrecked", encoding="utf-8")
+            sync._commit()
+            sync._push(sync.read_repo())
+
+        with beta.active():
+            sync.run()
+            self.assertEqual(
+                set(sync.State.load().merged.get(f"{alpha.id}/{self.DAY}", set())),
+                before,
+                "an unverifiable manifest emptied the day's record",
+            )
+            # Not stamped *as it now stands*. An older stamp from the last
+            # good sync may still be recorded; what matters is that it does not
+            # match, so the day keeps being looked at.
+            self.assertNotEqual(
+                sync.State.load().merged_at.get(f"{alpha.id}/{self.DAY}"),
+                store.day_stamp(alpha.id, self.DAY),
+                "an unverifiable manifest settled the day",
+            )
+            # And nothing was written twice.
+            self.assertEqual(len(beta.entries()), 2)
+
+
 class TestSkippingAnUnchangedDay(SyncTestCase):
     """Issue #85: listing a peer's archive is what an idle merge costs.
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import io
 import os
 import secrets
+import shutil
 import subprocess
 import tempfile
 import time
@@ -3126,6 +3127,52 @@ class TestADayIsWhatItsManifestSays(SyncTestCase):
         self.assertEqual(self.remembered(beta, alpha), live, "names of chunks that are gone")
         with beta.active():
             self.assertEqual(len(beta.commands()), 6, "compaction lost history")
+
+    def test_a_day_whose_manifest_went_backwards_is_rebuilt(self) -> None:
+        """What pruning gives up, and how it is paid for.
+
+        Before the prune, `state.merged` remembered every chunk this machine had
+        ever merged, so a working tree rolled back to before a compaction simply
+        found them all already merged. Pruned, it remembers only the compacted
+        chunk -- and the old manifest's chunks look new, so appending them writes
+        the day's lines a second time.
+
+        The signal is the manifest having *lost* a name this machine merged,
+        which cannot happen while a day only grows. Rebuilding from what it now
+        lists is right whether the rollback is a restore, a half-applied backup,
+        or a `git checkout` of an older commit over the working tree.
+        """
+        alpha, beta = self.history_across_days(days=1, per_day=4)
+        with beta.active():
+            sync.run()
+            self.assertEqual(len(beta.entries()), 4)
+            backup = store.history_dir().with_name("history.backup")
+            shutil.copytree(store.history_dir(), backup, symlinks=True)
+
+        with alpha.active():
+            self.assertEqual(sync.compact(before="2023-12-01")[0], 1)
+            sync.run()
+        with beta.active():
+            sync.run()
+            self.assertEqual(len(self.remembered(beta, alpha)), 1, "the prune did not happen")
+
+            # The working tree only: HEAD stays where it is, so the next fetch
+            # finds nothing to bring forward and the rollback sticks.
+            live = store.history_dir()
+            for entry in live.iterdir():
+                if entry.name != ".git":
+                    shutil.rmtree(entry) if entry.is_dir() else entry.unlink()
+            for entry in backup.iterdir():
+                if entry.name != ".git":
+                    if entry.is_dir():
+                        shutil.copytree(entry, live / entry.name, symlinks=True)
+                    else:
+                        shutil.copy2(entry, live / entry.name)
+
+            for _ in range(3):
+                sync.run()
+            self.assertEqual(len(beta.entries()), 4, "the day was written twice over")
+            self.assertEqual(beta.commands(), {f"day 0 command {i}" for i in range(4)})
 
     def test_a_manifest_that_will_not_verify_settles_nothing(self) -> None:
         """The hazard both halves share, and the one that loses history.

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1523,10 +1523,31 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
 
         day.flush(report)
 
-        # Only a day with nothing left over. A chunk that failed to open, or one
-        # in no signed manifest, is not in `merged` -- so the day is unfinished
-        # and must be read again, stamp or no stamp.
-        _stamp(state, key, stamp, settled=not set(names) - state.merged.get(key, set()))
+        # Judged against what the host *signed*, not against what is in the
+        # directory. A name the manifest does not list is not part of the day --
+        # it is debris from an interrupted write, or something a stranger
+        # dropped in -- and nothing will ever merge it, so waiting for it means
+        # the day is re-listed and its manifest re-verified, one `ssh-keygen`
+        # fork, on every sync for ever (#87).
+        #
+        # An empty `listed` is not "a day holding nothing": `read_manifest`
+        # answers that way for a manifest that is missing, unsigned, or will not
+        # verify. Settling on it would stamp a day whose every chunk is still
+        # being refused, and pruning on it would forget the whole day and merge
+        # it again from scratch, duplicating its lines.
+        signed = set(day.listed)
+        settled = bool(signed) and signed <= state.merged.get(key, set())
+        if settled:
+            # Pruned to the same statement. Compaction *removes* the names it
+            # subsumed from the manifest, so this is what stops `state.merged`
+            # growing with every chunk that ever existed -- including while the
+            # archive it describes is getting smaller (#86).
+            #
+            # To the manifest and never to the directory: a chunk missing from
+            # this checkout for a moment would otherwise be forgotten and then
+            # merged again when it came back, and `_Day` appends.
+            state.merged[key] = signed
+        _stamp(state, key, stamp, settled=settled)
 
 
 class _Day:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -380,7 +380,10 @@ class State:
 
     #: log relpath -> plaintext bytes already sealed into a chunk.
     exported: dict[str, int] = field(default_factory=dict)
-    #: "<host>/<day>" -> the chunk filenames already merged into logs/.
+    #: "<host>/<day>" -> the chunk filenames of that day already merged into
+    #: logs/. Pruned to the day's *signed manifest* once every name in it has
+    #: been merged, so this shrinks when a peer compacts -- it is a record of
+    #: what the host says the day holds, not of every file ever seen.
     #:
     #: A set, not a high-water mark. A single "highest name seen" cannot say
     #: "all of these except that one", and chunk names are only loosely ordered:
@@ -406,8 +409,8 @@ class State:
     #: `hosts/<id>/signer.pub` included, so the key a host is held to has to be
     #: remembered somewhere the remote cannot reach.
     signers: dict[str, str] = field(default_factory=dict)
-    #: "<host>/<day>" -> the day directory's mtime when every chunk it held had
-    #: been merged. A day whose stamp still matches has gained nothing since, so
+    #: "<host>/<day>" -> the day directory's mtime when every chunk its signed
+    #: manifest listed had been merged. A day whose stamp still matches has gained nothing since, so
     #: it needs no listing at all -- and listing is what a peer's whole archive
     #: costs on a timer that fires every minute. See `store.day_stamp`.
     #:
@@ -1458,11 +1461,22 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             # merged from elsewhere. Recording it here is what stops the next
             # run listing that day too, and for ever.
             #
-            # The same condition as the write below the merge, reached earlier:
-            # `not fresh` means every name is in `already`, which *is*
-            # `state.merged[key]`. `names` because an empty directory is not a
-            # day (see `store.iter_chunk_days`), and stamping one would put a
-            # permanent entry in `state.json` for something that is not there.
+            # Judged on the directory here, and on the manifest below the
+            # merge. Deliberately, and the two do not have to agree: `not fresh`
+            # means every name on disk is already merged, so the only thing a
+            # manifest could add is a name with no file behind it -- which
+            # nothing can merge now, and whose arrival would move the day's
+            # mtime and bring it back here anyway.
+            #
+            # This branch has no manifest to judge against, because reading one
+            # is the `ssh-keygen` fork that #87 exists to stop paying. That also
+            # means it cannot prune: a day settling here keeps whatever
+            # `state.merged` already held, and is pruned on the next pass that
+            # has a reason to read the manifest.
+            #
+            # `names` because an empty directory is not a day (see
+            # `store.iter_chunk_days`), and stamping one would put a permanent
+            # entry in `state.json` for something that is not there.
             _stamp(state, key, stamp, settled=bool(names))
             continue
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1600,7 +1600,19 @@ class _Day:
         # `state.merged` on a pass that rewrote the file. So a rewrite cut short
         # by an unopenable day key is still owed on the next pass, with no
         # second record of what was rebuilt to keep in step with this one.
-        self.rewrite = bool(self.compacted - already)
+        # Or when the manifest has lost a name this machine merged. A name only
+        # enters `merged` while the manifest lists it, so in ordinary growth
+        # this is empty; it is not empty when the manifest went *backwards* --
+        # a working tree rolled back to before a compaction, a half-applied
+        # restore. Appending then would write the day's lines a second time,
+        # because `merged` was pruned to the compaction and no longer remembers
+        # the chunks it replaced. Rebuilding from what the manifest now lists is
+        # right either way.
+        #
+        # An unverifiable manifest lands here too, with nothing listed -- and
+        # nothing then merges, so `flush` has no blocks and leaves the day
+        # alone rather than replacing it with nothing.
+        self.rewrite = bool(self.compacted - already) or bool(already - set(listed))
         self._blocks: list[bytes] = []
         self._bytes = 0
 


### PR DESCRIPTION
Closes #86. Closes #87.

Both were the same mistake: judging a day by what is in its **directory** rather
than by what its host **signed**. Done together because the fix is one
comparison — separately, the manifest check would have been written twice, and
#87 would have landed a rule #86 immediately rewrote.

```python
signed = set(day.listed)
settled = bool(signed) and signed <= state.merged.get(key, set())
if settled:
    state.merged[key] = signed
```

**#87** — a name the manifest does not list is not part of the day, so waiting
for it to be merged waits for ever. A single stray `*.age` file made its day
re-listed *and* its manifest re-verified — an `ssh-keygen` fork — on every sync,
and anyone with push access could turn that on with one byte. Manifest
verifications on three consecutive syncs: `[1, 1, 1]` → `[1, 0, 0]`.

**#86** — compaction *removes* the names it subsumed from the manifest, so
pruning to it is what stops `state.merged` growing while the archive it describes
shrinks. After a peer compacts a six-chunk day: **7 names remembered for 1 chunk
that exists → 1**.

## Two hazards, one of which I introduced

**An unverifiable manifest is not an empty day.** `read_manifest` answers `{}` for
one that is missing, unsigned or mis-signed. Without the `bool(signed)` guard
that reads as "every signed chunk is merged": the day is stamped while its chunks
are all still refused, and its record is pruned to nothing — so it merges again
from scratch, and `_Day` appends. Every line twice.

**Pruning broke rollback recovery, and the review caught it.** The old
never-shrinking record was the only thing remembering that a compacted day's
original chunks were already in the log. Pruned, a working tree rolled back to
before the compaction — a restore, a half-applied backup, `git checkout <old> --`
over the tree — makes those chunks look new. Measured on this branch before the
fix: **8 lines where there should be 4**, and it never heals.

The signal is the manifest having *lost* a name this machine merged, which cannot
happen while a day only grows:

```python
self.rewrite = bool(self.compacted - already) or bool(already - set(listed))
```

I reproduced it independently before believing it — my first attempt showed no
duplication, because I had restored `.git` along with the tree and the rebase
simply re-applied the compaction. It needs the working tree rolled back with HEAD
left alone.

## Tests

Seven mutations, each caught:

```
caught  no rewrite when the manifest went backwards
caught  always rewrite when anything is merged
caught  settle against the directory again, as before #87
caught  settle on an unverifiable manifest
caught  never prune
caught  prune to the directory rather than the manifest
caught  prune without the settled guard
```

"prune to the directory rather than the manifest" survived at first: it records a
name that was never merged, which is invisible unless you assert on what is
*remembered* rather than on what is merged. Two of my tests were also wrong
before they were right — one asserted a day would settle after I had just
disturbed it again, and one wrecked a manifest on an already-settled day, where
it is correctly never consulted.

## The one thing this gives up

A planted chunk is now reported once rather than on every sync. That is the point
of #87, but the report was also the only standing signal that someone is writing
into the repository — filed as **#90** for `doctor` to answer on demand.

## Also found while stressing this, filed not fixed

**#89 (P1)** — a rewrite that cannot read one of its chunks writes the day anyway,
with a hole in it: beta's five-line day became **one line**, permanently, from one
damaged chunk. Pre-existing and reproduced identically before this branch, but
this is the machinery that surfaced it.

## No migration needed

Per rule 8. An existing `state.merged` simply shrinks to the manifest the first
time each day is fully merged.
