### PR TITLE
sync: a rewrite is all or nothing

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3052,6 +3052,102 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
             self.assertEqual(reads, [], "a day with nothing new still read its manifest")
 
 
+class TestARewriteIsAllOrNothing(SyncTestCase):
+    """Issue #89: a rewrite replaces the day, so a partial one destroys history.
+
+    The chunks a compaction subsumed are unlinked, so their lines exist only
+    inside the compacted chunk. A rewrite that cannot open it, but can open
+    something else in the day, used to write the day out as that something
+    else -- trading lines this machine already had for the ones it could get.
+    """
+
+    DAY = "2023-11-14"
+
+    def compacted_and_growing(self) -> tuple[Fake, Fake, str]:
+        """A day compacted into one chunk, plus a later one the rewrite can read."""
+        alpha, beta = self.history_across_days(days=1, per_day=5)
+        with beta.active():
+            sync.run()
+            self.assertEqual(len(beta.entries()), 5)
+        with alpha.active():
+            self.assertEqual(sync.compact(before="2023-12-01")[0], 1)
+            verify_key = sync.signing_public()
+            listed = sync.read_manifest(alpha.id, self.DAY, verify_key)
+            compacted = next(name for name, entry in listed.items() if entry.subsumes)
+            alpha.record(self.DAY, 1_700_000_600, "and another")
+            sync.run()
+        return alpha, beta, compacted
+
+    def damaged(self, name: str) -> Callable[[Path, str], bytes]:
+        real = sync.open_chunk
+
+        def refuse(path: Path, expected: str) -> bytes:
+            if path.name == name:
+                raise ValueError(f"{path.name} is not the chunk its manifest names")
+            return real(path, expected)
+
+        return refuse
+
+    def test_a_day_keeps_what_it_had_when_a_chunk_will_not_open(self) -> None:
+        alpha, beta, compacted = self.compacted_and_growing()
+
+        with beta.active(), mock.patch.object(sync, "open_chunk", self.damaged(compacted)):
+            report = sync.run()
+            self.assertIn(f"{alpha.id}/{self.DAY}", report.stale)
+            self.assertEqual(len(beta.entries()), 5, "the day was rewritten from a partial read")
+
+            # And it stays whole for as long as the chunk stays damaged.
+            for _ in range(3):
+                sync.run()
+            self.assertEqual(len(beta.entries()), 5)
+
+    def test_the_chunks_it_did_read_are_not_recorded_as_merged(self) -> None:
+        """Otherwise the refusal is worse than the truncation it prevents.
+
+        A refused rewrite discards the plaintext it had collected. Marking those
+        chunks merged would mean never reading them again -- losing exactly the
+        lines the refusal exists to protect.
+        """
+        alpha, beta, compacted = self.compacted_and_growing()
+        with beta.active(), mock.patch.object(sync, "open_chunk", self.damaged(compacted)):
+            sync.run()
+            self.assertNotIn(
+                compacted, sync.State.load().merged.get(f"{alpha.id}/{self.DAY}", set())
+            )
+
+        # Once the chunk reads, the day is rebuilt whole: the five it had, plus
+        # the one that arrived while it could not be.
+        with beta.active():
+            sync.run()
+            self.assertEqual(len(beta.entries()), 6)
+            self.assertIn("and another", beta.commands())
+
+    def test_appending_is_still_allowed_to_be_partial(self) -> None:
+        """Only a rewrite is all-or-nothing.
+
+        An append adds to what is there, and `_Day.add` may already have flushed
+        part of it, so refusing the whole pass would strand chunks that are
+        already on disk -- and gains nothing, since nothing was replaced.
+        """
+        alpha, beta = self.history_across_days(days=1, per_day=2)
+        with beta.active():
+            sync.run()
+        with alpha.active():
+            for i in range(2):
+                alpha.record(self.DAY, 1_700_000_700 + i, f"later {i}")
+                sync.run()
+            names = store.chunk_names(alpha.id, self.DAY)
+
+        with beta.active(), mock.patch.object(sync, "open_chunk", self.damaged(names[-1])):
+            report = sync.run()
+            self.assertNotIn(f"{alpha.id}/{self.DAY}", report.stale)
+            # The one that read was kept, rather than held back with the other.
+            self.assertEqual(len(beta.entries()), 3)
+        with beta.active():
+            sync.run()
+            self.assertEqual(len(beta.entries()), 4)
+
+
 class TestADayIsWhatItsManifestSays(SyncTestCase):
     """Issues #86 and #87: the signed manifest is the statement of a day.
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3109,11 +3109,18 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
         lines the refusal exists to protect.
         """
         alpha, beta, compacted = self.compacted_and_growing()
+        with alpha.active():
+            readable = next(
+                name for name in store.chunk_names(alpha.id, self.DAY) if name != compacted
+            )
+
         with beta.active(), mock.patch.object(sync, "open_chunk", self.damaged(compacted)):
             sync.run()
-            self.assertNotIn(
-                compacted, sync.State.load().merged.get(f"{alpha.id}/{self.DAY}", set())
-            )
+            remembered = sync.State.load().merged.get(f"{alpha.id}/{self.DAY}", set())
+        # Not the one that failed, and -- the point -- not the one that read
+        # either: its plaintext was discarded with the refused rewrite.
+        self.assertNotIn(compacted, remembered)
+        self.assertNotIn(readable, remembered, "a discarded chunk was recorded as merged")
 
         # Once the chunk reads, the day is rebuilt whole: the five it had, plus
         # the one that arrived while it could not be.
@@ -3121,6 +3128,22 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
             sync.run()
             self.assertEqual(len(beta.entries()), 6)
             self.assertIn("and another", beta.commands())
+
+    def test_a_stray_file_does_not_hold_a_rewrite_back(self) -> None:
+        """A name the manifest does not list is not part of the day.
+
+        Counting it as a chunk the rewrite failed to get would leave the day
+        stale for ever, which is #87 reached by another route -- and anyone with
+        push access could arrange it with one byte.
+        """
+        alpha, beta, _compacted = self.compacted_and_growing()
+        with beta.active():
+            (store.chunk_dir(alpha.id, self.DAY) / "1700000000-dead.age").write_bytes(b"x")
+
+            report = sync.run()
+            self.assertIn(f"{alpha.id}/{self.DAY}", report.unauthenticated)
+            self.assertNotIn(f"{alpha.id}/{self.DAY}", report.stale)
+            self.assertEqual(len(beta.entries()), 6, "the stray blocked the rebuild")
 
     def test_appending_is_still_allowed_to_be_partial(self) -> None:
         """Only a rewrite is all-or-nothing.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3220,6 +3220,50 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
         self.assertIn("could not be rebuilt", said)
         self.assertIn(f"{alpha.id}/{self.DAY}", said, "it did not say which day")
 
+    def test_a_chunk_deleted_from_the_repo_does_not_truncate_the_day(self) -> None:
+        """The route with no mock in it, and the one that said nothing.
+
+        A chunk the manifest lists but that is *absent* never reaches the merge
+        loop, so measuring what was missed against the directory counted it as
+        nothing to miss: the day was rewritten without it, five commands became
+        one, and neither `stale` nor `unauthenticated` fired. Anyone with push
+        access can delete a chunk; woswoar itself never does.
+        """
+        alpha, beta, compacted = self.compacted_and_growing()
+        with alpha.active():
+            (store.chunk_dir(alpha.id, self.DAY) / compacted).unlink()
+            sync._commit()
+            sync._push(sync.read_repo())
+
+        with beta.active():
+            report = sync.run()
+            self.assertIn(f"{alpha.id}/{self.DAY}", report.stale)
+            self.assertEqual(len(beta.entries()), 5, "the day was rewritten without it")
+            for _ in range(3):
+                sync.run()
+            self.assertEqual(len(beta.entries()), 5)
+
+    def test_a_machine_awaiting_grant_is_not_told_its_history_is_damaged(self) -> None:
+        """An unopenable day key skips every chunk, which is not damage.
+
+        It is the ordinary state of a machine between `init` and someone running
+        `grant`, which the rest of the output goes out of its way to describe as
+        expected. Nothing decrypted, so there was never a partial rewrite to
+        refuse -- and `unreadable` already names the day with the right remedy.
+        """
+        alpha, _beta = self.history_across_days(days=1, per_day=3)
+        with alpha.active():
+            self.assertEqual(sync.compact(before="2023-12-01")[0], 1)
+            sync.run()
+
+        gamma = self.machine("gamma")  # enrolled, never granted
+        errors = io.StringIO()
+        with gamma.active(), redirect_stderr(errors), redirect_stdout(io.StringIO()):
+            self.assertEqual(main(["sync"]), 0)
+        said = errors.getvalue()
+        self.assertIn(_GRANT_REMEDY.splitlines()[0], said)
+        self.assertNotIn("could not be rebuilt", said, "an ungranted machine was accused")
+
     def test_appending_is_still_allowed_to_be_partial(self) -> None:
         """Only a rewrite is all-or-nothing.
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3154,17 +3154,56 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
         prune the day and skip it from then on, leaving a log that is wrong and
         never looked at again.
         """
-        alpha, beta, compacted = self.compacted_and_growing()
+        # Three things at once, which is why the guard is easy to miss: a
+        # manifest rolled back to one listing *fewer* chunks (so every name it
+        # lists is already merged, and a rebuild is owed because this machine
+        # merged one more), something unmerged in the directory (so the day is
+        # looked at at all), and one listed chunk that will not open (so the
+        # rebuild is refused). Without the guard the day is then pruned and
+        # stamped as finished, with a log that was deliberately not rebuilt.
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
         key = f"{alpha.id}/{self.DAY}"
-        with beta.active(), mock.patch.object(sync, "open_chunk", self.damaged(compacted)):
-            sync.run()
-            self.assertIn(key, sync.run().stale)
-            self.assertNotIn(key, sync.State.load().merged_at, "a refused rewrite was stamped")
-
-        # So it is still owed, and taken as soon as the chunk reads.
+        with alpha.active():
+            for i in range(4):
+                alpha.record(self.DAY, 1_700_000_001 + i, f"early {i}")
+                sync.run()
+            sync.grant()
         with beta.active():
             sync.run()
-            self.assertEqual(len(beta.entries()), 6)
+            self.assertEqual(len(beta.entries()), 4)
+            backup = store.history_dir().with_name("history.backup")
+            shutil.copytree(store.history_dir(), backup, symlinks=True)
+            first = min(store.chunk_names(alpha.id, self.DAY))
+
+        with alpha.active():
+            alpha.record(self.DAY, 1_700_000_009, "the fifth")
+            sync.run()
+        with beta.active():
+            sync.run()
+            self.assertEqual(len(beta.entries()), 5)
+
+            # Working tree only, so HEAD stays put and the rollback sticks.
+            live = store.history_dir()
+            for entry in live.iterdir():
+                if entry.name != ".git":
+                    shutil.rmtree(entry) if entry.is_dir() else entry.unlink()
+            for entry in backup.iterdir():
+                if entry.name != ".git":
+                    if entry.is_dir():
+                        shutil.copytree(entry, live / entry.name, symlinks=True)
+                    else:
+                        shutil.copy2(entry, live / entry.name)
+
+            # ...and something unmerged in the directory, or the day has
+            # nothing fresh and is skipped before any of this is reached.
+            (store.chunk_dir(alpha.id, self.DAY) / "1700000000-dead.age").write_bytes(b"x")
+
+        self.settle(beta, alpha, self.DAY)
+        with beta.active(), mock.patch.object(sync, "open_chunk", self.damaged(first)):
+            self.assertIn(key, sync.run().stale)
+            self.assertNotIn(key, sync.State.load().merged_at, "a refused rewrite was stamped")
+            self.assertEqual(len(beta.entries()), 5, "the day was rebuilt from a partial read")
 
     def test_sync_says_which_day_it_left_alone(self) -> None:
         """New user-facing behaviour, so it is pinned like its neighbours."""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3145,6 +3145,42 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
             self.assertNotIn(f"{alpha.id}/{self.DAY}", report.stale)
             self.assertEqual(len(beta.entries()), 6, "the stray blocked the rebuild")
 
+    def test_a_refused_rewrite_is_never_treated_as_finished(self) -> None:
+        """The settle rule reads `state.merged`, which a refusal does not write.
+
+        A rewrite owed because the manifest went *backwards* can leave every
+        name it lists already merged -- so "every signed chunk is merged" is
+        true while the file was deliberately not rebuilt. Stamping that would
+        prune the day and skip it from then on, leaving a log that is wrong and
+        never looked at again.
+        """
+        alpha, beta, compacted = self.compacted_and_growing()
+        key = f"{alpha.id}/{self.DAY}"
+        with beta.active(), mock.patch.object(sync, "open_chunk", self.damaged(compacted)):
+            sync.run()
+            self.assertIn(key, sync.run().stale)
+            self.assertNotIn(key, sync.State.load().merged_at, "a refused rewrite was stamped")
+
+        # So it is still owed, and taken as soon as the chunk reads.
+        with beta.active():
+            sync.run()
+            self.assertEqual(len(beta.entries()), 6)
+
+    def test_sync_says_which_day_it_left_alone(self) -> None:
+        """New user-facing behaviour, so it is pinned like its neighbours."""
+        alpha, beta, compacted = self.compacted_and_growing()
+        errors = io.StringIO()
+        with (
+            beta.active(),
+            mock.patch.object(sync, "open_chunk", self.damaged(compacted)),
+            redirect_stderr(errors),
+            redirect_stdout(io.StringIO()),
+        ):
+            self.assertEqual(main(["sync"]), 0)
+        said = errors.getvalue()
+        self.assertIn("could not be rebuilt", said)
+        self.assertIn(f"{alpha.id}/{self.DAY}", said, "it did not say which day")
+
     def test_appending_is_still_allowed_to_be_partial(self) -> None:
         """Only a rewrite is all-or-nothing.
 

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -429,11 +429,14 @@ def cmd_sync(args: argparse.Namespace) -> int:
         )
 
     if report.stale:
+        stale = ", ".join(sorted(report.stale))
         print(
-            f"\n{len(report.stale)} day(s) could not be rebuilt: a chunk they are made of\n"
-            "would not open, so each was left exactly as it was rather than rewritten\n"
-            "from the part that did. Nothing was lost. If it persists, the chunk is\n"
-            "damaged in this checkout - 'woswoar doctor' has the detail.",
+            f"\n{len(report.stale)} day(s) could not be rebuilt, and were left exactly as\n"
+            "they were rather than rewritten from the part that could be read:\n"
+            f"{stale}\n"
+            "Nothing was lost. If it persists, a chunk of that day is damaged in this\n"
+            "checkout; 'git -C ~/.local/share/woswoar/history log --diff-filter=M' finds\n"
+            "who changed it, because woswoar itself never rewrites one.",
             file=sys.stderr,
         )
 

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -435,8 +435,9 @@ def cmd_sync(args: argparse.Namespace) -> int:
             "they were rather than rewritten from the part that could be read:\n"
             f"{stale}\n"
             "Nothing was lost. If it persists, a chunk of that day is damaged in this\n"
-            "checkout; 'git -C ~/.local/share/woswoar/history log --diff-filter=M' finds\n"
-            "who changed it, because woswoar itself never rewrites one.",
+            "checkout, or missing from it; woswoar never rewrites or deletes a chunk,\n"
+            "so 'git -C ~/.local/share/woswoar/history log --diff-filter=MD' finds who\n"
+            "did.",
             file=sys.stderr,
         )
 

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -428,6 +428,15 @@ def cmd_sync(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
+    if report.stale:
+        print(
+            f"\n{len(report.stale)} day(s) could not be rebuilt: a chunk they are made of\n"
+            "would not open, so each was left exactly as it was rather than rewritten\n"
+            "from the part that did. Nothing was lost. If it persists, the chunk is\n"
+            "damaged in this checkout - 'woswoar doctor' has the detail.",
+            file=sys.stderr,
+        )
+
     if report.untrusted:
         print(
             f"\n{len(report.untrusted)} machine(s) publish history this one has not been\n"

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1488,9 +1488,8 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         day = _Day(host_id, chunk_day, listed, already)
         pending = names if day.rewrite else fresh
         directory = store.chunk_dir(host_id, chunk_day)
-        #: Chunks whose plaintext reached `day`, and whether any was skipped.
+        #: Chunk names whose plaintext reached `day`.
         taken: list[str] = []
-        missed = False
 
         for name in pending:
             if name not in day.listed:
@@ -1499,7 +1498,6 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 # well as a chunk simply absent from a good one -- see
                 # `Report.unauthenticated`.
                 report.unauthenticated.add(key)
-                missed = True
                 continue
 
             if chunk_day not in day_keys:
@@ -1515,7 +1513,6 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             secret = day_keys[chunk_day]
             if secret is None:
                 report.unreadable.add(key)
-                missed = True
                 continue
 
             # Authenticated before it is decrypted or decompressed, so age, zlib
@@ -1525,7 +1522,6 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 blob = open_chunk(directory / name, day.listed[name].digest)
             except (OSError, ValueError):
                 report.unauthenticated.add(key)
-                missed = True
                 continue
 
             try:
@@ -1538,7 +1534,6 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 # and every other host's readable chunks, on this run and every
                 # run after it.
                 report.unreadable.add(key)
-                missed = True
                 continue
 
             day.add(plaintext, report)
@@ -1553,7 +1548,12 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         #
         # Appending is safe partially, by contrast, and `add` may already have
         # flushed some of it -- which is why only the rewrite is refused.
-        if day.rewrite and missed:
+        # Measured against what the manifest lists, so a stray file in the
+        # directory cannot hold a day back: it is not part of the day, and
+        # counting it would leave that day stale for ever (which is #87 by
+        # another route).
+        wanted = {name for name in pending if name in day.listed}
+        if day.rewrite and wanted - set(taken):
             report.stale.add(key)
         else:
             day.flush(report)

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1548,12 +1548,25 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         #
         # Appending is safe partially, by contrast, and `add` may already have
         # flushed some of it -- which is why only the rewrite is refused.
-        # Measured against what the manifest lists, so a stray file in the
-        # directory cannot hold a day back: it is not part of the day, and
-        # counting it would leave that day stale for ever (which is #87 by
-        # another route).
-        refused = day.rewrite and bool(
-            {name for name in pending if name in day.listed} - set(taken)
+        # Against the manifest, and against the whole of it -- not against the
+        # names that happened to be on disk. A chunk the manifest lists but that
+        # is *absent* never reaches the loop at all, so measuring the directory
+        # counted it as nothing to miss and rewrote the day without it: five
+        # commands became one, with nothing reported. A machine with push access
+        # can delete a chunk; woswoar itself never does.
+        #
+        # A stray file is excluded for free, because it is not in the manifest:
+        # it is not part of the day, and counting it would leave that day stale
+        # for ever, which is #87 by another route.
+        #
+        # Not when the day key will not open, though. Then nothing decrypted,
+        # there is nothing partial to write, and `unreadable` already names that
+        # day with the remedy -- it is the ordinary state of a machine that has
+        # not been granted access yet, and calling it damage would be a lie.
+        refused = (
+            day.rewrite
+            and day_keys.get(chunk_day) is not None
+            and bool(set(day.listed) - set(taken))
         )
         if refused:
             report.stale.add(key)

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -63,6 +63,10 @@ class Report:
     #: that was already level with the remote and committed nothing sets it
     #: without sending anything, because there was nothing to send.
     pushed: bool = False
+    #: "<host>/<day>" left exactly as it was, because rebuilding it would have
+    #: needed a chunk this machine could not read. Stale rather than short: the
+    #: day keeps every line it already had, and the next sync tries again.
+    stale: set[str] = field(default_factory=set)
     hosts_seen: set[str] = field(default_factory=set)
     #: "<host>/<day>" entries sealed before this machine was enrolled. Not an
     #: error: it is what a freshly joined machine sees until someone runs
@@ -1484,6 +1488,9 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         day = _Day(host_id, chunk_day, listed, already)
         pending = names if day.rewrite else fresh
         directory = store.chunk_dir(host_id, chunk_day)
+        #: Chunks whose plaintext reached `day`, and whether any was skipped.
+        taken: list[str] = []
+        missed = False
 
         for name in pending:
             if name not in day.listed:
@@ -1492,6 +1499,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 # well as a chunk simply absent from a good one -- see
                 # `Report.unauthenticated`.
                 report.unauthenticated.add(key)
+                missed = True
                 continue
 
             if chunk_day not in day_keys:
@@ -1507,6 +1515,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             secret = day_keys[chunk_day]
             if secret is None:
                 report.unreadable.add(key)
+                missed = True
                 continue
 
             # Authenticated before it is decrypted or decompressed, so age, zlib
@@ -1516,6 +1525,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 blob = open_chunk(directory / name, day.listed[name].digest)
             except (OSError, ValueError):
                 report.unauthenticated.add(key)
+                missed = True
                 continue
 
             try:
@@ -1528,14 +1538,32 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 # and every other host's readable chunks, on this run and every
                 # run after it.
                 report.unreadable.add(key)
+                missed = True
                 continue
 
             day.add(plaintext, report)
-            state.merged.setdefault(key, set()).add(name)
-            if name not in already:
-                report.chunks_merged += 1
+            taken.append(name)
 
-        day.flush(report)
+        # A rewrite *replaces* the day's file, so it must not run on a partial
+        # read: it would drop lines this machine already had in exchange for
+        # the ones it could get. Measured before this guard, on a day of five
+        # commands whose compacted chunk would not open: the day was rewritten
+        # to one line, and stayed at one for as long as the chunk stayed
+        # damaged. The lines it lost were in that chunk and nowhere else.
+        #
+        # Appending is safe partially, by contrast, and `add` may already have
+        # flushed some of it -- which is why only the rewrite is refused.
+        if day.rewrite and missed:
+            report.stale.add(key)
+        else:
+            day.flush(report)
+            # Recorded only once the bytes are on disk. A refused rewrite that
+            # had marked its chunks merged would never read them again, and
+            # would have lost exactly what it was trying not to lose.
+            for name in taken:
+                if name not in already:
+                    report.chunks_merged += 1
+                state.merged.setdefault(key, set()).add(name)
 
         # Judged against what the host *signed*, not against what is in the
         # directory. A name the manifest does not list is not part of the day --

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1552,8 +1552,10 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         # directory cannot hold a day back: it is not part of the day, and
         # counting it would leave that day stale for ever (which is #87 by
         # another route).
-        wanted = {name for name in pending if name in day.listed}
-        if day.rewrite and wanted - set(taken):
+        refused = day.rewrite and bool(
+            {name for name in pending if name in day.listed} - set(taken)
+        )
+        if refused:
             report.stale.add(key)
         else:
             day.flush(report)
@@ -1577,8 +1579,13 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         # verify. Settling on it would stamp a day whose every chunk is still
         # being refused, and pruning on it would forget the whole day and merge
         # it again from scratch, duplicating its lines.
+        # Never on a pass that refused to rebuild. A rewrite owed because the
+        # manifest went *backwards* can leave every listed name already merged,
+        # so this would otherwise read as complete -- and stamp and prune a day
+        # whose file was deliberately not rebuilt, which is a day left wrong and
+        # then never looked at again.
         signed = set(day.listed)
-        settled = bool(signed) and signed <= state.merged.get(key, set())
+        settled = not refused and bool(signed) and signed <= state.merged.get(key, set())
         if settled:
             # Pruned to the same statement. Compaction *removes* the names it
             # subsumed from the manifest, so this is what stops `state.merged`


### PR DESCRIPTION
Closes #89.

A rewrite replaces the day's log file outright. If it could read some of the
day's chunks but not others, it wrote the day out as just the ones it got —
destroying lines that existed only inside the chunk it could not read, because
compaction had already unlinked the originals.

Reproduced, no mocks: a five-command day whose compacted chunk was deleted from
the repo became **one line**, and stayed there. Nothing was reported.

A rewrite is now all-or-nothing. If any chunk the signed manifest lists did not
reach the day, the file is left exactly as it was and the day is reported
`stale`. The chunks it did read are *not* recorded as merged — their plaintext
was discarded with the refusal, so recording them would mean never reading them
again, losing precisely what the refusal protects.

## Three defects in my own fix, each found by review or mutation

**It measured the directory instead of the manifest.** A chunk the manifest
lists but that is *absent from disk* never reaches the merge loop, so counting
"what did I miss" over the directory counted it as nothing to miss. The original
bug was still fully reachable, and now with no report at all — the reviewer's
reproduction used a third machine with push access deleting a chunk, which needs
no corruption and no mock. `set(day.listed) - set(taken)` is the whole fix.

**A refused rewrite could still be judged finished.** The settle rule reads
`state.merged`, which a refusal deliberately does not write. Where a rewrite is
owed because the manifest went *backwards*, every listed name can already be
merged — so the day was pruned and stamped as complete with a log that was
deliberately not rebuilt, and never looked at again. Reaching that in a test
needs three coincident conditions, which is why it was easy to miss.

**A stray `.age` file would have blocked its day from ever being rewritten** —
I counted any skipped name, including one the manifest does not list. That is
#87 by another route, and a byte of push access turns it on.

## And one thing it told users that was not true

The `cmd_sync` message pointed at `woswoar doctor` for detail. `doctor` checks
sixteen things and none of them verifies a chunk against its manifest, so the
instruction sent people somewhere that could not help. It now names the affected
day and points at `git log --diff-filter=MD`, which finds who modified *or
deleted* the chunk — deletion being the route above.

It also no longer fires for a machine between `init` and `grant`. An unopenable
day key skips every chunk, so every compacted day looked "damaged" — accusing
the repo of tampering in the one state the rest of the output goes out of its way
to call normal. Nothing decrypts then, so there was never a partial rewrite to
refuse, and `unreadable` already names the day with the right remedy.

## Tests

Eight mutations, each caught:

```
caught  write a partial rewrite anyway, as before #89
caught  measure against the directory, not the manifest
caught  accuse a machine that has no day key
caught  refuse a partial append too
caught  record the chunks a refused rewrite read
caught  settle a refused rewrite
caught  say nothing when a rewrite is refused
caught  the message does not name the day
```

Appending is deliberately still allowed to be partial: it adds to what is there,
`_Day.add` may already have flushed some of it, and nothing was replaced — so
holding the whole pass back would strand chunks already on disk for no gain.

## Reviewed as the top row

Per the rule merged in #92: this changes what reaches disk when part of a read
fails, so it got the full `/simplify`. Both reviewers found real defects — one
correctness, one that would have shipped a false accusation — which is the row
paying for itself.

## No migration needed

Per rule 8. `Report` gains a field; nothing on disk changed shape.
