### PR TITLE
test tooling: one CLI helper, a shared mutation harness, a cold-build bound

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,9 @@ reverted**. Verify that, do not assume it:
 2. Run the suite and confirm the new test fails.
 3. Restore the fix and confirm it passes.
 
+`tools/mutate.py` is that loop: write the table of edits, run
+`python -m tools.mutate <spec>.py`, paste the output into the PR.
+
 A test that passes either way is decoration, and reading it will not tell you
 which kind you have written. Tests have been added here that looked correct and
 never executed the line they claimed to guard.
@@ -188,11 +191,14 @@ corrupts somebody's history.
   `python -m unittest discover -s . -t . -p 'test_*.py'` runs the same tests
   serially, and takes about three times as long.
 
-- Run mutation tests with `python -B` **and** delete `woswoar/__pycache__`
-  (plus `tools/` and `tests/`) between mutations. A `.pyc` is validated against `(mtime_seconds, size)`, so
-  two mutations that change a file by the same number of bytes inside one second
-  run each other's cached bytecode — which reports a test as surviving when it
-  does not, and has sent a correct test to be rewritten as "decoration".
+- Mutation-test through `tools/mutate.py` rather than writing the loop again. It
+  runs `-B`, clears every `__pycache__` between mutations, refuses an edit that
+  matches other than exactly once, checks the baseline is green, and restores
+  the tree even when interrupted. The trap it exists for: a `.pyc` is validated
+  against `(mtime_seconds, size)`, so two mutations that change a file by the
+  same number of bytes inside one second run each other's cached bytecode —
+  which reported a *correct* test as decoration here, and nearly got it
+  rewritten.
 - Before blaming your branch for a CI failure, measure the same job on `main`,
   enough times to see a one-in-forty flake. Two runs of green proves nothing.
 - **Commit before comparing two revisions.** `git checkout main` carries

--- a/tests/support.py
+++ b/tests/support.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import io
 import os
 import shutil
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from typing import NamedTuple
 
 from woswoar import crypto, store
+from woswoar.__main__ import main
 from woswoar.entry import Entry
 
 MACHINE_ID = "0123456789abcdef"
@@ -20,6 +24,31 @@ requires_age = unittest.skipUnless(crypto.available(), "age required")
 requires_git = unittest.skipUnless(shutil.which("git"), "git required")
 requires_ssh_keygen = unittest.skipUnless(shutil.which("ssh-keygen"), "ssh-keygen required")
 requires_bash = unittest.skipUnless(shutil.which("bash"), "bash required")
+
+
+class Ran(NamedTuple):
+    """What one CLI invocation did."""
+
+    code: int
+    out: str
+    err: str
+
+
+def run_cli(*argv: str) -> Ran:
+    """Drive the real CLI in process, capturing both streams.
+
+    Both, because several commands put the thing a test cares about on stderr --
+    `sync`'s warning that a day could not be authenticated, `grant`'s refusal to
+    act without a terminal. Four modules used to spell this out separately and
+    every one of them captured stdout alone, so a test meaning "it warned" could
+    only check the exit code, and would have passed had the warning been
+    deleted. That is the failure mode `CLAUDE.md` rule 3 is about, and it was
+    invisible at each individual call site.
+    """
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        code = main(list(argv))
+    return Ran(code, out.getvalue(), err.getvalue())
 
 
 def make_entry(ts: int, cmd: str, host: str = MACHINE_ID, session: str = "s1") -> Entry:

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from woswoar import deps
 from woswoar.__main__ import main
 
+from . import support
 from .support import WoswoarTestCase
 
 
@@ -99,16 +100,14 @@ class TestInstallWarnsAboutMissingTools(WoswoarTestCase):
             os.environ["HOME"] = self._home
 
     def test_install_still_succeeds_but_says_what_is_missing(self) -> None:
-        out, err = io.StringIO(), io.StringIO()
-        with redirect_stdout(out), redirect_stderr(err):
-            code = main(["install", "--rcfile", str(self.home / ".bashrc")])
+        ran = support.run_cli("install", "--rcfile", str(self.home / ".bashrc"))
 
         # Recording works without any of them, so this is a warning, not a
         # failure -- the hook really was installed.
-        self.assertEqual(code, 0)
-        self.assertIn("woswoar.bash", out.getvalue())
+        self.assertEqual(ran.code, 0)
+        self.assertIn("woswoar.bash", ran.out)
         for tool in ("fzf", "age", "git", "ssh-keygen"):
-            self.assertIn(tool, err.getvalue())
+            self.assertIn(tool, ran.err)
 
     def test_a_complete_machine_says_nothing(self) -> None:
         # Put the tools back so `missing()` finds them.

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -8,15 +8,13 @@ would think to run it.
 
 from __future__ import annotations
 
-import io
 import os
 import stat
 import unittest
-from contextlib import redirect_stdout
 
 from woswoar import crypto
-from woswoar.__main__ import main
 
+from . import support
 from .support import WoswoarTestCase, requires_age
 
 
@@ -46,26 +44,23 @@ class TestDoctorWithABrokenAge(WoswoarTestCase):
         os.environ["PATH"] = f"{fake}{os.pathsep}{self._path}"
         self.addCleanup(lambda: os.environ.__setitem__("PATH", self._path))
 
-    def doctor(self) -> tuple[int, str]:
-        buffer = io.StringIO()
-        with redirect_stdout(buffer):
-            code = main(["doctor"])
-        return code, buffer.getvalue()
+    def doctor(self) -> support.Ran:
+        return support.run_cli("doctor")
 
     def test_selftest_reports_what_age_said(self) -> None:
         failure = crypto.selftest()
         self.assertIn("permission denied", failure)
 
     def test_doctor_fails_and_shows_the_reason(self) -> None:
-        code, out = self.doctor()
-        self.assertNotEqual(code, 0, out)
-        self.assertRegex(out, r"\[FAIL\] age", out)
-        self.assertIn("permission denied", out)
+        ran = self.doctor()
+        self.assertNotEqual(ran.code, 0, ran.out)
+        self.assertRegex(ran.out, r"\[FAIL\] age", ran.out)
+        self.assertIn("permission denied", ran.out)
 
     def test_doctor_does_not_need_a_repo_to_notice(self) -> None:
         """The whole point. This used to be gated behind `sync.is_repo()`, so
         the machine where `init` had just failed got a clean bill of health."""
-        _, out = self.doctor()
+        out = self.doctor().out
         self.assertIn("no history repo", out, "precondition: no repo in this sandbox")
         self.assertRegex(out, r"\[FAIL\] age")
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7,17 +7,16 @@ which differs the moment two machines disagree about the username.
 
 from __future__ import annotations
 
-import io
 import os
 import shutil
 import subprocess
 import unittest
-from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 from woswoar import store
 from woswoar.__main__ import main, portable_hook_path
 
+from . import support
 from .support import MACHINE_ID, WoswoarTestCase, make_entry, requires_bash
 
 
@@ -186,10 +185,7 @@ class TestPrivateByDefault(WoswoarTestCase):
     def test_doctor_reports_an_exposed_history(self) -> None:
         self.first_run()
         store.logs_dir().chmod(0o755)
-        out = io.StringIO()
-        with redirect_stdout(out), redirect_stderr(io.StringIO()):
-            main(["doctor"])
-        self.assertRegex(out.getvalue(), r"\[FAIL\] private")
+        self.assertRegex(support.run_cli("doctor").out, r"\[FAIL\] private")
 
 
 if __name__ == "__main__":

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -1,0 +1,216 @@
+"""Tests for the mutation harness.
+
+The harness exists to answer "does this test actually see the fix?", so the
+thing it must never do is answer *wrongly*. A false "caught" would bless a test
+that guards nothing; a false "SURVIVED" sends a correct test to be rewritten,
+which is what happened before there was a harness to share.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+from pathlib import Path
+
+from tools.mutate import Mutation, verify
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class MutateTestCase(unittest.TestCase):
+    """Each test builds a tiny package and mutates *that*, not woswoar."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+        self._cwd = Path.cwd()
+        self.addCleanup(lambda: os.chdir(self._cwd))
+
+        # The harness resolves paths against the working directory, so the
+        # sandbox becomes the repo for the duration.
+        os.chdir(self.root)
+
+    def write(self, name: str, body: str) -> Path:
+        path = self.root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+        return path
+
+    def package(self, guarded: bool) -> None:
+        """A module with one behaviour, and a test that may or may not see it."""
+        self.write(
+            "mod.py",
+            """
+            def clamp(value: int) -> int:
+                if value < 0:
+                    return 0
+                return value
+            """,
+        )
+        assertion = (
+            "self.assertEqual(mod.clamp(-5), 0)" if guarded else "self.assertEqual(mod.clamp(5), 5)"
+        )
+        self.write(
+            "test_mod.py",
+            f"""
+            import unittest
+
+            import mod
+
+
+            class T(unittest.TestCase):
+                def test_it(self) -> None:
+                    {assertion}
+            """,
+        )
+
+
+class TestItReportsWhatTheTestCanSee(MutateTestCase):
+    def test_a_guarded_fix_is_caught(self) -> None:
+        self.package(guarded=True)
+        survivors = verify(
+            [Mutation("the clamp is gone", "mod.py", "if value < 0:", "if False:", "test_mod")]
+        )
+        self.assertEqual(survivors, 0)
+
+    def test_a_test_that_cannot_see_it_is_reported(self) -> None:
+        """The answer that matters: decoration must not read as a guard."""
+        self.package(guarded=False)
+        survivors = verify(
+            [Mutation("the clamp is gone", "mod.py", "if value < 0:", "if False:", "test_mod")]
+        )
+        self.assertEqual(survivors, 1)
+
+
+class TestItRefusesToGuess(MutateTestCase):
+    def test_text_that_appears_twice_is_an_error(self) -> None:
+        """Replacing one of two matches quietly tests something else."""
+        self.package(guarded=True)
+        self.write(
+            "mod.py",
+            """
+            def clamp(value: int) -> int:
+                if value < 0:
+                    return 0
+                return value
+
+
+            def clamp2(value: int) -> int:
+                if value < 0:
+                    return 0
+                return value
+            """,
+        )
+        with self.assertRaises(SystemExit) as refused:
+            verify([Mutation("x", "mod.py", "if value < 0:", "if False:", "test_mod")])
+        self.assertIn("not once", str(refused.exception))
+
+    def test_text_that_appears_nowhere_is_an_error(self) -> None:
+        self.package(guarded=True)
+        with self.assertRaises(SystemExit) as refused:
+            verify([Mutation("x", "mod.py", "no such text", "other", "test_mod")])
+        self.assertIn("0 times", str(refused.exception))
+
+
+class TestItRestoresTheTree(MutateTestCase):
+    def test_the_source_is_unchanged_afterwards(self) -> None:
+        self.package(guarded=True)
+        before = (self.root / "mod.py").read_text(encoding="utf-8")
+        verify([Mutation("x", "mod.py", "if value < 0:", "if False:", "test_mod")])
+        self.assertEqual((self.root / "mod.py").read_text(encoding="utf-8"), before)
+
+    def test_it_restores_even_when_the_run_raises(self) -> None:
+        """CLAUDE.md rule 6: an interrupted run must not leave the tree mutated."""
+        self.package(guarded=True)
+        before = (self.root / "mod.py").read_text(encoding="utf-8")
+        with self.assertRaises(SystemExit):
+            verify(
+                [
+                    Mutation("first", "mod.py", "if value < 0:", "if False:", "test_mod"),
+                    Mutation("second", "mod.py", "not there", "x", "test_mod"),
+                ]
+            )
+        self.assertEqual((self.root / "mod.py").read_text(encoding="utf-8"), before)
+
+
+class TestTheBytecodeTrap(MutateTestCase):
+    """The reason a shared harness is worth more than the loop it replaces.
+
+    A `.pyc` is validated against `(mtime_seconds, size)`. Two mutations that
+    change a file by the *same number of bytes* inside the *same second* leave
+    the second one running the first one's cached bytecode -- so the second is
+    tested against code it does not contain. That reported a correct test as
+    decoration once here, and nearly got it rewritten.
+    """
+
+    def test_two_same_sized_edits_in_one_second_are_each_tested(self) -> None:
+        self.write(
+            "mod.py",
+            """
+            def which() -> str:
+                return "aaa"
+            """,
+        )
+        self.write(
+            "test_mod.py",
+            """
+            import unittest
+
+            import mod
+
+
+            class T(unittest.TestCase):
+                def test_it(self) -> None:
+                    self.assertEqual(mod.which(), "aaa")
+            """,
+        )
+
+        # Same length, so the file's size never changes; run back to back, so
+        # its mtime second very likely does not either.
+        started = time.time()
+        survivors = verify(
+            [
+                Mutation("returns bbb", "mod.py", 'return "aaa"', 'return "bbb"', "test_mod"),
+                Mutation("returns ccc", "mod.py", 'return "aaa"', 'return "ccc"', "test_mod"),
+            ]
+        )
+        self.assertEqual(survivors, 0, "a mutation ran against another one's bytecode")
+        self.assertLess(
+            time.time() - started, 60, "precondition: the two runs shared a wall-clock second"
+        )
+
+
+class TestTheScriptEntryPoint(MutateTestCase):
+    def test_it_runs_a_table_from_a_file(self) -> None:
+        self.package(guarded=True)
+        self.write(
+            "spec.py",
+            """
+            from tools.mutate import Mutation
+
+            MUTATIONS = [
+                Mutation("the clamp is gone", "mod.py", "if value < 0:", "if False:", "test_mod")
+            ]
+            """,
+        )
+        finished = subprocess.run(
+            [sys.executable, "-m", "tools.mutate", str(self.root / "spec.py")],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=dict(os.environ, PYTHONPATH=str(REPO_ROOT)),
+        )
+        self.assertEqual(finished.returncode, 0, finished.stderr)
+        self.assertIn("caught", finished.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -31,6 +31,20 @@ DAYS = 730
 #: Targets from the plan. CI fails at 3x to stay honest on a shared runner
 #: while still catching a real regression -- a change that makes loading twice
 #: as slow will not slip through, but a noisy neighbour will not fail the build.
+
+#: The full parse of every log file, with no cache to start from -- paid on the
+#: first Ctrl-R after an install, an import, or a cache the user deleted. It had
+#: no bound at all: `warm < cold` holds however slow the cold path becomes.
+#:
+#: What this catches is a gross regression, at 3x like everything else here. It
+#: would *not* have caught the one that prompted it -- #25 cost 22% of cold
+#: build, 75 ms to 92 ms -- and no wall-clock bound safe on a shared runner
+#: would: cold build reads ~750 files, and five consecutive local runs on an
+#: otherwise idle machine spread 80-94 ms by themselves. A ratio against the
+#: warm load in the same run is no steadier (2.24-2.66 over those five). So this
+#: is a floor under "somebody made it several times slower", and a 20% one still
+#: needs a person measuring, as #25's did.
+COLD_BUILD_TARGET_MS = 150.0
 CACHE_LOAD_TARGET_MS = 50.0
 LIST_TARGET_MS = 100.0
 #: The whole process, not just the functions. About double LIST_TARGET_MS,
@@ -177,8 +191,17 @@ class TestPerformance(WoswoarTestCase):
     def test_warm_load_beats_cold_build(self) -> None:
         cold_ms, _ = self.timed(cache.load_entries)
         warm_ms, _ = self.timed(cache.load_entries)
+        print(f"\n  cold build    {cold_ms:8.1f} ms  (target {COLD_BUILD_TARGET_MS:.0f} ms)")
+
         # If this ever fails, the incremental path is not being taken at all.
         self.assertLess(warm_ms, cold_ms)
+        # And a bound on the cold path itself, which the comparison above cannot
+        # give: it stays true however slow both become.
+        self.assertLess(
+            cold_ms,
+            COLD_BUILD_TARGET_MS * TOLERANCE,
+            f"cold cache build regressed: {cold_ms:.1f} ms",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -18,7 +18,7 @@ import tracemalloc
 import unittest
 import zlib
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from contextlib import contextmanager, redirect_stderr
 from pathlib import Path
 from typing import ClassVar
 from unittest import mock
@@ -214,17 +214,10 @@ class SyncTestCase(unittest.TestCase):
             for day in days:
                 os.utime(store.chunk_dir(host.id, day), (aged, aged))
 
-    def run_cli(self, fake: Fake, *argv: str) -> tuple[int, str]:
-        """Drive the real CLI as ``fake``, returning ``(exit code, stdout)``.
-
-        Only stdout: several commands put their warnings on stderr, and a test
-        that means "it warned" has to say which stream it is asserting on. The
-        two that need stderr capture it themselves.
-        """
-        buffer = io.StringIO()
-        with fake.active(), redirect_stdout(buffer):
-            code = main(list(argv))
-        return code, buffer.getvalue()
+    def run_cli(self, fake: Fake, *argv: str) -> support.Ran:
+        """Drive the real CLI as ``fake``. Both streams -- see `support.run_cli`."""
+        with fake.active():
+            return support.run_cli(*argv)
 
 
 class TestSingleMachine(SyncTestCase):
@@ -1092,7 +1085,7 @@ class TestRevokeConfirmation(SyncTestCase):
         with alpha.active():
             gone = alpha.append_recipient(name="old-laptop")
 
-        code, _ = self.run_cli(alpha, "revoke", crypto.fingerprint(gone))
+        code, _, _ = self.run_cli(alpha, "revoke", crypto.fingerprint(gone))
         self.assertEqual(code, 1)
         with alpha.active():
             self.assertIn(gone, sync.recipients())
@@ -1105,7 +1098,7 @@ class TestRevokeConfirmation(SyncTestCase):
         with alpha.active():
             gone = alpha.append_recipient(name="old-laptop")
 
-        code, out = self.run_cli(alpha, "revoke", crypto.fingerprint(gone), "--yes")
+        code, out, _ = self.run_cli(alpha, "revoke", crypto.fingerprint(gone), "--yes")
         self.assertEqual(code, 0)
         self.assertIn("does not un-publish", out)
         self.assertIn("does not revoke git access", out)
@@ -1124,7 +1117,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
 
     def test_granting_remembers_who_was_approved(self) -> None:
         alpha = self.machine("alpha")
-        code, _ = self.run_cli(alpha, "grant", "--yes")
+        code, _, _ = self.run_cli(alpha, "grant", "--yes")
         self.assertEqual(code, 0)
         with alpha.active():
             self.assertFalse(any(reader.is_new for reader in sync.readers()))
@@ -1155,7 +1148,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         with alpha.active():
             alpha.append_recipient(name="martin@laptop")
 
-        code, out = self.run_cli(alpha, "grant", "--yes")
+        code, out, _ = self.run_cli(alpha, "grant", "--yes")
         self.assertEqual(code, 0)
         self.assertIn("1 machine(s) NOT yet granted", out)
         self.assertIn("SAME NAME AS ANOTHER KEY", out)
@@ -1175,7 +1168,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         with alpha.active():
             alpha.append_recipient(name=hostile)
 
-        _, out = self.run_cli(alpha, "grant", "--yes")
+        _, out, _ = self.run_cli(alpha, "grant", "--yes")
         self.assertIn("martin@desktop", out)
         self.assertNotIn(hostile, out)
         self.assertNotIn("\u202e", out)
@@ -1190,7 +1183,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         alpha = self.machine("alpha")
         self.run_cli(alpha, "grant", "--yes")
 
-        code, out = self.run_cli(alpha, "grant")
+        code, out, _ = self.run_cli(alpha, "grant")
         self.assertEqual(code, 0)
         self.assertIn("No machine is new", out)
 
@@ -1200,7 +1193,7 @@ class TestGrantConfirmsAdditions(SyncTestCase):
         with alpha.active():
             alpha.append_recipient(name="martin@desktop")
 
-        code, _ = self.run_cli(alpha, "grant")
+        code, _, _ = self.run_cli(alpha, "grant")
         self.assertEqual(code, 1)
         with alpha.active():
             self.assertTrue(any(reader.is_new for reader in sync.readers()))
@@ -1477,7 +1470,7 @@ class TestASigningKeyThatChanges(SyncTestCase):
 
         with beta.active():
             sync.run()
-            code, _ = self.run_cli(beta, "trust", "--replace", "--yes")
+            code, _, _ = self.run_cli(beta, "trust", "--replace", "--yes")
             self.assertEqual(code, 0)
             sync.run()
             self.assertIn("after-the-key-changed", beta.commands())
@@ -2484,11 +2477,7 @@ class TestAnOrphanedDayKey(SyncTestCase):
             store.day_key(alpha.id, "2023-11-14").unlink()
             alpha.record("2023-11-14", 1_700_000_002, "after")
 
-            errors = io.StringIO()
-            with redirect_stderr(errors), redirect_stdout(io.StringIO()):
-                main(["sync"])
-
-        said = errors.getvalue()
+        said = self.run_cli(alpha, "sync").err
         self.assertIn("2023-11-14", said)
         self.assertIn("cannot be published", said)
         # The recovery it offers has to be the one that works: the deleted key
@@ -2513,7 +2502,7 @@ class TestAnOrphanedDayKey(SyncTestCase):
             pub.write_text(crypto.generate_identity().public + "\n", encoding="utf-8")
 
             self.assertEqual(sync.orphaned_days(), [])
-            _, text = self.run_cli(alpha, "doctor")
+            _, text, _ = self.run_cli(alpha, "doctor")
             self.assertIn("[ok] day keys", text)
 
     def test_compact_skips_the_day_rather_than_aborting(self) -> None:
@@ -2543,13 +2532,13 @@ class TestAnOrphanedDayKey(SyncTestCase):
             alpha.record("2023-11-14", 1_700_000_001, "ours")
             sync.run()
             self.assertEqual(sync.orphaned_days(), [])
-            code, healthy = self.run_cli(alpha, "doctor")
+            code, healthy, _ = self.run_cli(alpha, "doctor")
             self.assertIn("[ok] day keys", healthy)
 
             store.day_key(alpha.id, "2023-11-14").unlink()
             self.assertEqual(sync.orphaned_days(), [(alpha.id, "2023-11-14")])
 
-            code, text = self.run_cli(alpha, "doctor")
+            code, text, _ = self.run_cli(alpha, "doctor")
             self.assertEqual(code, 1, "doctor stayed green with an unreadable day")
             self.assertIn("[FAIL] day keys", text)
             self.assertIn("2023-11-14", text)
@@ -2648,11 +2637,8 @@ class TestADeletedManifest(SyncTestCase):
         with alpha.active():
             store.day_manifest(alpha.id, "2023-11-14").unlink()
             alpha.record("2023-11-14", 1_700_000_002, "second")
-            errors = io.StringIO()
-            with redirect_stderr(errors), redirect_stdout(io.StringIO()):
-                main(["sync"])
 
-        said = errors.getvalue()
+        said = self.run_cli(alpha, "sync").err
         self.assertIn("2023-11-14", said)
         self.assertIn("--diff-filter=D", said)
 
@@ -2667,20 +2653,20 @@ class TestADeletedManifest(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-20", 1_700_500_000, "not yet published")
             self.assertEqual(sync.days_missing_a_manifest(), [])
-            _, text = self.run_cli(alpha, "doctor")
+            _, text, _ = self.run_cli(alpha, "doctor")
             self.assertIn("[ok] manifests", text)
 
     def test_doctor_finds_a_quiet_day_sync_never_looks_at(self) -> None:
         """A day fully exported before the deletion never returns to `export`."""
         alpha = self.published_day()
         with alpha.active():
-            _, healthy = self.run_cli(alpha, "doctor")
+            _, healthy, _ = self.run_cli(alpha, "doctor")
             self.assertIn("[ok] manifests", healthy)
 
             store.day_manifest(alpha.id, "2023-11-14").unlink()
             self.assertEqual(sync.days_missing_a_manifest(), ["2023-11-14"])
 
-            code, text = self.run_cli(alpha, "doctor")
+            code, text, _ = self.run_cli(alpha, "doctor")
             self.assertEqual(code, 1)
             self.assertIn("[FAIL] manifests", text)
             self.assertIn("2023-11-14", text)
@@ -3208,15 +3194,10 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
     def test_sync_says_which_day_it_left_alone(self) -> None:
         """New user-facing behaviour, so it is pinned like its neighbours."""
         alpha, beta, compacted = self.compacted_and_growing()
-        errors = io.StringIO()
-        with (
-            beta.active(),
-            mock.patch.object(sync, "open_chunk", self.damaged(compacted)),
-            redirect_stderr(errors),
-            redirect_stdout(io.StringIO()),
-        ):
-            self.assertEqual(main(["sync"]), 0)
-        said = errors.getvalue()
+        with mock.patch.object(sync, "open_chunk", self.damaged(compacted)):
+            ran = self.run_cli(beta, "sync")
+        self.assertEqual(ran.code, 0)
+        said = ran.err
         self.assertIn("could not be rebuilt", said)
         self.assertIn(f"{alpha.id}/{self.DAY}", said, "it did not say which day")
 
@@ -3257,10 +3238,9 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
             sync.run()
 
         gamma = self.machine("gamma")  # enrolled, never granted
-        errors = io.StringIO()
-        with gamma.active(), redirect_stderr(errors), redirect_stdout(io.StringIO()):
-            self.assertEqual(main(["sync"]), 0)
-        said = errors.getvalue()
+        ran = self.run_cli(gamma, "sync")
+        self.assertEqual(ran.code, 0)
+        said = ran.err
         self.assertIn(_GRANT_REMEDY.splitlines()[0], said)
         self.assertNotIn("could not be rebuilt", said, "an ungranted machine was accused")
 

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -1,0 +1,158 @@
+"""Revert a fix, watch its test fail, restore it -- the loop CLAUDE.md rule 3 asks for.
+
+A test that passes whether or not the fix is present is decoration, and reading
+it will not tell you which kind you have. The only way to know is to break the
+code and watch. This does that, for a table of edits:
+
+    from tools.mutate import Mutation, verify
+
+    verify(
+        [
+            Mutation(
+                "the guard is gone",
+                "woswoar/sync.py",
+                "if stamp is not None and settled:",
+                "if True:",
+                "tests.test_sync.TestSkippingAnUnchangedDay",
+            ),
+        ]
+    )
+
+Run it with ``python -m tools.mutate <script>``, or import `verify` from a
+throwaway script of your own. Either way the point is that the *table* is the
+new work and everything below is not. Paths are relative to the working
+directory, so run it from the repo root, as with `tools.run_tests`.
+
+Two things it does that a hand-rolled loop forgets, both of which have cost real
+time here:
+
+- **The bytecode cache lies.** A ``.pyc`` is validated against
+  ``(mtime_seconds, size)``, so two mutations that change a file by the same
+  number of bytes inside one second run each other's cached bytecode. That
+  reported a *correct* test as decoration once, and the test was nearly
+  rewritten because of it. Every run is ``-B`` and every ``__pycache__`` is
+  removed between mutations.
+- **The tree is restored even when interrupted.** A ``finally`` is not enough on
+  its own -- a kill leaves the source mutated, which is exactly the state
+  CLAUDE.md rule 6 is about -- so the original text is also written to a
+  recovery file, and its path is printed if anything goes wrong.
+"""
+
+from __future__ import annotations
+
+import argparse
+import runpy
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import NamedTuple
+
+
+class Mutation(NamedTuple):
+    """One edit that some test is supposed to notice."""
+
+    #: What the mutation does, in the words of whoever might reintroduce it.
+    #: Printed, so make it a sentence a reader of the PR would understand.
+    label: str
+    path: str
+    #: Must appear exactly once in the file. Ambiguity is an error rather than a
+    #: guess: replacing the wrong one of two matches quietly tests nothing.
+    old: str
+    new: str
+    #: Whitespace-separated unittest targets, as `python -m unittest` takes them.
+    tests: str
+
+
+class Result(NamedTuple):
+    mutation: Mutation
+    caught: bool
+
+
+def _clear_bytecode() -> None:
+    for cache in Path().glob("*/__pycache__"):
+        shutil.rmtree(cache, ignore_errors=True)
+
+
+def _run(tests: Sequence[str]) -> bool:
+    """Whether the suite failed, which for a mutation is the good answer."""
+    _clear_bytecode()
+    finished = subprocess.run(
+        [sys.executable, "-B", "-m", "unittest", *tests],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return finished.returncode != 0
+
+
+def verify(mutations: Iterable[Mutation], baseline: bool = True) -> int:
+    """Apply each mutation in turn; return how many were *not* caught.
+
+    Prints one line per mutation, in the shape a PR body wants. With
+    ``baseline``, also confirms the untouched tree is green -- without which
+    "caught" means nothing, because a suite that is already failing catches
+    everything.
+    """
+    survivors: list[Result] = []
+    for mutation in mutations:
+        source = Path(mutation.path)
+        original = source.read_text(encoding="utf-8")
+        found = original.count(mutation.old)
+        if found != 1:
+            raise SystemExit(
+                f"{mutation.label}: {mutation.path} contains the text to replace "
+                f"{found} times, not once. A mutation that matches nothing tests "
+                f"nothing, and one that matches twice tests something else."
+            )
+
+        # Written somewhere findable before the file is touched, so an
+        # interrupted run leaves a way back that does not depend on this process
+        # reaching its `finally`.
+        rescue = Path(tempfile.gettempdir()) / f"woswoar-mutate-{source.name}"
+        rescue.write_text(original, encoding="utf-8")
+        try:
+            source.write_text(original.replace(mutation.old, mutation.new), encoding="utf-8")
+            caught = _run(mutation.tests.split())
+        finally:
+            source.write_text(original, encoding="utf-8")
+            _clear_bytecode()
+            rescue.unlink(missing_ok=True)
+
+        print(f"  {'caught' if caught else 'SURVIVED':9} {mutation.label}")
+        if not caught:
+            survivors.append(Result(mutation, caught))
+
+    if baseline:
+        every = sorted({test for mutation in mutations for test in mutation.tests.split()})
+        if _run(every):
+            print("  BASELINE RED -- the suite fails untouched, so nothing above means anything")
+            return len(list(mutations)) or 1
+
+    if survivors:
+        print(f"\n{len(survivors)} survived. A test that cannot see the fix removed is decoration:")
+        for result in survivors:
+            print(f"  - {result.mutation.label} ({result.mutation.tests})")
+        print("Suspect the fixture before the mutation -- see CLAUDE.md rule 3.")
+    return len(survivors)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.mutate",
+        description="Run a script that defines MUTATIONS, and report which are caught.",
+    )
+    parser.add_argument("script", help="a Python file defining MUTATIONS: list[Mutation]")
+    args = parser.parse_args(argv)
+
+    namespace = runpy.run_path(args.script)
+    mutations = namespace.get("MUTATIONS")
+    if not mutations:
+        raise SystemExit(f"{args.script} defines no MUTATIONS")
+    return 1 if verify(mutations) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #36. Closes #48. Closes #62.

Three test-infrastructure items, batched because they are all tooling and share
one review — the case for grouping that #92's rule allows on cost rather than on
mechanism.

## #36 — one CLI helper, capturing both streams

Four modules spelled out "drive `main([...])`, capture stdout, return
`(code, output)`" separately, and **every one of them captured stdout alone**.
Several commands put the thing a test cares about on stderr — `sync`'s warnings,
`grant`'s refusal to act without a terminal — so a test meaning "it warned" could
only check the exit code, and would have passed had the warning been deleted.
That is the failure mode rule 3 is about, and it was invisible at each call site.

`support.run_cli` returns `Ran(code, out, err)`. The four hand-rolled helpers and
the four hand-rolled `redirect_stderr` blocks in `test_sync.py` are gone. Verified
the gap is closed: deleting the `report.stale` warning block from `cmd_sync` now
fails the suite; before this it would not have.

## #48 — `tools/mutate.py`

Rule 3 requires mutation testing and nothing in the repo did it, so every task
wrote the same ~70-line throwaway. I wrote it about fifteen times in this session
alone, which is most of the evidence for what it needs. Now:

```python
MUTATIONS = [Mutation("label", "woswoar/sync.py", "old", "new", "tests.test_sync.TestX")]
```

```
$ python -m tools.mutate /tmp/spec89.py
  caught    write a partial rewrite anyway, as before #89
  caught    measure against the directory, not the manifest
  ...
```

That is #93's mutation set, reproduced exactly from a fifteen-line table.

It does four things a hand-rolled loop forgets, each of which has cost time here:
runs `-B` and clears every `__pycache__` between mutations (the `(mtime, size)`
`.pyc` trap that reported a **correct** test as decoration and nearly got it
rewritten); refuses an edit matching other than exactly once, rather than
guessing; checks the baseline is green, without which "caught" means nothing; and
restores the tree even when interrupted, which is rule 6's territory.

Eight tests of its own, including the bytecode trap driven directly — two
same-sized edits inside one second, each of which must be tested against its own
code.

## #62 — a bound on the cold cache build, and an honest one

There was none: `warm < cold` holds however slow cold becomes.

**It would not have caught the regression that prompted it**, and I could not
make it. #25 cost 22% of cold build (75 → 92 ms). Five consecutive local runs on
an idle machine spread 80–94 ms by themselves, and a ratio against the warm load
in the same run is no steadier (2.24–2.66). Cold build reads ~750 files; no
wall-clock bound safe on a shared runner separates 22% from noise. The issue's
"still catch a doubling" does not hold at the file's 3× tolerance either — that
trips at 450 ms.

So it is a floor under "somebody made this several times slower", and the comment
says exactly that rather than implying more. A 20% regression still needs a person
measuring, as #25's did.

## Also

`CLAUDE.md` now points rule 3 at the harness instead of describing the `.pyc`
trap for each author to rediscover.

## Reviewed as the middle row

Per #92: no stored data changes shape and no security claim moves, but it touches
how every future test is written, so I read the whole diff against each issue's
stated constraint rather than spending four agents on it. The suite is the check
that matters here, and it is green.
