### PR TITLE
grant: do not re-seal what is already sealed

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1107,6 +1107,89 @@ class TestRevokeConfirmation(SyncTestCase):
             self.assertNotIn(gone, sync.recipients())
 
 
+class TestGrantDoesNotRepeatItself(SyncTestCase):
+    """Issue #35: re-sealing a key file that is already sealed to everyone.
+
+    `grant` opens and re-seals every day key of every host, two `age` forks
+    apiece, to produce different ciphertext of identical plaintext for an
+    identical recipient list. On 120 days across two machines that is 255
+    subprocesses and 575 ms; it grows with the history, and the command is run
+    by hand.
+    """
+
+    def granting_pair(self) -> tuple[Fake, Fake]:
+        alpha, beta = self.history_across_days(days=3, per_day=1)
+        with beta.active():
+            sync.run()
+        return alpha, beta
+
+    def sealed(self, machine: Fake) -> int:
+        """Key files one `grant` actually rewrites."""
+        with machine.active():
+            return sync.grant(approved=[reader.key for reader in sync.readers()]).resealed
+
+    def test_a_second_grant_with_nothing_new_seals_nothing(self) -> None:
+        alpha, beta = self.granting_pair()
+        self.assertGreater(self.sealed(alpha), 0, "precondition: the first grant did work")
+        self.assertEqual(self.sealed(alpha), 0, "it re-sealed an unchanged list")
+
+        # And access is unchanged, which is the only thing that matters about
+        # skipping the work.
+        with beta.active():
+            sync.run()
+            self.assertEqual(len(beta.commands()), 3)
+
+    def test_a_machine_that_enrols_later_is_still_sealed_to(self) -> None:
+        """The half that would silently stop granting if the skip overreached."""
+        alpha, _beta = self.granting_pair()
+        self.sealed(alpha)
+        self.assertEqual(self.sealed(alpha), 0)
+
+        gamma = self.machine("gamma")  # enrols, so the recipient list changes
+        self.assertGreater(self.sealed(alpha), 0, "a new machine was not sealed to")
+        with gamma.active():
+            sync.run()
+            self.assertEqual(len(gamma.commands()), 3)
+
+    def test_a_partial_grant_is_not_remembered_as_complete(self) -> None:
+        """The subtlety that makes "nothing new" insufficient on its own.
+
+        A machine that cannot open a key file leaves it sealed to the older,
+        smaller list. The recipient list is unchanged either way, so a gate that
+        looked only at that would skip for ever and those files would never be
+        re-sealed -- and the machines they were missing would never read those
+        days.
+        """
+        alpha, _beta = self.granting_pair()
+        gamma = self.machine("gamma")
+
+        # gamma has never been granted, so it can open none of the keys.
+        with gamma.active():
+            partial = sync.grant(approved=[reader.key for reader in sync.readers()])
+            # Its own key it can open; every other host's it cannot.
+            self.assertGreater(partial.skipped, 0, "precondition: gamma was left work undone")
+            self.assertFalse(sync.State.load().granted_complete)
+
+        # Now gamma is granted by a machine that can, and gamma tries again. The
+        # recipient list has not moved, but the last pass left files behind.
+        self.assertGreater(self.sealed(alpha), 0)
+        with gamma.active():
+            sync.run()
+            self.assertGreater(
+                sync.grant(approved=[reader.key for reader in sync.readers()]).resealed,
+                0,
+                "a partial grant was remembered as complete",
+            )
+
+    def test_it_says_nothing_to_do_rather_than_re_sealed_zero(self) -> None:
+        alpha, _beta = self.granting_pair()
+        self.sealed(alpha)
+        ran = self.run_cli(alpha, "grant", "--yes")
+        self.assertEqual(ran.code, 0)
+        self.assertIn("nothing to do", ran.out)
+        self.assertNotIn("re-sealed 0", ran.out)
+
+
 class TestGrantConfirmsAdditions(SyncTestCase):
     """A confirmation listing everything makes the one new line easy to miss."""
 

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -611,7 +611,12 @@ def cmd_grant(args: argparse.Namespace) -> int:
         return 1
 
     report = sync.grant(approved=[reader.key for reader in readers])
-    print(f"\nre-sealed {report.resealed} key file(s)")
+    if report.resealed or report.skipped:
+        print(f"\nre-sealed {report.resealed} key file(s)")
+    else:
+        # Not "re-sealed 0", which reads as a failure. Every key file is already
+        # sealed to exactly these machines, so there was nothing to do.
+        print("\nnothing to do: every key is already sealed to these machines")
     if report.pushed:
         print("published to the remote")
         print("\nOn each machine that was waiting, run:  woswoar sync")

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -407,6 +407,11 @@ class State:
     #: answer, and a record kept in the repo could be edited by exactly the
     #: attacker the confirmation exists to catch.
     granted: list[str] = field(default_factory=list)
+    #: Whether the grant that recorded `granted` sealed *every* key file. A
+    #: partial one -- this machine could not open some of them -- leaves key
+    #: files that are not sealed to everyone, so "the recipient list has not
+    #: changed" is not enough on its own to skip the work.
+    granted_complete: bool = False
     #: host id -> the signing key this machine accepts history from that host
     #: under. *The* trust anchor, and local for the reason the rest of this class
     #: is: everything in the repo can be rewritten by anyone who can push,
@@ -432,6 +437,7 @@ class State:
         exported = raw.get("exported", {})
         merged = raw.get("merged", {})
         granted = raw.get("granted", [])
+        granted_complete = raw.get("granted_complete", False)
         signers = raw.get("signers", {})
         merged_at = raw.get("merged_at", {})
         if not isinstance(exported, dict) or not isinstance(merged, dict):
@@ -450,6 +456,9 @@ class State:
             # A malformed list costs the prompt its memory, which shows every
             # machine as new -- the safe direction to be wrong in.
             granted=[str(k) for k in granted] if isinstance(granted, list) else [],
+            # Anything but a true boolean means "assume it was partial", which
+            # costs one full re-seal rather than leaving a key file behind.
+            granted_complete=granted_complete is True,
             # And a malformed map costs every pin, which refuses every host until
             # a human re-runs `trust` -- also the safe direction, and loud,
             # because `sync` reports the untrusted hosts rather than skipping on.
@@ -476,6 +485,7 @@ class State:
             "exported": dict(self.exported),
             "merged": {key: sorted(names) for key, names in self.merged.items()},
             "granted": list(self.granted),
+            "granted_complete": self.granted_complete,
             "signers": dict(self.signers),
             "merged_at": dict(self.merged_at),
         }
@@ -2322,7 +2332,21 @@ def grant(approved: list[str] | None = None) -> ReencryptReport:
                 "run 'woswoar grant' again to see the current list"
             )
 
-        resealed, skipped = _reseal(change.identity, keys)
+        # Nothing new, and nothing left behind last time: every key file is
+        # already sealed to exactly these recipients, and re-sealing would fork
+        # `age` twice per file to produce different ciphertext of identical
+        # plaintext. On three hosts with a year of history that is ~1000 files
+        # and ~2000 subprocesses.
+        #
+        # Both halves are needed. "The list has not changed" alone is not
+        # enough, because a *partial* grant leaves key files this machine could
+        # not open, and those are still sealed to the older, smaller list.
+        #
+        # Key files created since are already right: `export` seals a new day to
+        # whatever `recipients.txt` said, and by this branch it has not changed.
+        state = State.load()
+        settled = state.granted_complete and sorted(state.granted) == sorted(keys)
+        resealed, skipped = (0, 0) if settled else _reseal(change.identity, keys)
 
         if approved is not None:
             # Recorded rather than counted: what the next confirmation subtracts
@@ -2330,8 +2354,8 @@ def grant(approved: list[str] | None = None) -> ReencryptReport:
             # re-sealable from here. A machine that could open nothing still
             # approved these, and a grant with no approved list behind it -- an
             # unattended one -- must not silence the next prompt.
-            state = State.load()
             state.granted = keys
+            state.granted_complete = skipped == 0 or settled
             state.save()
 
     return ReencryptReport(resealed, skipped, pushed=change.remote)


### PR DESCRIPTION
Closes #35.

`grant` opened and re-sealed **every** day key of **every** host on every run —
two `age` forks per file — to produce different ciphertext of identical plaintext
for an identical recipient list.

Measured, a second `grant` with nothing changed:

| history | before | after |
|---|---|---|
| 3 days, 2 machines | 31 subprocesses, 79 ms | **10, 23 ms** |
| 120 days, 2 machines | 255 subprocesses, 575 ms | **10, 24 ms** |

The cost was proportional to the history; it is now constant. On the ~1000 key
files the issue describes, that is ~2000 `age` invocations not run.

## Both halves of the gate are needed

"The recipient list has not changed" is not sufficient on its own, and this is
the part that is easy to get wrong: a *partial* grant — one where this machine
could not open some key files — leaves those files sealed to the older, smaller
list. The list is unchanged either way, so a gate looking only at that would skip
for ever, and the machines missing from those files would never read those days.

So `State` remembers whether the grant that recorded `granted` sealed everything,
and the gate is "nothing new **and** nothing was left behind". A malformed value
reads as incomplete, which costs one full re-seal rather than leaving a key file
behind.

Key files created since are already correct: `export` seals a new day to whatever
`recipients.txt` said, and by that branch it has not changed.

## The double fetch is left alone, deliberately

The issue's other half. Both fetches are load-bearing individually, and the
second is also what makes the "the machines changed while you were deciding"
check meaningful — so it cannot just be deleted. With the re-seal skipped it is
now most of what a repeat `grant` does at all, which is one network round trip on
a command run by hand a handful of times per machine. Taking the issue's own
second option: left as the price of the race check.

## And it no longer reports success as "re-sealed 0"

Which reads as a failure. It says "nothing to do: every key is already sealed to
these machines".

## Tests

Seven mutations, each caught — the first real use of the harness from #94, from a
table rather than a fresh script:

```
caught  re-seal every time, as before #35
caught  skip whenever the list matches, ignoring a partial grant
caught  skip regardless of the recipient list
caught  a partial grant is remembered as complete
caught  completeness is never persisted
caught  completeness is never loaded back
caught  it says "re-sealed 0" again
```

One of my assertions was wrong before it was right: a machine doing a partial
grant re-seals its *own* key, so `resealed` is not zero there — only `skipped`
and the completeness flag say what happened.

## Reviewed as the middle row

Per #92: `state.json` gains a field and the change gates work rather than
rewriting stored history, so I read the diff against the issue's stated
constraint rather than spending four agents. The constraint — that a partial
grant must not read as complete — is the mutation above and the third test.

## No migration needed

Per rule 8. A `state.json` with no `granted_complete` reads as incomplete, so the
first `grant` after this does the full pass once and then settles.
