### PR TITLE
sync: a remote is an address, not an option to git

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -245,6 +245,7 @@ Claims rot. The ones that matter are asserted in CI on every push:
 | The repo does not blow up | a simulated multi-day, multi-machine run is measured after `git gc` |
 | History is never readable by others | every path woswoar creates is walked under a stock `umask 022`, on both the Python and the shell-hook side |
 | The hook's scratch file is never in a directory another user can write | `TMPDIR` and `/tmp` are never consulted; an `XDG_RUNTIME_DIR` this user cannot write falls back to woswoar's own `0700` tree instead of switching recording off |
+| A remote is an address, never an option to git | `woswoar init -- --upload-pack=<command>` is refused, and both git calls that are handed the remote pass `--` first; the command never runs |
 | The cache cannot execute | a pickle that would run code on load is written to the cache path; it is refused and a witness file never appears |
 | Search stays fast | latency measured on 52,000 entries |
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1107,6 +1107,78 @@ class TestRevokeConfirmation(SyncTestCase):
             self.assertNotIn(gone, sync.recipients())
 
 
+class TestARemoteIsAnAddressNotAnOption(SyncTestCase):
+    """Issue #26: `git clone --upload-pack=<cmd>` runs <cmd>.
+
+    `woswoar init -- --upload-pack=...` reaches argparse as a positional,
+    because `--` ends *woswoar's* option parsing and hands the rest through. It
+    is the user's own URL, so this is low severity -- until the URL comes from a
+    README, a chat message, or a provisioning script that wraps `init`.
+    """
+
+    def test_a_remote_that_would_run_a_command_does_not(self) -> None:
+        """The attack, not the message: a witness file must never appear."""
+        witness = self.root / "OWNED"
+        hostile = f"--upload-pack=touch {witness}"
+
+        alpha = self.machine("alpha")
+        with alpha.active(), self.assertRaises(sync.SyncError) as refused:
+            sync.initialise(remote=hostile)
+        self.assertIn("may not start with", str(refused.exception))
+        self.assertFalse(witness.exists(), "the remote was executed")
+
+    def test_git_is_told_where_the_options_end(self) -> None:
+        """The guard behind the message, so one is not the only defence.
+
+        A remote reaching `git clone` unseparated is an option to git whatever
+        woswoar checked first, and the check is a string comparison that a later
+        edit could narrow.
+        """
+        seen: list[tuple[str, ...]] = []
+        real = sync.git
+
+        def spy(*args: str, **kwargs: object) -> str:
+            seen.append(args)
+            return real(*args, **kwargs)  # type: ignore[arg-type]
+
+        # A machine that has never been set up, because those are the only two
+        # calls that are ever handed a remote -- an already-initialised one
+        # clones nothing and this would watch an empty list.
+        with mock.patch.object(sync, "git", spy):
+            alpha = self.machine("alpha")
+
+        # `remote add` is only reached when the repo was *not* cloned -- a clone
+        # sets origin itself. That is `woswoar init` with no remote, and a
+        # remote given later; without it this watches the clone alone.
+        with alpha.active():
+            sync.git("remote", "remove", "origin")
+            with mock.patch.object(sync, "git", spy):
+                sync.initialise(remote=str(self.origin))
+
+        handed = [call for call in seen if call[:1] == ("clone",) or call[:2] == ("remote", "add")]
+        self.assertTrue(handed, "precondition: no call was handed the remote")
+        for call in handed:
+            self.assertIn("--", call, f"no separator before the remote: {call}")
+            self.assertLess(
+                call.index("--"),
+                call.index(str(self.origin)),
+                f"the separator comes after the remote: {call}",
+            )
+
+    def test_an_ordinary_remote_still_works(self) -> None:
+        """`--` must not break the thing it guards."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            self.assertTrue(sync.run().pushed)
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+        with beta.active():
+            sync.run()
+            self.assertEqual(beta.commands(), {"git status"})
+
+
 class TestGrantDoesNotRepeatItself(SyncTestCase):
     """Issue #35: re-sealing a key file that is already sealed to everyone.
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -2028,6 +2028,17 @@ def initialise(
     crypto.require()
     crypto.require_signing()
 
+    if remote is not None and remote.startswith("-"):
+        # Refused here rather than only guarded with `--` at the git calls, so
+        # the user gets a sentence instead of git's own error, and so the rule
+        # is stated once where it can be tested. `--` is still passed below:
+        # this is the message, that is the defence.
+        raise SyncError(
+            f"a remote may not start with '-': {remote!r}\n"
+            "That is an option to git, not an address -- 'git clone' takes\n"
+            "'--upload-pack=<command>' and runs it."
+        )
+
     chosen = choose_identity(new_identity=new_identity, explicit=identity)
     known = store.machine()._replace(identity=str(chosen))
     store.save_machine(known)
@@ -2036,12 +2047,17 @@ def initialise(
     if not is_repo():
         store.private_dir(history.parent)
         if remote and not any(history.glob("*")):
-            git("clone", "--quiet", remote, str(history), cwd=history.parent)
+            # `--` before anything the user supplied. `git clone` takes
+            # `--upload-pack=<cmd>` and runs it, so a "remote" beginning with a
+            # dash is a command, not an address -- and argparse hands one
+            # through happily, because `--` ends *woswoar's* option parsing and
+            # makes the rest a positional.
+            git("clone", "--quiet", "--", remote, str(history), cwd=history.parent)
         else:
             history.mkdir(parents=True, exist_ok=True)
             git("init", "--quiet", "-b", "main")
     if remote and not has_remote():
-        git("remote", "add", "origin", remote)
+        git("remote", "add", "origin", "--", remote)
 
     # After the remote is added, not before: that is what decides `has_remote`.
     repo = read_repo()


### PR DESCRIPTION
Closes #26.

`woswoar init <remote>` passed the remote straight to `git clone` and
`git remote add`, so a "remote" beginning with `-` reached git as an option.
`git clone --upload-pack=<command>` runs `<command>`.

argparse does not stop it: `--` ends *woswoar's* option parsing and hands the
rest through as a positional.

Two defences, because either alone is one edit from being wrong:

- **`--` before the remote** in both calls, so what follows cannot be an option
  whatever else changed.
- **A refusal in `sync.initialise`**, so the user gets a sentence rather than
  git's error — in the library rather than the CLI, matching where compaction's
  `--before` guard and `add_recipient`'s own `-`-prefix refusal live, so the rule
  is stated once and can be tested.

## Tests

The first asserts the *attack*, not the message: it points the hostile remote at
`touch <witness>` and requires the witness never to appear.

Three mutations, each caught:

```
caught  no -- before the cloned remote
caught  no -- before the added remote
caught  a dash-prefixed remote is accepted
```

**Two of them survived at first, and the fixture was the reason both times** —
the failure mode rule 3 now names explicitly:

- `initialise` on an already-initialised machine clones nothing, so the test
  watched an empty list of calls and asserted over it happily.
- `git remote add` is only reached when the repo was *not* cloned, because a
  clone sets `origin` itself. It needs `init` with no remote and a remote given
  afterwards.

The test now asserts a precondition that a call was actually observed, which is
what would have caught the first of those without the mutation run.

## docs/security.md

A row, backed by those tests rather than by prose: *a remote is an address, never
an option to git*.

## Reviewed as the middle row

Per #92: nothing stored changes shape, and the diff is four lines of source. It
does move a security claim, so I read it against the issue's own reproduction and
wrote the test to run the exploit rather than to check the wording — but a
four-agent pass on four lines would not have earned its cost.

## No migration needed

Per rule 8; nothing on disk is involved.
