### PR TITLE
doctor: report chunks in no signed manifest

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1138,9 +1138,9 @@ class TestDoctorFindsAChunkNobodySigned(SyncTestCase):
 
             # ...and still answerable.
             self.assertEqual(sync.unlisted_chunks(), [(alpha.id, self.DAY, 1)])
-        ran = self.run_cli(beta, "doctor")
-        self.assertIn("in no signed list", ran.out)
-        self.assertNotEqual(ran.code, 0, "doctor passed with a planted chunk")
+        # The line, not just the exit code: this fixture has other findings, so
+        # a non-zero exit would be true whether or not the check existed.
+        self.assertRegex(self.run_cli(beta, "doctor").out, r"\[FAIL\] chunks .*no signed list")
 
     def test_a_clean_repo_says_so_and_forks_nothing(self) -> None:
         """The design: a signature check only where there is something to check.
@@ -1180,16 +1180,33 @@ class TestDoctorFindsAChunkNobodySigned(SyncTestCase):
             store.day_manifest(alpha.id, self.DAY).write_text("wrecked", encoding="utf-8")
             self.assertEqual(sync.unlisted_chunks(), [])
 
-    def test_a_host_this_machine_has_not_pinned_is_left_alone(self) -> None:
-        """No key to check against, so every chunk would read as unlisted."""
+    def test_a_host_this_machine_has_not_pinned_is_not_even_checked(self) -> None:
+        """Nothing to check its manifests against, so there is nothing to learn.
+
+        Reporting is unaffected either way -- an unverifiable manifest accounts
+        for nothing, and the guard against *that* already suppresses it. What
+        the skip buys is the `ssh-keygen` per day that asking anyway would cost,
+        on precisely the host where the answer is known in advance.
+        """
         alpha, _beta = self.history_across_days(days=1, per_day=2)
         gamma = self.machine("gamma")  # cloned after alpha, so alpha *is* pinned
+        self.planted(gamma, alpha)
         with gamma.active():
-            sync.run()
             state = sync.State.load()
             del state.signers[alpha.id]
             state.save()
-            self.assertEqual(sync.unlisted_chunks(), [])
+
+            spawns = 0
+            real = subprocess.run
+
+            def counted(argv: list[str], *args: Any, **kwargs: Any) -> Any:
+                nonlocal spawns
+                spawns += 1
+                return real(argv, *args, **kwargs)
+
+            with mock.patch.object(subprocess, "run", counted):
+                self.assertEqual(sync.unlisted_chunks(), [])
+            self.assertEqual(spawns, 0, "an unpinned host was checked anyway")
 
 
 class TestARemoteIsAnAddressNotAnOption(SyncTestCase):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -20,7 +20,7 @@ import zlib
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, redirect_stderr
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 from unittest import mock
 
 from woswoar import cache, crypto, search, store, sync
@@ -1105,6 +1105,91 @@ class TestRevokeConfirmation(SyncTestCase):
         self.assertIn("nothing that machine publishes is accepted", out)
         with alpha.active():
             self.assertNotIn(gone, sync.recipients())
+
+
+class TestDoctorFindsAChunkNobodySigned(SyncTestCase):
+    """Issue #90: `sync` says it once, then the day settles and it stops.
+
+    Right for a one-minute timer -- #87 -- and no use to somebody asking
+    afterwards, especially as that one report most likely went to a journal.
+    """
+
+    DAY = "2023-11-14"
+
+    def planted(self, machine: Fake, host: Fake, name: str = "1700000000-dead.age") -> None:
+        with machine.active():
+            (store.chunk_dir(host.id, self.DAY) / name).write_bytes(b"not a chunk anyone signed")
+
+    def test_it_is_found_after_sync_has_stopped_saying_so(self) -> None:
+        alpha, beta = self.history_across_days(days=1, per_day=2)
+        with beta.active():
+            sync.run()
+        self.planted(beta, alpha)
+
+        with beta.active():
+            # Said once...
+            self.assertIn(f"{alpha.id}/{self.DAY}", sync.run().unauthenticated)
+        # Settling moves the mtime, so one more pass records the stamp; the one
+        # after it is the quiet steady state this exists for.
+        self.settle(beta, alpha, self.DAY)
+        with beta.active():
+            sync.run()
+            self.assertEqual(sync.run().unauthenticated, set(), "precondition: it settled")
+
+            # ...and still answerable.
+            self.assertEqual(sync.unlisted_chunks(), [(alpha.id, self.DAY, 1)])
+        ran = self.run_cli(beta, "doctor")
+        self.assertIn("in no signed list", ran.out)
+        self.assertNotEqual(ran.code, 0, "doctor passed with a planted chunk")
+
+    def test_a_clean_repo_says_so_and_forks_nothing(self) -> None:
+        """The design: a signature check only where there is something to check.
+
+        Verifying every day's manifest would be an `ssh-keygen` fork per
+        host-day -- thousands on a real archive -- to answer "nothing here" in
+        the case that is always true.
+        """
+        _alpha, beta = self.history_across_days(days=3, per_day=1)
+        with beta.active():
+            sync.run()
+
+            spawns = 0
+            real = subprocess.run
+
+            def counted(argv: list[str], *args: Any, **kwargs: Any) -> Any:
+                nonlocal spawns
+                spawns += 1
+                return real(argv, *args, **kwargs)
+
+            with mock.patch.object(subprocess, "run", counted):
+                self.assertEqual(sync.unlisted_chunks(), [])
+            self.assertEqual(spawns, 0, "a clean repo paid for signature checks")
+
+        self.assertIn("all accounted for", self.run_cli(beta, "doctor").out)
+
+    def test_a_manifest_that_will_not_verify_is_not_reported_as_planted(self) -> None:
+        """Otherwise one broken signature reads as every chunk being forged.
+
+        That state has its own name -- `sync` reports the day unauthenticated
+        and every peer refuses all of it -- and calling it "somebody planted
+        three chunks" would point at the wrong thing entirely.
+        """
+        alpha, beta = self.history_across_days(days=1, per_day=2)
+        with beta.active():
+            sync.run()
+            store.day_manifest(alpha.id, self.DAY).write_text("wrecked", encoding="utf-8")
+            self.assertEqual(sync.unlisted_chunks(), [])
+
+    def test_a_host_this_machine_has_not_pinned_is_left_alone(self) -> None:
+        """No key to check against, so every chunk would read as unlisted."""
+        alpha, _beta = self.history_across_days(days=1, per_day=2)
+        gamma = self.machine("gamma")  # cloned after alpha, so alpha *is* pinned
+        with gamma.active():
+            sync.run()
+            state = sync.State.load()
+            del state.signers[alpha.id]
+            state.save()
+            self.assertEqual(sync.unlisted_chunks(), [])
 
 
 class TestARemoteIsAnAddressNotAnOption(SyncTestCase):

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -330,6 +330,22 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         else:
             detail = "all sealed"
         check("day keys", not orphaned, detail)
+
+        # `sync` says this once, on the pass that first sees the file, and then
+        # the day settles and it stops -- which is right for a one-minute timer
+        # and no use to somebody asking afterwards. Costs no subprocess unless
+        # there is something to find; see `unlisted_chunks`.
+        planted = sync.unlisted_chunks()
+        if planted:
+            host, day, count = planted[0]
+            detail = (
+                f"{sum(n for _, _, n in planted)} chunk(s) in no signed list, e.g."
+                f" {count} under {host[:8]}/{day} - no machine will read them,"
+                " and this one did not write them"
+            )
+        else:
+            detail = "all accounted for"
+        check("chunks", not planted, detail)
     else:
         info("sync", "no history repo - run 'woswoar init <url>' to sync machines")
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -689,6 +689,63 @@ def manifest_gone(host_id: str, day: str) -> bool:
     return not store.day_manifest(host_id, day).exists()
 
 
+def unlisted_chunks() -> list[tuple[str, str, int]]:
+    """``(host, day, how many)`` for chunks no signed manifest accounts for.
+
+    A chunk in no manifest is one somebody wrote into the repository that the
+    host it sits under never vouched for. Every peer refuses it -- that is what
+    the signature is for -- so nothing is at risk, and `sync` says so the first
+    time it sees one. But since #87 a day settles once its *listed* chunks are
+    merged, so `sync` says it once and then not again, most likely into a
+    journal from the timer rather than to a person. This is where the question
+    can be asked afterwards.
+
+    Cheap in the case that matters. The manifest body is read without verifying
+    it first, which needs no subprocess; only a day that appears to hold an
+    unaccounted-for name pays the `ssh-keygen -Y verify` to be sure. On a
+    repository where nothing is planted -- every repository, almost always --
+    that is a listing and a file read per day and no forks at all.
+
+    Skips a host this machine has not pinned. There is no key to check its
+    manifests against, so every chunk would read as unlisted; `sync` reports
+    that host as untrusted, which is the more useful sentence.
+    """
+    state = State.load()
+    found: list[tuple[str, str, int]] = []
+    for host_id in store.repo_hosts():
+        verify_key = state.signers.get(host_id)
+        if verify_key is None:
+            continue
+        for day, names in store.iter_chunk_days(host_id):
+            claimed = _manifest_names(host_id, day)
+            if not set(names) - claimed:
+                continue
+            # Only now is it worth a signature check: an unverifiable manifest
+            # accounts for nothing, and would make every chunk of the day look
+            # planted when the manifest is what is wrong.
+            listed = read_manifest(host_id, day, verify_key)
+            strays = set(names) - set(listed)
+            if strays and listed:
+                found.append((host_id, day, len(strays)))
+    return found
+
+
+def _manifest_names(host_id: str, day: str) -> set[str]:
+    """The names a day's manifest claims, *without* checking who signed it.
+
+    Only ever used to decide whether a signature check is worth doing. A forged
+    manifest can make a chunk look accounted for here, and that is fine: the
+    same forgery makes every peer refuse the whole day, which `sync` reports as
+    unauthenticated rather than as a stray file.
+    """
+    try:
+        blob = store.day_manifest(host_id, day).read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    _, _, body = blob.partition(_MANIFEST_SEPARATOR)
+    return {line.partition(" ")[0] for line in body.splitlines()[1:]}
+
+
 def days_missing_a_manifest() -> list[str]:
     """Days this machine published and whose signed manifest is no longer there.
 


### PR DESCRIPTION
Closes #90.

#87 made a day settle once every chunk its signed manifest lists has been
merged. That is right — otherwise one stray `*.age` file costs an `ssh-keygen`
fork a minute for ever, which anyone with push access could turn on with a byte —
but it means a planted chunk is reported on **one** sync and then never again.
And per `contrib/systemd/woswoar-sync.service` that report most likely went to a
journal from the timer, not to a person.

`doctor` can now answer it afterwards:

```
[FAIL] chunks       3 chunk(s) in no signed list, e.g. 1 under 8787f226/2023-11-14
                    - no machine will read them, and this one did not write them
```

## It costs nothing on a repository where nothing is planted

Which is every repository, almost always. Verifying each day's manifest to ask
"anything unaccounted for?" would be a fork per host-day — thousands on a real
archive — to confirm what is nearly always true.

So the manifest body is read *unverified* first, which needs no subprocess, and
only a day that appears to hold an unaccounted-for name pays the signature check
to be sure. A test asserts the clean case spawns **zero** subprocesses.

An unverifiable manifest can therefore make a chunk look accounted for. That is
deliberate and harmless: the same forgery makes every peer refuse the whole day,
which `sync` already reports — as unauthenticated, which is the useful sentence.
The inverse matters more and is also guarded: a manifest that will not verify
accounts for *nothing*, so without care one broken signature would read as "three
chunks were planted here" and point at entirely the wrong thing.

A host this machine has not pinned is skipped, for the same cost reason — there
is no key to check against, so the answer is known in advance, and `sync` reports
that host as untrusted.

## Tests

Five mutations, each caught:

```
caught  doctor never looks
caught  report a day whose manifest will not verify
caught  verify every day, planted or not
caught  check hosts this machine has not pinned
caught  doctor does not fail on the finding
```

Two survived at first, and both were my assertions rather than the code:

- the unpinned-host skip is a *cost* guard, not a correctness one — the
  unverifiable-manifest check already suppresses the report either way. The test
  now asserts what the skip actually buys: no subprocess.
- `assertNotEqual(code, 0)` was true whether or not the check existed, because
  that fixture has other findings. It asserts the `[FAIL] chunks` line now.

## Reviewed as the middle row

Per #92: nothing stored changes shape and no data is rewritten; it adds a
read-only check. I read the diff against the issue's stated constraints — do not
restore the per-sync report, do not delete the file — and both hold.

## No migration needed

Per rule 8; `doctor` gains a check and nothing on disk is involved.
