### PR TITLE
sync: crash débris is not an intruder

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -7,6 +7,7 @@ are enough, and that is only meaningful if it is actually demonstrated.
 
 from __future__ import annotations
 
+import contextlib
 import io
 import os
 import secrets
@@ -1105,6 +1106,70 @@ class TestRevokeConfirmation(SyncTestCase):
         self.assertIn("nothing that machine publishes is accepted", out)
         with alpha.active():
             self.assertNotIn(gone, sync.recipients())
+
+
+class TestCrashDebrisIsNotCalledAnIntruder(SyncTestCase):
+    """Issue #66: the same evidence has two explanations, and one is ordinary.
+
+    `export` writes a chunk and then signs the day's list. Killed between the
+    two, it leaves a chunk in no manifest -- and `state.save()` never ran, so the
+    next sync republishes those lines under a chunk that *is* signed. Nothing is
+    lost and nothing is duplicated; the abandoned one is inert for ever.
+
+    It used to be reported as "someone else can write into this repository",
+    which sends a user hunting an intruder after a power cut.
+    """
+
+    def debris(self) -> tuple[Fake, str]:
+        """One chunk left behind by a run that died before signing."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "one")
+            sync.run()
+            before = set(store.chunk_names(alpha.id, "2023-11-14"))
+
+            alpha.record("2023-11-14", 1_700_000_002, "two")
+
+            def die(*args: object, **kwargs: object) -> None:
+                raise KeyboardInterrupt("power cut")
+
+            with (
+                contextlib.suppress(KeyboardInterrupt),
+                mock.patch.object(sync, "write_manifest", die),
+            ):
+                sync.run()
+            left = set(store.chunk_names(alpha.id, "2023-11-14")) - before
+        self.assertEqual(len(left), 1, "precondition: a chunk was left unsigned")
+        return alpha, left.pop()
+
+    def test_nothing_is_lost_and_nothing_is_duplicated(self) -> None:
+        """The claim the message makes, checked rather than asserted in prose."""
+        alpha, _stray = self.debris()
+        with alpha.active():
+            self.assertTrue(sync.run().foreign)
+            self.assertEqual(alpha.commands(), {"one", "two"})
+            self.assertEqual(len(alpha.entries()), 2, "a line was published twice")
+
+    def test_it_does_not_accuse_anyone(self) -> None:
+        alpha, _stray = self.debris()
+        said = self.run_cli(alpha, "sync").err
+        self.assertIn("never signed", said)
+        self.assertIn("killed between writing a chunk and signing", said)
+        self.assertNotIn("someone else can write into this repository", said)
+
+    def test_doctor_lists_it(self) -> None:
+        """The message points there, so the pointer has to be true.
+
+        `unlisted_chunks` reports every host, including this one, which is what
+        makes it the right place to send someone -- `sync` says it once and then
+        the day settles.
+        """
+        alpha, stray = self.debris()
+        with alpha.active():
+            sync.run()
+            self.assertEqual(sync.unlisted_chunks(), [(alpha.id, "2023-11-14", 1)])
+        self.assertRegex(self.run_cli(alpha, "doctor").out, r"\[FAIL\] chunks .*no signed list")
+        del stray
 
 
 class TestDoctorFindsAChunkNobodySigned(SyncTestCase):

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -528,9 +528,14 @@ def cmd_sync(args: argparse.Namespace) -> int:
 
     if report.foreign:
         print(
-            f"\nWARNING: {len(report.foreign)} chunk(s) sit under this machine's own id\n"
-            "that it never published. They were not signed and will not be offered to\n"
-            "anyone, but someone else can write into this repository.",
+            f"\n{len(report.foreign)} chunk(s) sit under this machine's own id that it\n"
+            "never signed. They are inert: no machine will read them, including this\n"
+            "one, and nothing was lost -- whatever was in them has been published again\n"
+            "under a chunk that is signed.\n"
+            "Two things look like this and cannot be told apart from here: a run of\n"
+            "this machine that was killed between writing a chunk and signing for it,\n"
+            "and someone else writing into the repository. A power cut is the ordinary\n"
+            "explanation. 'woswoar doctor' lists them under 'chunks'.",
             file=sys.stderr,
         )
 


### PR DESCRIPTION
Closes #66.

A run killed between writing a chunk and signing the day's list leaves that chunk
in no manifest. `state.save()` never ran either, so the next sync republishes the
same lines under a chunk that *is* signed, and the abandoned one sits there
inert. Reproduced: one chunk left, nothing lost, nothing duplicated.

It was reported as:

> WARNING: 1 chunk(s) sit under this machine's own id that it never published.
> They were not signed and will not be offered to anyone, but **someone else can
> write into this repository.**

which sends a user hunting an intruder after a power cut.

## Only the message, because the two cases genuinely cannot be told apart

The issue suggested `export` could recognise its own débris — "a chunk whose
timestamp prefix is at or after this machine's last export watermark is its own".
That does not work: the watermark is a byte offset into a log file, not a time,
and a chunk's name carries the *sync* time. I looked for a signal that does work
and there is not one:

- **Sealing** proves nothing. Day public keys are in the clear by design, so
  anyone can seal a chunk to one.
- **git provenance** proves nothing. Every machine commits under the same pinned
  `woswoar <woswoar@localhost>` identity, and the débris is committed and pushed
  by this machine's own next sync anyway.
- **"It was never pushed"** stops being true after that same sync.

Making it decidable would mean recording the intent *before* writing the chunk —
a file written, fsynced and cleaned up per chunk, inside the window the crash
happens in. That is real machinery for a P3 where nothing is lost.

So the message says what is actually known: the chunks are inert, nothing was
lost, two things look like this, and a power cut is the ordinary one. It points
at `woswoar doctor`, which lists them under `chunks` — and that pointer only
became true with #90, since `unlisted_chunks` covers this machine's own host too.

## Not doing the sweep

The issue's second half — delete débris at the start of `export` — is left. Its
own constraint is the reason: nothing may delete an unlisted chunk without
proving it is ours, and per the above, nothing can.

## Tests

Three tests, three mutations, each caught:

```
caught  accuse an intruder again, as before #66
caught  stop naming the crash explanation
caught  say nothing at all
```

One test checks the *claims* rather than the wording: that the commands survive
and that nothing was published twice. A message asserting "nothing was lost"
should have something behind it.

## Reviewed as the bottom row

Per #92: no stored data changes shape, no new state, and the diff is one message
plus tests. I read it against the issue's own constraints and reproduced the
scenario first.
