### PR TITLE
credentials: a webhook URL is a credential, measured against 55k real commands

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -282,6 +282,13 @@ Being straight about the limits is part of the security story:
 >   token formats, which is where the risk is concentrated. But **no pattern
 >   catches everything**. [What it does and does not catch](shell-integration.md#commands-that-are-never-recorded)
 >   is written down; read it before relying on it.
+>
+>   For a sense of scale rather than a promise: measured against one
+>   maintainer's real atuin history of **55,017 commands**, the rules skipped 32
+>   and missed **one** shape -- a Slack webhook URL, where the address *is* the
+>   credential. That rule now exists, and the shape is in the corpus. One
+>   history is not a survey, and the number that matters for you is the one from
+>   your own; `woswoar import --dry-run` prints what it would skip.
 > - **Lose your key, lose your access.** There is no recovery service, because
 >   there is no service. If a machine loses its identity, re-enrol it and run
 >   `woswoar grant` from another machine. If it loses its *signing* key it mints

--- a/tests/credential_shapes.py
+++ b/tests/credential_shapes.py
@@ -11,6 +11,26 @@ from __future__ import annotations
 #: Command shapes the default `WOSWOAR_IGNORE` must drop. Most come from #23,
 #: which listed them as *not* caught by the pattern this replaces.
 SECRET_SHAPES = [
+    # A credential that is a *path component* of a URL rather than a
+    # `user:pass@` prefix. Measured against 55,017 commands of one maintainer's
+    # real history, this was the only shape the rules missed -- twice, in `curl`
+    # calls to a Slack webhook. Anyone holding the URL can fire that integration,
+    # so it is a credential in the ordinary sense.
+    #
+    # The tokens here are deliberately too short and too obviously fake to match
+    # a vendor's own shape. A corpus of credential examples is a file full of
+    # things that look like credentials, and GitHub's push protection rejected
+    # an earlier draft of it: a 24-character token after `/services/` is exactly
+    # what its Slack rule matches. woswoar's rule needs only the host and one
+    # character of path, so nothing is lost by staying well clear.
+    'curl -X POST -d \'{"text":"hi"}\' https://hooks.slack.com/services/EXAMPLE-NOT-REAL',
+    # The one that actually turned up: a workflow *trigger*, not an incoming
+    # webhook. Anchoring the rule on `/services/` -- the shape that comes to
+    # mind -- would have missed the only real instance in 55,017 commands, which
+    # is why the rule names the host and not a path under it.
+    "curl -X POST https://hooks.slack.com/triggers/EXAMPLE-NOT-REAL",
+    "curl -H 'Content-type: application/json' https://discord.com/api/webhooks/EXAMPLE-NOT-REAL",
+    "curl -d @body.json https://discordapp.com/api/webhooks/EXAMPLE-NOT-REAL",
     "export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI",
     "export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7",
     "AWS_SESSION_TOKEN=abc aws s3 ls",

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -202,12 +202,14 @@ HOOK = Path(__file__).resolve().parent.parent / "woswoar" / "shell" / "woswoar.b
 def as_posix_ere(pattern: str) -> str:
     r"""Rewrite one Python pattern into the POSIX ERE dialect bash `[[ =~ ]]` uses.
 
-    Only the two constructs `_SHARED` actually uses need translating: ERE has no
-    non-capturing group, and no `\s`. Inside a bracket expression the class is
-    spelled `[:space:]`; outside one it needs its own brackets.
+    Only the constructs `_SHARED` actually uses need translating: ERE has no
+    non-capturing group, and no `\s` or `\S`. Inside a bracket expression the
+    class is spelled `[:space:]`; outside one it needs its own brackets, and the
+    negated form needs the negated bracket.
     """
     pattern = pattern.replace("(?:", "(")
     pattern = re.sub(r"\[([^]]*?)\\s([^]]*?)\]", r"[\1[:space:]\2]", pattern)
+    pattern = pattern.replace(r"\S", "[^[:space:]]")
     return pattern.replace(r"\s", "[[:space:]]")
 
 

--- a/woswoar/credentials.py
+++ b/woswoar/credentials.py
@@ -46,8 +46,17 @@ _SHARED = (
     r"--(?:[a-z]+-)*(?:(?:passw|token|secret|credential)[a-z-]*|api-?key|access-?key|auth)"
     r"(?:[=\s]|$)",
     r"--from-literal=",
-    # Credentials inside a URL.
+    # Credentials inside a URL. Two shapes: a `user:pass@` prefix, and a token
+    # that *is* a path component -- a webhook URL, where holding the address is
+    # holding the credential. Anchored on the known hosts rather than on
+    # "looks random", for the reason the module docstring gives.
+    #
+    # The whole host, not a path under it. Measured against real history, the
+    # one that turned up was `hooks.slack.com/triggers/...`, not the
+    # `/services/...` an incoming webhook uses -- and every path on that host
+    # carries a trigger a holder can fire.
     r"://[^/\s]+:[^/@\s]+@",
+    r"://(?:hooks\.slack\.com|discord(?:app)?\.com/api/webhooks)/\S",
     r"[Aa]uthorization:\s*[A-Za-z]",
     # The three tools that exist to take a password on the command line.
     r"(?:sshpass|htpasswd|openssl passwd)\s",

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -135,7 +135,14 @@ export WOSWOAR_SESSION
 # the pattern's *length*, not how much of it can match. Measured here: 30us for
 # the four-keyword pattern this replaces, 54us for this one, against a 288us ->
 # 324us record path. Weigh anything added against that.
-: "${WOSWOAR_IGNORE=(TOKEN|SECRET|PASSW|CREDENTIAL|APIKEY|_KEY|_PASS|_AUTH)[A-Za-z0-9_]*=|--([a-z]+-)*((passw|token|secret|credential)[a-z-]*|api-?key|access-?key|auth)([=[:space:]]|\$)|--from-literal=|://[^/[:space:]]+:[^/@[:space:]]+@|[Aa]uthorization:[[:space:]]*[A-Za-z]|(sshpass|htpasswd|openssl passwd)[[:space:]]|curl[^|;&]*[[:space:]]-u[[:space:]]|mysql[a-z]*[^|;&]*[[:space:]]-p[^-[:space:]]|docker login[^|;&]*[[:space:]]-p|ssh-keygen[^|;&]*[[:space:]]-N[[:space:]]}"
+: "${WOSWOAR_IGNORE=(TOKEN|SECRET|PASSW|CREDENTIAL|APIKEY|_KEY|_PASS|_AUTH)[A-Za-z0-9_]*=|--([a-z]+-)*((passw|token|secret|credential)[a-z-]*|api-?key|access-?key|auth)([=[:space:]]|\$)|--from-literal=|://[^/[:space:]]+:[^/@[:space:]]+@|://(hooks\.slack\.com|discord(app)?\.com/api/webhooks)/[^[:space:]]|[Aa]uthorization:[[:space:]]*[A-Za-z]|(sshpass|htpasswd|openssl passwd)[[:space:]]|curl[^|;&]*[[:space:]]-u[[:space:]]|mysql[a-z]*[^|;&]*[[:space:]]-p[^-[:space:]]|docker login[^|;&]*[[:space:]]-p|ssh-keygen[^|;&]*[[:space:]]-N[[:space:]]}"
+
+# The webhook alternative above measured +7.4us per command, 58.3us to 65.7us
+# for the test itself against a record path of ~306us. Paid because the URL *is*
+# the credential -- anyone holding it can post as that integration -- and because
+# the hook is what protects commands typed from now on; `import` only covers what
+# is already recorded. Sharing the `://` prefix with the rule before it measured
+# no faster and reads worse, so the two stay separate.
 
 # Appended, not merged into the default above, so that adding one rule of your
 # own does not pin you to today's default forever. Overriding `WOSWOAR_IGNORE`


### PR DESCRIPTION
Measured the credential filter against a real corpus — the last piece before a
release — and closed the one gap it found.

## The measurement

One maintainer's atuin history, read through woswoar's own importer:

| | |
|---|---|
| commands | **55,017** |
| skipped as credential-shaped | 34 (0.06%) |
| commands carrying an unambiguous vendor token | 15 |
| caught, before this change | 13 |
| **false negatives, before** | **2** |
| **false negatives, after** | **0** |

The independent net was deliberately not the rules under test: vendor token
shapes that are unambiguous on sight, so anything it flagged and woswoar did not
is a miss rather than a matter of taste. Also checked and not missed, zero each:
`Bearer <token>`, private-key blocks, and `--token=/--key=/--secret=<value>`.

## The gap: a credential that *is* the URL

woswoar caught `://user:pass@host`, but a webhook address carries its token as a
path component — no `user:pass`, no `--password`, no `Authorization:` header.
Anyone holding the URL can fire that integration.

**My first pattern was still wrong, and only the real history showed it.** I
anchored on `hooks.slack.com/services/`, the incoming-webhook shape that comes to
mind. The one that actually appears is `hooks.slack.com/triggers/…`, a workflow
trigger. So the rule names the host, not a path under it, and both shapes are in
the corpus. A curated example would have enshrined my guess.

## Cost, measured because it is on the prompt path

**58.3 µs → 65.7 µs** per test, +7.4 µs per command against a record path of
~306 µs — 2.4%. Sharing the `://` prefix with the neighbouring rule was no faster
and read worse, so the two stay separate. Pattern length 455 → 523.

`tests/credential_shapes.py` is shared by the Python filter and the bash hook, so
adding the shape there forced both — which is the point: `import` covers history
already recorded, the hook protects what you type tomorrow.

## Two things worth knowing

**GitHub's push protection rejected the first version of this branch** — my *test
fixtures* looked like real webhooks, because a 24-character token after
`/services/` is exactly its Slack rule. A corpus of credential examples is a file
full of things that look like credentials. The fixtures are now too short and too
obviously fake to match any vendor shape, which costs nothing: woswoar's rule
needs only the host and one character of path. That reasoning is in the file.

**`as_posix_ere` in the parity test learned `\S`**, since the shared rules now use
it.

## What this does and does not establish

One history is not a survey, and 15 vendor-token commands is a thin sample. What
it says is that a corpus of 34 curated shapes held up against 55,017 commands it
had never seen, missing one class. `docs/security.md` carries the number with
that caveat and points readers at `woswoar import --dry-run` for their own.

## Reviewed as the middle row

Per #92: no stored data changes shape. It moves a security claim, so the
measurement *is* the review — run before and after on real data, with the cost
measured too. Three mutations, each caught, including the narrow-anchor mistake:

```
caught  the importer stops catching webhooks
caught  the hook stops catching webhooks
caught  anchored on /services/ again, missing the real shape
```
