### PR TITLE
release: 0.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,31 +147,34 @@ single largest waste of a session so far, twice over.
 Not after. Undoing a commit that landed on `main` means branching at `HEAD` and
 then `git reset --hard origin/main` — the operation rule 6 is about.
 
-## 8. Write no migration code: nothing is deployed yet
+## 8. There is a user now: changing a format means moving what exists
 
-woswoar has no users. Nobody has installed it, so there is no history in the
-field and no repository built by an older version.
+woswoar is installed and recording. Until v0.2.0 this rule said the opposite —
+change any format outright, write no upgrade path — because nothing was
+deployed. It said to delete itself the moment someone installed, rather than
+reason about who might be affected. This is that deletion.
 
-Change the record format, the repo layout, `state.json`, the cache, the day-key
-scheme — outright. Do **not** write an upgrade path, a version field two code
-paths branch on, an "if this is the old shape" fallback, or a deprecation
-period. A clean cut is the norm here, not something to argue for.
+So: a change to the record format, the repo layout, `state.json`, the cache or
+the day-key scheme now needs a way for an existing installation to arrive at the
+new shape. Not necessarily *code* — a one-line note in the release saying
+"delete the cache, it rebuilds" is an upgrade path, and a good one where the
+thing is derived. What is no longer acceptable is a change that leaves a running
+machine silently wrong.
 
-Two things this does not license:
+The distinction that decides how much care a change needs:
 
-- **Say so in the PR body, with the rebuild command**, in case the maintainer's
-  own machine is on the old shape:
-  `rm -rf ~/.local/share/woswoar/history ~/.local/share/woswoar/state.json`,
-  then `woswoar init <url>` and `woswoar grant`.
-- `logs/` is the plaintext history and the primary copy; `history/` is derived
-  from it and can always be rebuilt. Discarding the derived tree is cheap;
-  discarding `logs/` loses data. That distinction outlives this rule.
+- `logs/` is the plaintext history and the **primary copy**. Losing it loses
+  data. Nothing may require it to be discarded.
+- `history/` is the encrypted git tree, derived from `logs/` and rebuildable.
+  `cache.txt` likewise. Telling someone to delete either is cheap.
+- `state.json` is progress, not history: losing it costs a re-merge and a
+  re-export, never a command. Fields there may be added freely, and `State.load`
+  already degrades an unreadable value to a safe default — that is the pattern
+  to follow rather than a version field two code paths branch on.
 
-**This expires the moment woswoar is published and someone installs it.** Delete
-the rule then, rather than reasoning about who might be affected. Both errors
-cost: assuming a user base that does not exist wastes work — issue #54 was filed
-at P1 and closed for exactly that — and assuming forever that there is none
-corrupts somebody's history.
+Nothing in the repo records which version wrote it, so a change to the *repo*
+format has no marker to hang an upgrade on. That is worth fixing before the
+first such change, not during one.
 
 ## Repository conventions worth matching
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ one machine.
 > **The same line upgrades an existing install** — run it again whenever you want
 > the latest release. `stable` tracks the most recent tag, so the command never
 > changes and you never edit a version number on five machines. Swap `@stable`
-> for `@main` to track the tip, or `@v0.1.0` to pin exactly.
+> for `@main` to track the tip, or `@v0.2.0` to pin exactly.
 
 **Needs:** bash 5.0+ (Linux) · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) ·

--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
Cuts v0.2.0, and retires rule 8 because you are about to install it.

## The version bump

41 commits since v0.1.0. `woswoar/__init__.py` and the README's pin example; the
release workflow does everything after the tag.

Minor rather than patch, and not 1.0. Nothing in the *repo* format changed, so
existing clones stay readable — but `state.json` gained fields, `grant` and
`sync` say different things, and `doctor` grew a check. 1.0 would promise format
stability the design has not earned yet: this session alone changed `state.json`
three times.

## Rule 8 deletes itself here

It said:

> **This expires the moment woswoar is published and someone installs it.**
> Delete the rule then, rather than reasoning about who might be affected.

You are the someone. So the rule is replaced by what now holds: a format change
needs a way for an existing installation to reach the new shape. Not necessarily
code — "delete the cache, it rebuilds" is an upgrade path, and a good one for
something derived. What is no longer acceptable is a change that leaves a running
machine silently wrong.

The new text keeps the distinction that outlives the rule, because it is the one
that decides how much care a change needs:

- **`logs/` is the primary copy.** Losing it loses data. Nothing may require
  discarding it.
- **`history/` and `cache.txt` are derived** and rebuildable. Telling someone to
  delete either is cheap.
- **`state.json` is progress, not history.** Losing it costs a re-merge, never a
  command. `State.load` already degrades an unreadable value to a safe default,
  which is the pattern to follow rather than a version field two code paths
  branch on.

## What I would fix before the first repo-format change

**Nothing in the repo records which version wrote it.** `state.json` is
forgiving by design, but the encrypted tree — chunk layout, manifest body, the
`woswoar-manifest-v1` namespace — has no marker to hang an upgrade on. Today
that costs nothing, because every format is the only one that has existed. The
first time it matters will be the worst time to discover it.

I have not filed it as an issue on the reasoning that the backlog is empty and
this is a decision rather than a defect; say the word and I will, at P2.

## What is in 0.2.0

Two silent history-loss bugs fixed, both found by adversarial review of changes
that looked right:

- a rewrite that could read only some of a day's chunks replaced the day with
  the part it got — a five-command day became one line, permanently (#89)
- pruning what a peer remembers broke rollback recovery, writing a day's lines
  twice (#91)

The one-minute timer got roughly 6x cheaper at 20k chunks — 85 ms to about
14 ms — and stopped growing with the size of the history (#50, #73, #80, #82,
#85). `grant` no longer re-seals what is already sealed (#95). A remote can no
longer be an option to git (#96). `doctor` reports chunks in no signed manifest
(#97). And the credential filter gained the one shape it missed against 55,017
commands of real history (#99).
