### PR TITLE
history repo README, uninstall instructions, and the public-repo question

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,53 @@ truthful. Re-running an import is idempotent.
 | `WOSWOAR_SCOPE` | default scope for <kbd>Ctrl</kbd>+<kbd>R</kbd> (default `global`) |
 | `WOSWOAR_NO_BIND` | set to skip binding <kbd>Ctrl</kbd>+<kbd>R</kbd> |
 
+## Uninstalling
+
+There is no `woswoar uninstall`, because every step is one you should see. In
+order, and each is independent:
+
+```sh
+# 1. Stop the timer, if you installed one.
+systemctl --user disable --now woswoar-sync.timer
+rm -f ~/.config/systemd/user/woswoar-sync.{service,timer}
+
+# 2. Remove the hook from your shell. `woswoar install` wrote a marked block;
+#    delete the three lines between the markers, or:
+sed -i '/# >>> woswoar >>>/,/# <<< woswoar <<</d' ~/.bashrc
+
+# 3. Remove the program.
+pipx uninstall woswoar
+
+# 4. Remove its data. THIS DELETES YOUR RECORDED HISTORY -- see below first.
+rm -rf ~/.local/share/woswoar ~/.config/woswoar ~/.cache/woswoar
+```
+
+Open a new shell afterwards; the current one still has the hook loaded.
+
+### Before you run step 4
+
+`~/.local/share/woswoar/logs/` is the **only** plaintext copy of what this
+machine recorded. `history/` beside it is the encrypted git checkout, and
+`~/.config/woswoar/` holds this machine's identity and its signing key.
+
+- **Keeping the history?** Copy `logs/` somewhere first. It is TSV, one command
+  per line, readable without woswoar.
+- **Other machines still syncing?** Deleting local files does not remove this
+  machine from the shared repository, and it does not stop peers accepting what
+  it published. Run `woswoar revoke <fingerprint>` from **another** machine,
+  otherwise its key stays in `recipients.txt` as a machine that can still read
+  everything. `woswoar grant` on that other machine lists every enrolled
+  machine by fingerprint and name, which is where that value comes from — it
+  asks before changing anything, and does nothing at all if nothing is new.
+- **Reinstalling later?** Deleting `~/.config/woswoar/` discards the identity.
+  The machine can rejoin with `woswoar init <url>`, but it enrols as a *new*
+  machine: someone must run `woswoar grant` again, and every other machine must
+  `woswoar trust` it. Keep that directory if you only meant to move the data.
+
+The remote repository is untouched by all of this. Delete it separately if you
+want it gone, remembering that other machines still hold their own copies of
+everything in it.
+
 ## How it works
 
 ```

--- a/docs/security.md
+++ b/docs/security.md
@@ -268,6 +268,68 @@ sense. Dropping `grant` entirely would be perfectly safe — a new machine would
 simply never read history recorded before it enrolled. What is unsafe is keeping
 the capability and removing the person.
 
+## 🌐 Can I use a public repository?
+
+You can, and the encryption holds — a public repository is still a pile of
+unreadable blobs, and because "public" on a git host means *readable*, not
+writable, push access is unchanged and so is everything the signatures
+guarantee.
+
+**Use a private one anyway.** Three things change, and two of them cannot be
+undone afterwards.
+
+### Your SSH public key names you
+
+By default the recipient woswoar enrols is your existing **SSH public key** —
+preferred because it means no new secret exists to lose. GitHub publishes every
+user's SSH public keys at `github.com/<username>.keys`, and GitLab does the
+same. So a public history repository can be matched to your account, and to
+every other place that key is used, by anyone who cares to look.
+
+The opaque host directories exist so that an archive does not publish which
+machines you have. This would hand over who you are instead.
+
+`woswoar init --new-identity` avoids it: a dedicated age key that exists nowhere
+else, and is therefore not a handle to anything.
+
+### Harvest now, decrypt later
+
+Against a private repository an attacker needs access **and** a key. Public
+removes the first requirement permanently and retroactively: anyone can take a
+copy today and keep it. If a key is ever compromised, or age's primitives are
+ever broken, everything published becomes readable back to the first commit.
+
+And there is no taking it back. Forks, mirrors and archives mean "I will make it
+private later" does not undo a day of it being public.
+
+### The metadata becomes a continuous public record
+
+Encryption covers file contents. It does not cover file *names*, and those carry:
+
+```
+hosts/6941894815e14751/2023-11-14/1700000500-f400be.age
+                       ^ which days   ^ the sync time, to the second
+```
+
+Which days you worked, how many chunks each day, and the second at which every
+sync ran — plus a commit timestamp beside it. Over months that is working hours,
+timezone, sleep, and holidays, published continuously. *What is not protected*
+below already lists metadata as something the design does not hide; a public
+repository turns it from *what a leak would reveal* into *a feed*.
+
+### And one that compounds
+
+The credential filter is best-effort by design, and says so. In a private
+repository a command that slips past it still has both encryption and access
+control in front of it. Public removes one of those, and combines with
+harvest-now-decrypt-later above.
+
+### If you want a public one anyway
+
+For a demonstration repository — showing what the format looks like, say — use a
+throwaway with `--new-identity` and history you do not mind publishing. That is
+a different thing from syncing the machines you actually work on.
+
 ## 📦 Minimal supply chain
 
 No on-disk format woswoar reads can execute code. The parse cache under

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2537,6 +2537,48 @@ class TestADecompressionBomb(SyncTestCase):
         self.assertEqual(len({e.cmd for e in entries}), before)
 
 
+class TestTheRepoExplainsItself(SyncTestCase):
+    """A history repository is opaque by design, which makes it unreadable in
+    the other sense too: a stranger who finds it, or its owner three years on,
+    sees directories of random hex and encrypted blobs and no way to tell what
+    it is or what touching it would break."""
+
+    def test_init_commits_a_readme(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            committed = sync.git("ls-files").splitlines()
+            self.assertIn(store.README, committed, "the README was not committed")
+            text = (store.history_dir() / store.README).read_text(encoding="utf-8")
+        self.assertIn("github.com/martinus/woswoar", text, "no link to the project")
+        self.assertIn("Do not edit", text)
+
+    def test_a_peer_receives_it(self) -> None:
+        """It is in the repo, so it arrives with the clone rather than per machine."""
+        self.machine("alpha")
+        beta = self.machine("beta")
+        with beta.active():
+            self.assertTrue((store.history_dir() / store.README).is_file())
+
+    def test_it_is_written_once_and_then_left_alone(self) -> None:
+        """A machine on another version must not rewrite a peer's wording.
+
+        `.gitattributes` *is* compared and rewritten, because `merge=union` on
+        `recipients.txt` is what keeps two machines enrolling at once
+        conflict-free. Prose earns no such thing: rewriting it would mean two
+        versions putting it back at each other every time anyone ran `init`.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            readme = store.history_dir() / store.README
+            readme.write_text("written by another version\n", encoding="utf-8")
+            sync._commit()
+
+            # `init` again is the path that could rewrite it -- `sync` never
+            # touches repo metadata at all.
+            sync.initialise(remote=str(self.origin))
+            self.assertEqual(readme.read_text(encoding="utf-8"), "written by another version\n")
+
+
 class TestRecipientsPublishNoNames(SyncTestCase):
     """#22: the one plaintext file in the repo named every machine.
 
@@ -2626,7 +2668,12 @@ class TestRecipientsPublishNoNames(SyncTestCase):
         `docs/security.md` says the repo does not publish machine names. This is
         what makes that a guarantee instead of a sentence.
         """
-        alpha = self.machine("alpha", display="martinus@secret-box")
+        # A user name that cannot occur in the repo for any other reason. The
+        # earlier fixture used "martinus", which is also the owner of the
+        # project URL in `store.README_CONTENT` -- so this failed on a string
+        # that names no machine, and would have kept failing for every user
+        # whose account happens to match a word in a committed file.
+        alpha = self.machine("alpha", display="zqoperator@secret-box")
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "git status")
             sync.run()
@@ -2638,7 +2685,14 @@ class TestRecipientsPublishNoNames(SyncTestCase):
                 path.read_bytes() for path in store.history_dir().rglob("*") if path.is_file()
             )
         self.assertNotIn(b"secret-box", committed)
-        self.assertNotIn(b"martinus", committed)
+        self.assertNotIn(b"zqoperator", committed)
+
+        # And the one plaintext file a machine name could most easily creep
+        # into is exactly what the constant says, so nothing can ever be
+        # interpolated into it.
+        with alpha.active():
+            readme = (store.history_dir() / store.README).read_text(encoding="utf-8")
+        self.assertEqual(readme, store.README_CONTENT)
 
     def test_no_name_is_written_into_recipients_at_all(self) -> None:
         """#22: the label used to be `$USER@$(uname -n)`, in cleartext.

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -32,6 +32,39 @@ _NAME_FILE = ".name"
 
 RECIPIENTS = "recipients.txt"
 GITATTRIBUTES = ".gitattributes"
+README = "README.md"
+
+#: What a stranger finding the repository sees first, and what its owner sees in
+#: three years having forgotten what it was. Deliberately says nothing about
+#: whose it is: the host directories are opaque hex precisely so the archive does
+#: not name machines, and a README that undid that would be worse than none.
+#:
+#: Written only when absent, unlike `.gitattributes`, which is compared and
+#: rewritten to match. Both are written by `init` rather than by `sync`, so the
+#: cost of getting this wrong is bounded -- but a machine on a newer version
+#: would still rewrite a peer's wording the next time anyone ran `init`, and the
+#: older one would put it back. `.gitattributes` earns that because its content
+#: is load-bearing: `merge=union` on `recipients.txt` is what makes two machines
+#: enrolling at once conflict-free. Prose does not.
+README_CONTENT = """# woswoar history
+
+Encrypted shell history, written by [woswoar](https://github.com/martinus/woswoar).
+
+Every `.age` file here is ciphertext. There is nothing readable in this
+repository, including the directory names -- they are random hex so that an
+archive of it does not publish which machines exist.
+
+## Do not edit this by hand
+
+Chunks are written once and never rewritten, and each machine signs a list of
+what it published each day. A file that no signed list accounts for is refused
+by every other machine and reported. Editing or deleting one here does not
+remove history -- other machines keep their own copies -- and will make them
+report the repository as tampered with.
+
+To take a machine's access away, run `woswoar revoke` from another one. To see
+what state this repository is in, run `woswoar doctor`.
+"""
 
 #: `recipients.txt` is the one file every machine appends to, so it is also the
 #: only place a merge conflict could arise. A union merge resolves it: the file

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -2164,6 +2164,13 @@ def _write_repo_metadata(known: Machine, identity: Path) -> bool:
         store.write_atomic(attrs, store.GITATTRIBUTES_CONTENT.encode("utf-8"))
         changed = True
 
+    # Only when absent -- see `store.README_CONTENT` for why it is not compared
+    # and rewritten the way `.gitattributes` is.
+    readme = store.history_dir() / store.README
+    if not readme.is_file():
+        store.write_atomic(readme, store.README_CONTENT.encode("utf-8"))
+        changed = True
+
     recipient = crypto.recipient_for(identity).strip()
     if add_recipient(recipient):
         changed = True


### PR DESCRIPTION
Three things you asked for. Two are documentation; the first is a small change to
what `init` commits.

## A README in the history repository

A history repo is opaque by design — directories of random hex and encrypted
blobs — which makes it unreadable in the other sense too. `init` now commits a
`README.md` saying what it is, linking to this project, and warning that editing
files by hand does not remove history but does make every other machine report
the repository as tampered with.

It says nothing about *whose* it is. The opaque host directories exist precisely
so an archive does not name machines, and a README that undid that would be worse
than none — so the file is a constant, and a test asserts the committed bytes
equal that constant exactly, which is what stops anyone later interpolating a
machine name into it.

**Written only when absent**, unlike `.gitattributes`, which is compared and
rewritten. That one earns it: `merge=union` on `recipients.txt` is what keeps two
machines enrolling at once conflict-free. Prose does not — two versions would
otherwise put their wording back at each other.

## An uninstall section in the README

Four steps, each independent and each one you should see: the systemd timer, the
marked block in `~/.bashrc`, `pipx uninstall`, and the data directories. Then
what to know *before* the last one:

- `logs/` is the only plaintext copy of what this machine recorded — copy it
  first if you want it. It is TSV, readable without woswoar.
- Deleting local files does not remove the machine from the shared repository.
  `woswoar revoke` from another machine is what does that, otherwise its key
  stays in `recipients.txt` as something that can still read everything.
- Deleting `~/.config/woswoar/` discards the identity, so rejoining enrols a
  *new* machine needing `grant` and `trust` again. Keep it if you only meant to
  move the data.

## "Can I use a public repository?" in the security document

Short answer in the document: you can, the encryption holds, use a private one
anyway. Three reasons, two irreversible:

**Your SSH public key names you.** The default recipient is your existing SSH
key, and GitHub publishes every user's at `github.com/<username>.keys`. A public
history repo is therefore matchable to your account and to everywhere else that
key is used — the opaque directories avoid publishing which machines you have,
and this would hand over who you are instead. `--new-identity` avoids it.

**Harvest now, decrypt later.** Private needs access *and* a key; public removes
the first requirement permanently and retroactively, and forks and archives mean
going private later does not undo it.

**The metadata becomes a feed.** Filenames carry which days you worked and the
second each sync ran; over months that is working hours, timezone and holidays,
published continuously.

## Two corrections I made to my own work while checking it

**A claim in the uninstall section was wrong.** I wrote that `woswoar doctor`
prints the fingerprint you need for `revoke`. It prints the *signing* key's
fingerprint; `revoke` matches the *recipient* fingerprint. Ran both commands
rather than trusting the grep. The text now points at `woswoar grant`, which
lists every machine by recipient fingerprint and name.

**The "written once" rationale overstated the hazard**, and the mutation run
caught it: I claimed a rewrite would mean a commit on every sync, but
`_write_repo_metadata` is only reached from `init`. The comment and the test now
describe the real path, and the test drives `init` rather than `sync`.

Also: `TestRecipientsPublishNoNames` used the fixture name `martinus@secret-box`,
which collides with the owner of the project URL now committed in the README. The
fixture is a name that cannot occur for any other reason, so the guarantee is
tested rather than a coincidence.

## Reviewed as the middle row

Per #92: this changes what `init` writes into the repository, so I checked what a
stranger with read access actually sees — the committed file list, the plaintext
of `recipients.txt`, and the commit log — before writing a word of the security
section. Three mutations, each caught.
