### PR TITLE
init: leave nothing another account can read

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -51,6 +51,24 @@ def run_cli(*argv: str) -> Ran:
     return Ran(code, out.getvalue(), err.getvalue())
 
 
+def loose_paths() -> list[str]:
+    """Paths another account could read, walked independently of the code.
+
+    Deliberately not `store.readable_by_others()`: asking the helper about
+    itself could not catch it forgetting a path, which is the failure this
+    guards against. `history/` is excluded -- it is ciphertext arriving from
+    `git clone`, and the directory above it is owner-only.
+    """
+    roots = [store.data_dir(), store.config_dir(), store.cache_dir()]
+    seen = [r for r in roots if r.is_dir()]
+    seen += [p for r in list(seen) for p in r.rglob("*")]
+    return sorted(
+        f"{p} is {oct(p.stat().st_mode & 0o777)}"
+        for p in seen
+        if p.stat().st_mode & 0o077 and store.history_dir() not in [p, *p.parents]
+    )
+
+
 def make_entry(ts: int, cmd: str, host: str = MACHINE_ID, session: str = "s1") -> Entry:
     """An Entry with plausible defaults, so fixture fields live in one place."""
     return Entry(ts=ts, host=host, session=session, cwd="/tmp", exit_code=0, duration_ms=1, cmd=cmd)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -7,6 +7,7 @@ the incident that established it.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import tempfile
 import unittest
@@ -192,6 +193,37 @@ NS = "woswoar-test"
 
 
 @requires_ssh_keygen
+@requires_ssh_keygen
+class TestTheSigningKeyIsOwnerOnly(unittest.TestCase):
+    """`generate_signing_key` creates two files and a directory, so it owns the
+    modes of all three -- rather than depending on some earlier caller having
+    made the directory, which is what made this worth pinning."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        previous = os.umask(0o022)
+        self.addCleanup(os.umask, previous)
+
+    def test_it_creates_its_directory_owner_only(self) -> None:
+        """The directory does not exist here, which is the case that was never
+        reached in practice: every caller happens to make it first. Depending on
+        that is the fragile part."""
+        key = Path(self._tmp.name) / "fresh" / "signing_key"
+        crypto.generate_signing_key(key)
+        self.assertEqual(key.parent.stat().st_mode & 0o777, 0o700)
+
+    def test_both_halves_are_owner_only(self) -> None:
+        """A public key exposes nothing. What a loose one breaks is the
+        guarantee that every path woswoar creates is owner-only, which `doctor`
+        enforces by walking them -- so it reported a failure on the first run of
+        a fresh machine, about a file woswoar had just written."""
+        key = Path(self._tmp.name) / "signing_key"
+        crypto.generate_signing_key(key)
+        for half in (key, crypto.public_half(key)):
+            self.assertEqual(half.stat().st_mode & 0o777, 0o600, f"{half} is loose")
+
+
 class TestSigning(unittest.TestCase):
     """Authorship, which age cannot answer and a shared secret cannot either."""
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -118,22 +118,6 @@ class TestPrivateByDefault(WoswoarTestCase):
     downgrade on any box with a group- or world-readable home.
     """
 
-    def loose(self) -> list[str]:
-        """Paths another account could read, walked independently of the code.
-
-        Deliberately not `store.readable_by_others()`: asking the helper about
-        itself could not catch it forgetting a path, which is the failure this
-        is guarding against.
-        """
-        roots = [store.data_dir(), store.config_dir(), store.cache_dir()]
-        seen = [r for r in roots if r.is_dir()]
-        seen += [p for r in list(seen) for p in r.rglob("*")]
-        return sorted(
-            f"{p} is {oct(p.stat().st_mode & 0o777)}"
-            for p in seen
-            if p.stat().st_mode & 0o077 and store.history_dir() not in [p, *p.parents]
-        )
-
     def as_if_never_installed(self) -> None:
         """Drop the config directory the shared harness pre-creates.
 
@@ -156,16 +140,16 @@ class TestPrivateByDefault(WoswoarTestCase):
         previous = os.umask(0o022)
         self.addCleanup(os.umask, previous)
         self.first_run()
-        self.assertEqual(self.loose(), [])
+        self.assertEqual(support.loose_paths(), [])
 
     def test_an_older_install_is_retightened(self) -> None:
         self.first_run()
         for path in (store.data_dir(), store.logs_dir(), *store.logs_dir().rglob("*")):
             path.chmod(0o755 if path.is_dir() else 0o644)
-        self.assertTrue(self.loose(), "the fixture is not actually loose")
+        self.assertTrue(support.loose_paths(), "the fixture is not actually loose")
 
         store.harden()
-        self.assertEqual(self.loose(), [])
+        self.assertEqual(support.loose_paths(), [])
 
     def test_creating_a_file_does_not_repermission_a_directory_it_found(self) -> None:
         """`write_atomic` is a durability primitive, not a permissions one.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2537,6 +2537,49 @@ class TestADecompressionBomb(SyncTestCase):
         self.assertEqual(len({e.cmd for e in entries}), before)
 
 
+class TestInitLeavesNothingReadable(SyncTestCase):
+    """The first thing a new machine does must not fail its own check.
+
+    `woswoar install` walks these paths and re-tightens them, and `doctor`
+    reports any that another account could read. But `init` can run first, and
+    it creates the signing key -- so before this, the very first `doctor` on a
+    fresh machine said `[FAIL] private` about a file woswoar had just written,
+    with the user having done nothing wrong.
+    """
+
+    def test_a_stock_umask_cannot_loosen_what_init_writes(self) -> None:
+        # 022 is the default nearly everywhere, and is what left the public half
+        # 0644: ssh-keygen honours it. Pinned rather than inherited, so this
+        # cannot pass vacuously on a strict runner.
+        previous = os.umask(0o022)
+        self.addCleanup(os.umask, previous)
+
+        alpha = self.machine("alpha")
+        with alpha.active():
+            # The harness makes WOSWOAR_DIR with a plain mkdir, so it arrives
+            # 0755. A real one is created by woswoar at 0700 -- and a directory
+            # woswoar *found* is deliberately not re-permissioned, since a
+            # user-chosen WOSWOAR_DIR is not its to clamp. Set it to what a real
+            # install has, so what is asserted below is what woswoar wrote.
+            store.data_dir().chmod(0o700)
+
+            self.assertEqual(support.loose_paths(), [])
+            # And the helper the code uses agrees, which is what `doctor` reads.
+            self.assertEqual(store.readable_by_others(), [])
+
+    def test_the_signing_key_is_owner_only_on_both_halves(self) -> None:
+        """A public key exposes nothing; the guarantee is what it would break."""
+        previous = os.umask(0o022)
+        self.addCleanup(os.umask, previous)
+
+        alpha = self.machine("alpha")
+        with alpha.active():
+            private = store.signing_key_file()
+            for half in (private, crypto.public_half(private)):
+                self.assertTrue(half.is_file(), half)
+                self.assertEqual(half.stat().st_mode & 0o777, 0o600, f"{half} is loose")
+
+
 class TestTheRepoExplainsItself(SyncTestCase):
     """A history repository is opaque by design, which makes it unreadable in
     the other sense too: a stranger who finds it, or its owner three years on,

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -325,12 +325,26 @@ def generate_signing_key(path: Path) -> str:
     useful copy of, because nobody else ever needed it to verify.
     """
     require_signing()
-    path.parent.mkdir(parents=True, exist_ok=True)
+    # 0700 on the leaf. This module deliberately does not import `store`, so
+    # `private_dir` is out of reach -- but the directory it makes here is
+    # woswoar's own, and inheriting a 022 umask would leave it 0755.
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     # ssh-keygen refuses to overwrite, and would prompt about it on a terminal.
     path.unlink(missing_ok=True)
     public_half(path).unlink(missing_ok=True)
     _run_signer([SSH_KEYGEN, "-t", "ed25519", "-N", "", "-C", "woswoar", "-q", "-f", str(path)])
+    # Both halves, not just the secret one. ssh-keygen writes the private key
+    # 0600 and the public key at the umask -- 0644 on a stock install. Nothing
+    # is exposed by a public key being readable; what breaks is the guarantee
+    # that *every* path woswoar creates is owner-only, which `doctor` enforces
+    # by walking them. It reported `[FAIL] private` on the first run of a fresh
+    # machine, before the user had done anything wrong.
+    # The private half is belt and braces: ssh-keygen writes a private key 0600
+    # whatever the umask, so removing this line changes nothing observable and
+    # no test can catch it. Kept anyway, because the mode of a file woswoar
+    # creates should not depend on another tool's habits.
     path.chmod(0o600)
+    public_half(path).chmod(0o600)
     return signing_public(path)
 
 


### PR DESCRIPTION
`woswoar init` on a fresh machine, followed by `woswoar doctor`:

```
[FAIL] private      1 path(s) other users can read, e.g. .../signing_key.pub
                    - run 'woswoar install' to fix
```

The first thing a new user sees after setting up is a failure, about a file
woswoar had just written, with nothing done wrong.

## The cause was an asymmetry

`generate_signing_key` creates two files and chmodded one of them. `ssh-keygen`
writes the private key `0600` and the public key at the umask — `0644` on a
stock install.

Nothing is *exposed* by a public key being readable. What it breaks is the
guarantee `doctor` enforces by walking every path: **everything woswoar creates
is owner-only**. `install` re-tightens it, but `init` can run first, and does.

Both halves are chmodded now, and the directory is created `0700` rather than at
the umask. `crypto` deliberately does not import `store`, so `private_dir` is out
of reach there — the mode goes on the `mkdir` instead, with a note saying why.

## Why the existing owner-only test did not catch it

`test_a_stock_umask_cannot_loosen_what_is_written` walks every path
independently — but its fixture is `save_machine` + `append_entries`, which never
creates a signing key. The `init` path had no such test at all.

There is one now, and the walk moved to `tests/support.py` so both hold to the
same rule rather than one having its own copy. Plus a direct test of
`generate_signing_key`, which matters more than it looks: the directory mode was
**never reachable in practice**, because every caller happens to create the
directory first. Depending on that is the fragile part, and testing the function
directly is what pins it.

## One mutation survives, deliberately

```
caught     the public half is left at the umask, as before
caught     the config directory inherits the umask
SURVIVED   the private half is left at the umask too
```

That last one cannot be caught: `ssh-keygen` writes a private key `0600`
whatever the umask, so deleting the line changes nothing observable. It stays,
with a comment saying exactly that — the mode of a file woswoar creates should
not depend on another tool's habits, and the next reader should not spend the
mutation run I just spent discovering why no test covers it.

## A fixture correction

The new test found `WOSWOAR_DIR` itself at `0755` — the harness makes it with a
plain `mkdir`. That is *correct* to leave alone: a directory woswoar found is
deliberately not re-permissioned, since a user-chosen `WOSWOAR_DIR` is not
woswoar's to clamp. The test sets it to what a real install has, so what it
asserts is what woswoar wrote rather than what the harness left.

## Reviewed as the middle row

Per #92: no stored data changes shape, but it moves a security claim from
"enforced after `install`" to "true from `init`". I reproduced the failure first
by running `init` and `doctor` in a sandbox, and confirmed the fix against both
the independent walk and `store.readable_by_others`, which is what `doctor`
reads.
