### PR TITLE
release: 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ one machine.
 > **The same line upgrades an existing install** — run it again whenever you want
 > the latest release. `stable` tracks the most recent tag, so the command never
 > changes and you never edit a version number on five machines. Swap `@stable`
-> for `@main` to track the tip, or `@v0.2.0` to pin exactly.
+> for `@main` to track the tip, or `@v0.3.0` to pin exactly.
 
 **Needs:** bash 5.0+ (Linux) · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) ·

--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
Cuts v0.3.0. Four commits since v0.2.0, all user-facing.

- **A README in the history repository** (#102). `init` commits one saying what
  the repository is, linking to this project, and warning that editing files by
  hand does not remove history but does make every other machine report the
  repository as tampered with. It names no machine, and a test pins the
  committed bytes to the constant so nothing can be interpolated into it later.
- **Uninstall instructions** (#102), and **"Can I use a public repository?"** in
  the security document — short answer: you can, the encryption holds, use a
  private one anyway, and the reason that matters most is that the default
  recipient is your SSH public key, which GitHub publishes at
  `github.com/<username>.keys`.
- **`grant` and `trust` explained side by side** (#101), which is the question
  that prompted it: they are on different axes and neither can absorb the other.
- **`init` leaves nothing another account can read** (#103). Running `init` then
  `doctor` on a fresh machine reported `[FAIL] private` about `signing_key.pub`,
  which `init` itself had just written `0644`. The first thing a new user saw
  after setting up was a failure they had not caused.

- **`init` no longer hardlinks the origin's git objects** (#105). Found by this
  very release PR failing CI on a version-string change: `git clone` of a *local
  path* links objects from the source, so a machine joining while others push to
  a shared bare repo fails with `fatal: hardlink different from source` — and a
  clone that succeeds shares object files with the origin, where a `git gc` on
  either side reaches the other. Rebased in rather than left to follow, so the
  release contains it.

Minor rather than patch: the repository gains a file it did not have.

## Upgrade path

Rule 8 now asks for one, so: **there is nothing to do.** No format changed, and
nothing on disk is read differently.

The one visible difference for a repository created under v0.2.0 is that it has
no `README.md`. It is written only when absent, so it appears the next time
anyone runs `woswoar init` against that repository — from any machine, including
one joining it. Nothing depends on it being there; it is for the human who finds
the repository later.

## A note on how #105 was found

I had closed that issue as not actionable, having failed to reproduce it in 50
runs on a quiet machine. The trigger is not load, which is what I assumed and
tested for; it is *another writer on the source repository*. The CI failure here
carried the error text that named the mechanism. Worth recording because the
negative result was real and still wrong.

## What is not in it

I recommended a shakedown before tagging — install, init against a throwaway
remote, record across a day boundary, add a second machine, grant, trust, sync,
compact, revoke, checking `doctor` at each step. That has not been run. Every
failure this session was found by driving the thing rather than reading it, and
the paths a first week exercises — a real timer, a real remote, a real clock —
are the ones the suite cannot reach. Worth doing before you rely on it, and I am
happy to run it after this lands.
