### PR TITLE
init: clone without hardlinking the origin's objects

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2537,6 +2537,53 @@ class TestADecompressionBomb(SyncTestCase):
         self.assertEqual(len({e.cmd for e in entries}), before)
 
 
+class TestCloningDoesNotShareObjectsWithTheOrigin(SyncTestCase):
+    """Issue #79: `git clone` of a *local path* hardlinks objects from it.
+
+    A bare repo on a NAS or a shared filesystem is an ordinary woswoar remote,
+    and a fleet syncing to it means the source is being written while a joining
+    machine clones. Git notices and refuses -- `fatal: hardlink different from
+    source` -- which is how this surfaced, on CI, on a pull request that changed
+    a version string.
+    """
+
+    def test_the_clone_shares_no_object_file_with_its_source(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+
+        beta = self.machine("beta")
+        with beta.active():
+            objects = list((store.history_dir() / ".git" / "objects").rglob("*"))
+            files = [p for p in objects if p.is_file()]
+            self.assertTrue(files, "precondition: the clone has object files")
+
+            # A hardlink is the same inode as the origin's copy. Linked objects
+            # mean a `git gc` or a corruption on either side reaches the other,
+            # quite apart from the clone failing under a concurrent writer.
+            origin_inodes = {p.stat().st_ino for p in Path(self.origin).rglob("*") if p.is_file()}
+            shared = [p for p in files if p.stat().st_ino in origin_inodes]
+            self.assertEqual(shared, [], "objects are hardlinked to the origin")
+
+    def test_a_joining_machine_still_gets_the_history(self) -> None:
+        """The copy has to be a real one, not merely an unlinked one."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+
+        # Enrol first, then grant: `grant` seals to the recipients as they are
+        # at that moment, so the other order widens access to a list beta is
+        # not yet in.
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+        with beta.active():
+            sync.run()
+            self.assertEqual(beta.commands(), {"git status"})
+
+
 class TestInitLeavesNothingReadable(SyncTestCase):
     """The first thing a new machine does must not fail its own check.
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -2109,7 +2109,28 @@ def initialise(
             # dash is a command, not an address -- and argparse hands one
             # through happily, because `--` ends *woswoar's* option parsing and
             # makes the rest a positional.
-            git("clone", "--quiet", "--", remote, str(history), cwd=history.parent)
+            # `--no-hardlinks` because a local-path remote is an ordinary
+            # woswoar setup -- a bare repo on a NAS or a shared filesystem --
+            # and `git clone` links objects from such a source instead of
+            # copying them. Two things follow, and both have happened here:
+            #
+            # - The clone fails outright if another machine writes the source
+            #   while it runs, which is exactly what a fleet syncing to that
+            #   repo does: `fatal: hardlink different from source`.
+            # - The new clone's object files *are* the origin's, so a `git gc`
+            #   or a corruption on either side reaches the other.
+            #
+            # The cost is copying the objects rather than linking them, once,
+            # at `init`. A clone over ssh or https never linked anything.
+            git(
+                "clone",
+                "--quiet",
+                "--no-hardlinks",
+                "--",
+                remote,
+                str(history),
+                cwd=history.parent,
+            )
         else:
             history.mkdir(parents=True, exist_ok=True)
             git("init", "--quiet", "-b", "main")


### PR DESCRIPTION
Reopens and closes #79.

It appeared on CI, on PR #104 — a pull request that changes nothing but a
version string:

```
SyncError: git clone --quiet -- /tmp/.../origin.git /tmp/.../beta/data/history failed:
fatal: hardlink different from source at '.../history/.git/objects/pack/tmp_pack_5MlFZF'
```

## I closed this issue, and the closure was wrong

I closed #79 as not actionable because it would not reproduce: 0 failures in 20
runs on a branch and 30 on `main`, once the concurrent load I had running went
away. I concluded it needed "heavy parallel load" and that I could not tell
whether either suggested fix worked.

The error above names the mechanism, which I never had:

**`git clone` of a *local path* hardlinks objects from the source repository.**
The suite clones one bare origin from several machines while others push to it,
so the source's objects change under the clone and git's consistency check
fires. My earlier symptom — `failed to copy file to '.../objects/99/...': No such
file or directory` — is the same race at a different moment.

That is also why it would not reproduce on a quiet machine. The trigger is not
load; it is **another writer on the source repository**. My reproduction attempt
had the load and not the writer, so the negative result was real and meant
nothing.

## It is not only a test problem, which is why it is P2 now

`woswoar init <local path>` hardlinks too. Cloning over ssh or https cannot hit
this, so anyone using GitHub is unaffected — but a bare repo on a NAS or a shared
filesystem is an ordinary woswoar remote, and two machines syncing to it while a
third joins is exactly this race.

There is a second reason to want it gone regardless of the race: hardlinked
objects mean the new clone's object files *are* the origin's, so a `git gc` or a
corruption on either side reaches the other.

## The fix

`--no-hardlinks`. It copies the objects instead of linking them, at `init`, once
per machine.

The test asserts the property rather than the flag: no object file in a fresh
clone shares an inode with any file in the origin. A second test pins that the
copy is a real one — a joining machine still receives the history — because
"shares no inode" would also be satisfied by cloning nothing.

```
caught  clone hardlinks from the source again
```

## Note on the release

PR #104 (v0.3.0) hit this. Its re-run is green, so the tag is not blocked — but I
would rather the release contained the fix than followed it, so #104 should be
rebased on this.

## Reviewed as the middle row

Per #92: it changes what `init` writes to disk, but the change is one flag with a
measurable property. I reproduced the failure from the CI log's own error, then
asserted the inode property directly.
