### PR TITLE
init: clone through the transport, and quiet git's own housekeeping in the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,11 @@ jobs:
           # build -- and it is a perfectly well-formed chunk. What the attacker
           # cannot do is get it into a manifest alpha signed.
           ATTACK="$BASE/attacker"
-          git clone --quiet "$BASE/origin.git" "$ATTACK"
+          # --no-local for the same reason `init` uses it: a local clone reads
+          # the origin's object store through a directory listing that nothing
+          # holds still. How the attacker got its copy is beside the point of
+          # this test, and a flake here would look like a security failure.
+          git clone --quiet --no-local "$BASE/origin.git" "$ATTACK"
           DAY_PUB=$(cat "$ATTACK/hosts/$ALPHA_ID/keys/2023-11-14.pub")
           printf '1700000009\ts1\t~\t0\t5\tforged-marker-command\n' \
             | python3 -c 'import sys; from woswoar import sync; sys.stdout.buffer.write(sync.pack(sys.stdin.buffer.read()))' \

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -35,6 +35,25 @@ from .support import requires_age, requires_git, requires_ssh_keygen
 #: One authoritative list, plus HOME which only these tests need to redirect.
 _ENV = (*support.ENV_KEYS, "HOME")
 
+#: `gc --auto` runs after a commit and after a push, and `gc.autoDetach` sends
+#: it to the background -- so it is still repacking while the *next* git command
+#: runs. A real installation wants exactly that. These tests want a repo that
+#: changes only when they change it, and every one of the five red mains before
+#: this came of not having one, in three different disguises:
+#:
+#: - a clone dying on a loose object the background prune had already removed,
+#:   twice, in two unrelated tests;
+#: - `git gc` in a test colliding with the repack already running there:
+#:   "failed to run repack", "could not find pack '.tmp-...'";
+#: - teardown finding the directory not empty, which `ignore_cleanup_errors`
+#:   did not absorb on 3.12.
+#:
+#: None of those is the hazard under test, and a suite that reddens somewhere
+#: new each time teaches people to re-run it rather than read it. What makes the
+#: *clone* safe is `--no-local`, which has its own test; this only stops git's
+#: housekeeping showing up as whichever test was unlucky.
+QUIET_MAINTENANCE = "[gc]\n\tauto = 0\n\tautoDetach = false\n[receive]\n\tautogc = false\n"
+
 
 class Fake:
     """One simulated machine with its own config, logs, and clone."""
@@ -45,6 +64,8 @@ class Fake:
         self._id: str | None = None
         for sub in ("data", "conf", "cache"):
             (self.root / sub).mkdir(parents=True, exist_ok=True)
+        # This machine's HOME, so its clone inherits it.
+        (self.root / ".gitconfig").write_text(QUIET_MAINTENANCE, encoding="utf-8")
 
     @property
     def env(self) -> dict[str, str]:
@@ -136,20 +157,17 @@ class Fake:
 @requires_git
 class SyncTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        # `ignore_cleanup_errors` because git may still be finishing
-        # background maintenance in the repo when the directory goes: it
-        # creates a file under `.git` between the walk and the rmdir, and
-        # `rmtree` fails with "Directory not empty". Measured at about one
-        # run in forty, on this change and on main alike, so it is a
-        # teardown race rather than anything under test -- and a suite that
-        # reddens at random teaches people to re-run it rather than read it.
         # `ignore_cleanup_errors` because git may still be finishing background
         # maintenance in the repo when the directory goes: it creates a file
         # under `.git` between the walk and the rmdir, and `rmtree` fails with
         # "Directory not empty". Measured at about one run in forty, on this
         # branch and on main alike, so it is a teardown race rather than
         # anything under test -- and a suite that reddens at random teaches
-        # people to re-run it rather than read it.
+        # people to re-run it rather than read it. It did not always absorb it:
+        # main went red on 3.12 with "Directory not empty" here regardless.
+        # QUIET_MAINTENANCE removes the writer that loses the race, which is the
+        # better fix; the tolerance stays because it costs nothing and proving
+        # the absence of a one-in-forty event does not.
         self._tmp = tempfile.TemporaryDirectory(prefix="woswoar-sync-", ignore_cleanup_errors=True)
         self.addCleanup(self._tmp.cleanup)
         self.root = Path(self._tmp.name)
@@ -157,6 +175,13 @@ class SyncTestCase(unittest.TestCase):
         self.origin = self.root / "origin.git"
         subprocess.run(
             ["git", "init", "--quiet", "--bare", str(self.origin)], check=True, timeout=60
+        )
+        # In the repo itself, not just in a HOME: a push's `receive-pack` runs
+        # here with the *pushing* machine's environment, and the origin outlives
+        # any one of them.
+        (self.origin / "config").write_text(
+            (self.origin / "config").read_text(encoding="utf-8") + QUIET_MAINTENANCE,
+            encoding="utf-8",
         )
 
     def machine(self, name: str, enrol: bool = True, display: str | None = None) -> Fake:
@@ -2565,6 +2590,47 @@ class TestCloningDoesNotShareObjectsWithTheOrigin(SyncTestCase):
             origin_inodes = {p.stat().st_ino for p in Path(self.origin).rglob("*") if p.is_file()}
             shared = [p for p in files if p.stat().st_ino in origin_inodes]
             self.assertEqual(shared, [], "objects are hardlinked to the origin")
+
+    def test_the_clone_reads_no_object_file_out_of_the_origin(self) -> None:
+        """The stronger claim, and the one that keeps main green.
+
+        Not sharing an inode is not enough. `--no-hardlinks` still walks the
+        origin's `objects/` and copies whatever the directory listing named,
+        and that listing is not a snapshot: a concurrent push migrating its
+        quarantine, or a `gc --auto` the last push detached into the
+        background, removes a loose object between the listing and the open.
+        The clone then dies with `fatal: failed to copy file to ...`, which is
+        how main went red at v0.3.0 -- and in the hardlink spelling it is #79
+        itself, because a failed `link()` falls back to this same copy.
+
+        `--no-local` asks `upload-pack` for a pack. So every object the origin
+        holds *loose* has to arrive here *packed*: that is the difference
+        between reading someone else's live object store and being sent one.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+
+        def loose(objects: Path) -> set[str]:
+            """Object ids stored as individual files, as `objects/ab/cdef...`."""
+            return {p.parent.name + p.name for p in objects.glob("??/*") if p.is_file()}
+
+        # Without this the test is vacuous: a fully packed origin has nothing
+        # for the local path to copy, so both spellings would pass. A push
+        # small enough for `transfer.unpackLimit` is exploded into loose
+        # objects on arrival, which is every push woswoar makes.
+        from_origin = loose(Path(self.origin) / "objects")
+        self.assertTrue(from_origin, "precondition: the origin holds loose objects")
+
+        beta = self.machine("beta")
+        with beta.active():
+            objects = store.history_dir() / ".git" / "objects"
+            self.assertTrue(list((objects / "pack").glob("*.pack")), "the clone received no pack")
+            # beta has committed its own enrolment by now, so it has loose
+            # objects of its own -- they are simply not the origin's.
+            copied = sorted(from_origin & loose(objects))
+            self.assertEqual(copied, [], "the clone copied the origin's loose objects")
 
     def test_a_joining_machine_still_gets_the_history(self) -> None:
         """The copy has to be a real one, not merely an unlinked one."""

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -2109,23 +2109,38 @@ def initialise(
             # dash is a command, not an address -- and argparse hands one
             # through happily, because `--` ends *woswoar's* option parsing and
             # makes the rest a positional.
-            # `--no-hardlinks` because a local-path remote is an ordinary
-            # woswoar setup -- a bare repo on a NAS or a shared filesystem --
-            # and `git clone` links objects from such a source instead of
-            # copying them. Two things follow, and both have happened here:
+            # `--no-local` because a local-path remote is an ordinary woswoar
+            # setup -- a bare repo on a NAS or a shared filesystem -- and for
+            # one of those `git clone` skips the transport entirely: it walks
+            # the origin's `objects/` and hardlinks, or copies, what the
+            # directory listing showed. That listing is not a snapshot, and the
+            # object store underneath it has writers:
             #
-            # - The clone fails outright if another machine writes the source
-            #   while it runs, which is exactly what a fleet syncing to that
-            #   repo does: `fatal: hardlink different from source`.
-            # - The new clone's object files *are* the origin's, so a `git gc`
-            #   or a corruption on either side reaches the other.
+            # - another machine pushing, whose `receive-pack` migrates its
+            #   incoming objects out of a quarantine directory;
+            # - git's own `gc --auto`, which the push before this one detached
+            #   into the background and which is still pruning loose objects
+            #   that are now packed.
             #
-            # The cost is copying the objects rather than linking them, once,
-            # at `init`. A clone over ssh or https never linked anything.
+            # Either way an object named by the listing is gone by the time
+            # clone opens it, and the clone dies -- `fatal: failed to copy file
+            # to ...`, or in the hardlink spelling of the same defect (#79)
+            # `fatal: hardlink different from source`. Those are one bug, not
+            # two: when `link()` fails git silently falls back to copying, so
+            # both spellings end in the same unguarded read.
+            #
+            # `--no-local` asks `upload-pack` for a pack instead -- the path
+            # every clone over ssh or https already took, against servers that
+            # repack constantly. It also settles #79's other half for free: a
+            # received pack is this machine's own file, so a `git gc` here
+            # cannot reach the origin's objects.
+            #
+            # git ignores the option for a remote that is not a local path, so
+            # it costs an ssh clone nothing.
             git(
                 "clone",
                 "--quiet",
-                "--no-hardlinks",
+                "--no-local",
                 "--",
                 remote,
                 str(history),


### PR DESCRIPTION
Main is red at `v0.3.0`. This fixes the cause, and the four other flakes that
share it.

## What broke

```
git clone --quiet --no-hardlinks -- .../origin.git .../beta/data/history failed:
fatal: failed to copy file to '.../history/.git/objects/63/d2f3e9...': No such file or directory
```

`git clone` of a **local path** skips the transport entirely: it walks the
origin's `objects/`, then hardlinks — or copies — whatever the directory
listing named. That listing is not a snapshot, and the object store beneath it
has writers:

- another machine pushing, whose `receive-pack` migrates its incoming objects
  out of a quarantine directory (`objects/tmp_objdir-incoming-*`, confirmed
  with `inotifywait`);
- git's own `gc --auto`, which the *previous* push detached into the background
  and which is still pruning loose objects that are now packed.

Either way an object the listing named is gone by the time clone opens it. The
`ENOENT` is on the **source**: `copy_file()` opens src before dst, and
`die_errno` reports the dst path, which is what made this read like a
destination problem.

**#79 and this are one bug.** When `link()` fails, git sets `option_no_hardlinks`
and falls through to the same copy — so `fatal: hardlink different from source`
and `fatal: failed to copy file to ...` are two spellings of one unguarded read.
#105 changed the spelling. Both symptoms are in the last five main failures.

## The fix

`--no-local` asks `upload-pack` for a pack instead — the path every clone over
ssh or https already took, against servers that repack constantly. It also
settles #79's *other* half for free: a received pack is this machine's own file,
so a `git gc` here cannot reach the origin's objects. git ignores the option for
a remote that is not a local path, so an ssh clone pays nothing.

Cost at `init`, once, on 20,000 chunks / 25 MB:

| origin | `--no-hardlinks` | `--no-local` |
|---|---|---|
| packed | 0.25 s | 0.36 s |
| loose objects | 0.64 s | 1.44 s |

## The tests: git's housekeeping is a background writer

Every one of the **five** red mains before this was detached auto-maintenance in
a test repo, in three disguises:

| | |
|---|---|
| `fatal: failed to copy file to ...` in a clone | `ff6669e`, `e5a8fd44` — two unrelated tests |
| `failed to run repack`, `could not find pack '.tmp-...'` | `f9a5af0b`, `225b3aad` — colliding with the explicit `git gc` in `test_repo_growth_...` |
| `OSError: Directory not empty` in teardown | `3fbda1a8` — `ignore_cleanup_errors` did **not** absorb it on 3.12 |

So the repos the tests build now set `gc.auto=0` (and `receive.autogc=false` on
the origin, in its own config — a push's `receive-pack` runs there with the
*pushing* machine's environment). An installation wants that maintenance; a test
wants a repo that changes only when it says so.

This is not what makes the clone safe — `--no-local` is, and it has its own
test. Silencing maintenance only stops git's housekeeping surfacing as whichever
test was unlucky.

## Regression test

`test_the_clone_reads_no_object_file_out_of_the_origin`: every object the origin
holds **loose** must arrive in the clone **packed**. Deterministic — it asserts
the transport that was used, not the race.

Mutation-tested per rule 3, and attributed, because the class already had a test
that could have been the one catching it:

```
caught    --no-hardlinks, offered to the NEW test alone
SURVIVED  --no-hardlinks, offered to the OLD inode test alone
```

The old `st_ino` test cannot see this: `--no-hardlinks` *copies*, so the inodes
differ and #79's test is happy while the defect is fully present. Also caught:
dropping the flag entirely (#79's original form).

The test carries an explicit precondition that the origin holds loose objects —
a fully packed origin has nothing to copy, and both spellings would pass. It
holds 20 at that point, because every push woswoar makes is small enough for
`transfer.unpackLimit` to explode on arrival.

## What I could not do

**I did not reproduce the CI failure locally**: 40 runs of the failing test
under 8-way load, plus targeted harnesses racing a clone against a repack and
against a concurrent push, all green on git 2.55 here (CI runs 2.54). The fix
removes the mechanism rather than the trigger, and the evidence for the trigger
is the five failures above plus git's source, not a local repro.

`.github/workflows/ci.yml` also gains `--no-local` on the install job's attacker
clone. Same hazard, and a flake there would read as a security failure.

## Should v0.3.0 be re-tagged?

Your call. The user-visible part is an `init` from a local-path origin failing
while something writes to that origin — rare, loud, and recoverable by re-running
`init`. Nothing is corrupted and no released behaviour changes otherwise.
