### PR TITLE
release: 0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ one machine.
 > **The same line upgrades an existing install** — run it again whenever you want
 > the latest release. `stable` tracks the most recent tag, so the command never
 > changes and you never edit a version number on five machines. Swap `@stable`
-> for `@main` to track the tip, or `@v0.3.0` to pin exactly.
+> for `@main` to track the tip, or `@v0.3.1` to pin exactly.
 
 **Needs:** bash 5.0+ (Linux) · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) ·

--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
Cuts v0.3.1. One commit since v0.3.0, and it is the one that made `v0.3.0`'s own
CI red.

- **`init` clones through the transport, not the origin's object store** (#106).
  `git clone` of a *local path* walks the origin's `objects/` and copies what
  the directory listing named — but the listing is not a snapshot, and a
  concurrent push or the background `gc --auto` from the last one removes an
  object before clone opens it. `init` from a local-path remote could fail with
  `fatal: failed to copy file to ...`. `--no-local` asks `upload-pack` for a
  pack instead. This is #79 again: `--no-hardlinks` in v0.3.0 changed the
  spelling and left the unguarded read, because a failed `link()` falls back to
  the same copy.

Patch rather than minor: no format change, no new file in the repository, no
behaviour anyone was relying on.

## Upgrade path

Nothing to do. `--no-local` affects only how a *new* machine's `init` fetches
its first copy; an existing clone is untouched, and the repository format is
unchanged from v0.2.0 onward.

## What is not in it

The end-to-end shakedown still has not been run — install from the published
wheel, `init`, record across a day boundary, add a second machine, then
`grant`/`trust`/`sync`/`compact`/`revoke` with `doctor` clean at each step. CI
covers each piece; nobody has walked the whole path on a real install.
