### PR TITLE
Show the name at the prompt that asks about it, and say what a slow command is doing

### DIFF
--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,118 @@
+"""Progress output: what it says, and the two cases where it must say nothing.
+
+The reason a test file exists for something cosmetic is that both silences are
+load-bearing. `woswoar sync` runs from a timer once a minute into the journal,
+and `woswoar list` is read by fzf through a pipe; a progress bar in either is
+not a cosmetic regression.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from unittest import mock
+
+from woswoar import progress
+
+
+class Fake(io.StringIO):
+    """A stream that can claim to be a terminal, which StringIO cannot."""
+
+    def __init__(self, tty: bool) -> None:
+        super().__init__()
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+class TestItStaysQuietWhenItShould(unittest.TestCase):
+    def test_a_pipe_gets_nothing(self) -> None:
+        """fzf reads `list` through one of these, and the timer's journal too.
+
+        With PATIENCE at its real value this passes whether or not anything
+        checks for a terminal, because nothing here waits long enough to print
+        -- so it would have guarded nothing. Zero patience leaves the tty check
+        as the only reason for the silence, which is the reason under test.
+        """
+        with mock.patch.object(progress, "PATIENCE", 0.0):
+            out = Fake(tty=False)
+            with progress.to_terminal(out):
+                progress.phase("sealing")
+                for i in range(1000):
+                    progress.tick(i, 1000, "days")
+        self.assertEqual(out.getvalue(), "")
+
+    def test_a_fast_command_gets_nothing_even_on_a_terminal(self) -> None:
+        """An idle sync is ~10 ms and runs 1440 times a day."""
+        out = Fake(tty=True)
+        with progress.to_terminal(out):
+            progress.phase("sealing")
+            progress.tick(0, 10, "days")
+            progress.tick(9, 10, "days")
+        self.assertEqual(out.getvalue(), "")
+
+    def test_nothing_is_said_with_no_reporter_installed(self) -> None:
+        """Library code calls these unconditionally; `import woswoar.sync` and
+        calling `run()` from Python must not print progress at all."""
+        progress.phase("sealing")
+        progress.tick(1, 2, "days")  # must not raise, must not print
+
+
+class TestItSpeaksWhenTheWaitIsLong(unittest.TestCase):
+    def setUp(self) -> None:
+        self.out = Fake(tty=True)
+        # A reporter whose clock started long enough ago that the patience has
+        # already run out -- rather than sleeping for PATIENCE in a unit test.
+        self.reporter = progress._Terminal(self.out, started=-progress.PATIENCE * 10)
+
+    def test_the_phase_and_the_count_reach_the_terminal(self) -> None:
+        with progress._install(self.reporter):
+            progress.phase("sealing this machine's history")
+            # Printing the phase starts the rate limit, so the tick immediately
+            # after it is deliberately swallowed -- the phase line is already on
+            # screen and saying the same thing. This is about what a tick shows
+            # once it is due, not about when it becomes due.
+            self.reporter._last = 0.0
+            progress.tick(3, 12, "days")
+        shown = self.out.getvalue()
+        self.assertIn("sealing this machine's history", shown)
+        self.assertIn("3/12 days", shown)
+        self.assertIn("25%", shown)
+
+    def test_a_shorter_line_does_not_leave_the_last_one_behind(self) -> None:
+        """`\\r` alone would leave `...100/1000 days` reading `...9/1000 dayss`."""
+        with progress._install(self.reporter):
+            progress.phase("x")
+            progress.tick(1000, 1000, "days")
+            self.reporter._last = 0.0  # the interval is not what is under test
+            progress.tick(1, 1, "d")
+        last = self.out.getvalue().rsplit("\r", 1)[-1]
+        self.assertNotIn("days", last)
+
+    def test_the_line_is_cleared_when_the_command_ends(self) -> None:
+        """Otherwise the count stays under whatever the command prints next."""
+        with progress._install(self.reporter):
+            progress.phase("x")
+            progress.tick(1, 2, "days")
+        self.assertTrue(self.out.getvalue().endswith("\r"))
+        self.assertNotIn("1/2 days", self.out.getvalue().rsplit("\r", 1)[-1])
+
+    def test_no_percentage_is_claimed_for_an_unknown_total(self) -> None:
+        with progress._install(self.reporter):
+            progress.phase("x")
+            progress.tick(0, 0, "days")
+        self.assertNotIn("%", self.out.getvalue())
+
+    def test_updates_are_rate_limited(self) -> None:
+        """A 20,000-chunk merge must not spend its time on escape codes."""
+        with progress._install(self.reporter):
+            progress.phase("x")
+            for i in range(5000):
+                progress.tick(i, 5000, "days")
+        # One write got through; the rest were inside the interval.
+        self.assertLess(self.out.getvalue().count("days"), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 from unittest import mock
 
-from woswoar import cache, crypto, search, store, sync
+from woswoar import cache, crypto, progress, search, store, sync
 from woswoar.__main__ import _GRANT_REMEDY, main
 from woswoar.entry import Entry, format_line
 from woswoar.sync import COMMIT_MESSAGE as COMMIT
@@ -589,6 +589,52 @@ class TestGrantConfirmation(SyncTestCase):
         with alpha.active():
             labels = {reader.label for reader in sync.readers()}
         self.assertIn("martinus@box", labels)
+
+    def test_a_machine_that_just_enrolled_is_named_before_it_has_synced(self) -> None:
+        """The name has to be there at the prompt, not one sync later.
+
+        `name_for` reads the mirror a *merge* fills, and a machine you are being
+        asked to grant is by definition one whose history you have never merged.
+        So the confirmation that widens access to everything showed `(unnamed)`,
+        and the name appeared afterwards, when nobody was being asked anything.
+        Reported from a real two-machine setup.
+
+        The sealed name is in the tree by now -- `readers` fetches -- so this is
+        a decrypt of something already present.
+        """
+        alpha = self.machine("alpha", display="martin@desktop")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+
+        # Enrols, pushes its name, and merges nothing. Exactly the state a
+        # newcomer is in when someone turns to the old machine and runs `grant`.
+        self.machine("beta", display="martin@laptop")
+
+        with alpha.active():
+            labels = {reader.label for reader in sync.readers()}
+        self.assertIn("martin@laptop", labels, f"the newcomer is unnamed: {labels}")
+        self.assertNotIn(sync.UNNAMED, labels)
+
+    def test_trust_names_the_machine_it_is_asking_about(self) -> None:
+        """`trust` had it worse: it is *only* ever asked about an unmerged host.
+
+        Every candidate it listed was therefore `(unnamed)`, while README.md
+        showed a name in that very prompt.
+        """
+        alpha = self.machine("alpha", display="martin@desktop")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+
+        beta = self.machine("beta", display="martin@laptop")
+        with beta.active():
+            beta.record("2023-11-15", 1_700_100_001, "cargo build")
+            sync.run()
+
+        with alpha.active():
+            labels = {c.label for c in sync.trust_candidates()}
+        self.assertEqual(labels, {"martin@laptop"})
 
     def test_a_key_with_no_name_yet_is_not_named_after_itself(self) -> None:
         """The fallback label used to be an abbreviation of the key.
@@ -4697,6 +4743,82 @@ class TestTheCommitIdentityIsStillPinned(SyncTestCase):
             report = sync.run()
             self.assertEqual(report.chunks_written, 1)
             self.assertFalse(report.pushed)
+
+
+class TestLongCommandsSayWhatTheyAreDoing(SyncTestCase):
+    """Reported from a real setup: "some commands take a long time and do not
+    print anything, so I don't know if they are doing something or hanging".
+
+    Measured at two years of history: a first sync is 6.5 s and a grant 3.2 s,
+    and neither wrote a character until it was finished. What a terminal shows
+    is `tests/test_progress.py`; this is about the calls being *made*, from the
+    loops where the time actually goes.
+    """
+
+    def days_of_history(self, alpha: Fake, days: int) -> None:
+        for day in range(days):
+            stamp = f"2024-{day // 28 + 1:02d}-{day % 28 + 1:02d}"
+            alpha.record(stamp, 1_700_000_000 + day * 86400, f"command on day {day}")
+
+    def test_a_first_sync_counts_the_days_it_is_sealing(self) -> None:
+        alpha = self.machine("alpha", display="martin@desktop")
+        with alpha.active():
+            self.days_of_history(alpha, 40)
+            with progress.recording() as said:
+                sync.run()
+
+        self.assertIn("phase:sealing this machine's history", said)
+        # The count has to move, or it is a spinner: a bar stuck at 0/40 says
+        # exactly as little as no bar at all.
+        ticks = [line for line in said if line.startswith("tick:")]
+        self.assertIn("tick:0/40 days", ticks)
+        self.assertIn("tick:39/40 days", ticks)
+
+    def test_merging_names_the_machine_it_is_reading(self) -> None:
+        """ "reading history from 'martin@laptop'" -- not "host 3f2a...".
+
+        The same fix that put a name in `grant`'s prompt puts one here, and this
+        is the one place a name is worth more than a fingerprint: nobody is
+        authorising anything, they are waiting.
+        """
+        alpha = self.machine("alpha", display="martin@desktop")
+        beta = self.machine("beta", display="martin@laptop")
+        with alpha.active():
+            self.days_of_history(alpha, 30)
+            sync.run()
+            sync.grant()
+        self.accept_everyone(beta)
+
+        with beta.active(), progress.recording() as said:
+            sync.run()
+
+        # beta is reading alpha, so it is alpha's name that has to appear.
+        self.assertIn("phase:reading history from martin@desktop", said)
+        self.assertIn("tick:0/30 days", said)
+
+    def test_grant_counts_the_keys_it_re_seals(self) -> None:
+        alpha = self.machine("alpha", display="martin@desktop")
+        with alpha.active():
+            self.days_of_history(alpha, 25)
+            sync.run()
+            with progress.recording() as said:
+                sync.grant()
+
+        self.assertIn("phase:re-sealing the day keys", said)
+        # 25 day keys plus this machine's sealed name.
+        self.assertIn("tick:0/26 keys", said)
+        self.assertIn("tick:25/26 keys", said)
+
+    def test_an_idle_sync_still_has_nothing_to_count(self) -> None:
+        """The timer runs this every minute; the loops must stay skipped."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            self.days_of_history(alpha, 5)
+            sync.run()
+            with progress.recording() as said:
+                sync.run()
+
+        self.assertEqual([line for line in said if line.startswith("tick:")], [])
 
 
 if __name__ == "__main__":

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -895,9 +895,17 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    from . import progress
+
     args = build_parser().parse_args(argv)
     try:
-        result: int = args.func(args)
+        # Around every command, not only the slow ones. What a command costs
+        # depends on how much history is behind it, and the reporter shows
+        # nothing until a wait has already gone on too long -- so the ones that
+        # are fast today stay silent, without anyone having to predict which
+        # those are.
+        with progress.to_terminal():
+            result: int = args.func(args)
     except KeyboardInterrupt:
         return 130
     except BrokenPipeError:

--- a/woswoar/progress.py
+++ b/woswoar/progress.py
@@ -1,0 +1,178 @@
+"""Say what a long command is doing, while it is still doing it.
+
+A first sync of two years of history takes about six and a half seconds and a
+`grant` over the same history about three, and until this both printed their
+first character *after* all of them. Reported from a real setup as "some
+commands take a long time and do not print anything, so I don't know if they are
+doing something or hanging" -- which is the correct thing to wonder, because
+nothing on screen distinguished the two.
+
+Three rules, and they are the whole design:
+
+**Silent until it is slow.** Nothing appears for the first `PATIENCE` seconds,
+so the sync that runs every minute and finishes in ten milliseconds is as quiet
+as it ever was. A progress bar that fires on fast operations is noise, and noise
+is what people learn to stop reading.
+
+**Only when a human is watching.** `stderr`, and only when it is a terminal.
+The systemd timer runs `sync` a thousand times a day into the journal; `list`
+is read by fzf through a pipe. Both must stay exactly as they are, and both do,
+because neither is a tty.
+
+**stderr, not stdout.** `woswoar list` is piped into fzf and `stats` is read by
+people with `grep`. Progress is not part of either answer.
+
+Library code calls `phase` and `tick` unconditionally and they do nothing until
+a reporter is installed. That keeps the signatures of `sync.run` and its
+half-dozen helpers free of a parameter threaded through purely to be passed on
+-- at the price of module state, which is deliberate and is the reason
+`recording` exists: the tests install a reporter and read back what was said,
+rather than grepping a terminal.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Protocol, TextIO
+
+#: How long a command may run before it owes the user a word. Below this,
+#: printing costs more attention than it saves: an idle sync is ~10 ms, and the
+#: timer runs one every minute.
+PATIENCE = 0.7
+
+#: How often the counter may be rewritten once it is showing. A 20,000-chunk
+#: merge would otherwise spend real time on escape codes, and nobody can read
+#: more than a few updates a second anyway.
+INTERVAL = 0.1
+
+
+class Reporter(Protocol):
+    """Where progress goes. Two implementations: a terminal, and a test."""
+
+    def phase(self, text: str) -> None:
+        """Start a named step. Ends whatever was on the line before."""
+
+    def tick(self, done: int, total: int, noun: str) -> None:
+        """Report position within the current phase."""
+
+    def finish(self) -> None:
+        """Leave the line as it was found."""
+
+
+class _Terminal:
+    """Rewrites one line in place, and only after the wait is long enough."""
+
+    def __init__(self, stream: TextIO, started: float | None = None) -> None:
+        self._stream = stream
+        # The clock starts when the *command* does, not when the first tick
+        # arrives: an export that spends four seconds before its first day is
+        # exactly the case this exists for.
+        self._started = time.monotonic() if started is None else started
+        self._last = 0.0
+        self._label = ""
+        self._showing = False
+        self._width = 0
+
+    def _due(self, now: float) -> bool:
+        return now - self._started >= PATIENCE and now - self._last >= INTERVAL
+
+    def _write(self, text: str) -> None:
+        # `\r` and a pad to the previous width: shorter text must not leave the
+        # tail of longer text behind it. `\x1b[K` would be neater and is not
+        # portable to every terminal woswoar might meet.
+        self._stream.write("\r" + text.ljust(self._width) + "\r" + text)
+        self._stream.flush()
+        self._width = len(text)
+        self._showing = True
+
+    def phase(self, text: str) -> None:
+        self._label = text
+        now = time.monotonic()
+        if now - self._started >= PATIENCE:
+            self._last = now
+            self._write(f"  {text}...")
+
+    def tick(self, done: int, total: int, noun: str) -> None:
+        now = time.monotonic()
+        if not self._due(now):
+            return
+        self._last = now
+        # No percentage when the total is unknown or zero: "0%" for a while and
+        # then "100%" is worse than a plain count.
+        share = f" ({done * 100 // total}%)" if total > 0 else ""
+        self._write(f"  {self._label}... {done}/{total} {noun}{share}")
+
+    def finish(self) -> None:
+        if self._showing:
+            self._stream.write("\r" + " " * self._width + "\r")
+            self._stream.flush()
+            self._showing = False
+
+
+class _Recorder:
+    """Everything said, in order, for tests to assert on."""
+
+    def __init__(self) -> None:
+        self.said: list[str] = []
+
+    def phase(self, text: str) -> None:
+        self.said.append(f"phase:{text}")
+
+    def tick(self, done: int, total: int, noun: str) -> None:
+        self.said.append(f"tick:{done}/{total} {noun}")
+
+    def finish(self) -> None:
+        self.said.append("finish")
+
+
+_current: Reporter | None = None
+
+
+def phase(text: str) -> None:
+    """Name the step now starting. A no-op unless someone is listening."""
+    if _current is not None:
+        _current.phase(text)
+
+
+def tick(done: int, total: int, noun: str) -> None:
+    """Position within the current phase. A no-op unless someone is listening."""
+    if _current is not None:
+        _current.tick(done, total, noun)
+
+
+@contextmanager
+def _install(reporter: Reporter | None) -> Iterator[None]:
+    global _current
+    before = _current
+    _current = reporter
+    try:
+        yield
+    finally:
+        if reporter is not None:
+            reporter.finish()
+        _current = before
+
+
+@contextmanager
+def to_terminal(stream: TextIO | None = None) -> Iterator[None]:
+    """Report progress, if there is a terminal to report it to.
+
+    Wrapped around the *whole* command rather than each slow part, so the
+    patience clock measures what the user is waiting for rather than what any
+    one loop is doing.
+    """
+    out = sys.stderr if stream is None else stream
+    watched = out.isatty()
+    with _install(_Terminal(out) if watched else None):
+        yield
+
+
+@contextmanager
+def recording() -> Iterator[list[str]]:
+    """Collect what would have been shown. For tests."""
+    recorder = _Recorder()
+    with _install(recorder):
+        yield recorder.said

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -30,13 +30,13 @@ import subprocess
 import time
 import zlib
 from collections import Counter
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NamedTuple
 
-from . import crypto, store
+from . import crypto, progress, store
 from .entry import make_inert
 from .errors import WoswoarError
 from .store import Machine
@@ -365,6 +365,29 @@ def name_for(host_id: str | None) -> Name:
         return Name(UNNAMED, known=False)
     name = store.host_name(host_id)
     return Name(make_inert(name), known=True) if name else Name(UNNAMED, known=False)
+
+
+def learn_names(known: Machine, host_ids: Iterable[str]) -> None:
+    """Open any `name.age` this machine has not read yet.
+
+    `name_for` reads the mirror `_merge_name` fills during a *merge*, which is
+    the right trade everywhere except the two places it matters most. `grant`
+    and `trust` are both asked about a machine that just enrolled, and a machine
+    that just enrolled is precisely one whose history has never been merged --
+    so the confirmation that widens access showed `(unnamed)`, and the name
+    turned up a sync later, once nobody was looking at it.
+
+    The sealed name is already in the tree by then: both callers fetch first,
+    and it is sealed to the recipients, this machine among them. So this is a
+    decrypt of something already present, once per machine ever, not a fetch.
+
+    It cannot fail loudly: `_merge_name` swallows a name it cannot open, which
+    is the correct answer for a machine that enrolled before this one and has
+    not granted since. `(unnamed)` beside a fingerprint is still true, and the
+    fingerprint was always the part being consented to.
+    """
+    for host_id in host_ids:
+        _merge_name(known, host_id)
 
 
 def is_repo() -> bool:
@@ -915,6 +938,10 @@ def trust_candidates() -> list[Candidate]:
         state = State.load()
         live = set(recipients())
 
+        # Every host, before the loop: `trust` is *always* about a machine this
+        # one has never merged, so without this it never had a name to show.
+        learn_names(known, store.repo_hosts())
+
         out: list[Candidate] = []
         for host_id in store.repo_hosts():
             if host_id == known.id:
@@ -1291,7 +1318,12 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
 
     # One pass for the whole host, not one per day.
 
-    for day, tails in sorted(fresh.items()):
+    # The first sync after an import is the long one: a day-key minted, sealed
+    # and signed per day, which at two years of history is where six of its six
+    # and a half seconds go.
+    progress.phase("sealing this machine's history")
+    for done, (day, tails) in enumerate(sorted(fresh.items())):
+        progress.tick(done, len(fresh), "days")
         # Before the manifest, not after. Refusing does not advance
         # `state.exported`, so a refused day comes back on every sync -- and
         # `read_manifest` forks `ssh-keygen -Y verify`. Checked afterwards, one
@@ -1400,9 +1432,12 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
 
 def merge(known: Machine, state: State, report: Report) -> None:
     """Decrypt every chunk from other hosts that we have not merged yet."""
-    for host_id in store.repo_hosts():
-        if host_id == known.id:
-            continue  # our own plaintext is already the source of truth
+    # Our own plaintext is already the source of truth, so it is dropped here
+    # rather than skipped in the loop: the phase names the machine being read,
+    # and `_merge_host` counts that machine's days underneath it.
+    others = [host for host in store.repo_hosts() if host != known.id]
+    for host_id in others:
+        progress.phase(f"reading history from {name_for(host_id).text}")
         report.hosts_seen.add(host_id)
         _merge_host(known, host_id, state, report)
         _merge_name(known, host_id)
@@ -1507,7 +1542,13 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
     # that is the difference between ~3.6s and nearly two minutes.
     # Names rather than `Chunk` objects, and paths built only for the chunks
     # actually read -- see `store.chunk_names` for what that is worth here.
-    for chunk_day in store.chunk_days(host_id):
+    #
+    # Materialised for its length alone, so the counter can say how far along a
+    # first sync is. An idle sync skips every one of these on the stamp check
+    # below, and never gets far enough into the wait for anything to be shown.
+    days = list(store.chunk_days(host_id))
+    for done, chunk_day in enumerate(days):
+        progress.tick(done, len(days), "days")
         key = f"{host_id}/{chunk_day}"
 
         # Read before the listing, not after: a chunk arriving between the two
@@ -1904,6 +1945,10 @@ def _resolve(*refs: str) -> list[str]:
 def _fetch_and_rebase(repo: Repo) -> bool:
     """Adopt the remote's history under ours; say whether we now match it.
 
+    Announced rather than counted: this is one `git fetch` over the network, so
+    there is nothing to be a fraction of, and a slow one here is a slow remote
+    rather than anything woswoar is doing.
+
     Fetch-then-rebase rather than ``git pull --rebase`` because the tracking ref
     may legitimately not exist: cloning an *empty* remote configures a branch
     pointing at nothing, which is the normal state for the first machine to
@@ -1924,6 +1969,7 @@ def _fetch_and_rebase(repo: Repo) -> bool:
     machine holding commits nobody else has would read as level and never
     publish them. Only where HEAD lands says anything.
     """
+    progress.phase("fetching from the remote")
     git("fetch", "--quiet", "origin")
     local, upstream = _resolve("HEAD", f"refs/remotes/origin/{repo.branch}")
     if not upstream:
@@ -1945,6 +1991,7 @@ def _fetch_and_rebase(repo: Repo) -> bool:
 
 def _push(repo: Repo) -> None:
     """Publish, retrying once if someone else pushed while we worked."""
+    progress.phase("publishing to the remote")
     try:
         git("push", "--quiet", "-u", "origin", repo.branch)
     except SyncError:
@@ -2302,6 +2349,7 @@ def readers() -> list[Reader]:
         except (WoswoarError, OSError):
             mine = ""
 
+        learn_names(store.machine(), {host for host in owners.values() if host})
         labelled = [(key, name_for(owners.get(key))) for key in enrolled]
         names = Counter(name.text for _, name in labelled if name.known)
         return [
@@ -2385,7 +2433,12 @@ def _reseal(identity: Path, keys: list[str]) -> tuple[int, int]:
         sealed.append(store.name_seal(host_id))
 
     resealed = skipped = 0
-    for path in sealed:
+    # Two `age` invocations per file that is ours -- open, then seal to the new
+    # list -- and one file per day per machine. At two years that is where
+    # `grant`'s three seconds go, all of it after the last thing it printed.
+    progress.phase("re-sealing the day keys")
+    for done, path in enumerate(sealed):
+        progress.tick(done, len(sealed), "keys")
         if not path.is_file():
             continue
         try:


### PR DESCRIPTION
Two of the three things you reported. The setup simplification (`woswoar setup`
and `woswoar accept`) follows in its own PRs — this is the half that changes what
you *see*, with no new commands to learn.

## 1. `grant` and `trust` said `(unnamed)`

You saw a new key with no name, and a name later. Reproduced:

```
-- what grant shows, right after the new machine enrolled --
   new=True  age1a6d…  'martin@desktop' (this machine)
   new=True  age1qjg…  '(unnamed)'
-- the same list after a sync --
   new=True  age1qjg…  'martin@laptop'
```

`name_for` (`sync.py:357`) reads the plaintext mirror that `_merge_name` fills
during a **merge** — and a machine you are being asked to authorise is by
definition one whose history you have never merged. So the one confirmation that
widens access to your entire history had no name on it, and the name appeared a
sync later when nobody was being asked anything.

**`trust` was worse.** It is *only* ever asked about an unmerged host, so every
candidate it ever listed was `(unnamed)` — while `README.md` documents a name in
that exact prompt.

The sealed `name.age` is already in the tree at that point (both commands fetch
first) and is sealed to the recipients, this machine among them. So the fix is
to open it: one `age` decrypt per machine, ever. A name that *cannot* be opened
— a machine that enrolled before this one and has not granted since — still
falls back to `(unnamed)`, which is the honest answer.

## 2. Long commands printed nothing

Measured on 51,100 commands across 730 days:

| | time | output |
|---|---|---|
| `import bash` | 0.37 s | 1 line, at the end |
| **first `sync`** | **6.5 s** | 2 lines, at the end |
| **`grant`** | **3.2 s** | all of it *before* the work |
| idle `sync` | 0.01 s | 2 lines |

Both slow paths are per-day loops with an `age` invocation inside, so they grow
with your history. New `woswoar/progress.py`, on those loops, under three rules:

- **Silent until it is slow** — nothing for the first 0.7 s. The sync the timer
  runs every minute finishes in ~10 ms and stays as quiet as it was. This is
  what stops it becoming noise.
- **Only when a human is watching** — stderr, and only when it is a tty. fzf
  reads `list` through a pipe; the timer writes to the journal.
- **Never stdout**, which is somebody's answer.

Live, from a real 400-day sync:

```
  sealing this machine's history... 76/400 days (19%)
  sealing this machine's history... 395/400 days (98%)
  publishing to the remote...
```

and the phase names the machine, which is the first fix again: `reading history
from martin@desktop`, not `reading history from 3f2a9c…`.

## Regression tests

Mutation-tested per rule 3 — all eight caught:

```
caught    grant stops learning the newcomer's name (the reported bug)
caught    trust stops learning the name it is asking about
caught    the export loop stops counting
caught    the merge loop stops counting
caught    grant's re-seal stops counting
caught    progress speaks on a pipe too (fzf and the journal)
caught    progress speaks immediately, with no patience (an idle sync would print)
caught    the line is never cleared, so the count stays under the next output
```

The sixth needed the fixture fixed first. `test_a_pipe_gets_nothing` passed
whether or not anything checked for a terminal, because nothing in it waited
long enough to print — patience, not the tty check, was producing the silence.
It now runs with `PATIENCE` patched to zero, so the tty check is the only thing
left that can keep it quiet.

## Notes

- `progress` is module state with an installed reporter, rather than a parameter
  threaded through `run`, `export`, `merge`, `_merge_host` and `_reseal` purely
  to be passed on. That is a deliberate trade and the reason `recording()`
  exists: the tests install a reporter and read back what was said instead of
  grepping a terminal.
- The counter is materialised in `_merge_host` (`list(store.chunk_days(...))`)
  so it has a total to divide by. An idle sync never enters that loop far enough
  to matter, and `test_an_idle_sync_still_has_nothing_to_count` pins it.
