### PR TITLE
accept: one command for "that machine is mine", and an init that finishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,51 +57,59 @@ Then on **every** machine, first or fifth, the same four lines:
 pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
 woswoar install                                       # hook it into bash
 woswoar import atuin --this-host-only                 # optional: this machine's past
-woswoar init git@github.com:you/woswoar-history.git   # join the repo
+woswoar init git@github.com:you/woswoar-history.git   # join, and sync
 ```
 
-From the **second** machine onwards, one extra step on a machine you set up
-earlier:
+`init` does the first sync itself, so the new machine starts publishing straight
+away — it signs its own commands and waits for nobody.
+
+From the **second** machine onwards, one more line, on each machine you already
+use:
 
 ```bash
-woswoar grant
+woswoar accept
 ```
 
-That is what lets the newcomer read history from before it existed. It lists the
-machines by name and asks first, because it widens who can read *everything*:
-
-```
-This will let each of these machines read your ENTIRE history,
-including days recorded before it ever existed:
-
-  martinus@box   (this machine)
-  martin@work-laptop
-
-Grant all 2 machines full access? [y/N]
-```
-
-That is what lets the newcomer read history from before it existed. It starts
-publishing its own commands straight away, without waiting for anything: it
-signs them with a key of its own.
-
-The other direction needs one more step, on each machine that will read the
-newcomer:
+That is the whole of it. `accept` lists what is new, says what accepting it
+does, and asks:
 
 ```console
-$ woswoar trust
-These machines publish history this one has not been told to accept.
+$ woswoar accept
+1 machine(s) not yet accepted here:
 
-  SHA256:2xQ5…  'martin@work-laptop'
+  'martin@work-laptop'
+      reads with                  age1qjg…
+      signs with                  SHA256:2xQ5…
 
-Accept history from 1 machine(s) here? [y/N]
+Accepting does two separate things:
+
+  read     1 machine(s) get to read your ENTIRE history, including
+           days recorded before they existed. This is published, so it
+           applies everywhere — and it cannot be taken back for what
+           they have already read.
+
+  believe  this machine will accept what 1 machine(s) publish.
+           Local only: every other machine of yours has to be told
+           separately, because the repository is the thing that decision
+           defends against.
+
+A name is free text written by whoever added the key. The fingerprints are
+not — run these on the machine they belong to and compare:
+
+    reads with   age-keygen -y ~/.config/woswoar/identity
+    signs with   ssh-keygen -lf ~/.config/woswoar/signing_key.pub
+
+Accept 1 machine(s)? [y/N]
 ```
 
-That is deliberate. The history repo is somewhere anyone with push access can
-write, so every machine signs what it publishes and each of your machines
-decides for itself whose signature it believes — a decision that cannot be kept
-in the repository, because the repository is the thing it defends against.
-Revoking a machine removes that decision everywhere automatically, since taking
-trust away can only ever cause a refusal.
+Two keys, because there really are two questions, and they stay separate
+commands — [`grant`](docs/security.md) for who may *read*, `trust` for whose
+word this machine *believes*. `accept` is both at once for the ordinary case
+where the machine is yours. The second one is why it has to be run on each
+machine you already own rather than once: the repository is somewhere anyone
+with push access can write, so what a machine believes cannot be decided by
+anything kept inside it. Revoking removes that decision everywhere
+automatically, since taking trust away can only ever cause a refusal.
 
 > [!TIP]
 > `.bashrc` is written with `$HOME` rather than your username, so one shared
@@ -185,7 +193,9 @@ truthful. Re-running an import is idempotent.
 | `woswoar doctor` | check the installation and the tools it needs |
 | `woswoar init [url]` | create or join an encrypted history repo |
 | `woswoar sync` | exchange history with the remote |
+| `woswoar accept` | add a machine you own: `grant` and `trust` at once |
 | `woswoar grant` | let newly enrolled machines read the older history |
+| `woswoar trust` | accept another machine's published history here |
 | `woswoar compact` | merge old chunks to reduce the working-tree file count |
 
 | variable | meaning |
@@ -234,10 +244,12 @@ machine recorded. `history/` beside it is the encrypted git checkout, and
   everything. `woswoar grant` on that other machine lists every enrolled
   machine by fingerprint and name, which is where that value comes from — it
   asks before changing anything, and does nothing at all if nothing is new.
+  (`woswoar accept` shows the same fingerprints, but only for machines it has
+  something left to do about.)
 - **Reinstalling later?** Deleting `~/.config/woswoar/` discards the identity.
   The machine can rejoin with `woswoar init <url>`, but it enrols as a *new*
-  machine: someone must run `woswoar grant` again, and every other machine must
-  `woswoar trust` it. Keep that directory if you only meant to move the data.
+  machine: `woswoar accept` has to be run again on every machine you keep.
+  Keep that directory if you only meant to move the data.
 
 The remote repository is untouched by all of this. Delete it separately if you
 want it gone, remembering that other machines still hold their own copies of

--- a/docs/security.md
+++ b/docs/security.md
@@ -115,6 +115,14 @@ trust` on each machine that will read it**, on top of `woswoar grant` once. A
 machine that clones later pins whatever it finds at that moment, so the ceremony
 only runs in one direction.
 
+`woswoar accept` runs both for a machine you own, which is what almost everyone
+is doing. It does not merge the two decisions — it shows both keys, says what
+each half does, and asks once. The one thing it deliberately will not do is
+accept a *changed* signing key: that is either a machine you re-enrolled or
+someone rewriting the repository, nothing can tell those apart, and rolling it
+into the newcomer prompt is how it would get agreed to by someone answering a
+different question. It stays behind `woswoar trust --replace`.
+
 ## 🔑 No secret is ever copied between machines
 
 age takes **SSH public keys as recipients**, so each machine encrypts to the
@@ -202,6 +210,9 @@ with `--identity <path>` or `--new-identity`.
 
 Two commands, both asking a human, and it is easy to assume one could replace
 the other. They are on different axes and neither can absorb the other.
+
+`woswoar accept` is both of these at once, for the ordinary case where the
+machine in question is yours. The distinction below is still what it does.
 
 | | `woswoar grant` | `woswoar trust` |
 |---|---|---|

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,0 +1,90 @@
+"""Every subcommand has to explain itself.
+
+`add_parser(help=...)` shows a line in `woswoar --help` and nothing at all in
+`woswoar <command> -h`, which needs `description=`. Every subcommand was missing
+it, so `woswoar doctor -h` printed a usage line, `-h, --help`, and no statement
+of what doctor does. These are the tests that stop that coming back one
+subcommand at a time.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stdout
+
+from woswoar.__main__ import build_parser
+
+
+def _subparsers_action() -> object:
+    """The single `_SubParsersAction` this parser has.
+
+    Reached through the public `_actions` list because argparse offers nothing
+    better, and identified by what it holds rather than by an isinstance on a
+    private class -- so this breaks loudly if the parser is restructured, rather
+    than quietly checking nothing.
+    """
+    parser = build_parser()
+    for action in parser._actions:
+        choices = getattr(action, "choices", None)
+        if isinstance(choices, dict) and "sync" in choices:
+            return action
+    raise AssertionError("no subcommands found; build_parser changed shape")
+
+
+def subcommands() -> dict[str, object]:
+    """Every registered subparser, aliases included, keyed by name."""
+    return dict(_subparsers_action().choices)  # type: ignore[attr-defined]
+
+
+def summaries() -> dict[str, str]:
+    """The one-liners `woswoar --help` lists, keyed by command name."""
+    listed = _subparsers_action()._choices_actions  # type: ignore[attr-defined]
+    return {action.dest: action.help or "" for action in listed}
+
+
+class TestEveryCommandExplainsItself(unittest.TestCase):
+    def test_there_are_subcommands_to_check(self) -> None:
+        """Without this the rest is vacuous if `subcommands` ever returns {}."""
+        self.assertGreaterEqual(len(subcommands()), 13)
+
+    def test_each_one_has_a_description(self) -> None:
+        missing = [name for name, p in subcommands().items() if not p.description]  # type: ignore[attr-defined]
+        self.assertEqual(missing, [], "these print nothing useful for `-h`")
+
+    def test_each_description_says_more_than_the_one_line_summary(self) -> None:
+        """A `description` that repeats `help` verbatim is the same nothing in a
+        longer form: it tells someone who ran `-h` what they already read."""
+        thin = []
+        for name, sub in subcommands().items():
+            body = str(sub.description).strip()  # type: ignore[attr-defined]
+            # First line is the summary; there has to be something after it.
+            rest = body.split("\n", 1)[1].strip() if "\n" in body else ""
+            if len(rest) < 80:
+                thin.append(name)
+        self.assertEqual(thin, [], "these say nothing beyond their one-line summary")
+
+    def test_each_one_still_has_the_short_summary(self) -> None:
+        """`woswoar --help` lists these; a subcommand with no `help=` is
+        invisible there even though it exists and runs."""
+        listed = summaries()
+        self.assertIn("sync", listed, "precondition: summaries were found at all")
+        self.assertEqual([name for name, text in listed.items() if not text], [])
+
+    def test_help_is_printed_and_exits_cleanly(self) -> None:
+        """The description is only worth having if `-h` actually reaches it."""
+        for name in subcommands():
+            # Captured: argparse prints to the real stdout, and thirteen help
+            # texts in the suite's output is how people stop reading it.
+            with (
+                self.subTest(command=name),
+                redirect_stdout(io.StringIO()) as shown,
+                self.assertRaises(SystemExit) as exited,
+            ):
+                build_parser().parse_args([name, "-h"])
+            self.assertEqual(exited.exception.code, 0)
+            self.assertIn("usage:", shown.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -4745,6 +4745,157 @@ class TestTheCommitIdentityIsStillPinned(SyncTestCase):
             self.assertFalse(report.pushed)
 
 
+class TestAcceptIsGrantAndTrustAtOnce(SyncTestCase):
+    """One command for "that machine is mine", which is the whole of setup.
+
+    `grant` and `trust` answer genuinely different questions and stay separate
+    commands. What they were not is something a person adding their second
+    laptop should have to hold in their head, and both being needed -- one of
+    them on *every* machine you already own -- is what made the setup feel like
+    too much.
+    """
+
+    def two_machines(self) -> tuple[Fake, Fake]:
+        alpha = self.machine("alpha", display="martin@desktop")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "history from before beta existed")
+            sync.run()
+
+        beta = self.machine("beta", display="martin@laptop")
+        with beta.active():
+            beta.record("2023-11-15", 1_700_100_001, "history beta published itself")
+            sync.run()
+        return alpha, beta
+
+    def test_one_command_does_what_grant_and_trust_did(self) -> None:
+        alpha, beta = self.two_machines()
+
+        code, out, _ = self.run_cli(alpha, "accept", "--yes")
+        self.assertEqual(code, 0, out)
+
+        # Both halves, checked by what each machine can actually see afterwards
+        # rather than by what the command printed.
+        with alpha.active():
+            sync.run()
+            self.assertIn("history beta published itself", alpha.commands())
+        with beta.active():
+            sync.run()
+            self.assertIn("history from before beta existed", beta.commands())
+
+    def test_it_names_both_keys_and_both_things_it_does(self) -> None:
+        """The prompt may get shorter; it may not get vaguer.
+
+        Two keys really are involved and they are checked with different
+        commands, so both fingerprints and both check lines have to be on
+        screen -- one of them being unfamiliar is what a machine that is not
+        yours looks like.
+        """
+        alpha, beta = self.two_machines()
+        with beta.active():
+            reads = crypto.recipient_for(sync.identity_path(store.machine())).strip()
+            signs = crypto.fingerprint(sync.signing_public())
+
+        out = self.run_cli(alpha, "accept", "--yes").out
+        self.assertIn(reads, out)
+        self.assertIn(signs, out)
+        self.assertIn("ENTIRE history", out)
+        self.assertIn(crypto.how_to_check_signer(), out)
+        self.assertIn(crypto.how_to_check(reads), out)
+
+    def test_there_is_nothing_to_do_the_second_time(self) -> None:
+        alpha, _ = self.two_machines()
+        self.run_cli(alpha, "accept", "--yes")
+        code, out, _ = self.run_cli(alpha, "accept", "--yes")
+        self.assertEqual(code, 0)
+        self.assertIn("already granted and trusted", out)
+
+    def test_a_changed_signing_key_is_not_swept_along(self) -> None:
+        """The one thing `accept` must not make easy.
+
+        A key that changed is either a machine you re-enrolled or someone
+        rewriting the repository, and nothing can tell those apart. Rolling it
+        into the newcomer prompt is exactly how the second gets agreed to by
+        someone answering the first.
+        """
+        alpha, beta = self.two_machines()
+        self.run_cli(alpha, "accept", "--yes")
+
+        # beta re-enrols with a new signing key and publishes under it.
+        with beta.active():
+            store.signing_key_file().unlink()
+            beta.record("2023-11-16", 1_700_200_001, "after the key changed")
+            sync.run()
+
+        code, out, err = self.run_cli(alpha, "accept", "--yes")
+        self.assertEqual(code, 1, out)
+        self.assertIn("trust --replace", err)
+        # And it did not quietly pin the new key on the way past.
+        with alpha.active():
+            changed = [c for c in sync.trust_candidates() if c.changed]
+        self.assertEqual(len(changed), 1)
+
+
+class TestInitFinishesTheJob(SyncTestCase):
+    """`init` used to end by telling you to run `sync`."""
+
+    def joining_machine(self) -> Fake:
+        """A machine with history of its own, not yet enrolled.
+
+        Not through the harness's `machine()`, which calls `sync.initialise`
+        directly -- this is the real `woswoar init` and nothing else. Recording
+        before enrolment is the ordinary case: the shell hook starts logging the
+        moment `woswoar install` runs, which is before anyone types a git URL.
+        """
+        beta = Fake(self.root, "beta")
+        with beta.active():
+            beta.record("2023-11-15", 1_700_100_001, "typed before beta enrolled")
+        return beta
+
+    def test_it_syncs_rather_than_telling_you_to(self) -> None:
+        """Reading old history still waits for `accept` -- that is the design.
+        What no longer waits is this machine publishing its own."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+
+        beta = self.joining_machine()
+        code, out, _ = self.run_cli(beta, "init", str(self.origin), "--new-identity")
+        self.assertEqual(code, 0, out)
+        self.assertIn("published 1 line(s)", out)
+
+        # On the remote, not merely on disk here: "it synced" means the other
+        # machines can see it.
+        with alpha.active():
+            sync.run()
+            self.assertIn(beta.id, store.repo_hosts())
+            self.assertTrue(store.chunk_names(beta.id, "2023-11-15"))
+
+    def test_no_sync_still_joins_without_exchanging_anything(self) -> None:
+        beta = self.joining_machine()
+        out = self.run_cli(beta, "init", str(self.origin), "--new-identity", "--no-sync").out
+        self.assertIn("Next: 'woswoar sync'", out)
+        with beta.active():
+            self.assertEqual(list(store.chunk_days(beta.id)), [])
+
+    def test_it_points_at_accept_when_there_is_another_machine(self) -> None:
+        """The step that is easy to miss, because it happens somewhere else."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+
+        beta = Fake(self.root, "beta")
+        out = self.run_cli(beta, "init", str(self.origin), "--new-identity").out
+        self.assertIn("woswoar accept", out)
+
+    def test_the_first_machine_is_not_told_to_accept_anything(self) -> None:
+        """There is nobody to run it on, and a step that cannot be done is
+        worse than no step: it reads as something having gone wrong."""
+        alpha = Fake(self.root, "alpha")
+        out = self.run_cli(alpha, "init", str(self.origin), "--new-identity").out
+        self.assertNotIn("woswoar accept", out)
+        self.assertIn("first machine", out)
+
+
 class TestLongCommandsSayWhatTheyAreDoing(SyncTestCase):
     """Reported from a real setup: "some commands take a long time and do not
     print anything, so I don't know if they are doing something or hanging".

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -4809,6 +4809,85 @@ class TestAcceptIsGrantAndTrustAtOnce(SyncTestCase):
         self.assertEqual(code, 0)
         self.assertIn("already granted and trusted", out)
 
+    def test_a_machine_enrolling_during_the_prompt_is_refused(self) -> None:
+        """`grant(approved=...)` means "what a human agreed to", and refuses if
+        its own fetch disagrees. Rebuilding that list *after* the prompt made
+        the refusal unable to fire for the window it exists to cover: the new
+        machine is picked up by both reads, they agree, and it is sealed into
+        the entire history without ever having been displayed.
+
+        Found by a review of this command, not by the suite -- the existing test
+        of the refusal drives `sync.grant` directly, so `accept` walked past it.
+        """
+        alpha, _ = self.two_machines()
+
+        def enrol_then_agree(question: str, yes: bool = False) -> bool:
+            # Somebody runs `woswoar init` on a third machine while the prompt
+            # is on screen. Written straight into the repo, which is what that
+            # looks like from here.
+            alpha.append_recipient("martin@somewhere-else")
+            return True
+
+        with mock.patch("woswoar.__main__._confirm", enrol_then_agree):
+            code, out, err = self.run_cli(alpha, "accept")
+
+        self.assertEqual(code, 1, out)
+        self.assertIn("changed while you were deciding", err + out)
+
+    def test_a_machine_new_to_read_and_changed_to_sign_is_not_called_accepted(self) -> None:
+        """The two lists have to be a partition.
+
+        `changed_key` excludes `needs_trust` but not `needs_grant`, and a
+        machine that has just joined has granted nobody while TOFU has pinned
+        everybody -- so any peer that re-keys is both. Listed among the
+        newcomers, its *unpinned* new fingerprint was printed under the words
+        "already accepted here", on the same screen that said its key had
+        changed.
+        """
+        alpha = self.machine("alpha", display="martin@desktop")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "old history")
+            sync.run()
+
+        gamma = self.machine("gamma", display="martin@server")  # pins alpha, grants nobody
+        with gamma.active():
+            sync.run()
+
+        with alpha.active():
+            store.signing_key_file().unlink()
+            alpha.record("2023-11-17", 1_700_300_001, "after alpha re-keyed")
+            sync.run()
+
+        with gamma.active():
+            (machine,) = sync.newcomers().machines
+            self.assertTrue(machine.needs_grant, "precondition: also new to read")
+            self.assertTrue(machine.changed_key, "precondition: and changed to sign")
+
+        code, out, err = self.run_cli(gamma, "accept", "--yes")
+        self.assertEqual(code, 1, out)
+        self.assertNotIn("already accepted here", out)
+        self.assertIn("trust --replace", err + out)
+
+    def test_two_machines_with_one_name_are_flagged(self) -> None:
+        """`grant` has said this since it existed, and `accept` widens read
+        access on the same evidence -- so it cannot be the quieter of the two.
+        Two machines really can share a name, and so can a key someone added."""
+        alpha, _ = self.two_machines()
+        with alpha.active():
+            alpha.append_recipient("martin@laptop")  # the name beta already uses
+
+        out = self.run_cli(alpha, "accept", "--yes").out
+        self.assertIn("SAME NAME AS ANOTHER KEY", out)
+
+    def test_it_says_when_this_machine_could_not_open_the_keys(self) -> None:
+        """Run on the machine that just joined -- which is where the remedies
+        now send people -- `accept` said "re-sealed 0 key file(s), so they can
+        read the older history". Both halves of that are false."""
+        _, beta = self.two_machines()
+        _, out, err = self.run_cli(beta, "accept", "--yes")
+        self.assertNotIn("so they can read the older history", out)
+        self.assertIn("could not be opened by this machine", err)
+
     def test_a_changed_signing_key_is_not_swept_along(self) -> None:
         """The one thing `accept` must not make easy.
 
@@ -4877,6 +4956,25 @@ class TestInitFinishesTheJob(SyncTestCase):
         with beta.active():
             self.assertEqual(list(store.chunk_days(beta.id)), [])
 
+    def test_a_failed_first_sync_does_not_fail_the_join(self) -> None:
+        """The join is done and durable by the time the sync runs -- identity
+        saved, repo cloned, peers pinned. A remote that blinked must not report
+        all of that as failure, because the obvious response to a failed `init`
+        is to run it again."""
+        beta = self.joining_machine()
+
+        def unreachable(*args: object, **kwargs: object) -> None:
+            raise sync.SyncError("could not read from remote repository")
+
+        with mock.patch.object(sync, "run", unreachable):
+            code, out, err = self.run_cli(beta, "init", str(self.origin), "--new-identity")
+
+        self.assertEqual(code, 0, err)
+        self.assertIn("joined, but the first sync failed", err)
+        self.assertIn("woswoar sync", out + err)
+        with beta.active():
+            self.assertTrue(sync.is_repo(), "the join itself was still completed")
+
     def test_it_points_at_accept_when_there_is_another_machine(self) -> None:
         """The step that is easy to miss, because it happens somewhere else."""
         alpha = self.machine("alpha")
@@ -4894,6 +4992,58 @@ class TestInitFinishesTheJob(SyncTestCase):
         out = self.run_cli(alpha, "init", str(self.origin), "--new-identity").out
         self.assertNotIn("woswoar accept", out)
         self.assertIn("first machine", out)
+
+
+class TestNewcomersIsAskedDirectly(SyncTestCase):
+    """The pairing decides who is offered read access, so it is asserted here
+    rather than through `accept`'s stdout -- which is the rule `Reader`'s own
+    docstring states and the one place the new seam was not following it."""
+
+    def test_this_machine_is_not_a_newcomer_to_itself(self) -> None:
+        alpha = self.machine("alpha", display="martin@desktop")
+        with alpha.active():
+            sync.run()
+            self.assertEqual(sync.newcomers().machines, [])
+
+    def test_the_enrolled_list_is_every_recipient_not_only_the_new_ones(self) -> None:
+        """`grant` re-seals to all of them, so a partial list would narrow
+        access to whoever happened to be pending."""
+        alpha, _ = self.two()
+        with alpha.active():
+            pending = sync.newcomers()
+            self.assertEqual(sorted(pending.enrolled), sorted(sync.recipients()))
+            self.assertEqual(len(pending.machines), 1, "only the newcomer is pending")
+
+    def test_a_machine_already_accepted_is_not_offered_again(self) -> None:
+        alpha, _ = self.two()
+        self.run_cli(alpha, "accept", "--yes")
+        with alpha.active():
+            self.assertEqual(sync.newcomers().machines, [])
+
+    def test_the_reader_and_the_candidate_are_the_same_machine(self) -> None:
+        alpha, beta = self.two()
+        with beta.active():
+            reads = crypto.recipient_for(sync.identity_path(store.machine())).strip()
+            signs = sync.signing_public()
+        with alpha.active():
+            (machine,) = sync.newcomers().machines
+        self.assertIsNotNone(machine.reader)
+        self.assertIsNotNone(machine.candidate)
+        assert machine.reader is not None and machine.candidate is not None
+        self.assertEqual(machine.reader.key, reads)
+        self.assertEqual(machine.candidate.verify_key, signs)
+        self.assertEqual(machine.label, "martin@laptop")
+
+    def two(self) -> tuple[Fake, Fake]:
+        alpha = self.machine("alpha", display="martin@desktop")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "old history")
+            sync.run()
+        beta = self.machine("beta", display="martin@laptop")
+        with beta.active():
+            beta.record("2023-11-15", 1_700_100_001, "beta history")
+            sync.run()
+        return alpha, beta
 
 
 class TestLongCommandsSayWhatTheyAreDoing(SyncTestCase):

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import re
 import sys
+import textwrap
 import time
 from collections import Counter
 from pathlib import Path
@@ -969,23 +970,73 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--version", action="version", version=f"woswoar {__version__}")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
+    def sub(
+        name: str, summary: str, detail: str, aliases: list[str] | None = None
+    ) -> argparse.ArgumentParser:
+        """One subcommand, with the same sentence in the listing and in `-h`.
+
+        `help=` alone appears only in `woswoar --help`; `woswoar doctor -h` used
+        to print a usage line, `-h, --help`, and nothing whatever about what
+        doctor does. Every subcommand was like that. So `description` is not
+        optional here, and `Raw...HelpFormatter` keeps the paragraphs from being
+        reflowed into one block.
+        """
+        return subparsers.add_parser(
+            name,
+            help=summary,
+            description=f"{summary[0].upper()}{summary[1:]}.\n\n{textwrap.dedent(detail).strip()}",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            aliases=aliases or [],
+        )
+
     def add_scope(sub: argparse.ArgumentParser) -> None:
         sub.add_argument("--scope", choices=search.SCOPES, default="global")
         sub.add_argument(
             "--no-dedup", action="store_true", help="keep repeated commands instead of collapsing"
         )
 
-    p_search = subparsers.add_parser("search", help="pick a command interactively with fzf")
+    p_search = sub(
+        "search",
+        "pick a command interactively with fzf",
+        """
+        What Ctrl-R runs. The chosen command is placed on your prompt for
+        editing, never executed.
+
+        Ctrl-G, Ctrl-H and Ctrl-S switch between every machine, this machine,
+        and this shell session, without leaving the picker.
+        """,
+    )
     add_scope(p_search)
     p_search.add_argument("--query", default="", help="initial fzf query")
     p_search.set_defaults(func=cmd_search)
 
-    p_list = subparsers.add_parser("list", help="print matching lines (used by fzf reload)")
+    p_list = sub(
+        "list",
+        "print matching lines as plain text",
+        """
+        Mostly internal: this is what the picker re-runs when you switch scope
+        with Ctrl-G, Ctrl-H or Ctrl-S. It is also how to read your history
+        without fzf installed, and it pipes -- `woswoar list | grep docker`.
+        """,
+    )
     add_scope(p_list)
     p_list.add_argument("--limit", type=int, default=None)
     p_list.set_defaults(func=cmd_list)
 
-    p_import = subparsers.add_parser("import", help="import an existing shell history")
+    p_import = sub(
+        "import",
+        "import an existing shell history",
+        """
+        Idempotent: importing the same file twice adds nothing the second time,
+        so it is safe to re-run. Commands that look like credentials are
+        skipped; `--dry-run` lists what would be skipped without importing.
+
+        For atuin on more than one woswoar machine, use `--this-host-only` on
+        each. atuin keeps every machine it has synced with in one database, and
+        sync publishes only this machine's own commands -- so importing all of
+        them everywhere stores each machine's history once per machine.
+        """,
+    )
     p_import.add_argument("kind", choices=importer.KINDS)
     p_import.add_argument(
         "--file",
@@ -1000,18 +1051,58 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_import.set_defaults(func=cmd_import)
 
-    p_install = subparsers.add_parser("install", help="install the shell hook into .bashrc")
+    p_install = sub(
+        "install",
+        "install the shell hook into .bashrc",
+        """
+        Copies the bash hook and adds a marked block to your rcfile. Safe to
+        re-run: the block is replaced rather than repeated, which is also how
+        to upgrade the hook after installing a new woswoar.
+
+        Reports any missing tool (fzf, age, git) and the command to install it.
+        """,
+    )
     p_install.add_argument("--rcfile", help="file to modify (default: ~/.bashrc)")
     p_install.set_defaults(func=cmd_install)
 
-    p_stats = subparsers.add_parser("stats", help="summarise recorded history")
+    p_stats = sub(
+        "stats",
+        "summarise recorded history",
+        """
+        How much is recorded, over what period, per machine, and which commands
+        you run most.
+        """,
+    )
     p_stats.add_argument("--top", type=int, default=10)
     p_stats.set_defaults(func=cmd_stats)
 
-    p_doctor = subparsers.add_parser("doctor", help="check the installation")
+    p_doctor = sub(
+        "doctor",
+        "check the installation and report what is wrong",
+        """
+        Run this first when something is not working. Checks the tools woswoar
+        needs, the shell hook, file permissions, the identity and signing keys,
+        and the state of the history repo -- and prints what to do about each
+        failure rather than only that it failed.
+
+        Changes nothing.
+        """,
+    )
     p_doctor.set_defaults(func=cmd_doctor)
 
-    p_init = subparsers.add_parser("init", help="create or join a history repo")
+    p_init = sub(
+        "init",
+        "create or join an encrypted history repo",
+        """
+        Run once per machine, with the git URL of a repository you own -- an
+        empty GitHub repo, a bare repo on a NAS, a folder on a USB stick. There
+        is no server and no account.
+
+        It enrols this machine, does the first sync, and tells you the one
+        remaining step. On the second and later machines that step is
+        `woswoar accept`, run on a machine you already use.
+        """,
+    )
     p_init.add_argument("remote", nargs="?", help="git URL of the history repo")
     p_init.add_argument(
         "--new-identity",
@@ -1026,22 +1117,60 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_init.set_defaults(func=cmd_init)
 
-    p_sync = subparsers.add_parser("sync", help="exchange history with the remote")
+    p_sync = sub(
+        "sync",
+        "exchange history with the remote",
+        """
+        Publishes this machine's new commands and merges everyone else's. Safe
+        to run at any time and safe to run concurrently; normally a systemd
+        timer runs it once a minute.
+
+        Only this machine's own commands are ever published from here.
+        """,
+    )
     p_sync.add_argument("--no-push", action="store_true", help="stay local; do not contact remote")
     p_sync.set_defaults(func=cmd_sync)
 
-    p_grant = subparsers.add_parser(
+    p_grant = sub(
         "grant",
+        "let newly enrolled machines read the older history",
+        """
+        Answers one question: who may READ what is already here. It re-seals
+        the small per-day keys to every enrolled machine, so they can decrypt
+        days recorded before they existed. The history itself is not rewritten.
+
+        Widens access to everything, so it lists the machines and asks first.
+        Run it once, on any machine that can already read the history.
+
+        Most of the time you want `woswoar accept`, which does this and the
+        other half together. Reach for `grant` on its own to let a machine read
+        the history WITHOUT this machine believing what that machine publishes
+        -- sharing a repository with someone else, rather than adding your own
+        laptop.
+        """,
         # `reencrypt` named the mechanism, which hid what it does to the user's
         # history. Kept working so older notes and error messages do not rot.
         aliases=["reencrypt"],
-        help="let newly enrolled machines read the older history",
     )
     p_grant.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
     p_grant.set_defaults(func=cmd_grant)
 
-    p_revoke = subparsers.add_parser(
-        "revoke", help="withdraw a machine's access to history recorded from now on"
+    p_revoke = sub(
+        "revoke",
+        "withdraw a machine's access to history recorded from now on",
+        """
+        Permanent, and deliberately so: there is no un-revoke. Every other
+        machine stops accepting what the revoked one publishes, automatically,
+        at its next sync.
+
+        Three things it cannot do. It cannot make the revoked machine forget
+        history it has already read; it cannot recall what it already
+        published; and it cannot re-key days it could already open. Take the
+        machine's own copy seriously.
+
+        Run `woswoar sync` before revoking if you still want the history that
+        machine published and yours have not merged yet.
+        """,
     )
     p_revoke.add_argument(
         "fingerprint",
@@ -1050,8 +1179,25 @@ def build_parser() -> argparse.ArgumentParser:
     p_revoke.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
     p_revoke.set_defaults(func=cmd_revoke)
 
-    p_trust = subparsers.add_parser(
-        "trust", help="accept another machine's published history on this machine"
+    p_trust = sub(
+        "trust",
+        "accept another machine's published history on this machine",
+        """
+        Answers the other question: whose new history does THIS machine
+        believe. Every machine signs what it publishes, and each of yours
+        decides for itself whose signature it accepts.
+
+        Local only. Nothing is written to the repository and nothing is
+        published -- which is the point, because the repository is exactly what
+        this decision defends against: anyone who can push to it can rewrite
+        what it claims. So it has to be run on each machine that will read the
+        new one.
+
+        Most of the time you want `woswoar accept`. Use `--replace` for a
+        machine whose signing key CHANGED, which `accept` refuses on purpose:
+        that is either a machine you re-enrolled or someone rewriting the
+        repository, and nothing can tell those apart -- you can.
+        """,
     )
     p_trust.add_argument(
         "--replace",
@@ -1061,14 +1207,43 @@ def build_parser() -> argparse.ArgumentParser:
     p_trust.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
     p_trust.set_defaults(func=cmd_trust)
 
-    p_accept = subparsers.add_parser(
+    p_accept = sub(
         "accept",
-        help="add a machine you own: 'grant' and 'trust' in one step",
+        "add a machine you own: 'grant' and 'trust' in one step",
+        """
+        Run this on each machine you already use, after `woswoar init` on the
+        new one. It does both halves of adding a machine:
+
+          read     the new machine may read your entire history, including
+                   days recorded before it existed. Published, so it applies
+                   everywhere, and it cannot be taken back for what has already
+                   been read.
+          believe  this machine accepts what the new one publishes. Local only,
+                   so every other machine of yours needs telling separately.
+
+        Shows both keys and asks first. A name is free text written by whoever
+        added the key; the fingerprints are not, so check those on the machine
+        they belong to.
+
+        It will not accept a CHANGED signing key -- see `woswoar trust
+        --replace`.
+        """,
     )
     p_accept.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
     p_accept.set_defaults(func=cmd_accept)
 
-    p_compact = subparsers.add_parser("compact", help="merge old chunks (reduces file count)")
+    p_compact = sub(
+        "compact",
+        "merge old chunks to reduce the file count",
+        """
+        Each sync writes a small encrypted chunk, so a busy machine accumulates
+        a lot of files. This merges each past day's chunks into one.
+
+        Only days before today, and only this machine's own. Nothing is lost:
+        the plaintext in logs/ is untouched, and the old chunks stay in git
+        history like every other commit.
+        """,
+    )
     p_compact.add_argument("--before", help="only days before this YYYY-MM-DD (default: today)")
     p_compact.set_defaults(func=cmd_compact)
 

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -16,7 +16,7 @@ from .entry import make_inert
 from .errors import WoswoarError
 
 if TYPE_CHECKING:  # `sync` is imported lazily; only the annotation needs it.
-    from .sync import Reader
+    from .sync import Reader, ReencryptReport
 
 #: Both "no repo key yet" and "some days unreadable" have the same fix, and
 #: used to say so in two independently worded paragraphs.
@@ -415,14 +415,26 @@ def cmd_init(args: argparse.Namespace) -> int:
         print("\nNext: 'woswoar sync'.")
     else:
         print()
-        report = sync.run()
-        print(
-            f"published {report.lines_exported} line(s) of this machine's history; "
-            f"merged {report.lines_imported} line(s) from {len(report.hosts_seen)} other machine(s)"
-        )
+        try:
+            report = sync.run()
+        except WoswoarError as exc:
+            # The join itself is done and durable by this point -- the identity
+            # is saved, the repo is cloned, the peers are pinned. A remote that
+            # blinked must not make all of that report failure, because the
+            # obvious response to a failed `init` is to run it again.
+            print(f"joined, but the first sync failed:\n  {exc}", file=sys.stderr)
+            print("Nothing is lost; run 'woswoar sync' when the remote is reachable.")
+        else:
+            print(
+                f"published {report.lines_exported} line(s) of this machine's history; "
+                f"merged {report.lines_imported} line(s) from "
+                f"{len(report.hosts_seen)} other machine(s)"
+            )
 
-    others = [key for key in sync.recipients() if key != crypto.recipient_for(identity).strip()]
-    if others:
+    # Asked of `sync`, which already knows how to fail softly at working out
+    # this machine's own key: open-coding `crypto.recipient_for` here turned an
+    # unreadable identity into a failed `init` that had actually succeeded.
+    if sync.others_enrolled():
         # The step that is easy to miss, because it happens somewhere else. Said
         # in terms of what is missing rather than of the commands: `accept` is
         # one thing to run, and it names both halves itself.
@@ -658,7 +670,20 @@ def cmd_grant(args: argparse.Namespace) -> int:
     if new and not _confirm(f"Grant {len(new)} new machine(s) full access?", args.yes):
         return 1
 
-    report = sync.grant(approved=[reader.key for reader in readers])
+    _report_reseal(sync.grant(approved=[reader.key for reader in readers]))
+    return 0
+
+
+def _report_reseal(report: ReencryptReport, waiting: bool = True) -> None:
+    """Say what re-sealing did. Shared, because the half that is easy to omit
+    is the half that matters.
+
+    `skipped` is what distinguishes "nothing needed doing" from "this machine
+    could not do it" -- the state a *newly joined* machine is in, which is
+    exactly where someone lands after being told to run this. `accept` reported
+    only `resealed`, so on that machine it said "re-sealed 0 key file(s), so
+    they can read the older history", which is false in both halves.
+    """
     if report.resealed or report.skipped:
         print(f"\nre-sealed {report.resealed} key file(s)")
     else:
@@ -667,7 +692,8 @@ def cmd_grant(args: argparse.Namespace) -> int:
         print("\nnothing to do: every key is already sealed to these machines")
     if report.pushed:
         print("published to the remote")
-        print("\nOn each machine that was waiting, run:  woswoar sync")
+        if waiting:
+            print("\nOn each machine that was waiting, run:  woswoar sync")
     else:
         print("no remote configured, so nothing was published")
 
@@ -681,7 +707,6 @@ def cmd_grant(args: argparse.Namespace) -> int:
             "those instead.",
             file=sys.stderr,
         )
-    return 0
 
 
 def cmd_revoke(args: argparse.Namespace) -> int:
@@ -812,12 +837,17 @@ def cmd_accept(args: argparse.Namespace) -> int:
     from . import crypto, sync
 
     pending = sync.newcomers()
-    if not pending:
+    if not pending.machines:
         print("nothing to accept; every machine here is already granted and trusted")
         return 0
 
-    changed = [n for n in pending if n.changed_key]
-    fresh = [n for n in pending if n.needs_grant or n.needs_trust]
+    # A partition, not two overlapping filters. A machine can be new to read
+    # *and* changed to sign -- the ordinary state on a machine that has just
+    # joined, where TOFU pinned every peer and nothing has been granted yet --
+    # and listing it among the newcomers printed its unpinned new key under
+    # "already accepted here" on the same screen that said its key had changed.
+    changed = [n for n in pending.machines if n.changed_key]
+    fresh = [n for n in pending.machines if not n.changed_key]
 
     if not fresh:
         print(
@@ -831,7 +861,11 @@ def cmd_accept(args: argparse.Namespace) -> int:
 
     print(f"{len(fresh)} machine(s) not yet accepted here:\n")
     for machine in fresh:
-        print(f"  {machine.display_name()}")
+        # `shares_name` is why this cannot just print the name: two machines
+        # really can both be `martin@laptop`, and so can a key someone else
+        # added. `grant` has said this since it existed.
+        note = "   (SAME NAME AS ANOTHER KEY)" if machine.shares_name else ""
+        print(f"  {machine.display_name()}{note}")
         if machine.reader is not None:
             said = "reads with" if machine.needs_grant else "already reads your history"
             print(f"      {said:<28}{machine.reader.fingerprint}")
@@ -877,21 +911,31 @@ def cmd_accept(args: argparse.Namespace) -> int:
         # Deliberately not part of the prompt above. Accepting a *new* machine
         # and accepting a new key for one already accepted are different
         # decisions, and rolling them together is how the second gets made by
-        # someone answering the first.
-        print(
-            f"\nSeparately, {len(changed)} machine(s) changed their signing key. That is not"
-            "\npart of this and needs:  woswoar trust --replace"
-        )
+        # someone answering the first. Both fingerprints, as `trust --replace`
+        # shows them: which key is being left behind is half the question.
+        print(f"\nSeparately, {len(changed)} machine(s) changed their signing key:\n")
+        for machine in changed:
+            print(f"  {machine.display_name()}")
+            if machine.candidate is not None:
+                print(f"      now signs with              {machine.candidate.fingerprint}")
+                print(f"      accepted here              {machine.candidate.pinned_fingerprint}")
+        print("\nThat is not part of this, and needs:  woswoar trust --replace")
 
     if not _confirm(f"Accept {len(fresh)} machine(s)?", args.yes):
         return 1
 
     if granting:
-        report = sync.grant(approved=[reader.key for reader in sync.readers()])
-        print(f"\nre-sealed {report.resealed} key file(s), so they can read the older history")
+        # `pending.enrolled`, from the fetch that produced what was on screen --
+        # never a fresh `readers()` call. `grant` refuses when its own fetch
+        # disagrees with what a human agreed to, and asking again *after* the
+        # prompt makes that refusal unable to fire for the window it exists to
+        # cover: a machine enrolling while the prompt is up would be picked up
+        # by both reads, they would agree, and it would be sealed into the whole
+        # history without ever having been shown.
+        _report_reseal(sync.grant(approved=pending.enrolled), waiting=False)
     if trusting:
         sync.trust([n.candidate for n in trusting if n.candidate is not None])
-        print(f"accepted the history published by {len(trusting)} machine(s)")
+        print(f"\naccepted the history published by {len(trusting)} machine(s)")
 
     print("\nNext: 'woswoar sync' to exchange history with them.")
     return 0

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:  # `sync` is imported lazily; only the annotation needs it.
 #: used to say so in two independently worded paragraphs.
 _GRANT_REMEDY = (
     "On a machine that is already enrolled run:\n"
-    "    woswoar grant\n"
+    "    woswoar accept\n"
     "then sync here again. Nothing is lost in the meantime."
 )
 
@@ -403,10 +403,37 @@ def cmd_init(args: argparse.Namespace) -> int:
             print(f"  {crypto.fingerprint(verify_key)}")
         print("Check these against the machines themselves if the repository is shared.")
 
-    if args.remote:
+    if not args.remote:
+        return 0
+
+    # The sync `init` used to tell you to run. Nothing about it is a separate
+    # decision -- joining a repository and then not exchanging anything with it
+    # is not a state anyone wants -- and leaving it to a second command meant
+    # the machine published nothing until one was run. `--no-sync` is there for
+    # the case where the remote is not reachable yet.
+    if args.no_sync:
         print("\nNext: 'woswoar sync'.")
-        print("On a machine that already has access, run 'woswoar grant' so this")
-        print("one can read history sealed before it joined.")
+    else:
+        print()
+        report = sync.run()
+        print(
+            f"published {report.lines_exported} line(s) of this machine's history; "
+            f"merged {report.lines_imported} line(s) from {len(report.hosts_seen)} other machine(s)"
+        )
+
+    others = [key for key in sync.recipients() if key != crypto.recipient_for(identity).strip()]
+    if others:
+        # The step that is easy to miss, because it happens somewhere else. Said
+        # in terms of what is missing rather than of the commands: `accept` is
+        # one thing to run, and it names both halves itself.
+        print(
+            "\nLast step, on each machine you already use:\n"
+            "    woswoar accept\n"
+            "That is what lets this machine read history from before it joined, and"
+            "\nwhat tells the others to accept what it publishes."
+        )
+    else:
+        print("\nThis is the first machine here. Run 'woswoar init' on the next one.")
     return 0
 
 
@@ -462,7 +489,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
             f"\n{len(report.untrusted)} machine(s) publish history this one has not been\n"
             "told to accept, so none of it was merged. That is what a machine enrolled\n"
             "since this one last looked is supposed to look like.\n"
-            "    woswoar trust",
+            "    woswoar accept",
             file=sys.stderr,
         )
 
@@ -772,6 +799,104 @@ def cmd_trust(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_accept(args: argparse.Namespace) -> int:
+    """`grant` and `trust` for a machine you own, in one step.
+
+    The two stay separate commands: they answer different questions, and someone
+    sharing a repository with a colleague may well answer them differently. This
+    is for the common case, where the answer to both is "yes, that one is mine"
+    -- reported as the thing that made setting up a second machine feel like too
+    much. Both are still named and described here, because what is being agreed
+    to is exactly what it was before.
+    """
+    from . import crypto, sync
+
+    pending = sync.newcomers()
+    if not pending:
+        print("nothing to accept; every machine here is already granted and trusted")
+        return 0
+
+    changed = [n for n in pending if n.changed_key]
+    fresh = [n for n in pending if n.needs_grant or n.needs_trust]
+
+    if not fresh:
+        print(
+            f"{len(changed)} machine(s) now sign with a different key than the one\n"
+            "accepted here. That is either a machine you re-enrolled or someone\n"
+            "rewriting the repository, and nothing can tell those apart:\n"
+            "    woswoar trust --replace",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"{len(fresh)} machine(s) not yet accepted here:\n")
+    for machine in fresh:
+        print(f"  {machine.display_name()}")
+        if machine.reader is not None:
+            said = "reads with" if machine.needs_grant else "already reads your history"
+            print(f"      {said:<28}{machine.reader.fingerprint}")
+        if machine.candidate is not None:
+            said = "signs with" if machine.needs_trust else "already accepted here"
+            print(f"      {said:<28}{machine.candidate.fingerprint}")
+
+    granting = [n for n in fresh if n.needs_grant]
+    trusting = [n for n in fresh if n.needs_trust]
+    print("\nAccepting does two separate things:\n")
+    if granting:
+        print(
+            f"  read     {len(granting)} machine(s) get to read your ENTIRE history, including"
+            "\n           days recorded before they existed. This is published, so it"
+            "\n           applies everywhere -- and it cannot be taken back for what"
+            "\n           they have already read.\n"
+        )
+    if trusting:
+        print(
+            f"  believe  this machine will accept what {len(trusting)} machine(s) publish."
+            "\n           Local only: every other machine of yours has to be told"
+            "\n           separately, because the repository is the thing that decision"
+            "\n           defends against.\n"
+        )
+    # One line per *kind* of key on screen, not one blanket command. There are
+    # two here and they are checked differently -- `grant` sends you to the age
+    # identity, `trust` to woswoar's own signing key -- and advice that does not
+    # match what is above it is advice nobody follows.
+    checks = []
+    if granting:
+        reads = dict.fromkeys(
+            crypto.how_to_check(n.reader.fingerprint) for n in granting if n.reader is not None
+        )
+        checks += [f"    reads with   {command}" for command in reads]
+    if trusting:
+        checks.append(f"    signs with   {crypto.how_to_check_signer()}")
+    print(
+        "A name is free text written by whoever added the key. The fingerprints are"
+        "\nnot -- run these on the machine they belong to and compare:\n"
+    )
+    print("\n".join(checks))
+    if changed:
+        # Deliberately not part of the prompt above. Accepting a *new* machine
+        # and accepting a new key for one already accepted are different
+        # decisions, and rolling them together is how the second gets made by
+        # someone answering the first.
+        print(
+            f"\nSeparately, {len(changed)} machine(s) changed their signing key. That is not"
+            "\npart of this and needs:  woswoar trust --replace"
+        )
+
+    if not _confirm(f"Accept {len(fresh)} machine(s)?", args.yes):
+        return 1
+
+    if granting:
+        report = sync.grant(approved=[reader.key for reader in sync.readers()])
+        print(f"\nre-sealed {report.resealed} key file(s), so they can read the older history")
+    if trusting:
+        sync.trust([n.candidate for n in trusting if n.candidate is not None])
+        print(f"accepted the history published by {len(trusting)} machine(s)")
+
+    print("\nNext: 'woswoar sync' to exchange history with them.")
+    return 0
+
+
 def cmd_compact(args: argparse.Namespace) -> int:
     from . import sync
 
@@ -850,6 +975,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="generate a dedicated age key instead of reusing an SSH key",
     )
     p_init.add_argument("--identity", help="use this private key")
+    p_init.add_argument(
+        "--no-sync",
+        action="store_true",
+        help="join the repo but do not exchange history yet",
+    )
     p_init.set_defaults(func=cmd_init)
 
     p_sync = subparsers.add_parser("sync", help="exchange history with the remote")
@@ -886,6 +1016,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_trust.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
     p_trust.set_defaults(func=cmd_trust)
+
+    p_accept = subparsers.add_parser(
+        "accept",
+        help="add a machine you own: 'grant' and 'trust' in one step",
+    )
+    p_accept.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
+    p_accept.set_defaults(func=cmd_accept)
 
     p_compact = subparsers.add_parser("compact", help="merge old chunks (reduces file count)")
     p_compact.add_argument("--before", help="only days before this YYYY-MM-DD (default: today)")

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -923,6 +923,20 @@ class Candidate(NamedTuple):
         return repr(self.label)
 
 
+def _refresh() -> None:
+    """Take the remote's view, under a lock the caller already holds.
+
+    Every command that asks a human about another machine does this first, and
+    for the same reason: the machine being asked about is the one that enrolled
+    since this one last looked, so a pre-fetch answer lists fewer machines than
+    the operation is about to act on. That is the one direction a security
+    confirmation must never be wrong in.
+    """
+    repo = read_repo()
+    if repo.has_remote:
+        _fetch_and_rebase(repo)
+
+
 def trust_candidates() -> list[Candidate]:
     """Every other machine publishing here, with what this one accepts from it.
 
@@ -930,45 +944,52 @@ def trust_candidates() -> list[Candidate]:
     machine that appeared since this one last looked.
     """
     with lock():
-        repo = read_repo()
-        if repo.has_remote:
-            _fetch_and_rebase(repo)
+        _refresh()
+        return _trust_candidates()
 
-        known = store.machine()
-        state = State.load()
-        live = set(recipients())
 
-        # Every host, before the loop: `trust` is *always* about a machine this
-        # one has never merged, so without this it never had a name to show.
-        learn_names(known, store.repo_hosts())
+def _trust_candidates() -> list[Candidate]:
+    """The list itself, assuming the caller holds the lock and has fetched.
 
-        out: list[Candidate] = []
-        for host_id in store.repo_hosts():
-            if host_id == known.id:
-                continue
-            signer = read_signer(host_id)
-            if signer is None:
-                continue
-            # Only hosts whose owning recipient is *live* are offered. That
-            # covers both cases in one test, because `recipients` already
-            # subtracts tombstoned keys: a withdrawn machine is not in
-            # `live`, and neither is a host nothing ties to a recipient -- which
-            # must also stay unacceptable, or the tombstone that would stop it
-            # later would have nothing to act on.
-            if signer.owner not in live:
-                continue
-            pinned = state.signers.get(host_id)
-            out.append(
-                Candidate(
-                    host_id=host_id,
-                    verify_key=signer.verify_key,
-                    label=name_for(host_id).text,
-                    fingerprint=crypto.fingerprint(signer.verify_key),
-                    pinned=pinned,
-                    pinned_fingerprint=crypto.fingerprint(pinned) if pinned else "",
-                )
+    Split out for `newcomers`, which needs this *and* `_readers` and must not
+    pay for two fetches of the same repository to get them -- `accept` is a
+    command someone runs while waiting.
+    """
+    known = store.machine()
+    state = State.load()
+    live = set(recipients())
+
+    # Every host, before the loop: `trust` is *always* about a machine this
+    # one has never merged, so without this it never had a name to show.
+    learn_names(known, store.repo_hosts())
+
+    out: list[Candidate] = []
+    for host_id in store.repo_hosts():
+        if host_id == known.id:
+            continue
+        signer = read_signer(host_id)
+        if signer is None:
+            continue
+        # Only hosts whose owning recipient is *live* are offered. That
+        # covers both cases in one test, because `recipients` already
+        # subtracts tombstoned keys: a withdrawn machine is not in
+        # `live`, and neither is a host nothing ties to a recipient -- which
+        # must also stay unacceptable, or the tombstone that would stop it
+        # later would have nothing to act on.
+        if signer.owner not in live:
+            continue
+        pinned = state.signers.get(host_id)
+        out.append(
+            Candidate(
+                host_id=host_id,
+                verify_key=signer.verify_key,
+                label=name_for(host_id).text,
+                fingerprint=crypto.fingerprint(signer.verify_key),
+                pinned=pinned,
+                pinned_fingerprint=crypto.fingerprint(pinned) if pinned else "",
             )
-        return out
+        )
+    return out
 
 
 def trust(candidates: list[Candidate]) -> None:
@@ -2334,35 +2355,128 @@ def readers() -> list[Reader]:
     parses either side of the prompt, so they could describe different sets.
     """
     with lock():
-        repo = read_repo()
-        if repo.has_remote:
-            _fetch_and_rebase(repo)
-        granted = set(State.load().granted)
-        enrolled = recipients()
+        _refresh()
+        return _readers()
+
+
+def _readers() -> list[Reader]:
+    """The list itself, assuming the caller holds the lock and has fetched.
+
+    Split from `readers` for `newcomers`, which needs this and
+    `_trust_candidates` from one fetch rather than two.
+    """
+    granted = set(State.load().granted)
+    enrolled = recipients()
+    owners = _host_owners()
+
+    # Not fatal if this machine's own key cannot be worked out: the list is
+    # still true, it just loses the "(this machine)" note. `grant` is the
+    # command someone runs *because* something is wrong with enrolment.
+    try:
+        mine = crypto.recipient_for(identity_path(store.machine())).strip()
+    except (WoswoarError, OSError):
+        mine = ""
+
+    learn_names(store.machine(), {host for host in owners.values() if host})
+    labelled = [(key, name_for(owners.get(key))) for key in enrolled]
+    names = Counter(name.text for _, name in labelled if name.known)
+    return [
+        Reader(
+            key=key,
+            label=name.text,
+            fingerprint=crypto.fingerprint(key),
+            is_new=key not in granted,
+            is_mine=key == mine,
+            shares_name=name.known and names[name.text] > 1,
+        )
+        for key, name in labelled
+    ]
+
+
+class Newcomer(NamedTuple):
+    """One machine, and both of the things `accept` would do about it.
+
+    `grant` and `trust` answer different questions -- who may *read* what is
+    here, and whose word this machine *believes* -- and they are deliberately
+    separate commands with separate keys. That distinction is real and stays in
+    the interface. What it is not is something a person setting up their second
+    laptop should have to hold in their head to get there: the answer to both,
+    for a machine they own, is yes.
+
+    So this pairs them per machine, and `accept` says both out loud in one
+    prompt rather than collapsing them into one word. Two fingerprints are shown
+    because there really are two keys; one of them being unfamiliar is exactly
+    what a machine that is not yours looks like.
+    """
+
+    label: str
+    #: The age recipient it reads with. None when nothing in the repo ties this
+    #: host to a live recipient -- which `trust_candidates` already refuses.
+    reader: Reader | None
+    #: The signing key it publishes with. None for a machine that enrolled but
+    #: has never pushed a `signer.pub`.
+    candidate: Candidate | None
+
+    @property
+    def needs_grant(self) -> bool:
+        return self.reader is not None and self.reader.is_new
+
+    @property
+    def needs_trust(self) -> bool:
+        return self.candidate is not None and self.candidate.pinned is None
+
+    @property
+    def changed_key(self) -> bool:
+        """Re-enrolled, or someone rewriting the repository. Never guessed at."""
+        return self.candidate is not None and self.candidate.changed
+
+    def display_name(self) -> str:
+        """See `Reader.display_name`: never print `label` directly."""
+        return repr(self.label)
+
+
+def newcomers() -> list[Newcomer]:
+    """Every machine `accept` has something to do about, from one fetch.
+
+    Own machine excluded -- `_trust_candidates` drops it already, and a reader
+    with no candidate is dropped below for the same reason. A machine that is
+    fully granted and fully trusted is not returned at all: `accept` is about
+    what is left to decide.
+    """
+    with lock():
+        _refresh()
+        by_host = {c.host_id: c for c in _trust_candidates()}
         owners = _host_owners()
+        # Recipient -> host, inverted so a Reader can find its Candidate. A
+        # recipient with no host directory has nothing to pair with and cannot
+        # be trusted anyway, so it is carried with `candidate=None` and shows up
+        # as grant-only.
+        readers_by_host: dict[str, Reader] = {}
+        loose: list[Reader] = []
+        for reader in _readers():
+            host = owners.get(reader.key)
+            if host is None:
+                loose.append(reader)
+            else:
+                readers_by_host[host] = reader
 
-        # Not fatal if this machine's own key cannot be worked out: the list is
-        # still true, it just loses the "(this machine)" note. `grant` is the
-        # command someone runs *because* something is wrong with enrolment.
-        try:
-            mine = crypto.recipient_for(identity_path(store.machine())).strip()
-        except (WoswoarError, OSError):
-            mine = ""
-
-        learn_names(store.machine(), {host for host in owners.values() if host})
-        labelled = [(key, name_for(owners.get(key))) for key in enrolled]
-        names = Counter(name.text for _, name in labelled if name.known)
-        return [
-            Reader(
-                key=key,
-                label=name.text,
-                fingerprint=crypto.fingerprint(key),
-                is_new=key not in granted,
-                is_mine=key == mine,
-                shares_name=name.known and names[name.text] > 1,
+        out: list[Newcomer] = []
+        for host_id, candidate in by_host.items():
+            paired = readers_by_host.pop(host_id, None)
+            out.append(
+                Newcomer(
+                    label=candidate.label,
+                    reader=paired,
+                    candidate=candidate,
+                )
             )
-            for key, name in labelled
-        ]
+        # Enrolled, but publishing nothing this machine can be asked to believe:
+        # granting is still a real decision, so it is still offered.
+        for reader in [*readers_by_host.values(), *loose]:
+            if not reader.is_mine:
+                out.append(Newcomer(label=reader.label, reader=reader, candidate=None))
+
+        return [n for n in out if n.needs_grant or n.needs_trust or n.changed_key]
 
 
 class _AccessChange(NamedTuple):

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -923,6 +923,22 @@ class Candidate(NamedTuple):
         return repr(self.label)
 
 
+def others_enrolled() -> bool:
+    """Is any machine but this one enrolled here?
+
+    Its own function because the answer decides whether a human is told about a
+    step they must take on another machine, and because working out "this one"
+    can fail: `_readers` wraps the same call in a `try` and says why. Failing
+    soft here means erring towards *mentioning* the step, which costs a sentence
+    someone does not need -- the other direction costs them the setup.
+    """
+    try:
+        mine = _own_recipient(store.machine())
+    except (WoswoarError, OSError):
+        mine = ""
+    return any(key != mine for key in recipients())
+
+
 def _refresh() -> None:
     """Take the remote's view, under a lock the caller already holds.
 
@@ -2359,21 +2375,22 @@ def readers() -> list[Reader]:
         return _readers()
 
 
-def _readers() -> list[Reader]:
+def _readers(owners: dict[str, str] | None = None) -> list[Reader]:
     """The list itself, assuming the caller holds the lock and has fetched.
 
     Split from `readers` for `newcomers`, which needs this and
-    `_trust_candidates` from one fetch rather than two.
+    `_trust_candidates` from one fetch rather than two. `owners` is passed by a
+    caller that has already scanned every `signer.pub`, for the same reason.
     """
     granted = set(State.load().granted)
     enrolled = recipients()
-    owners = _host_owners()
+    owners = _host_owners() if owners is None else owners
 
     # Not fatal if this machine's own key cannot be worked out: the list is
     # still true, it just loses the "(this machine)" note. `grant` is the
     # command someone runs *because* something is wrong with enrolment.
     try:
-        mine = crypto.recipient_for(identity_path(store.machine())).strip()
+        mine = _own_recipient(store.machine())
     except (WoswoarError, OSError):
         mine = ""
 
@@ -2409,13 +2426,23 @@ class Newcomer(NamedTuple):
     what a machine that is not yours looks like.
     """
 
-    label: str
-    #: The age recipient it reads with. None when nothing in the repo ties this
-    #: host to a live recipient -- which `trust_candidates` already refuses.
+    #: The age recipient it reads with. None for a host publishing a signer this
+    #: machine cannot tie to any recipient it has -- two host directories naming
+    #: one owner, where `_host_owners` keeps the first.
     reader: Reader | None
     #: The signing key it publishes with. None for a machine that enrolled but
     #: has never pushed a `signer.pub`.
     candidate: Candidate | None
+
+    @property
+    def label(self) -> str:
+        """Both halves resolve the same name for the same host, so either does."""
+        return self.candidate.label if self.candidate is not None else self._reader.label
+
+    @property
+    def _reader(self) -> Reader:
+        assert self.reader is not None, "a Newcomer has a reader or a candidate"
+        return self.reader
 
     @property
     def needs_grant(self) -> bool:
@@ -2427,15 +2454,52 @@ class Newcomer(NamedTuple):
 
     @property
     def changed_key(self) -> bool:
-        """Re-enrolled, or someone rewriting the repository. Never guessed at."""
+        """Re-enrolled, or someone rewriting the repository. Never guessed at.
+
+        Kept apart from `needs_grant` and `needs_trust` by every caller, because
+        a machine can be *both* new to read and changed to sign -- which is the
+        ordinary state on a machine that has just joined, where TOFU has pinned
+        every peer and `granted` is still empty. Listing such a machine among
+        the newcomers printed its unpinned new key under the words "already
+        accepted here", while the same screen said its key had changed.
+        """
         return self.candidate is not None and self.candidate.changed
+
+    @property
+    def shares_name(self) -> bool:
+        """Another enrolled key carries this name too.
+
+        Legitimate -- two machines really can both be `martin@laptop` -- and also
+        exactly what a key somebody else added looks like. `grant` has said this
+        out loud since it existed; `accept` widens read access on the same
+        evidence, so it cannot be the quieter of the two.
+        """
+        return self.reader is not None and self.reader.shares_name
 
     def display_name(self) -> str:
         """See `Reader.display_name`: never print `label` directly."""
         return repr(self.label)
 
 
-def newcomers() -> list[Newcomer]:
+class Pending(NamedTuple):
+    """What `accept` has left to do, and the list it was decided against.
+
+    `enrolled` is here because `grant(approved=...)` means "the list a human at
+    this machine agreed to", and it refuses if its own fetch disagrees. Getting
+    that list by asking again *after* the prompt makes the refusal unable to
+    fire for the window it exists to cover: a machine that enrols while the
+    prompt is on screen is picked up by both reads, they agree, and it is sealed
+    into the whole history without ever having been shown. So the list travels
+    with the machines it was shown beside, from the one fetch that produced it.
+    """
+
+    machines: list[Newcomer]
+    #: Every enrolled recipient at the moment `machines` was computed -- not
+    #: only the ones with something to decide. `grant` re-seals to all of them.
+    enrolled: list[str]
+
+
+def newcomers() -> Pending:
     """Every machine `accept` has something to do about, from one fetch.
 
     Own machine excluded -- `_trust_candidates` drops it already, and a reader
@@ -2445,38 +2509,34 @@ def newcomers() -> list[Newcomer]:
     """
     with lock():
         _refresh()
-        by_host = {c.host_id: c for c in _trust_candidates()}
+        # One scan of every `signer.pub`, shared by both halves. Built here and
+        # passed down because `_readers` would otherwise build its own: the
+        # measurement in `_host_owners` is 0.35 ms at five machines and 89 ms at
+        # a hundred, and `accept` was paying it three times over.
         owners = _host_owners()
-        # Recipient -> host, inverted so a Reader can find its Candidate. A
-        # recipient with no host directory has nothing to pair with and cannot
-        # be trusted anyway, so it is carried with `candidate=None` and shows up
-        # as grant-only.
-        readers_by_host: dict[str, Reader] = {}
-        loose: list[Reader] = []
-        for reader in _readers():
-            host = owners.get(reader.key)
-            if host is None:
-                loose.append(reader)
-            else:
-                readers_by_host[host] = reader
+        by_host = {c.host_id: c for c in _trust_candidates()}
 
         out: list[Newcomer] = []
-        for host_id, candidate in by_host.items():
-            paired = readers_by_host.pop(host_id, None)
-            out.append(
-                Newcomer(
-                    label=candidate.label,
-                    reader=paired,
-                    candidate=candidate,
-                )
-            )
-        # Enrolled, but publishing nothing this machine can be asked to believe:
-        # granting is still a real decision, so it is still offered.
-        for reader in [*readers_by_host.values(), *loose]:
-            if not reader.is_mine:
-                out.append(Newcomer(label=reader.label, reader=reader, candidate=None))
+        enrolled = _readers(owners)
+        for reader in enrolled:
+            # `pop`, so what is left in `by_host` is exactly the hosts no reader
+            # claimed. `""` is never a host id, so an unpaired recipient misses.
+            candidate = by_host.pop(owners.get(reader.key, ""), None)
+            # Our own machine is not a newcomer to itself. It has no candidate
+            # either -- `_trust_candidates` drops it -- so this is the same test.
+            if candidate is None and reader.is_mine:
+                continue
+            out.append(Newcomer(reader=reader, candidate=candidate))
 
-        return [n for n in out if n.needs_grant or n.needs_trust or n.changed_key]
+        # Publishing a signer, but tied to no recipient this machine can see.
+        # Still offered: trusting it is a real decision, and refusing to show it
+        # would hide the machine rather than the problem.
+        out += [Newcomer(reader=None, candidate=c) for c in by_host.values()]
+
+        return Pending(
+            machines=[n for n in out if n.needs_grant or n.needs_trust or n.changed_key],
+            enrolled=[reader.key for reader in enrolled],
+        )
 
 
 class _AccessChange(NamedTuple):


### PR DESCRIPTION
Second of three. `setup` — the guided flow — is next; this is the part that
makes the sequence shorter rather than narrating it.

## `woswoar accept`

One command for "that machine is mine". Run it on each machine you already use:

```console
$ woswoar accept
1 machine(s) not yet accepted here:

  'martin@work-laptop'
      reads with                  age1qjg…
      signs with                  SHA256:2xQ5…

Accepting does two separate things:

  read     1 machine(s) get to read your ENTIRE history, including
           days recorded before they existed. …

  believe  this machine will accept what 1 machine(s) publish.
           Local only: every other machine of yours has to be told separately, …

A name is free text written by whoever added the key. The fingerprints are
not — run these on the machine they belong to and compare:

    reads with   age-keygen -y ~/.config/woswoar/identity
    signs with   ssh-keygen -lf ~/.config/woswoar/signing_key.pub

Accept 1 machine(s)? [y/N]
```

`grant` and `trust` stay as they are. They answer different questions, and
someone sharing a repository with a colleague may well answer them differently.
What they were not is something a person adding their second laptop should have
to hold in their head — and `trust` has to be run on *every* machine you already
own, which is where the sequence stopped fitting in one breath.

**It does not blur what is being agreed to.** Both keys are shown, because there
really are two and they are checked with different commands. Both halves are
named. And one thing it deliberately will not do is accept a **changed** signing
key: that is either a machine you re-enrolled or someone rewriting the
repository, nothing can tell those apart, and rolling it into the newcomer prompt
is exactly how it would get agreed to by someone answering a different question.
It stays behind `trust --replace`, and there is a test that it is not swept along.

## `init` finishes the job

It now runs the first sync itself — joining a repository and then not exchanging
anything with it is not a state anyone wants, and leaving it to a second command
meant the machine published nothing until one was run. `--no-sync` covers a
remote that is not reachable yet.

It then names the one remaining step, and says nothing at all on the *first*
machine, where there is nowhere to run it. A step you cannot do reads as
something having gone wrong.

## Also

- **One fetch, not two.** `readers()` and `trust_candidates()` each fetched, so
  asking both would have cost two round trips on a command someone is waiting
  for. Split into `_readers` / `_trust_candidates` under one `_refresh()`.
- **The remedies point at `accept`.** "run `woswoar grant`" and "run `woswoar
  trust`" each told a stuck user to do one half of what they needed.
- README rewritten for the new flow — including a paragraph that appeared twice
  in "Adding another machine", verbatim.
- `docs/security.md` says where `accept` sits relative to the two axes, and why
  a changed key is not part of it.

## Mutation-tested (rule 3)

```
caught    accept stops granting (reads nothing older than itself)
caught    accept stops trusting (the newcomer's history stays refused)
caught    a changed signing key is swept in with the newcomers
caught    the age recipient is left off the prompt
caught    the signing fingerprint is left off the prompt
caught    init goes back to telling you to sync
caught    --no-sync syncs anyway
caught    init stops naming the last step at all
caught    init tells the very first machine to go and accept something
```

The last two replaced a first attempt that survived — it deleted the heading
above `woswoar accept` but left the line itself, so the property under test still
held. The mutation was mis-aimed, not the test weak; re-aimed at the branch.

One test of mine was wrong on the first run and is worth recording: I asserted a
freshly `init`-ed machine could read the old history. It cannot, by design, until
`accept` runs. What `init` actually gained is that it *publishes* — which is what
the test checks now, on the remote rather than on local disk.
