### PR TITLE
Ctrl-R: start fzf first, so the picker is on screen while the history loads

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import io
 import os
 import sqlite3
+import subprocess
 import unittest
 from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
 
 from woswoar import search, store
 from woswoar.__main__ import main
@@ -237,3 +240,130 @@ class TestNoCommandPrintsControlBytes(WoswoarTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestThePickerAppearsBeforeTheHistoryIsBuilt(WoswoarTestCase):
+    """fzf is started first, and fed afterwards.
+
+    Measured on a real 55,000-command atuin history: the picker used to appear
+    after 121 ms, because nothing was spawned until every line had been loaded,
+    sorted, deduplicated and rendered. Starting fzf first puts it on screen at
+    41 ms -- the work is identical, but you spend it looking at the picker
+    instead of at nothing.
+    """
+
+    def fake_fzf(self, script: str) -> None:
+        """Put a stand-in for fzf first on PATH.
+
+        A real fzf needs a terminal, and CI has neither. What is under test is
+        woswoar's half of the conversation -- when the process is started, what
+        is written to it, and what happens when it leaves early -- so the stand
+        -in is the real subprocess boundary with a scripted other end.
+        """
+        binary = Path(self.root) / "bin" / "fzf"
+        binary.parent.mkdir(parents=True, exist_ok=True)
+        binary.write_text(f"#!/usr/bin/env python3\n{script}")
+        binary.chmod(0o755)
+        os.environ["PATH"] = f"{binary.parent}{os.pathsep}{os.environ['PATH']}"
+
+    def some_history(self) -> None:
+        with store.private_append(store.log_file(MACHINE_ID, "2023-11-14")) as handle:
+            for i in range(5):
+                handle.write(format_line(Entry(NOW - i, MACHINE_ID, "s1", "~", 0, 1, f"cmd {i}")))
+                handle.write("\n")
+
+    def test_fzf_is_running_before_the_lines_exist(self) -> None:
+        """The whole change, stated as an order of events.
+
+        The stand-in is installed even though `Popen` is mocked: `interactive`
+        looks fzf up on PATH first and returns early if it is missing, so
+        without this the test asserts nothing on any machine that lacks fzf --
+        which is every CI runner here, and is exactly how it first went red.
+        """
+        self.fake_fzf("import sys\n")
+        self.some_history()
+        order: list[str] = []
+
+        class Spawned:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                order.append("picker")
+                self.stdin = io.StringIO()
+                self.stdout = io.StringIO("")
+
+            def wait(self) -> int:
+                return 130  # as Esc does
+
+        def slow_lines(*args: object, **kwargs: object) -> list[str]:
+            order.append("history")
+            return ["  1s  cmd 0"]
+
+        with (
+            mock.patch("subprocess.Popen", Spawned),
+            mock.patch.object(search, "lines_for", slow_lines),
+        ):
+            search.interactive("global")
+
+        self.assertEqual(order, ["picker", "history"], "the picker waited for the history")
+
+    def test_the_lines_reach_fzf(self) -> None:
+        self.some_history()
+        self.fake_fzf("import sys\nprint(sys.stdin.read().splitlines()[0])\n")
+        with redirect_stdout(io.StringIO()):
+            chosen = search.interactive("global")
+        self.assertEqual(chosen, "cmd 0", "the newest entry did not survive the round trip")
+
+    def test_fzf_leaving_early_is_not_an_error(self) -> None:
+        """Selecting the first line the instant it appears closes the pipe
+        under us, and the write has to tolerate that at any point.
+
+        The history has to be bigger than a pipe buffer -- 64 KiB on Linux --
+        or the write lands in the buffer and returns happily even though
+        nothing will ever read it, and this passes with the handling removed.
+        Five short lines did exactly that.
+        """
+        with store.private_append(store.log_file(MACHINE_ID, "2023-11-14")) as handle:
+            for i in range(2000):
+                padded = f"cmd {i} " + "x" * 200
+                handle.write(format_line(Entry(NOW - i, MACHINE_ID, "s1", "~", 0, 1, padded)))
+                handle.write("\n")
+        self.assertGreater(
+            sum(len(line) for line in search.lines_for("global")),
+            1 << 16,
+            "precondition: more than one pipe buffer of history",
+        )
+        # Exits without reading stdin at all -- the harshest version.
+        self.fake_fzf("import sys\nsys.exit(130)\n")
+        with redirect_stdout(io.StringIO()):
+            self.assertIsNone(search.interactive("global"))
+
+    def test_a_machine_with_no_history_opens_no_picker(self) -> None:
+        """Ctrl-R on a fresh install did nothing, and must keep doing nothing
+        rather than opening an empty picker to escape out of.
+
+        The marker is written by the stand-in itself, so this fails if fzf is
+        started at all -- asserting on a file nothing ever creates would pass
+        either way, which is what the first version of this test did.
+        """
+        started = Path(self.root) / "fzf-was-started"
+        self.fake_fzf(f"import pathlib\npathlib.Path({str(started)!r}).write_text('yes')\n")
+
+        # The stand-in really does write it when it runs, or the test below is
+        # asserting the absence of something that never appears anyway.
+        subprocess.run([str(Path(self.root) / "bin" / "fzf")], check=True)
+        self.assertTrue(started.exists(), "precondition: the marker works")
+        started.unlink()
+
+        with redirect_stdout(io.StringIO()):
+            self.assertIsNone(search.interactive("global"))
+        self.assertFalse(started.exists(), "an empty history opened a picker")
+
+    def test_many_lines_survive_the_chunking(self) -> None:
+        """More than one chunk, so the loop runs more than once."""
+        with store.private_append(store.log_file(MACHINE_ID, "2023-11-14")) as handle:
+            for i in range(search._CHUNK * 2 + 7):
+                handle.write(format_line(Entry(NOW - i, MACHINE_ID, "s1", "~", 0, 1, f"cmd {i}")))
+                handle.write("\n")
+        self.fake_fzf("import sys\nseen = sys.stdin.read().splitlines()\nprint(seen[-1])\n")
+        with redirect_stdout(io.StringIO()):
+            chosen = search.interactive("global")
+        self.assertEqual(chosen, f"cmd {search._CHUNK * 2 + 6}", "a chunk went missing")

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -7,11 +7,15 @@ select).
 
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 import time
 from operator import attrgetter
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from typing import IO
 
 from . import cache, store
 from .entry import Entry, escape, make_inert, unescape
@@ -169,19 +173,58 @@ def interactive(scope: Scope, query: str = "", dedup: bool = True) -> str | None
         print("\nMeanwhile 'woswoar list' prints the same history as plain text.", file=sys.stderr)
         return None
 
-    lines = lines_for(scope, dedup=dedup)
-    if not lines:
+    # Nothing recorded at all -- a fresh install before the first command. The
+    # check is two stats on a machine that *has* history, because the cache is
+    # the first thing it finds, and it is what keeps "Ctrl-R does nothing yet"
+    # from becoming "Ctrl-R opens an empty picker you have to escape out of".
+    if not store.cache_file().exists() and not any(store.iter_log_files()):
         return None
 
-    result = subprocess.run(
+    # fzf is started *before* the history is built, which is the whole point:
+    # it paints its frame and prompt in about two milliseconds, and then reads
+    # stdin as it arrives -- exactly how `find | fzf` behaves. Building the
+    # lines first meant the screen stayed empty for the entire load-parse-sort-
+    # render, measured at 125 ms on a real 55k-command history. The work is the
+    # same either way; what changes is that you are looking at the picker while
+    # it happens instead of at nothing.
+    process = subprocess.Popen(
         _fzf_argv(scope, query, dedup),
-        input="\n".join(lines),
+        stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         text=True,
-        check=False,
     )
+    assert process.stdin is not None and process.stdout is not None
+
+    try:
+        _feed(process.stdin, lines_for(scope, dedup=dedup))
+    finally:
+        # Both closes can raise the same way, and neither is a failure: it only
+        # means fzf is already gone. Selecting the first line the moment it
+        # appears, or pressing Esc, does exactly that.
+        with contextlib.suppress(BrokenPipeError, OSError):
+            process.stdin.close()
+
+    selected = process.stdout.read()
+    process.stdout.close()
+    returncode = process.wait()
+
     # 1 = no match, 130 = interrupted with Esc or Ctrl-C. Both are ordinary
     # outcomes, not failures.
-    if result.returncode != 0 or not result.stdout.strip():
+    if returncode != 0 or not selected.strip():
         return None
-    return command_from_line(result.stdout.rstrip("\n"))
+    return command_from_line(selected.rstrip("\n"))
+
+
+#: Lines per write into fzf. Large enough that the write syscalls are not the
+#: cost, small enough that a `BrokenPipeError` from an early selection is
+#: noticed rather than buffered behind a megabyte.
+_CHUNK = 2000
+
+
+def _feed(stream: IO[str], lines: list[str]) -> None:
+    """Write the display lines into fzf, tolerating it leaving early."""
+    with contextlib.suppress(BrokenPipeError):
+        for start in range(0, len(lines), _CHUNK):
+            stream.write("\n".join(lines[start : start + _CHUNK]))
+            stream.write("\n")
+        stream.flush()

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -12,7 +12,6 @@ import contextlib
 import json
 import os
 import secrets
-import tempfile
 import time
 from collections.abc import Iterator
 from pathlib import Path
@@ -270,6 +269,13 @@ def write_atomic(path: Path, data: bytes) -> None:
     import watermarks, and the sync state. They all go through here so
     a crash mid-write leaves the previous version rather than a corrupt one.
     """
+    # Imported here rather than at module scope: `tempfile` pulls `shutil` and
+    # costs ~3 ms of interpreter startup, and this module is imported by every
+    # Ctrl-R -- which does not write anything unless the cache has drifted far
+    # enough to be worth saving. Measured on a 55k-entry history: 3.1 ms off a
+    # search that never reaches this function.
+    import tempfile
+
     private_dir(path.parent)
     fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}-", suffix=".tmp")
     try:


### PR DESCRIPTION
You asked whether Ctrl-R could stream into fzf, and whether there are multiple
passes that could be collapsed. Both measured against **your real atuin
history** — 55,018 commands, 9 hosts, 755 days — imported into a throwaway home
that is deleted afterwards. Nothing from it is in this repo or this PR.

## Result

| | before | after |
|---|---|---|
| **picker on screen** | 121.2 ms | **41.5 ms** |
| all 23,797 lines delivered | 123.2 ms | 115.3 ms |

The 41.5 ms includes ~10 ms of the benchmark's Python stand-in for fzf; the real
binary starts in ~2 ms, so it is closer to 32.

## On the multiple passes: real, but not the cost

They exist — `entries()` concatenates, `sorted()` copies, dedup builds a third
list, `render` a fourth, then `"\n".join` makes one ~1 MB string. Together:

| stage | |
|---|---|
| interpreter + imports | ~30 ms |
| `cache.load_entries()` | **42.4 ms** |
| `rank()` | 4.3 ms |
| `render()` | 10.0 ms |
| `"\n".join()` | 0.1 ms |
| argparse, write, teardown | ~38 ms |
| **whole process** | **124.6 ms** |

Collapsing every pass perfectly would buy 14 ms of 125. So the passes were the
wrong thread to pull — but the *streaming* instinct was right, for a different
reason: it does not reduce work at all, it changes when you can see it.

## What changed

**fzf is spawned before the history is built.** It paints its frame and prompt
immediately and reads stdin as it arrives — exactly how `find | fzf` behaves.
Previously nothing was spawned until every line was ready, so the screen stayed
empty for the entire load → sort → dedup → render.

**`store` no longer imports `tempfile` at module scope.** It pulls `shutil`, for
`write_atomic` — which a warm search never calls. `import woswoar.__main__`:
29.6 → 24.9 ms. `hashlib` stays: the cache fingerprints every file on refresh,
so a search needs it regardless.

Two behaviours held deliberately:

- **An empty history opens no picker.** Ctrl-R on a fresh install did nothing,
  and continues to, rather than opening an empty picker to escape out of.
- **fzf leaving early is not an error.** Selecting the first line the instant it
  appears closes the pipe mid-write, so the write is chunked and tolerates it.

## Tests

They drive a real subprocess with a scripted other end, rather than mocking
`Popen` — what is under test is woswoar's half of that conversation. No test
needs a real fzf, so nothing skips on CI.

Mutation-tested, all four caught:

```
caught  the history is built before the picker starts (the regression)
caught  fzf leaving early becomes an error again
caught  an empty history opens a picker
caught  only the first chunk is written
```

Two things worth recording from getting there:

- **My first before/after measured the same tree twice.** `python -m` puts the
  current directory ahead of `PYTHONPATH`, so a worktree at `main` ran this
  branch's code and reported an identical 41.7 ms. That is CLAUDE.md's
  "commit before comparing two revisions" trap in a new disguise; the fix was
  anchoring every subprocess with `cwd`.
- **The BrokenPipe test was decoration at first.** Five short lines fit inside
  the 64 KiB pipe buffer, so the write succeeded even with no reader, and the
  test passed with the handling removed. It now asserts it has more than one
  buffer of history before it starts.

## Not done

`load_entries` at 42.4 ms is now the single largest term, and it is spent
building 54,804 `Entry` namedtuples to display 23,797 lines. A display-oriented
cache could cut most of it, and rule 8 makes it cheap to ship — `cache.txt` is
derived, so "delete it, it rebuilds" is a valid upgrade path. Worth doing next
if this still feels slow.