### PR TITLE
release: 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ one machine.
 > **The same line upgrades an existing install** — run it again whenever you want
 > the latest release. `stable` tracks the most recent tag, so the command never
 > changes and you never edit a version number on five machines. Swap `@stable`
-> for `@main` to track the tip, or `@v0.3.1` to pin exactly.
+> for `@main` to track the tip, or `@v0.4.0` to pin exactly.
 
 **Needs:** bash 5.0+ (Linux) · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) ·

--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"


### PR DESCRIPTION
Cuts v0.4.0. Four commits since v0.3.1, all of them from using the thing on two
real machines.

**Minor rather than patch:** there is a new command.

## Setting up a second machine got shorter

- **`woswoar accept`** (#109) — one command for "that machine is mine", doing
  what `grant` and `trust` did separately. They remain, and answer different
  questions; `accept` is both for the ordinary case where the machine is yours.
  It refuses one thing on purpose: a *changed* signing key, which stays behind
  `woswoar trust --replace`.
- **`init` does the first sync itself** and names the one remaining step — and
  says nothing on the first machine, where there is nowhere to run it.
  `--no-sync` covers an unreachable remote.
- **Every command explains itself under `-h`.** None of the thirteen had a
  description; `woswoar doctor -h` printed a usage line and nothing about what
  doctor does.

## The prompts tell the truth now

- **`grant` and `trust` showed `(unnamed)`** (#108) for the machine they were
  asking about — which is *always* a machine whose history you have not merged,
  so the one confirmation that widens access to everything had no name on it.
- **`accept` no longer drops the duplicate-name warning**, and no longer prints
  an unaccepted key as "already accepted here".

## Ctrl-R

Measured on a real 54,804-command history over 755 days:

| | v0.3.1 | v0.4.0 |
|---|---|---|
| **picker on screen** | 121 ms | **~32 ms** |
| full list ready | 123 ms | 113 ms |

- **fzf starts before the history is built** (#111), so it paints immediately
  and fills in, rather than leaving the screen empty for the whole load.
- **The cache holds columns, not namedtuples** (#113). It was building 54,804
  seven-field objects per keypress to display two fields.
- **Long commands say what they are doing** (#108) — a first sync and a `grant`
  are seconds of work on a large history and used to print nothing until they
  finished. Silent for the first 0.7 s, and only on a terminal, so the
  once-a-minute timer stays as quiet as it was.

## Upgrade path

Nothing to do. The cache format is byte-identical, the repository format is
unchanged, and `accept` is additive.

## What is not in it

- **#110** (P2): `accept` pairs a machine's two keys through a claim the
  repository controls, and shows it as corroboration. The guarantee holds — the
  fingerprints will not match when you run the printed check on the real machine
  — but the presentation is weaker than it looks.
- **The end-to-end shakedown still has not been run** on a real install. Every
  piece is tested against real `age`, `git`, `ssh-keygen` and a real subprocess
  boundary for fzf, but nobody has walked install → init → record across a day
  boundary → second machine → accept → sync → compact → revoke with `doctor`
  clean at each step. Given all four of these came from you *using* it, that is
  where the next one is most likely hiding.