### PR TITLE
doctor: notice an age that works and is slow, because that is what a snap is

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ one machine.
 `woswoar install` checks for these and prints the install command for your
 distribution. `woswoar doctor` diagnoses anything else that looks wrong.
 
+> [!WARNING]
+> **Do not install `age` as a snap.** It works, and it starts a sandbox on every
+> call — about 250 ms against 2 ms for a distribution binary. woswoar runs `age`
+> roughly twice per day of recorded history, so on two years of history that is
+> the difference between a `sync` taking three seconds and taking six minutes.
+> `woswoar doctor` measures it and says so.
+
 ## Adding another machine
 
 Sync goes through **an ordinary git repository you already own** — no server, no

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -9,6 +9,7 @@ would think to run it.
 from __future__ import annotations
 
 import os
+import shutil
 import stat
 import unittest
 
@@ -67,3 +68,66 @@ class TestDoctorWithABrokenAge(WoswoarTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+@requires_age
+class TestDoctorWithASlowAge(WoswoarTestCase):
+    """The failure that is hardest to diagnose, because nothing is broken.
+
+    Reported from a real Ubuntu install where `age` came from a snap: `sync` and
+    `accept` took "about half a second per day" of history, roughly 100x the
+    same work on the same history with a distribution binary. woswoar spawns
+    `age` about twice per day-key, so a per-call cost that is invisible at 2 ms
+    turns a three-second grant into a six-minute one -- and every check passed.
+    """
+
+    #: Comfortably over `crypto.SLOW_MS` without making the suite crawl: five
+    #: timed runs at this cost is a third of a second.
+    DELAY_MS = 70
+
+    def setUp(self) -> None:
+        super().setUp()
+        real = shutil.which("age")
+        assert real is not None  # @requires_age
+        fake = self.root / "bin"
+        fake.mkdir()
+        script = fake / "age"
+        # Delegates to the real age after sleeping, so it is genuinely working
+        # and genuinely slow -- which is the combination under test. A stub that
+        # only slept would be caught by `selftest` instead, and prove nothing.
+        script.write_text(f'#!/bin/sh\nsleep {self.DELAY_MS / 1000}\nexec {real} "$@"\n')
+        script.chmod(script.stat().st_mode | stat.S_IXUSR)
+
+        self._path = os.environ["PATH"]
+        os.environ["PATH"] = f"{fake}{os.pathsep}{self._path}"
+        self.addCleanup(lambda: os.environ.__setitem__("PATH", self._path))
+
+    def test_the_cost_is_measured(self) -> None:
+        self.assertGreaterEqual(crypto.startup_ms(), self.DELAY_MS)
+
+    def test_doctor_fails_and_says_what_it_will_cost(self) -> None:
+        ran = support.run_cli("doctor")
+        # The age *line*, not the exit code: doctor in a bare temp home already
+        # fails on `hook` and `private`, so the exit code is non-zero either way
+        # and asserting on it tested nothing about age at all.
+        self.assertIn("[FAIL] age", ran.out)
+        self.assertNotEqual(ran.code, 0)
+        self.assertIn("ms to start", ran.out)
+        # Matched either side of the wrap rather than across it: the message is
+        # hard-wrapped, so a phrase that spans a line break matches nothing.
+        self.assertIn("woswoar runs it about twice per", ran.out)
+        self.assertIn("day of recorded history", ran.out)
+        self.assertIn("A distribution binary starts", ran.out)
+
+    def test_a_working_age_is_still_the_thing_being_measured(self) -> None:
+        """The stand-in really does work, so the FAIL is about speed alone."""
+        self.assertEqual(crypto.selftest(), "")
+
+
+@requires_age
+class TestAFastAgeIsNotFlagged(WoswoarTestCase):
+    def test_the_real_age_passes(self) -> None:
+        """Guards the threshold from being set somewhere that fails everyone."""
+        self.assertLess(crypto.startup_ms(), crypto.SLOW_MS)
+        self.assertIn("[ok] age", support.run_cli("doctor").out)
+        self.assertNotIn("ms to start. woswoar runs it", support.run_cli("doctor").out)

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -279,9 +279,33 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         info("age", f"not found, needed for 'woswoar sync' - {deps.advice([deps.AGE])}")
     else:
         failure = crypto.selftest()
-        check("age", not failure, age_path)
+        cost = crypto.startup_ms() if not failure else -1.0
+        detail = age_path if cost < 0 else f"{age_path}  ({cost:.0f} ms to start)"
+        check("age", not failure and 0 <= cost < crypto.SLOW_MS, detail)
         for line in failure.splitlines():
             print(f"     {line}")
+        if not failure and cost >= crypto.SLOW_MS:
+            # Not a broken age -- a slow one, which is worse to diagnose because
+            # everything works. woswoar runs it about twice per day of history,
+            # so this is the difference between a grant taking three seconds and
+            # taking six minutes, and nothing on screen would say why.
+            print(
+                f"     age takes {cost:.0f} ms to start. woswoar runs it about twice per\n"
+                f"     day of recorded history, so a year costs about "
+                f"{cost * 2 * 365 / 1000:.0f} s per sync,\n"
+                "     grant or accept that has work to do.",
+            )
+            if "/snap/" in age_path:
+                print(
+                    "     This one is a snap, which sets up a sandbox on every call.\n"
+                    "     Install the distribution package or the release binary instead:\n"
+                    f"       sudo snap remove age  &&  {deps.advice([deps.AGE])}"
+                )
+            else:
+                print(
+                    "     A distribution binary starts in a millisecond or two:\n"
+                    f"       {deps.advice([deps.AGE])}"
+                )
 
     # Checked whether or not a repo exists: `init` is exactly when this breaks,
     # and gating it behind is_repo() meant doctor was silent in the one state

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -505,6 +505,44 @@ def selftest() -> str:
     return ""
 
 
+#: A per-call cost above which woswoar is not usable at scale rather than
+#: merely slower. It runs `age` about twice per day of history, so 50 ms means
+#: 100 ms a day: a year takes 36 s to grant, two years over a minute. A
+#: distribution binary measures 2 ms on the machine this was written on, so
+#: anything near this threshold is a packaging problem, not a fast/slow machine.
+SLOW_MS = 50.0
+
+#: Runs to time. `age --version` does no cryptography, so this measures process
+#: start alone -- which is the whole of the difference: what a sandbox charges
+#: is the same however little the program then does.
+_TIMED_RUNS = 5
+
+
+def startup_ms() -> float:
+    """How long `age` takes to start, in milliseconds. ``-1.0`` if it will not run.
+
+    The number that decides whether woswoar is pleasant or unusable, and it has
+    nothing to do with woswoar: a snap-packaged age sets up a mount namespace
+    and a sandbox on every invocation, and woswoar invokes it once per day-key.
+    Reported from a real Ubuntu install as "about half a second per day", which
+    is 100x the same operation against the same history on the same network.
+    """
+    import statistics
+    import time
+
+    timings = []
+    for _ in range(_TIMED_RUNS):
+        started = time.perf_counter()
+        try:
+            _run([AGE, "--version"], b"")
+        except (AgeError, OSError):
+            return -1.0
+        timings.append((time.perf_counter() - started) * 1000)
+    # The median, not the mean: the first run pays for a cold page cache and
+    # would otherwise decide the answer on a machine that is merely busy.
+    return statistics.median(timings)
+
+
 def why_unusable(identity: Path) -> str:
     """``""`` if this identity can decrypt unattended, else why not.
 


### PR DESCRIPTION
> on a Ubuntu where I installed age with snap, sync and accept was very slow,
> about half a second per day. with a non snap version on another PC this was
> about 100 times faster

Reproduced as arithmetic, and it checks out exactly.

## The measurement

`age` spawns per day of history — counted with a shim on `PATH`, not estimated:

| | age calls | per day |
|---|---|---|
| first sync (export) | 40 over 20 days | **2.0** |
| `grant` | 44 | **2.2** |
| sync on the joining machine (merge) | 40 | **2.0** |

A distribution `age` starts in **2 ms** here. So:

| | per day | 755 days of history |
|---|---|---|
| distribution binary | 4 ms | ~3 s |
| snap | ~500 ms | **~6 min** |

Half a second per day is your number, from two spawns at ~250 ms each. A snap
sets up a mount namespace and a sandbox on every invocation, and it charges that
however little the program then does.

## Why not just spawn age less

The per-day key is what makes `grant` cheap — it re-seals a few hundred small
key files rather than the whole archive — and the `age` CLI takes one file per
invocation, so there is nothing to batch. Two calls per day-key is the design
working correctly. What was missing was any way to *find out* that your `age`
costs 250 ms.

## What this adds

`woswoar doctor` times `age` and fails above 50 ms:

```
[FAIL] age          /snap/bin/age  (250 ms to start)
     age takes 250 ms to start. woswoar runs it about twice per
     day of recorded history, so a year costs about 182 s per sync,
     grant or accept that has work to do.
     This one is a snap, which sets up a sandbox on every call.
     Install the distribution package or the release binary instead:
       sudo snap remove age  &&  sudo apt install age
```

50 ms because woswoar makes ~2 calls per day: a year then costs 36 s per
operation, which is already the wrong side of usable. A real binary is 2 ms, so
nothing near the threshold is a fast-or-slow machine — it is packaging.

`crypto.selftest` already caught a *confined* age that runs and then cannot open
a key (#13). This is the same packaging failing the other way: it opens keys
perfectly, just slowly.

README gains the warning where `age` is first mentioned — before anyone would
think to run `doctor`.

## Tests

The stand-in `sleep`s and then `exec`s the **real** age, so it is genuinely
working and genuinely slow, which is the combination under test. A stub that
only slept would be caught by `selftest` and prove nothing.

Mutation-tested, all four caught:

```
caught  a slow age passes doctor again
caught  the threshold is raised past anything anyone would hit
caught  the threshold is lowered so a normal age fails too
caught  doctor stops saying what the cost means
```

The first survived at first, and the fixture was the reason: the test asserted
`doctor`'s **exit code**, which in a bare temp home is already non-zero because
`hook` and `private` fail. It proved nothing about age. It now asserts the
`[FAIL] age` line itself.