### PR TITLE
doctor: a green tick and a red cross, for the person reading it

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -8,11 +8,13 @@ would think to run it.
 
 from __future__ import annotations
 
+import io
 import os
 import shutil
 import stat
 import unittest
 
+from woswoar import __main__ as main_module
 from woswoar import crypto
 
 from . import support
@@ -66,8 +68,6 @@ class TestDoctorWithABrokenAge(WoswoarTestCase):
         self.assertRegex(out, r"\[FAIL\] age")
 
 
-if __name__ == "__main__":
-    unittest.main()
 
 
 @requires_age
@@ -131,3 +131,57 @@ class TestAFastAgeIsNotFlagged(WoswoarTestCase):
         self.assertLess(crypto.startup_ms(), crypto.SLOW_MS)
         self.assertIn("[ok] age", support.run_cli("doctor").out)
         self.assertNotIn("ms to start. woswoar runs it", support.run_cli("doctor").out)
+class TestDoctorsMarkers(WoswoarTestCase):
+    """A tick for a person, the old text for everything else.
+
+    `[ok]`/`[FAIL]` is what the suite asserts on in a dozen places and what
+    `woswoar doctor | grep FAIL` in somebody's script depends on. A glyph only a
+    terminal renders must not become the thing those rest on, so the plain form
+    is unchanged and the coloured one appears only on a tty.
+    """
+
+    class Tty(io.StringIO):
+        def isatty(self) -> bool:
+            return True
+
+    def test_a_pipe_gets_the_plain_markers(self) -> None:
+        self.assertEqual(main_module._markers(io.StringIO()), main_module._PLAIN_MARKERS)
+
+    def test_a_terminal_gets_a_green_tick_and_a_red_cross(self) -> None:
+        markers = main_module._markers(self.Tty())
+        self.assertEqual(markers, main_module._COLOUR_MARKERS)
+        self.assertIn("\u2714", markers["ok"])
+        self.assertIn("\u2718", markers["fail"])
+        self.assertTrue(markers["ok"].startswith("\x1b[32m"), "the tick is not green")
+        self.assertTrue(markers["fail"].startswith("\x1b[31m"), "the cross is not red")
+        self.assertTrue(all(value.endswith("\x1b[0m") for value in markers.values()))
+
+    def test_no_color_is_honoured_on_a_terminal(self) -> None:
+        os.environ["NO_COLOR"] = "1"
+        self.addCleanup(lambda: os.environ.pop("NO_COLOR", None))
+        self.assertEqual(main_module._markers(self.Tty()), main_module._PLAIN_MARKERS)
+
+    def test_the_run_that_tests_and_scripts_see_is_unchanged(self) -> None:
+        """Captured output is not a tty, so this is the real regression guard."""
+        out = support.run_cli("doctor").out
+        self.assertIn("[ok] ", out)
+        self.assertNotIn("\x1b[", out)
+        self.assertNotIn("\u2714", out)
+
+    def test_the_coloured_markers_are_one_column_wide(self) -> None:
+        """Which is why the labels line up, and `[ok]` versus `[FAIL]` never
+        did -- four characters against six."""
+        widths = {
+            len(
+                value.replace("\x1b[32m", "")
+                .replace("\x1b[31m", "")
+                .replace("\x1b[2m", "")
+                .replace("\x1b[0m", "")
+            )
+            for value in main_module._COLOUR_MARKERS.values()
+        }
+        self.assertEqual(widths, {1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -219,6 +219,38 @@ def cmd_stats(args: argparse.Namespace) -> int:
     return 0
 
 
+#: What `doctor` puts at the front of each line, plain and coloured.
+#:
+#: The plain forms are byte-for-byte what this printed before there was a
+#: coloured one, and they are what everything that is not a person sees: the
+#: suite asserts on `[FAIL] day keys`, and `woswoar doctor | grep FAIL` is a
+#: reasonable thing to have in a script. A tick that only a terminal renders
+#: must not become the thing those depend on.
+#:
+#: The coloured forms are one column wide rather than four or six, so the labels
+#: line up -- which the plain `[ok]`/`[FAIL]` never have.
+_PLAIN_MARKERS = {"ok": "[ok]", "fail": "[FAIL]", "info": "[--]"}
+_COLOUR_MARKERS = {
+    "ok": "\x1b[32m\u2714\x1b[0m",
+    "fail": "\x1b[31m\u2718\x1b[0m",
+    "info": "\x1b[2m\u00b7\x1b[0m",
+}
+
+
+def _markers(stream: object | None = None) -> dict[str, str]:
+    """Coloured markers for a terminal, the plain ones for anything else.
+
+    `NO_COLOR` is honoured because it costs one condition and someone always
+    has a reason -- a terminal that renders neither colour nor the glyphs, a log
+    being captured through a pty, a screen reader.
+    """
+    out = sys.stdout if stream is None else stream
+    watched = bool(getattr(out, "isatty", lambda: False)())
+    if watched and not os.environ.get("NO_COLOR"):
+        return _COLOUR_MARKERS
+    return _PLAIN_MARKERS
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     import shutil
     import subprocess
@@ -226,16 +258,17 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     from . import crypto, deps, sync
 
     ok = True
+    marker = _markers()
 
     def check(label: str, good: bool, detail: str) -> None:
         """A pass/fail condition: failing means something needs fixing."""
         nonlocal ok
         ok = ok and good
-        print(f"[{'ok' if good else 'FAIL'}] {label:<12} {detail}")
+        print(f"{marker['ok' if good else 'fail']} {label:<12} {detail}")
 
     def info(label: str, detail: str) -> None:
         """Context that cannot fail, kept visually distinct from a real check."""
-        print(f"[--] {label:<12} {detail}")
+        print(f"{marker['info']} {label:<12} {detail}")
 
     bash = shutil.which("bash")
     version = ""


### PR DESCRIPTION
```
✔ bash         5.3 (5.0+ required)
✔ fzf          /usr/bin/fzf
✔ age          /usr/bin/age
· remote       origin  git@github.com:you/woswoar-history.git (fetch)
✔ trust        2 of 2 other machine(s) accepted
✔ day keys     all sealed
✘ private      2 path(s) other users can read
· logs         382 file(s) in ~/.local/share/woswoar/logs
```

Green U+2714, red U+2718, and a dim middle dot for the `[--]` lines — those are
context, not a result, and shouldn't read as either.

A side benefit worth naming: the labels line up now. `[ok]` is four characters
and `[FAIL]` is six, so every failing line used to sit two columns right of the
passing ones around it — exactly the lines you want to scan for.

## Only on a terminal

Everything that isn't a tty keeps byte-for-byte the text it had. That isn't
timidity:

- the suite asserts on `[FAIL] day keys` and `[ok] manifests` in a dozen places
- `woswoar doctor | grep FAIL` is a reasonable line to have in a script
- CI runs `woswoar doctor || true`

A glyph only a terminal renders must not become the thing any of those rest on.
`NO_COLOR` is honoured too — someone always has a terminal, or a screen reader,
that does neither colour nor the glyphs.

## Mutation-tested, all five caught

```
caught  a pipe gets the coloured markers too (fzf-style breakage for scripts)
caught  a terminal gets the plain markers, so the tick never appears
caught  NO_COLOR is ignored
caught  the cross is green like the tick
caught  the colour is never reset, so the rest of the line stays green
```

The last one is the bug this shape invites: forget the reset and every
subsequent character on the line — the whole path, the whole detail — stays
green.

Independent of #115, which is also open and touches `doctor`'s age line. They
touch different parts of the function; whichever lands second may want a trivial
rebase.