### PR TITLE
search: rank by recency when match scores tie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,17 +45,18 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
-      - name: install age
-        # Sync tests skip themselves without it, and a silently skipped suite
-        # looks exactly like a passing one.
+      - name: install age and fzf
+        # Sync tests skip themselves without age, the ranking tests without
+        # fzf, and a silently skipped suite looks exactly like a passing one.
+        # One apt-get for both: the round trip is what costs, not the packages.
         #
         # `update` only when the direct install misses: refreshing the lists
         # costs ~10s and the runner image usually already has what age needs,
         # which on the critical path is most of the job. The fallback keeps it
         # correct on an image where that stops being true.
         run: |
-          sudo apt-get install -y -qq age \
-            || { sudo apt-get update -qq && sudo apt-get install -y -qq age; }
+          sudo apt-get install -y -qq age fzf \
+            || { sudo apt-get update -qq && sudo apt-get install -y -qq age fzf; }
       - name: ssh-keygen is present
         # Signing needs it. Present on ubuntu-latest, asserted rather than
         # assumed for the same reason as bash below: a silently skipped suite
@@ -74,6 +75,12 @@ jobs:
       # job, so the fork-scaling tests legitimately skip. The `hook` job is
       # where they are made fatal.
       - run: python -m tools.run_tests
+      # The ranking tests are the one part of the suite whose subject is fzf's
+      # behaviour rather than woswoar's, so they cannot be asserted against a
+      # stand-in and they skip themselves when fzf is missing. fzf is installed
+      # above, so here a skip means the install stopped working -- and a green
+      # run that ranked nothing at all is exactly the failure worth catching.
+      - run: python -m tools.run_tests --only tests.test_search --no-skips
 
   hook:
     # Called on every prompt, so the hook gets its own job: the fork-scaling

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -432,7 +432,12 @@ multi-line command would appear as several unrelated candidates.
 
 - `--nth=2..` — match against the command only. Without it, typing `3d` matches
   the relative-time column and surfaces unrelated entries.
-- `--tiebreak=begin,index` — preserve newest-first when match scores tie.
+- `--tiebreak=index` — preserve newest-first when match scores tie, which for a
+  one-word query is nearly all of them. `begin,index` was tried first and does
+  the opposite: it ranks by where in the line the match starts, so a year-old
+  `sudo sync; …` sat above a three-minute-old `woswoar sync`. It also let the
+  right-aligned age column rank things, since fzf scores `begin` net of leading
+  whitespace and `1y` is padded one space wider than `10h`.
 - `--bind=ctrl-g/ctrl-h/ctrl-s:reload(woswoar list --scope …)` — switch scope
   without leaving the picker. This is why `list` exists as its own subcommand.
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -24,6 +24,7 @@ requires_age = unittest.skipUnless(crypto.available(), "age required")
 requires_git = unittest.skipUnless(shutil.which("git"), "git required")
 requires_ssh_keygen = unittest.skipUnless(shutil.which("ssh-keygen"), "ssh-keygen required")
 requires_bash = unittest.skipUnless(shutil.which("bash"), "bash required")
+requires_fzf = unittest.skipUnless(shutil.which("fzf"), "fzf required")
 
 
 class Ran(NamedTuple):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -15,7 +15,7 @@ from woswoar import search, store
 from woswoar.__main__ import main
 from woswoar.entry import Entry, format_line
 
-from .support import MACHINE_ID, WoswoarTestCase
+from .support import MACHINE_ID, WoswoarTestCase, requires_fzf
 
 NOW = 1_800_000_000
 
@@ -150,6 +150,102 @@ class TestFzfArgv(unittest.TestCase):
     def test_no_dedup_propagates_into_the_reload_command(self) -> None:
         argv = search._fzf_argv("global", "", False)
         self.assertIn("--no-dedup", " ".join(a for a in argv if a.startswith("--bind=")))
+
+
+MINUTE, HOUR, DAY = 60, 3600, 86400
+
+#: The history from the report that #115 came out of, newest first -- which is
+#: the order `rank_rows` hands to fzf, so any deviation in the output below is
+#: fzf's ranking and nothing else. Every one of these matches "sync" equally
+#: well as far as fzf's score is concerned, which is the whole point: with the
+#: scores tied, the tiebreak decides the entire list.
+SYNC_HISTORY = [
+    (3 * MINUTE, "woswoar sync"),
+    (15 * MINUTE, "time woswoar sync"),
+    (10 * HOUR, "sync"),
+    (10 * HOUR, "synci"),
+    (10 * HOUR, "atuin sync"),
+    (10 * HOUR, "chmod a+x sync_claude_skills.py"),
+    (11 * DAY, "sync; echo 3 | sudo tee /proc/sys/vm/drop_caches"),
+    (2 * 30 * DAY, "sync_claude_skills.py"),
+    (2 * 30 * DAY, "atuin sync -f"),
+    (3 * 30 * DAY, "aimgr repo sync"),
+    (365 * DAY, "sudo sync; echo 3 > /proc/sys/vm/drop_caches"),
+    (365 * DAY, "atuin sync -h"),
+    (365 * DAY, "chezmoi sync"),
+    (365 * DAY, "time m clean && time m && time sync"),
+]
+
+
+@requires_fzf
+class TestRealFzfRanking(unittest.TestCase):
+    """The order fzf actually produces, out of the real binary.
+
+    `--filter` does the same match-and-sort without needing a terminal, so this
+    drives the argv Ctrl-R uses rather than a copy of it: a change to `--nth` or
+    `--tiebreak` reaches this test. Nothing here can be asserted against a
+    stand-in -- the behaviour under test is fzf's, not woswoar's.
+    """
+
+    def ordered(self, query: str) -> list[str]:
+        lines = search.render_rows([(NOW - age, cmd) for age, cmd in SYNC_HISTORY], now=NOW)
+        completed = subprocess.run(
+            [*search._fzf_argv("global", "", True), f"--filter={query}"],
+            input="\n".join(lines) + "\n",
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return [search.command_from_line(line) for line in completed.stdout.splitlines()]
+
+    def test_the_newest_match_comes_first(self) -> None:
+        self.assertEqual(self.ordered("sync")[0], "woswoar sync")
+
+    def test_an_old_command_does_not_outrank_a_recent_one_for_starting_sooner(self) -> None:
+        """The report: a year-old entry above the command actually wanted.
+
+        The pair is chosen so that only the tiebreak can separate them. The
+        year-old one matches *earlier* in its line -- offset 5 in `sudo sync`
+        against 8 in `woswoar sync` -- so under `begin` it wins however recent
+        the other is, and under `index` it cannot.
+        """
+        order = self.ordered("sync")
+        self.assertLess(
+            order.index("woswoar sync"),
+            order.index("sudo sync; echo 3 > /proc/sys/vm/drop_caches"),
+            "a year-old command outranked one from three minutes ago",
+        )
+
+    def test_the_width_of_the_time_column_does_not_rank(self) -> None:
+        """`atuin sync` and `atuin sync -h` match at the same offset.
+
+        What differs is the column in front: "1y" is right-aligned into four
+        characters and so carries one more leading space than "10h". fzf scores
+        `begin` as (match offset - leading whitespace), which turned that
+        padding into a ranking signal and put the year-old line first.
+        """
+        order = self.ordered("atuin sync")
+        self.assertLess(
+            order.index("atuin sync"),
+            order.index("atuin sync -h"),
+            "the padding of the age column decided the order",
+        )
+
+    def test_the_time_column_is_still_not_matched_against(self) -> None:
+        """The reason `--nth=2..` is there, asserted through fzf itself.
+
+        `TestFzfArgv` checks the flag is passed; this checks what it buys. "10h"
+        is the age of five entries in the fixture and a substring of no command
+        in it, so without the flag this query returns them and with it nothing.
+        """
+        completed = subprocess.run(
+            [*search._fzf_argv("global", "", True), "--filter=10h"],
+            input="\n".join(search.render_rows([(NOW - age, c) for age, c in SYNC_HISTORY], NOW))
+            + "\n",
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.stdout, "", "the relative-time column was matched against")
 
 
 class TestRecalledCommandIsInert(unittest.TestCase):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -154,8 +154,8 @@ class TestFzfArgv(unittest.TestCase):
 
 MINUTE, HOUR, DAY = 60, 3600, 86400
 
-#: The history from the report that #115 came out of, newest first -- which is
-#: the order `rank_rows` hands to fzf, so any deviation in the output below is
+#: The history from the report this came out of, newest first -- which is the
+#: order `rank_rows` hands to fzf, so any deviation in the output below is
 #: fzf's ranking and nothing else. Every one of these matches "sync" equally
 #: well as far as fzf's score is concerned, which is the whole point: with the
 #: scores tied, the tiebreak decides the entire list.
@@ -187,15 +187,20 @@ class TestRealFzfRanking(unittest.TestCase):
     stand-in -- the behaviour under test is fzf's, not woswoar's.
     """
 
-    def ordered(self, query: str) -> list[str]:
+    def filtered(self, query: str) -> subprocess.CompletedProcess[str]:
+        """The fixture through the real fzf, with the real argv."""
         lines = search.render_rows([(NOW - age, cmd) for age, cmd in SYNC_HISTORY], now=NOW)
-        completed = subprocess.run(
+        # No `check`: 1 means "nothing matched", which one test below wants.
+        return subprocess.run(
             [*search._fzf_argv("global", "", True), f"--filter={query}"],
             input="\n".join(lines) + "\n",
             capture_output=True,
             text=True,
-            check=True,
         )
+
+    def ordered(self, query: str) -> list[str]:
+        completed = self.filtered(query)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
         return [search.command_from_line(line) for line in completed.stdout.splitlines()]
 
     def test_the_newest_match_comes_first(self) -> None:
@@ -235,17 +240,15 @@ class TestRealFzfRanking(unittest.TestCase):
         """The reason `--nth=2..` is there, asserted through fzf itself.
 
         `TestFzfArgv` checks the flag is passed; this checks what it buys. "10h"
-        is the age of five entries in the fixture and a substring of no command
+        is the age of four entries in the fixture and a substring of no command
         in it, so without the flag this query returns them and with it nothing.
+
+        The exit code is asserted too: an fzf that failed to start would also
+        print nothing, and this would pass having matched nothing at all.
         """
-        completed = subprocess.run(
-            [*search._fzf_argv("global", "", True), "--filter=10h"],
-            input="\n".join(search.render_rows([(NOW - age, c) for age, c in SYNC_HISTORY], NOW))
-            + "\n",
-            capture_output=True,
-            text=True,
-        )
+        completed = self.filtered("10h")
         self.assertEqual(completed.stdout, "", "the relative-time column was matched against")
+        self.assertEqual(completed.returncode, 1, f"not fzf's no-match exit: {completed.stderr}")
 
 
 class TestRecalledCommandIsInert(unittest.TestCase):

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -144,8 +144,19 @@ def _fzf_argv(scope: Scope, query: str, dedup: bool) -> list[str]:
         # Match against the command only. Without this, typing "3d" would match
         # the relative-time column and surface unrelated entries.
         "--nth=2..",
-        # Preserve our newest-first order when match scores tie.
-        "--tiebreak=begin,index",
+        # Preserve our newest-first order when match scores tie. `begin` used to
+        # come first here, and it did not preserve anything: for a query like
+        # "sync" every candidate scores the same, so `begin` -- not recency --
+        # decided the whole list, ranking a year-old `sudo sync; echo 3 > ...`
+        # above a three-minute-old `woswoar sync` purely because its match
+        # starts three characters earlier in the line.
+        #
+        # It also leaked the time column into the ranking. fzf scores `begin` as
+        # (match offset - leading whitespace), and the column is right-aligned,
+        # so a two-character age is padded with one more space than a
+        # three-character one: `1y  atuin sync -h` outranked `10h  atuin sync`
+        # with the offsets otherwise identical. `index` is what the intent was.
+        "--tiebreak=index",
         f"--query={query}",
         f"--prompt=woswoar ({scope}) ",
         "--header=ctrl-g global | ctrl-h host | ctrl-s session",


### PR DESCRIPTION
Reported: typing `sync` put a year-old entry above `woswoar sync`, the command actually wanted.

```
 10h  sync
 10h  synci
 11d  sync; echo 3 | sudo tee /proc/sys/vm/drop_caches
 ...
  1y  sudo sync; echo 3 > /proc/sys/vm/drop_caches     <- a year old
  1y  atuin sync -h
 10h  atuin sync
  3m  woswoar sync                                     <- three minutes old
```

## The cause

`_fzf_argv` passed `--tiebreak=begin,index`, with the comment "preserve our newest-first order when match scores tie". It did the opposite.

For a one-word query every candidate scores identically as far as fzf is concerned, so `begin` — where in the line the match starts — decided the **entire** list, and recency only broke ties within one offset. `sudo sync; …` matches at offset 5 and `woswoar sync` at 8, so the year-old one wins however recent the other is.

A second defect fell out of that one. fzf scores `begin` as *match offset minus the line's leading whitespace*, and the age column is right-aligned into four characters — so `1y` carries one more leading space than `10h`, and `  1y  atuin sync -h` outranked ` 10h  atuin sync` with the match offsets otherwise identical. The display padding was ranking the history.

Dropping `begin` leaves `index`, which is what the comment claimed all along: fzf's score first, our newest-first order for the ties.

## Measured, on the reported history through the real fzf

| `--tiebreak=begin,index` (before) | `--tiebreak=index` (after) |
|---|---|
| ` 10h  sync` | `  3m  woswoar sync` |
| ` 10h  synci` | ` 15m  time woswoar sync` |
| ` 11d  sync; echo 3 \| sudo tee …` | ` 10h  sync` |
| ` 18d  sync; echo 3 \| sudo tee … >/dev/null` | ` 10h  synci` |
| ` 2mo  sync_claude_skills.py` | ` 10h  atuin sync` |
| `  1y  sudo sync; echo 3 > …` | ` 10h  chmod a+x sync_claude_skills.py` |
| `  1y  atuin sync -h` | ` 11d  sync; echo 3 \| sudo tee …` |
| ` 10h  atuin sync` | … |
| ` 2mo  atuin sync -f` | ` 3mo  aimgr repo sync` |
| `  3m  woswoar sync` | `  1y  sudo sync; echo 3 > …` |
| `  1y  chezmoi sync` | `  1y  atuin sync -h` |
| ` 10h  chmod a+x sync_claude_skills.py` | `  1y  chezmoi sync` |
| … | `  1y  time m clean && time m && time sync` |

The "before" column reproduces the report line for line.

## Tests

`TestRealFzfRanking` drives the real fzf binary. `--filter` does the same match-and-sort without needing a terminal, over the argv `_fzf_argv` itself builds — so a change to `--nth` or `--tiebreak` reaches the test, and the subject under test is fzf's ranking rather than a stand-in's. The fixture is the reported history.

Four tests: the newest match comes first; the year-old `sudo sync` does not outrank the three-minute-old `woswoar sync` (a pair chosen so only the tiebreak can separate them); the width of the age column does not rank (`atuin sync` vs `atuin sync -h`, equal offsets, differing pad); and the age column is still not matched against, which is what `--nth=2..` buys — asserted through fzf here rather than by checking the flag is present.

Mutation-verified per rule 3 (`python -m tools.mutate`):

```
  caught    the old tiebreak is back: begin decides, recency only breaks its ties
  caught    no tiebreak at all: fzf's default (length) ranks
  caught    the age column is matched against again
```

CI installs fzf alongside age in the `test` job — one `apt-get` for both, the round trip is what costs — and re-runs `tests.test_search` with `--no-skips`, since these tests skip themselves without the binary and a skipped run is green.

## Review

Rule 1's middle row: behaviour on a path a user reaches, no stored data touched. Read the diff against the report, plus the mutation table above; no agents.

## Noticed, not filed

The reported screenshot shows `2mo  sync_claude_skills.py` twice, and `chmod a+x sync_claude_skills.py` at both `10h` and `2mo`, which `rank_rows` dedup should have collapsed. The underlying commands must differ invisibly — trailing whitespace is the likeliest. Not reproducible from here without the actual history, so it is a note rather than an issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmgrBymH812dZJtmsmALn2)_