### PR TITLE
lint: the blank lines ruff wants around the new doctor tests

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -68,8 +68,6 @@ class TestDoctorWithABrokenAge(WoswoarTestCase):
         self.assertRegex(out, r"\[FAIL\] age")
 
 
-
-
 @requires_age
 class TestDoctorWithASlowAge(WoswoarTestCase):
     """The failure that is hardest to diagnose, because nothing is broken.
@@ -131,6 +129,8 @@ class TestAFastAgeIsNotFlagged(WoswoarTestCase):
         self.assertLess(crypto.startup_ms(), crypto.SLOW_MS)
         self.assertIn("[ok] age", support.run_cli("doctor").out)
         self.assertNotIn("ms to start. woswoar runs it", support.run_cli("doctor").out)
+
+
 class TestDoctorsMarkers(WoswoarTestCase):
     """A tick for a person, the old text for everything else.
 


### PR DESCRIPTION
`main` is red. Two blank lines, in `tests/test_doctor.py`.

#115 and #116 each appended a test class to that file. Resolving the conflict
between them left four blank lines before one class and none before the other,
which `ruff format --check` rejects.

I had already fixed this locally — but `ruff format` ran *after* the rebase
commit was created, so the fix sat uncommitted in the working tree while the
commit itself still carried the bad spacing. My local `ruff format --check`
passed (it checks the tree) while CI failed (it checks the commit), which is why
it looked like a ruff version difference at first and was not.

Green after this: `ruff check`, `ruff format --check`, `mypy`, `shellcheck`, and
the full suite.