### PR TITLE
release: 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ one machine.
 > **The same line upgrades an existing install** — run it again whenever you want
 > the latest release. `stable` tracks the most recent tag, so the command never
 > changes and you never edit a version number on five machines. Swap `@stable`
-> for `@main` to track the tip, or `@v0.4.0` to pin exactly.
+> for `@main` to track the tip, or `@v0.4.1` to pin exactly.
 
 **Needs:** bash 5.0+ (Linux) · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) ·

--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
Cuts v0.4.1. Four commits since v0.4.0, all fixes.

**Patch:** no new commands, no format change, nothing to do on upgrade.

## Ctrl-R ranking

- **Recency decides ties again** (#117). `--tiebreak=begin,index` was meant to
  "preserve our newest-first order when match scores tie" and did the opposite:
  for a one-word query every candidate scores the same to fzf, so *where in the
  line* the match started decided the entire list. Typing `sync` put a year-old
  entry above the `woswoar sync` from three minutes ago.

## doctor

- **A slow `age` is now a failure, not a mystery** (#115). Reported from an
  Ubuntu install where `age` came from a snap: `sync` and `accept` took about
  half a second per day of history, ~100x a distribution binary. Nothing was
  broken — every check passed and the crypto was correct — so there was no way
  to find out. woswoar spawns `age` about twice per day-key (counted: 2.0
  exporting, 2.2 granting, 2.0 merging), so 250 ms per call is six minutes on
  two years of history instead of three seconds. `doctor` times it, fails above
  50 ms, says what it will cost, and names the snap when that is what it is.
- **A green tick and a red cross** (#116), and the labels line up — `[ok]` is
  four characters and `[FAIL]` is six, so failing lines used to sit two columns
  right of the passing ones. Only on a terminal: piped output keeps the plain
  text that the suite and anyone's `| grep FAIL` depend on, and `NO_COLOR` is
  honoured.

## Repository

- **`main` went red** (#118) between #116 landing and this release. Two blank
  lines: #115 and #116 each appended a test class to the same file, and the
  conflict resolution left the spacing `ruff format` rejects.

## Upgrade path

Nothing. The cache and repository formats are unchanged from v0.4.0.

## Still open

- **#110** (P2): `accept` pairs a machine's two keys through a claim the
  repository controls and shows it as corroboration. The guarantee holds — the
  fingerprints will not match when you run the printed check on the real machine.
- **The end-to-end shakedown has still not been run** on a real install.