### PR TITLE
accept: a key two hosts claim belongs to neither, and the pairing says whose claim it is

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -266,6 +266,23 @@ accept history they published. Disclosure would be prevented and injection
 introduced. `trust` avoids it by showing the verify key's own fingerprint, which
 is the thing being decided.
 
+`woswoar accept` shows both keys at once, which reopened the same question in a
+new form: a fingerprint you *can* check sitting directly above one you cannot
+reads as the first vouching for the second, and what puts them on the same line
+is the `owner` field of `signer.pub` — the very file this is about.
+
+Two things answer it. The pairing is **labelled as the repository's claim**
+where it is shown, rather than left to look like a fact. And a recipient that
+**more than one host directory claims** is paired with neither and reported:
+the mapping used to keep the first claim in sorted order and drop the rest, so
+a host id chosen to sort first could take another machine's recipient — and the
+name attached to it — without anything saying so. Two hosts claiming one key is
+not an ambiguity to resolve, because nothing in the repository could resolve it.
+
+> Asserted by `tests/test_sync.py::TestAHostCannotClaimAnotherMachinesKey`,
+> which mounts exactly that attack: a host directory whose id sorts first,
+> naming another machine's recipient as its own.
+
 ### What that costs, and what it does not
 
 Adding a laptop is `grant` once, and `trust` on the machines that will read it —

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -4997,6 +4997,100 @@ class TestInitFinishesTheJob(SyncTestCase):
         self.assertIn("first machine", out)
 
 
+class TestAHostCannotClaimAnotherMachinesKey(SyncTestCase):
+    """Issue #110: the pairing is a claim, and it used to be resolved silently.
+
+    `accept` shows a machine's age recipient and its signing key one above the
+    other. That they belong to one machine comes from the `owner` line in
+    `hosts/<id>/signer.pub` -- a file anyone with push access can write. The
+    mapping was built with `setdefault` over `store.repo_hosts()`, which is
+    sorted, and host ids are locally chosen hex: so a directory whose id sorts
+    first could name *your* recipient and win it.
+
+    The result was the attacker's verify key printed directly beneath your own
+    real, checkable age fingerprint -- which reads as the one confirming the
+    other, in the command that widens read access to everything.
+    """
+
+    def hostile_claim_on(self, victim_key: str) -> str:
+        """A host directory that says it owns `victim_key`. Returns its host id.
+
+        Written straight into the repo, like `append_recipient`: this is what
+        arrives by `git pull` from someone who can push.
+
+        The id is forced to sort *first*, because that is what made the old
+        `setdefault` prefer it -- an id chosen at random would win only half the
+        time and turn this into a coin flip.
+        """
+        host = "0" * 16
+        verify_key = crypto.generate_signing_key(self.root / f"signer-{host}")
+        store.write_atomic(store.signer_public(host), f"{verify_key}\n{victim_key}\n".encode())
+        store.write_atomic(store.name_file(host), b"martin@laptop\n")
+        return host
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.alpha = self.machine("alpha", display="martin@desktop")
+        with self.alpha.active():
+            self.alpha.record("2023-11-14", 1_700_000_001, "history")
+            sync.run()
+        self.beta = self.machine("beta", display="martin@laptop")
+        with self.beta.active():
+            self.beta.record("2023-11-15", 1_700_100_001, "beta history")
+            sync.run()
+            self.beta_key = crypto.recipient_for(sync.identity_path(store.machine())).strip()
+            self.beta_signer = sync.signing_public()
+
+    def test_the_stolen_key_is_not_paired_with_the_thief(self) -> None:
+        with self.alpha.active():
+            paired_before = {
+                n.reader.key: n.candidate.verify_key
+                for n in sync.newcomers().machines
+                if n.reader is not None and n.candidate is not None
+            }
+            self.assertEqual(
+                paired_before.get(self.beta_key),
+                self.beta_signer,
+                "precondition: beta's own two keys are paired before the attack",
+            )
+
+            host = self.hostile_claim_on(self.beta_key)
+            self.assertLess(host, self.beta.id, "precondition: the hostile id sorts first")
+
+            after = sync.newcomers()
+            paired = {
+                n.reader.key: n.candidate.verify_key
+                for n in after.machines
+                if n.reader is not None and n.candidate is not None
+            }
+        # Not paired with anyone -- neither the thief nor beta. Nothing in the
+        # repository can say which claim is real, so it makes neither.
+        self.assertNotIn(self.beta_key, paired)
+        self.assertIn(self.beta_key, after.contested)
+
+    def test_the_thief_cannot_put_a_name_on_the_stolen_key_either(self) -> None:
+        with self.alpha.active():
+            self.hostile_claim_on(self.beta_key)
+            labels = {r.key: r.label for r in sync.readers()}
+        self.assertEqual(labels[self.beta_key], sync.UNNAMED)
+
+    def test_accept_says_the_repository_is_claiming_it(self) -> None:
+        with self.alpha.active():
+            self.hostile_claim_on(self.beta_key)
+        _, _, err = self.run_cli(self.alpha, "accept", "--yes")
+        self.assertIn("claimed by more than one machine", err)
+
+    def test_an_honest_repository_still_pairs_and_says_it_is_a_claim(self) -> None:
+        """The other half: without an attacker nothing is contested, the two
+        keys are still shown together, and the line saying where that pairing
+        comes from is still there."""
+        with self.alpha.active():
+            self.assertEqual(sync.newcomers().contested, set())
+        _, out, _ = self.run_cli(self.alpha, "accept", "--yes")
+        self.assertIn("the repository's claim", out)
+        self.assertNotIn("claimed by more than one machine", out)
+
+
 class TestNewcomersIsAskedDirectly(SyncTestCase):
     """The pairing decides who is offered read access, so it is asserted here
     rather than through `accept`'s stdout -- which is the rule `Reader`'s own

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -930,6 +930,12 @@ def cmd_accept(args: argparse.Namespace) -> int:
         if machine.candidate is not None:
             said = "signs with" if machine.needs_trust else "already accepted here"
             print(f"      {said:<28}{machine.candidate.fingerprint}")
+        if machine.reader is not None and machine.candidate is not None:
+            # That these two keys belong to one machine is something the
+            # *repository* says, in a file anyone who can push can write. Left
+            # unsaid, a fingerprint the reader can verify sitting above one they
+            # cannot reads as the first vouching for the second (#110).
+            print("      (that these are one machine is the repository's claim)")
 
     granting = [n for n in fresh if n.needs_grant]
     trusting = [n for n in fresh if n.needs_trust]
@@ -978,6 +984,20 @@ def cmd_accept(args: argparse.Namespace) -> int:
                 print(f"      now signs with              {machine.candidate.fingerprint}")
                 print(f"      accepted here              {machine.candidate.pinned_fingerprint}")
         print("\nThat is not part of this, and needs:  woswoar trust --replace")
+
+    if pending.contested:
+        # Not a warning about a machine -- a statement about the repository.
+        # Two host directories claiming one recipient cannot both be right, and
+        # nothing here can say which is, so neither was paired with it above.
+        print(
+            f"\n{len(pending.contested)} key(s) are claimed by more than one machine"
+            " directory in the\nrepository. An honest repository does not do that."
+            " Nothing here can tell you\nwhich claim is real, so those keys are"
+            " listed on their own above rather than\nbeside a signing key."
+            "\nCheck the fingerprints on the machines themselves before accepting"
+            " anything.",
+            file=sys.stderr,
+        )
 
     if not _confirm(f"Accept {len(fresh)} machine(s)?", args.yes):
         return 1

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -304,22 +304,45 @@ def recipients() -> list[str]:
 UNNAMED = "(unnamed)"
 
 
-def _host_owners() -> dict[str, str]:
-    """``owning recipient -> host id``, from what each host publishes.
+class Owners(NamedTuple):
+    """Which host claims which recipient, and where two of them disagree."""
+
+    #: ``owning recipient -> host id``, for recipients exactly one host claims.
+    by_recipient: dict[str, str]
+    #: Recipients that more than one host directory claims to own. Deliberately
+    #: *not* resolved: see `_host_owners`.
+    contested: set[str]
+
+
+def _host_owners() -> Owners:
+    """Who each host says it is, and which of those claims collide.
 
     Built once per prompt rather than rescanned per recipient: `read_signer`
     opens a file per host, so asking "which host owns this key?" separately for
     each of them is quadratic -- 0.35 ms at five machines, 89 ms at a hundred.
 
-    Untrusted, like everything else `signer.pub` says: it decides a *label*, and
-    a label is shown quoted beside a fingerprint that cannot be chosen.
+    Everything `signer.pub` says is untrusted, and this used to keep the first
+    claim in sorted order and drop the rest -- `setdefault` over
+    `store.repo_hosts()`. Host ids are chosen locally, so anyone who can push
+    could add a directory whose id sorts first, name *your* recipient as its
+    owner, and win the mapping for it (#110). `accept` would then print that
+    host's verify key directly beneath your own real, checkable age
+    fingerprint, which reads as one machine confirming the other.
+
+    A recipient two hosts claim is not an ambiguity to resolve -- there is no
+    evidence here that could resolve it -- so it belongs to neither. It is
+    reported instead, and its keys are shown alone rather than beside each
+    other. Silently picking one is what made a contradiction look like a fact.
     """
-    owners: dict[str, str] = {}
+    claims: dict[str, list[str]] = {}
     for host_id in store.repo_hosts():
         signer = read_signer(host_id)
         if signer is not None:
-            owners.setdefault(signer.owner, host_id)
-    return owners
+            claims.setdefault(signer.owner, []).append(host_id)
+    return Owners(
+        by_recipient={key: hosts[0] for key, hosts in claims.items() if len(hosts) == 1},
+        contested={key for key, hosts in claims.items() if len(hosts) > 1},
+    )
 
 
 def name_of(recipient: str) -> str:
@@ -337,7 +360,7 @@ def name_of(recipient: str) -> str:
     ``(unnamed)`` and its fingerprint, which is the identity anyway -- a name is
     a convenience and was never the thing being consented to.
     """
-    return name_for(_host_owners().get(recipient)).text
+    return name_for(_host_owners().by_recipient.get(recipient)).text
 
 
 class Name(NamedTuple):
@@ -2375,7 +2398,7 @@ def readers() -> list[Reader]:
         return _readers()
 
 
-def _readers(owners: dict[str, str] | None = None) -> list[Reader]:
+def _readers(owners: Owners | None = None) -> list[Reader]:
     """The list itself, assuming the caller holds the lock and has fetched.
 
     Split from `readers` for `newcomers`, which needs this and
@@ -2394,8 +2417,11 @@ def _readers(owners: dict[str, str] | None = None) -> list[Reader]:
     except (WoswoarError, OSError):
         mine = ""
 
-    learn_names(store.machine(), {host for host in owners.values() if host})
-    labelled = [(key, name_for(owners.get(key))) for key in enrolled]
+    learn_names(store.machine(), {host for host in owners.by_recipient.values() if host})
+    # A contested recipient resolves to no host, so it also gets no name: a
+    # machine that could win the pairing by claiming someone else's key could
+    # otherwise put a *name* on it too.
+    labelled = [(key, name_for(owners.by_recipient.get(key))) for key in enrolled]
     names = Counter(name.text for _, name in labelled if name.known)
     return [
         Reader(
@@ -2428,7 +2454,7 @@ class Newcomer(NamedTuple):
 
     #: The age recipient it reads with. None for a host publishing a signer this
     #: machine cannot tie to any recipient it has -- two host directories naming
-    #: one owner, where `_host_owners` keeps the first.
+    #: one owner -- which `_host_owners` refuses to resolve, so neither gets it.
     reader: Reader | None
     #: The signing key it publishes with. None for a machine that enrolled but
     #: has never pushed a `signer.pub`.
@@ -2497,6 +2523,11 @@ class Pending(NamedTuple):
     #: Every enrolled recipient at the moment `machines` was computed -- not
     #: only the ones with something to decide. `grant` re-seals to all of them.
     enrolled: list[str]
+    #: Recipients that more than one host directory claims to own. Nothing here
+    #: can say which is telling the truth, so neither is paired with them and
+    #: the fact is put on screen: two hosts claiming one key is not something
+    #: an honest repository does.
+    contested: set[str]
 
 
 def newcomers() -> Pending:
@@ -2521,7 +2552,7 @@ def newcomers() -> Pending:
         for reader in enrolled:
             # `pop`, so what is left in `by_host` is exactly the hosts no reader
             # claimed. `""` is never a host id, so an unpaired recipient misses.
-            candidate = by_host.pop(owners.get(reader.key, ""), None)
+            candidate = by_host.pop(owners.by_recipient.get(reader.key, ""), None)
             # Our own machine is not a newcomer to itself. It has no candidate
             # either -- `_trust_candidates` drops it -- so this is the same test.
             if candidate is None and reader.is_mine:
@@ -2536,6 +2567,7 @@ def newcomers() -> Pending:
         return Pending(
             machines=[n for n in out if n.needs_grant or n.needs_trust or n.changed_key],
             enrolled=[reader.key for reader in enrolled],
+            contested=owners.contested,
         )
 
 


### PR DESCRIPTION
Closes #110.

## The attack

`accept` shows a machine's age recipient and its signing key one above the
other. What puts them on the same line is the `owner` field of
`hosts/<id>/signer.pub` — a file anyone with push access can write. The mapping
was built with `setdefault` over `store.repo_hosts()`, which is `sorted()`, and
host ids are locally chosen hex. So a directory whose id sorts first could name
**your** recipient and win it:

```
  'martin@laptop'                             <- attacker's name.age
      already reads your history  age1qjg…    <- your real, checkable fingerprint
      signs with                  SHA256:2xQ5… <- the attacker's verify key
```

Nothing was broken — you still could not be *tricked into decryption*, and the
check command was printed. What was wrong is that a fingerprint you can verify
sat directly above one you cannot, which reads as the first vouching for the
second, in the command that widens read access to your entire history.

## The fix, in two parts

**A recipient more than one host claims belongs to neither.** There is no
evidence in the repository that could say which claim is real, so it makes none.
`_host_owners` now collects every claim rather than keeping the first, and
reports collisions. The contested key also loses its **name** — resolving to no
host means `name_for` has nothing to read, so the thief cannot label it either.

**The pairing is labelled as what it is** where it is shown:

```
      reads with                  age1qjg…
      signs with                  SHA256:2xQ5…
      (that these are one machine is the repository's claim)
```

Plus a report before the prompt when anything is contested, because two hosts
claiming one key is not something an honest repository does.

Neither change trusts the `owner` line harder, and neither hides an unpaired
machine — hiding it would hide the machine rather than the problem, which is the
constraint the issue named.

## Tests

`TestAHostCannotClaimAnotherMachinesKey` mounts the real attack: a host
directory written straight into the repo (as one arriving by `git pull`), with
its id forced to `0000000000000000` so it sorts first — a random id would win
half the time and make the test a coin flip. It asserts the precondition that
beta's own two keys *were* paired before the attack, so the "not paired"
assertion cannot pass vacuously.

Mutation-tested. Restoring the vulnerability is caught by three tests
independently:

```
caught  the vulnerability, offered to the pairing test alone
caught  the vulnerability, offered to the naming test alone
caught  the vulnerability, offered to the accept-output test alone
caught  accept stops reporting a contested key
caught  the pairing stops being labelled as the repository's claim
```

One earlier mutation of mine was a false catch worth naming: it referenced a
helper that does not exist, so it caught a `NameError` rather than a behaviour.
Re-aimed at the actual regression, which is what the three above are.

`docs/security.md` gains this under "the sharp reason", with the pointer to the
test — claims there are backed by tests, not prose.