### PR TITLE
setup: a guided first run, and grant loses its reencrypt alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ when you need that one command from last Tuesday, on the other machine.
 
 ```bash
 pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
-woswoar install                  # hook it into ~/.bashrc
-woswoar import bash              # optional: bring your existing history along
+woswoar setup
 ```
+
+`setup` asks four questions — it checks the tools, installs the shell hook,
+offers to import whatever history it finds, and asks for a sync repository (leave
+it blank to stay on one machine). Every step is a command you can also run
+yourself: `install`, `import`, `init`.
 
 Open a new shell, press <kbd>Ctrl</kbd>+<kbd>R</kbd>. That is the whole thing on
 one machine.
@@ -58,17 +62,35 @@ Sync goes through **an ordinary git repository you already own** — no server, 
 account, no daemon. Create an empty one (`woswoar-history` on GitHub, a bare repo
 on a NAS, a folder on a USB stick). You do that once, ever.
 
-Then on **every** machine, first or fifth, the same four lines:
+Then on **every** machine, first or fifth, the same two lines:
 
 ```bash
 pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
-woswoar install                                       # hook it into bash
-woswoar import atuin --this-host-only                 # optional: this machine's past
-woswoar init git@github.com:you/woswoar-history.git   # join, and sync
+woswoar setup                    # paste the repository URL when it asks
 ```
 
-`init` does the first sync itself, so the new machine starts publishing straight
-away — it signs its own commands and waits for nobody.
+`setup` joins the repo and does the first sync itself, so the new machine starts
+publishing straight away — it signs its own commands and waits for nobody.
+
+> [!TIP]
+> **Importing atuin on more than one machine?** `setup` asks whether to import
+> only *this* machine's history, and on a fleet the answer is yes. atuin keeps
+> every machine it has synced with in one database, and woswoar publishes only a
+> machine's own commands — so importing all of them everywhere stores each
+> machine's history once per machine. Let each machine import its own.
+
+<details>
+<summary>The same thing without the questions</summary>
+
+```bash
+woswoar install
+woswoar import atuin --this-host-only     # optional
+woswoar init git@github.com:you/woswoar-history.git
+```
+
+`setup` calls exactly these. It needs a terminal, so this is also what to use
+from a script or a dotfiles bootstrap.
+</details>
 
 From the **second** machine onwards, one more line, on each machine you already
 use:
@@ -193,6 +215,7 @@ truthful. Re-running an import is idempotent.
 
 | command | |
 |---|---|
+| `woswoar setup` | guided first run: tools, hook, import, sync repo |
 | `woswoar search` | interactive picker (what <kbd>Ctrl</kbd>+<kbd>R</kbd> runs) |
 | `woswoar list` | plain output, used by fzf's scope-switch reload |
 | `woswoar import bash\|zsh\|atuin` | import an existing history |

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,200 @@
+"""`woswoar setup`: the guided first run.
+
+It owns no logic of its own -- every step calls the command someone would have
+run by hand -- so what these test is the *asking*: which questions appear, what
+the answers are turned into, and that it refuses rather than guessing when there
+is nobody to ask.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from woswoar import __main__ as main_module
+
+from . import support
+from .support import WoswoarTestCase
+
+
+class Answers:
+    """Scripted replies, in order, for `input`.
+
+    Runs out deliberately: a prompt this did not expect raises rather than
+    blocking the suite forever or silently taking a default.
+    """
+
+    def __init__(self, *replies: str) -> None:
+        self.remaining = list(replies)
+        self.asked: list[str] = []
+
+    def __call__(self, prompt: str = "") -> str:
+        self.asked.append(prompt)
+        if not self.remaining:
+            raise AssertionError(f"unexpected prompt: {prompt!r}")
+        return self.remaining.pop(0)
+
+
+class SetupTestCase(WoswoarTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        # `setup` refuses without one, and every test here is about what it does
+        # when it has one.
+        self._tty = mock.patch("sys.stdin.isatty", return_value=True)
+        self._tty.start()
+        self.addCleanup(self._tty.stop)
+
+        # `importer` resolves every default path from `Path.home()`, and
+        # `WoswoarTestCase` redirects the XDG variables but not HOME -- so
+        # without this these tests read the developer's own shell history and
+        # `setup` offers to import it.
+        previous = os.environ.get("HOME")
+        os.environ["HOME"] = str(self.root)
+        self.addCleanup(
+            lambda: (
+                os.environ.__setitem__("HOME", previous)
+                if previous is not None
+                else os.environ.pop("HOME", None)
+            )
+        )
+        self.rcfile = Path(self.root) / "bashrc"
+        self.rcfile.write_text("# existing\n", encoding="utf-8")
+
+    def run_setup(self, *replies: str) -> Answers:
+        answers = Answers(*replies)
+        with mock.patch("builtins.input", answers):
+            main_module.cmd_setup(argparse.Namespace(rcfile=str(self.rcfile)))
+        return answers
+
+
+def _never_asks(prompt: str = "") -> str:
+    """An `input` that fails instead of blocking.
+
+    Without this a `setup` that wrongly proceeds past the tty check reads the
+    test runner's own stdin and hangs the suite -- which is exactly what
+    happened the first time a mutation removed that check. A test that can hang
+    forever reports nothing; one that raises names the bug.
+    """
+    raise AssertionError(f"asked a question with nobody there: {prompt!r}")
+
+
+class TestItRefusesWithNobodyToAsk(WoswoarTestCase):
+    """No HOME redirection needed: it exits before reading anything."""
+
+    def test_a_pipe_gets_the_commands_to_run_instead(self) -> None:
+        with (
+            mock.patch("sys.stdin.isatty", return_value=False),
+            mock.patch("builtins.input", _never_asks),
+        ):
+            ran = support.run_cli("setup")
+        self.assertEqual(ran.code, 1)
+        # The alternative, not just a refusal: someone in a script needs the
+        # three commands, not the news that this one is interactive.
+        for command in ("woswoar install", "woswoar import", "woswoar init"):
+            self.assertIn(command, ran.err)
+
+    def test_it_changes_nothing_on_the_way_out(self) -> None:
+        rcfile = Path(self.root) / "bashrc"
+        rcfile.write_text("# existing\n", encoding="utf-8")
+        with (
+            mock.patch("sys.stdin.isatty", return_value=False),
+            mock.patch("builtins.input", _never_asks),
+        ):
+            support.run_cli("setup", "--rcfile", str(rcfile))
+        self.assertEqual(rcfile.read_text(encoding="utf-8"), "# existing\n")
+
+
+class TestWhatItOffersToImport(SetupTestCase):
+    def test_only_histories_that_exist_and_hold_something(self) -> None:
+        (Path.home() / ".bash_history").write_text("echo hi\n", encoding="utf-8")
+        (Path.home() / ".zsh_history").write_text("", encoding="utf-8")  # empty
+        kinds = [kind for kind, _, _ in main_module._importable()]
+        self.assertEqual(kinds, ["bash"], "an empty history is not worth offering")
+
+    def test_the_biggest_is_offered_first(self) -> None:
+        (Path.home() / ".bash_history").write_text("x\n", encoding="utf-8")
+        (Path.home() / ".zsh_history").write_text("y" * 5000, encoding="utf-8")
+        self.assertEqual([kind for kind, _, _ in main_module._importable()], ["zsh", "bash"])
+
+    def test_nothing_found_is_not_a_failure(self) -> None:
+        answers = self.run_setup("")  # only the repository URL is asked
+        self.assertEqual(len(answers.asked), 1)
+
+
+class TestTheAtuinQuestion(SetupTestCase):
+    """The one question `setup` asks that no single command asks.
+
+    atuin keeps every machine it has synced with in one database, and woswoar
+    publishes only a machine's own commands -- so importing all of them on every
+    machine stores each machine's history once per machine. Which answer is
+    right depends on something only the person knows: whether woswoar is going
+    on those other machines too.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        db = Path.home() / ".local/share/atuin/history.db"
+        db.parent.mkdir(parents=True, exist_ok=True)
+        db.write_bytes(b"x" * 4096)
+        self.imported: list[argparse.Namespace] = []
+
+        def record(args: argparse.Namespace) -> int:
+            self.imported.append(args)
+            return 0
+
+        patched = mock.patch.object(main_module, "cmd_import", record)
+        patched.start()
+        self.addCleanup(patched.stop)
+
+    def test_it_is_asked_and_yes_reaches_the_importer(self) -> None:
+        answers = self.run_setup("y", "y", "")
+        self.assertTrue(
+            any("only this machine" in prompt for prompt in answers.asked),
+            f"never asked: {answers.asked}",
+        )
+        self.assertTrue(self.imported[0].this_host_only)
+
+    def test_no_imports_every_machine(self) -> None:
+        self.run_setup("y", "n", "")
+        self.assertFalse(self.imported[0].this_host_only)
+
+    def test_declining_the_import_does_not_ask_it_at_all(self) -> None:
+        answers = self.run_setup("n", "")
+        self.assertFalse(any("only this machine" in prompt for prompt in answers.asked))
+        self.assertEqual(self.imported, [])
+
+    def test_it_is_not_asked_for_bash(self) -> None:
+        """The question is about atuin's multi-machine database, and asking it
+        of a file that holds one machine's history would be noise."""
+        (Path.home() / ".local/share/atuin/history.db").unlink()
+        (Path.home() / ".bash_history").write_text("echo hi\n", encoding="utf-8")
+        answers = self.run_setup("y", "")
+        self.assertFalse(any("only this machine" in prompt for prompt in answers.asked))
+        self.assertFalse(self.imported[0].this_host_only)
+
+
+class TestTheRepositoryStep(SetupTestCase):
+    def test_a_blank_url_stays_local_and_joins_nothing(self) -> None:
+        self.run_setup("")
+        self.assertFalse((Path(os.environ["WOSWOAR_DIR"]) / "history" / ".git").exists())
+
+    def test_the_hook_is_installed_either_way(self) -> None:
+        """Staying local is a supported outcome, not an abort: the single
+        machine case is the README's whole Quick Start."""
+        self.run_setup("")
+        self.assertIn("woswoar", self.rcfile.read_text(encoding="utf-8"))
+
+
+class TestItIsSafeToRunTwice(SetupTestCase):
+    def test_the_rcfile_gains_one_block_not_two(self) -> None:
+        self.run_setup("")
+        self.run_setup("")
+        text = self.rcfile.read_text(encoding="utf-8")
+        self.assertEqual(text.count(main_module._BEGIN), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -310,12 +310,12 @@ class TestTwoMachines(SyncTestCase):
             self.assertEqual(report.chunks_merged, 1)
             self.assertEqual(beta.commands(), {"git status", "make -j8"})
 
-    def test_reencrypt_alone_grants_access_without_a_surrounding_sync(self) -> None:
+    def test_grant_alone_gives_access_without_a_surrounding_sync(self) -> None:
         """The recipient list is a file in the working tree.
 
         Re-sealing against a checkout taken before the new machine enrolled
         rewrites every key to the *old* recipients and reports full success,
-        while granting nothing. So `reencrypt` has to fetch first, and this
+        while granting nothing. So `grant` has to fetch first, and this
         pins that it does -- alpha never syncs after beta joins.
         """
         alpha = self.machine("alpha")
@@ -334,7 +334,7 @@ class TestTwoMachines(SyncTestCase):
             sync.run()
             self.assertEqual(beta.commands(), {"git status"})
 
-    def test_a_new_machine_cannot_reencrypt_for_itself(self) -> None:
+    def test_a_new_machine_cannot_grant_to_itself(self) -> None:
         """Re-sealing means opening the key first, which beta cannot do.
 
         This is the property the encryption rests on, not a missing feature:

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -882,6 +882,141 @@ def cmd_trust(args: argparse.Namespace) -> int:
     return 0
 
 
+def _ask(question: str, default: str = "") -> str:
+    """Free text, with a default shown. Empty answer takes the default."""
+    shown = f" [{default}]" if default else ""
+    return input(f"{question}{shown}: ").strip() or default
+
+
+def _ask_yes(question: str, default: bool = True) -> bool:
+    """A yes/no with a default, for questions that change nothing dangerous.
+
+    Deliberately not `_confirm`: that one is a security control with an
+    `isatty` branch and a fixed refusal message about widening access. These
+    are "shall I install the shell hook" -- reusing the access gate for them
+    would blunt the thing it is for.
+    """
+    hint = "[Y/n]" if default else "[y/N]"
+    answer = input(f"{question} {hint} ").strip().lower()
+    if not answer:
+        return default
+    return answer in ("y", "yes")
+
+
+#: What `setup` offers to import, in the order it offers them. `importer` owns
+#: where each one lives; this only asks whether it is there.
+def _importable() -> list[tuple[str, Path, int]]:
+    """``(kind, path, size)`` for each history on this machine, largest first."""
+    from . import importer
+
+    found = []
+    for kind in importer.KINDS:
+        path = importer.atuin_db() if kind == "atuin" else importer.default_path(kind)
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        if size:
+            found.append((kind, path, size))
+    return sorted(found, key=lambda item: item[2], reverse=True)
+
+
+def cmd_setup(args: argparse.Namespace) -> int:
+    """Walk a fresh machine through the whole thing, asking as it goes."""
+    from . import deps
+
+    if not sys.stdin.isatty():
+        # It asks questions, so it cannot run unattended -- and silently
+        # choosing defaults for someone's script would be worse than refusing.
+        print(
+            "woswoar setup asks questions, so it needs a terminal.\n"
+            "Without one, the same thing is:\n"
+            "    woswoar install\n"
+            "    woswoar import bash|zsh|atuin      # optional\n"
+            "    woswoar init <url>                 # optional",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Setting up woswoar. Everything here can be re-run safely.\n")
+
+    print("1/4  Tools")
+    absent = deps.missing()
+    if absent:
+        print(f"     {deps.report(absent)}")
+        if not _ask_yes("     Carry on without them?", default=False):
+            return 1
+    else:
+        print("     everything woswoar needs is installed")
+
+    print("\n2/4  Shell hook")
+    cmd_install(argparse.Namespace(rcfile=args.rcfile))
+
+    print("\n3/4  Existing history")
+    _offer_imports()
+
+    print("\n4/4  Sync with your other machines")
+    return _offer_remote(args)
+
+
+def _offer_imports() -> None:
+    """Offer each history found on this machine, one at a time."""
+    found = _importable()
+    if not found:
+        print("     nothing to import (no bash, zsh or atuin history found)")
+        return
+
+    for kind, path, size in found:
+        if not _ask_yes(f"     Import {kind} history from {path} ({size / 1e6:.1f} MB)?"):
+            continue
+        this_host_only = False
+        if kind == "atuin":
+            # atuin keeps every machine it has synced with in one database, and
+            # woswoar publishes only this machine's own commands -- so importing
+            # all of them on every machine stores each machine's history once
+            # per machine. Asked rather than assumed: on a single woswoar
+            # machine, importing the lot is exactly what you want.
+            print(
+                "       atuin keeps other machines' history in the same database.\n"
+                "       If you will run woswoar on those machines too, import only\n"
+                "       this one's here and let each machine import its own --\n"
+                "       otherwise every machine stores every other machine twice."
+            )
+            this_host_only = _ask_yes("       Import only this machine's history?")
+        cmd_import(
+            argparse.Namespace(
+                kind=kind, file=str(path), dry_run=False, this_host_only=this_host_only
+            )
+        )
+
+
+def _offer_remote(args: argparse.Namespace) -> int:
+    """Join a history repo, or finish without one."""
+    from . import sync
+
+    if sync.is_repo():
+        print("     already joined a history repo; syncing")
+        return cmd_sync(argparse.Namespace(no_push=False))
+
+    print(
+        "     woswoar syncs through an ordinary git repository you own -- an\n"
+        "     empty GitHub repo, a bare repo on a NAS, a folder on a USB stick.\n"
+        "     There is no server and no account. Leave blank to stay on this\n"
+        "     machine only; you can run 'woswoar init <url>' any time later."
+    )
+    remote = _ask("     Repository URL")
+    if not remote:
+        print("\n     Staying local. Open a new shell and press Ctrl-R.")
+        return 0
+
+    # Through `cmd_init`, so the sequence has one source of truth: whatever it
+    # prints as the next step is what someone following this reads, and there
+    # is no second copy here to disagree with it.
+    return cmd_init(
+        argparse.Namespace(remote=remote, new_identity=False, identity=None, no_sync=False)
+    )
+
+
 def cmd_accept(args: argparse.Namespace) -> int:
     """`grant` and `trust` for a machine you own, in one step.
 
@@ -1128,6 +1263,25 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_import.set_defaults(func=cmd_import)
 
+    p_setup = sub(
+        "setup",
+        "set woswoar up from scratch, asking as it goes",
+        """
+        The guided version of `install`, `import` and `init`. Run it on a fresh
+        machine and answer four questions; it calls the same commands you would
+        have run yourself, so there is nothing it can do that they cannot.
+
+        Safe to re-run: the hook is replaced rather than repeated, importing the
+        same history twice adds nothing, and a machine that already joined a
+        repository just syncs.
+
+        Needs a terminal, because it asks. Without one it says what to run
+        instead rather than choosing for you.
+        """,
+    )
+    p_setup.add_argument("--rcfile", help="file to modify (default: ~/.bashrc)")
+    p_setup.set_defaults(func=cmd_setup)
+
     p_install = sub(
         "install",
         "install the shell hook into .bashrc",
@@ -1225,9 +1379,6 @@ def build_parser() -> argparse.ArgumentParser:
         -- sharing a repository with someone else, rather than adding your own
         laptop.
         """,
-        # `reencrypt` named the mechanism, which hid what it does to the user's
-        # history. Kept working so older notes and error messages do not rot.
-        aliases=["reencrypt"],
     )
     p_grant.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
     p_grant.set_defaults(func=cmd_grant)


### PR DESCRIPTION
Closes #120.

```console
$ woswoar setup
Setting up woswoar. Everything here can be re-run safely.

1/4  Tools
     everything woswoar needs is installed

2/4  Shell hook
machine : martinus@box (0c042d14…)
rcfile  : ~/.bashrc (added)

3/4  Existing history
     Import atuin history from ~/.local/share/atuin/history.db (29.2 MB)? [Y/n] y
       atuin keeps other machines' history in the same database.
       If you will run woswoar on those machines too, import only
       this one's here and let each machine import its own --
       otherwise every machine stores every other machine twice.
       Import only this machine's history? [Y/n] y
…

4/4  Sync with your other machines
     Repository URL: git@github.com:you/woswoar-history.git
```

## It owns no logic

Every step calls the command you would otherwise have run: `cmd_install`,
`cmd_import`, `cmd_init`. So there is nothing `setup` can do that they cannot,
and the "what next" it ends on is the one `cmd_init` already prints — not a
second copy to drift from it. That was the constraint the issue named.

## The atuin question

The one thing no single command asks. atuin keeps every machine it has synced
with in one database, and woswoar publishes only a machine's own commands — so
importing all of them on every machine stores each machine's history once per
machine. Which answer is right depends on something only you know, so it is
asked rather than assumed, and **not** asked for bash or zsh, where one file
holds one machine.

## The other constraints from #120

- **Refuses without a terminal**, and prints the three commands to run instead.
  Choosing defaults for an unattended script would be worse than not running.
- **Re-runnable** — the hook block is replaced not repeated, importing twice
  adds nothing, and an already-joined machine just syncs.
- **A blank URL is a real answer**, not an abort. The single-machine case is the
  README's whole Quick Start.

## `reencrypt` removed

You asked whether it could go. Yes — it was kept as an alias "so older notes and
error messages do not rot" when `grant` was renamed, and that rename happened
**before v0.2.0**, before anything was installed anywhere. So no note or message
it was protecting ever existed, and nothing in the tree emits it as advice. An
alias nobody is told about is surface with no reader.

## README

Quick start is now two lines. "Adding another machine" is two lines plus the
atuin tip, with the explicit three-command sequence kept in a `<details>` for
scripts and dotfiles bootstraps.

## Tests, and one worth reading

Mutation-tested, all five caught:

```
caught  setup runs without a terminal, choosing defaults for a script
caught  the atuin question is never asked, and every machine is imported
caught  the atuin answer is inverted
caught  declining an import imports it anyway
caught  an empty history file is still offered
caught  a blank URL joins something anyway
```

The first one **hung the mutation run** at first: with the tty check removed,
`setup` reached a real `input()` and blocked on the test runner's stdin until the
harness was killed — which then left the tree mutated, exactly what CLAUDE.md
rule 6 warns about. `tools/mutate.py`'s rescue file did its job and the leftover
was one line, rewritten rather than discarded.

The fix is in the test, not the harness: `input` is now patched to *raise* rather
than block, so a `setup` that wrongly proceeds names the bug instead of hanging
forever. A test that can hang reports nothing.

Also worth noting: these tests redirect `HOME`. `WoswoarTestCase` redirects the
XDG variables but not that, and `importer` resolves every default path from
`Path.home()` — so without it the suite read my own shell history and `setup`
offered to import it.