### PR TITLE
release: 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ one machine.
 > **The same line upgrades an existing install** — run it again whenever you want
 > the latest release. `stable` tracks the most recent tag, so the command never
 > changes and you never edit a version number on five machines. Swap `@stable`
-> for `@main` to track the tip, or `@v0.4.1` to pin exactly.
+> for `@main` to track the tip, or `@v0.5.0` to pin exactly.
 
 **Needs:** bash 5.0+ (Linux) · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) ·

--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"


### PR DESCRIPTION
Cuts v0.5.0. Two commits since v0.4.1.

**Minor:** a new command, and one removal.

## `woswoar setup`

Quick start is two lines now:

```bash
pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
woswoar setup
```

Four questions — tools, shell hook, import what it finds, sync repository (blank
to stay on one machine). Every step calls the command you would otherwise have
run, so there is nothing it can do that `install`, `import` and `init` cannot,
and the explicit sequence stays in the README for scripts and dotfiles.

It asks the one question no single command asks: **whether to import only this
machine's atuin history**. atuin keeps every machine it has synced with in one
database and woswoar publishes only a machine's own commands, so importing all
of them everywhere stores each machine's history once per machine. Asked rather
than assumed, and not asked for bash or zsh where one file holds one machine.

Refuses without a terminal and prints what to run instead; re-runnable.

## `accept` no longer lets one host claim another's key

A recipient that **more than one host directory claims** is now paired with
neither, and reported — the mapping used to keep the first claim in sorted
order, and host ids are locally chosen, so a directory named to sort first could
take another machine's recipient and have its own verify key printed directly
beneath that machine's real, checkable fingerprint. Where the two keys *are*
shown together, the line beneath says that pairing them is the repository's
claim.

Nothing was decryptable that should not have been, and the check command was
always printed. What changed is that a fingerprint you can verify no longer
appears to vouch for one you cannot.

## Removed

- **`woswoar reencrypt`**, the alias for `grant`. It was kept so older notes and
  messages would not rot, but the rename predates v0.2.0 — before anything was
  installed anywhere — so there were none. If you have it in a script, it is
  `woswoar grant`.

## Upgrade path

Nothing. No format change, cache and repository unchanged.

## What is not in it

**The end-to-end shakedown still has not been run** on a real install: install
from the published wheel, `init`, record across a day boundary, second machine,
`accept`, `sync`, `compact`, `revoke`, `doctor` clean at each step. Every piece
is tested against real `age`, `git`, `ssh-keygen` and a real subprocess boundary
for fzf — but the whole path, in order, on a machine that is not a test fixture,
has not been walked. It is the oldest outstanding item and every recent fix came
from ordinary use rather than from CI.