### PR TITLE
tests: setup must not change behaviour with fzf on the machine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,12 +48,19 @@ jobs:
             exit 1
           fi
 
-      - name: install age
+      - name: install age and fzf
         # The sync suite skips itself without age, and a skipped suite is green
         # -- so prove age is here rather than assume the install worked.
+        #
+        # fzf for a different reason: the suite does not skip without it, it
+        # takes a *different branch* -- `setup` asks an extra question when a
+        # tool is missing. CI installs both, this installed only age, and the
+        # two therefore ran different code. That difference is what failed a
+        # release after every check on the pull request was green.
         run: |
-          sudo apt-get update -qq && sudo apt-get install -y -qq age
+          sudo apt-get update -qq && sudo apt-get install -y -qq age fzf
           age --version
+          fzf --version
 
       - name: tests
         # A tag can be pushed to any commit by anyone. Re-running the suite here

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -60,6 +60,15 @@ class SetupTestCase(WoswoarTestCase):
                 else os.environ.pop("HOME", None)
             )
         )
+        # Step 1 asks an extra question when a tool is missing, so leaving this
+        # to the machine makes every scripted answer below land on a different
+        # prompt depending on whether fzf happens to be installed. CI installs
+        # it and the release workflow did not, which is exactly how this got
+        # through review and then failed while cutting a release.
+        self._tools = mock.patch("woswoar.deps.missing", return_value=[])
+        self._tools.start()
+        self.addCleanup(self._tools.stop)
+
         self.rcfile = Path(self.root) / "bashrc"
         self.rcfile.write_text("# existing\n", encoding="utf-8")
 
@@ -105,6 +114,24 @@ class TestItRefusesWithNobodyToAsk(WoswoarTestCase):
         ):
             support.run_cli("setup", "--rcfile", str(rcfile))
         self.assertEqual(rcfile.read_text(encoding="utf-8"), "# existing\n")
+
+
+class TestTheToolsStep(SetupTestCase):
+    """The branch the other tests patch away, tested on its own."""
+
+    def test_a_missing_tool_is_reported_and_can_be_carried_past(self) -> None:
+        from woswoar import deps
+
+        with mock.patch("woswoar.deps.missing", return_value=[deps.FZF]):
+            answers = self.run_setup("y", "")  # carry on, then blank URL
+        self.assertTrue(any("Carry on without them" in prompt for prompt in answers.asked))
+
+    def test_declining_stops_before_anything_is_written(self) -> None:
+        from woswoar import deps
+
+        with mock.patch("woswoar.deps.missing", return_value=[deps.FZF]):
+            self.run_setup("n")
+        self.assertEqual(self.rcfile.read_text(encoding="utf-8"), "# existing\n")
 
 
 class TestWhatItOffersToImport(SetupTestCase):


### PR DESCRIPTION
The v0.5.0 release workflow **failed** — after all eight checks on #122 were
green. No release was published and `stable` did not move.

## Why

CI installs `age` **and** `fzf`. The release workflow installed only `age`.

That matters because `setup` does not *skip* without fzf — it takes a different
branch. Step 1 asks "Carry on without them?" when a tool is missing, so every
scripted answer in `tests/test_setup.py` landed on a different prompt than
intended:

```
ERROR: test_no_imports_every_machine
FAIL:  test_it_is_asked_and_yes_reaches_the_importer
FAIL:  test_the_rcfile_gains_one_block_not_two
```

Two things were wrong, and both are fixed:

**The tests should not have depended on it.** They are about which questions get
asked, not about what happens to be installed. `deps.missing` is stubbed, and
the missing-tool branch gets two tests of its own rather than being an ambient
condition every other test is silently subject to. Verified by running the suite
with `fzf` hidden from `shutil.which` — the environment that broke it.

**The release workflow should run what CI ran.** It re-runs the suite so that "a
release is never cut from something that was not tested at this exact commit" —
but testing the same commit in an environment CI never used is not that
guarantee. It installs both now.

## Next

`v0.5.0` is tagged but unpublished, at a commit whose suite fails on a runner
without fzf. Once this lands I will delete that tag and re-tag on top, so the
release is cut from a commit that passes.