### PR TITLE
woswoar: one command that says where you stand and what to run next

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,28 @@ when you need that one command from last Tuesday, on the other machine.
 
 ```bash
 pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
-woswoar setup
+woswoar
 ```
 
-`setup` asks four questions — it checks the tools, installs the shell hook,
+**`woswoar` on its own is the only command you have to remember.** On a machine
+with nothing installed it sets up; after that it tells you where you stand and
+names the one command to run next, if there is one:
+
+```console
+$ woswoar
+woswoar 0.5.0 — 54,804 commands from 3 machines
+
+1 machine(s) waiting to be accepted here:
+    'martin@laptop'
+
+Next:  woswoar accept
+```
+
+It reads only what is already here and never widens who can read your history —
+it names `accept`, it does not ask. Deciding that stays something you go and do,
+so the moment you are asked is one you chose.
+
+`woswoar setup` asks four questions — it checks the tools, installs the shell hook,
 offers to import whatever history it finds, and asks for a sync repository (leave
 it blank to stay on one machine). Every step is a command you can also run
 yourself: `install`, `import`, `init`.
@@ -66,7 +84,7 @@ Then on **every** machine, first or fifth, the same two lines:
 
 ```bash
 pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
-woswoar setup                    # paste the repository URL when it asks
+woswoar                          # paste the repository URL when it asks
 ```
 
 `setup` joins the repo and does the first sync itself, so the new machine starts
@@ -215,6 +233,7 @@ truthful. Re-running an import is idempotent.
 
 | command | |
 |---|---|
+| `woswoar` | where this machine stands, and what to run next |
 | `woswoar setup` | guided first run: tools, hook, import, sync repo |
 | `woswoar search` | interactive picker (what <kbd>Ctrl</kbd>+<kbd>R</kbd> runs) |
 | `woswoar list` | plain output, used by fzf's scope-switch reload |

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -223,5 +223,45 @@ class TestItIsSafeToRunTwice(SetupTestCase):
         self.assertEqual(text.count(main_module._BEGIN), 1)
 
 
+class TestTheBareCommandOnAFreshMachine(SetupTestCase):
+    def test_nothing_at_all_here_runs_setup(self) -> None:
+        answers = Answers("")  # only the repository URL, which is left blank
+        with mock.patch("builtins.input", answers):
+            main_module.cmd_status(argparse.Namespace())
+        self.assertTrue(answers.asked, "setup never ran")
+        # `cmd_status` passes no --rcfile, so this is the default ~/.bashrc --
+        # under the redirected HOME, not the one the other tests here point at.
+        self.assertIn("woswoar", (Path.home() / ".bashrc").read_text(encoding="utf-8"))
+
+    def test_a_hook_alone_is_enough_to_be_reported_on_instead(self) -> None:
+        """Someone who ran `install` and nothing else has set something up, and
+        running `setup` at them would answer a question they did not ask."""
+        hook = Path(os.environ["WOSWOAR_DIR"]) / main_module.HOOK_NAME
+        hook.parent.mkdir(parents=True, exist_ok=True)
+        hook.write_text("#", encoding="utf-8")
+
+        def never(prompt: str = "") -> str:
+            raise AssertionError(f"setup ran on a machine that was not fresh: {prompt!r}")
+
+        with mock.patch("builtins.input", never):
+            ran = support.run_cli()
+        self.assertEqual(ran.code, 0)
+        self.assertIn("woswoar init", ran.out)
+
+    def test_an_imported_history_alone_is_too(self) -> None:
+        support.run_cli("import", "bash", "--file", str(self._history()))
+
+        def never(prompt: str = "") -> str:
+            raise AssertionError(f"setup ran on a machine that was not fresh: {prompt!r}")
+
+        with mock.patch("builtins.input", never):
+            self.assertEqual(support.run_cli().code, 0)
+
+    def _history(self) -> Path:
+        path = Path(self.root) / "history"
+        path.write_text("echo one\necho two\n", encoding="utf-8")
+        return path
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5091,6 +5091,90 @@ class TestAHostCannotClaimAnotherMachinesKey(SyncTestCase):
         self.assertNotIn("claimed by more than one machine", out)
 
 
+class TestTheStatusLine(SyncTestCase):
+    """`woswoar` on its own: the one command somebody has to know.
+
+    It routes; it does not act. Everything it can point at is still a command of
+    its own, and the ones that widen who can read the history stay that way --
+    a consent prompt that appears because you typed the bare command is one
+    whose moment somebody else chose.
+    """
+
+    def two_machines(self) -> tuple[Fake, Fake]:
+        alpha = self.machine("alpha", display="martin@desktop")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "old history")
+            sync.run()
+        beta = self.machine("beta", display="martin@laptop")
+        with beta.active():
+            beta.record("2023-11-15", 1_700_100_001, "beta history")
+            sync.run()
+        with alpha.active():
+            # The timer, which runs once a minute. `status` reports what the
+            # last sync brought in rather than fetching, so a beta that has not
+            # arrived here yet is correctly nothing for alpha to decide about.
+            sync.run()
+        return alpha, beta
+
+    def test_it_names_the_machine_waiting_and_the_command_to_run(self) -> None:
+        alpha, _ = self.two_machines()
+        ran = self.run_cli(alpha)
+        self.assertIn("martin@laptop", ran.out)
+        self.assertIn("woswoar accept", ran.out)
+
+    def test_it_asks_nothing_and_changes_nothing(self) -> None:
+        """The whole reason this reports rather than offers.
+
+        `input` raises, so a status line that grew a prompt fails here rather
+        than teaching someone to answer one they did not go looking for.
+        """
+        alpha, _ = self.two_machines()
+        with alpha.active():
+            before = sync.State.load()
+            granted, signers = set(before.granted), dict(before.signers)
+
+        def never(prompt: str = "") -> str:
+            raise AssertionError(f"the status line asked a question: {prompt!r}")
+
+        with mock.patch("builtins.input", never):
+            self.assertEqual(self.run_cli(alpha).code, 0)
+
+        with alpha.active():
+            after = sync.State.load()
+        self.assertEqual(set(after.granted), granted, "status granted something")
+        self.assertEqual(dict(after.signers), signers, "status trusted something")
+
+    def test_it_does_not_reach_the_network(self) -> None:
+        """Typed for its own sake, so it answers from what is already here --
+        and the timer fetches once a minute regardless."""
+        alpha, _ = self.two_machines()
+
+        def refuse(*args: object, **kwargs: object) -> None:
+            raise AssertionError("the status line fetched")
+
+        with mock.patch.object(sync, "_refresh", refuse):
+            self.assertEqual(self.run_cli(alpha).code, 0)
+
+    def test_a_settled_machine_is_told_to_press_ctrl_r(self) -> None:
+        alpha, _ = self.two_machines()
+        self.run_cli(alpha, "accept", "--yes")
+        self.assertIn("Ctrl-R", self.run_cli(alpha).out)
+
+    def test_a_changed_key_is_routed_to_trust_replace_not_accept(self) -> None:
+        alpha, beta = self.two_machines()
+        self.run_cli(alpha, "accept", "--yes")
+        with beta.active():
+            store.signing_key_file().unlink()
+            beta.record("2023-11-16", 1_700_200_001, "after the key changed")
+            sync.run()
+        with alpha.active():
+            sync.run()
+
+        out = self.run_cli(alpha).out
+        self.assertIn("trust --replace", out)
+        self.assertNotIn("woswoar accept", out)
+
+
 class TestNewcomersIsAskedDirectly(SyncTestCase):
     """The pairing decides who is offered read access, so it is asserted here
     rather than through `accept`'s stdout -- which is the rule `Reader`'s own

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -921,6 +921,86 @@ def _importable() -> list[tuple[str, Path, int]]:
     return sorted(found, key=lambda item: item[2], reverse=True)
 
 
+def _untouched() -> bool:
+    """Is there nothing here at all yet?
+
+    Three cheap questions, and it takes any of them as a yes: the shell hook,
+    a history repo, or a single recorded line. Not "has `install` run" -- a
+    machine that imported a history without wiring the hook, or joined a repo
+    without it, is set up enough to be told where it stands, and running `setup`
+    at it would be answering a question it did not ask.
+
+    `store.machine_file` is deliberately not one of them: `store.machine()`
+    creates it, so almost any command makes it exist and it says nothing about
+    whether anyone has set anything up.
+    """
+    from . import sync
+
+    if (store.data_dir() / HOOK_NAME).is_file() or sync.is_repo():
+        return False
+    return not any(store.iter_log_files())
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    """`woswoar` on its own: where you are, and the one command to run next.
+
+    The single entry point. Everything else is still there and still does
+    exactly what it did; this is so that nobody has to know which of them
+    applies before they can find out.
+
+    What it deliberately does *not* do is act on anything that widens who can
+    read your history. It names `accept` and shows what is waiting; it does not
+    ask. A prompt that appears because you typed the bare command is a prompt
+    someone else chose the moment for -- anyone who can push to the repository
+    can enrol a machine, and then the next `woswoar` you type for any reason has
+    a consent question in it. The one thing that makes that question mean
+    anything is that you went looking for it.
+
+    `setup` is the exception, and only when nothing is installed: it is all
+    questions already, and there is nothing here yet to widen access to.
+    """
+    from . import cache, sync
+
+    if _untouched():
+        print("Nothing installed here yet -- setting up.\n")
+        return cmd_setup(argparse.Namespace(rcfile=None))
+
+    loaded = cache.load_columns()
+    stamps, _ = loaded.stamps_and_commands()
+    hosts = {meta.host for meta in loaded.meta.values() if meta.host}
+    machines = f"{len(hosts)} machine{'s' if len(hosts) != 1 else ''}"
+    print(f"woswoar {__version__} -- {len(stamps)} commands from {machines}")
+
+    if not sync.is_repo():
+        print(
+            "\nThis machine keeps its history to itself.\n"
+            "Next:  woswoar init <url>   to share it with your other machines"
+        )
+        return 0
+
+    # Local only: see `sync.local_newcomers`. Typing this must not reach the
+    # network, and what has not arrived here is not yet this machine's decision.
+    pending = sync.local_newcomers().machines
+    if not pending:
+        print("\nNothing to do. Press Ctrl-R.")
+        return 0
+
+    waiting = [n for n in pending if not n.changed_key]
+    changed = [n for n in pending if n.changed_key]
+    if waiting:
+        print(f"\n{len(waiting)} machine(s) waiting to be accepted here:")
+        for machine in waiting:
+            print(f"    {machine.display_name()}")
+        print("\nNext:  woswoar accept")
+    if changed:
+        print(
+            f"\n{len(changed)} machine(s) changed their signing key, which is either a"
+            "\nre-enrolment or someone rewriting the repository:"
+            "\n\nNext:  woswoar trust --replace"
+        )
+    return 0
+
+
 def cmd_setup(args: argparse.Namespace) -> int:
     """Walk a fresh machine through the whole thing, asking as it goes."""
     from . import deps
@@ -1180,7 +1260,11 @@ def build_parser() -> argparse.ArgumentParser:
         description="Distributed shell history over git, searched with fzf.",
     )
     parser.add_argument("--version", action="version", version=f"woswoar {__version__}")
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    # Not required: `woswoar` on its own is the status line, which is the one
+    # command somebody has to know. argparse's answer to a bare invocation was
+    # a usage error listing fourteen names.
+    parser.set_defaults(func=cmd_status)
+    subparsers = parser.add_subparsers(dest="command")
 
     def sub(
         name: str, summary: str, detail: str, aliases: list[str] | None = None
@@ -1262,6 +1346,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="atuin: skip history belonging to other machines",
     )
     p_import.set_defaults(func=cmd_import)
+
+    p_status = sub(
+        "status",
+        "where this machine is, and what to run next",
+        """
+        What `woswoar` on its own prints. Everything else is still a command of
+        its own; this is so that nobody has to know which one applies before
+        they can find out.
+
+        It reads only what is already here -- no network -- and it does not act
+        on anything that widens who can read your history. It names the command
+        and shows what is waiting; deciding is still something you go and do.
+        """,
+    )
+    p_status.set_defaults(func=cmd_status)
 
     p_setup = sub(
         "setup",

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -2540,35 +2540,55 @@ def newcomers() -> Pending:
     """
     with lock():
         _refresh()
-        # One scan of every `signer.pub`, shared by both halves. Built here and
-        # passed down because `_readers` would otherwise build its own: the
-        # measurement in `_host_owners` is 0.35 ms at five machines and 89 ms at
-        # a hundred, and `accept` was paying it three times over.
-        owners = _host_owners()
-        by_host = {c.host_id: c for c in _trust_candidates()}
+        return _newcomers()
 
-        out: list[Newcomer] = []
-        enrolled = _readers(owners)
-        for reader in enrolled:
-            # `pop`, so what is left in `by_host` is exactly the hosts no reader
-            # claimed. `""` is never a host id, so an unpaired recipient misses.
-            candidate = by_host.pop(owners.by_recipient.get(reader.key, ""), None)
-            # Our own machine is not a newcomer to itself. It has no candidate
-            # either -- `_trust_candidates` drops it -- so this is the same test.
-            if candidate is None and reader.is_mine:
-                continue
-            out.append(Newcomer(reader=reader, candidate=candidate))
 
-        # Publishing a signer, but tied to no recipient this machine can see.
-        # Still offered: trusting it is a real decision, and refusing to show it
-        # would hide the machine rather than the problem.
-        out += [Newcomer(reader=None, candidate=c) for c in by_host.values()]
+def local_newcomers() -> Pending:
+    """`newcomers` without the fetch: what the last sync already brought in.
 
-        return Pending(
-            machines=[n for n in out if n.needs_grant or n.needs_trust or n.changed_key],
-            enrolled=[reader.key for reader in enrolled],
-            contested=owners.contested,
-        )
+    For the status line, which is typed for its own sake and must not reach the
+    network to answer. It is also the honest answer there: a machine that has
+    not arrived here yet is not something this machine has to decide about, and
+    the timer fetches once a minute anyway.
+
+    `accept` keeps the fetching version, because *that* is the moment the list
+    has to be current -- see `readers`.
+    """
+    with lock():
+        return _newcomers()
+
+
+def _newcomers() -> Pending:
+    """The pairing itself, assuming the caller holds the lock."""
+    # One scan of every `signer.pub`, shared by both halves. Built here and
+    # passed down because `_readers` would otherwise build its own: the
+    # measurement in `_host_owners` is 0.35 ms at five machines and 89 ms at
+    # a hundred, and `accept` was paying it three times over.
+    owners = _host_owners()
+    by_host = {c.host_id: c for c in _trust_candidates()}
+
+    out: list[Newcomer] = []
+    enrolled = _readers(owners)
+    for reader in enrolled:
+        # `pop`, so what is left in `by_host` is exactly the hosts no reader
+        # claimed. `""` is never a host id, so an unpaired recipient misses.
+        candidate = by_host.pop(owners.by_recipient.get(reader.key, ""), None)
+        # Our own machine is not a newcomer to itself. It has no candidate
+        # either -- `_trust_candidates` drops it -- so this is the same test.
+        if candidate is None and reader.is_mine:
+            continue
+        out.append(Newcomer(reader=reader, candidate=candidate))
+
+    # Publishing a signer, but tied to no recipient this machine can see.
+    # Still offered: trusting it is a real decision, and refusing to show it
+    # would hide the machine rather than the problem.
+    out += [Newcomer(reader=None, candidate=c) for c in by_host.values()]
+
+    return Pending(
+        machines=[n for n in out if n.needs_grant or n.needs_trust or n.changed_key],
+        enrolled=[reader.key for reader in enrolled],
+        contested=owners.contested,
+    )
 
 
 class _AccessChange(NamedTuple):


### PR DESCRIPTION
Your idea, with one part held back on purpose.

```console
$ woswoar
woswoar 0.5.0 -- 54,804 commands from 3 machines

1 machine(s) waiting to be accepted here:
    'martin@laptop'

Next:  woswoar accept
```

and on a machine with nothing on it:

```console
$ woswoar
Nothing installed here yet -- setting up.

1/4  Tools
...
```

## What is not folded in, and why

It does **not** offer to grant, trust or accept. Those widen who can read your
entire history, and folding them into a state-detecting command changes *when
you get asked*.

- The code already holds this line. `cmd_grant`: *"a prompt that fires when
  there is nothing to decide is a prompt people learn to answer without
  reading."*
- Sharper: **it hands the timing to the attacker.** Anyone who can push to the
  repository can enrol a machine — and then the next `woswoar` you type, for any
  reason at all, has a consent prompt in it. That the prompt appears only
  because you went looking for it is most of what makes it mean anything.

So the status line names `accept` and shows what is waiting. Deciding stays
something you go and do.

`test_it_asks_nothing_and_changes_nothing` pins it: `input` raises, and
`state.granted` / `state.signers` are compared before and after.

## Local state only

`sync.local_newcomers()` is `newcomers()` without the fetch. Faster, and the
more honest answer: a machine that has not arrived here yet is not this
machine's decision, and the timer fetches once a minute anyway. `accept` keeps
the fetching version, because that is the moment the list must be current.
`test_it_does_not_reach_the_network` patches `_refresh` to raise.

## "Nothing here yet"

Any of three absences — the shell hook, a history repo, a single recorded line —
rather than "has `install` run". Someone who imported a history without wiring
the hook has set something up, and running `setup` at them would answer a
question they did not ask. Deliberately not keyed on `store.machine_file`, which
almost any command creates.

## Mutation-tested, all four caught

```
caught  the status line fetches from the remote
caught  a changed signing key is routed to accept, which refuses it
caught  a machine with a hook already installed gets setup run at it
caught  a fresh machine is reported on instead of being set up
```

The second is worth naming: a changed signing key must route to
`trust --replace`, not `accept` — `accept` refuses that case on purpose (#121),
so pointing someone at it would be a dead end.

## One thing found while testing

The first version keyed "fresh" on the shell hook alone, and every machine in
the sync suite looked fresh — they join through `sync.initialise` and never
install a hook. That was the signal being wrong, not the tests: a joined machine
is not a fresh one.