### PR TITLE
hook: stop reporting a lost log directory at the user's prompt, and remake it

### DIFF
--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -13,6 +13,7 @@ import os
 import re
 import shlex
 import shutil
+import stat
 import subprocess
 import tempfile
 import textwrap
@@ -903,3 +904,71 @@ class TestTheScratchFileIsPrivate(ShellHookTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+@requires_bash5
+class TestALostLogDirectory(ShellHookTestCase):
+    """Reported from a real machine, on v0.4.1:
+
+        $ git s
+        ## mla/OA-...  [gone]
+        -bash: /home/.../logs/hosts/76326ac.../2026-08-03.tsv: No such file or directory
+
+    The hook makes its log directory when the shell starts, and a shell outlives
+    a lot -- an uninstall, a home directory moved, a work machine's cleanup. Once
+    it is gone, every command in every open shell writes into nothing, and said
+    so at the prompt, every time.
+    """
+
+    def logdir(self) -> Path:
+        return Path(os.environ["WOSWOAR_DIR"]) / "logs" / "hosts" / MACHINE_ID
+
+    def test_losing_it_mid_session_is_silent(self) -> None:
+        """Recording may stop. It may not talk about it.
+
+        The redirection order is the whole of this: `>>file 2>/dev/null` applies
+        the append first, so bash reports its failure to a stderr it has not
+        redirected yet.
+        """
+        out = self.run_shell(
+            f"""
+            echo first
+            rm -rf {self.logdir()}
+            echo second
+            echo third
+            """
+        )
+        self.assertNotIn("No such file or directory", out)
+        self.assertIn("third", out, "precondition: the shell kept running")
+
+    def test_it_comes_back_when_the_day_turns(self) -> None:
+        """The directory is remade on the once-a-day path, so a shell that was
+        open when it vanished records again rather than staying broken until
+        someone thinks to restart it."""
+        target = self.logdir()
+        out = self.run_shell(
+            f"""
+            echo before
+            rm -rf {target}
+            __woswoar_today=not-today
+            echo after
+            """
+        )
+        self.assertNotIn("No such file or directory", out)
+        self.assertTrue(target.is_dir(), "the log directory was not remade")
+        # The command as typed, which is what the hook records -- not its output.
+        self.assertIn("echo after", self.commands(), f"recording did not resume: {self.commands()}")
+
+    def test_the_remade_directory_is_owner_only(self) -> None:
+        """Remade under the same umask as the original, or an uninstall followed
+        by a day boundary quietly downgrades what is recorded afterwards."""
+        target = self.logdir()
+        self.run_shell(
+            f"""
+            echo before
+            rm -rf {target}
+            __woswoar_today=not-today
+            echo after
+            """
+        )
+        self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o700)

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -313,14 +313,28 @@ __woswoar_precmd() {
         # inline instead would be fork-free, but reading it costs a fork at
         # startup anyway and a failed read would leave this *setting* the user's
         # umask to a guess -- loosening it, in the one case it must not.
-        (umask 077 && : >>"$__woswoar_logdir/$day.tsv") 2>/dev/null
+        # `mkdir -p` as well, because the directory is otherwise only made when
+        # the shell starts, and a shell outlives a lot. Delete the data
+        # directory -- an uninstall, a home moved, a work machine's cleanup --
+        # and every command in every open shell writes into nothing until each
+        # of them is restarted. Once a day, in the subshell that was already
+        # being forked, is the cheapest place to notice.
+        (umask 077 && mkdir -p "$__woswoar_logdir" && : >>"$__woswoar_logdir/$day.tsv") \
+            2>/dev/null
     fi
 
     # One O_APPEND write. Linux serialises these under the inode lock, so
     # concurrent shells on this host cannot interleave lines.
+    #
+    # `2>/dev/null` *before* the append, not after. Redirections are applied
+    # left to right, so with it second bash reports a failed `>>` to a stderr it
+    # has not redirected yet -- and prints
+    # `bash: .../2026-08-03.tsv: No such file or directory` at the user's
+    # prompt, after every command, which is how this was reported. Recording is
+    # meant to fail silently; the whole hook is written that way.
     printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
         "$EPOCHSECONDS" "$WOSWOAR_SESSION" "$cwd" "$exit_code" "$duration" "$cmd" \
-        >>"$__woswoar_logdir/$day.tsv" 2>/dev/null
+        2>/dev/null >>"$__woswoar_logdir/$day.tsv"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Reported from a real machine on v0.4.1:

```
$ git s
## mla/OA-70148-Make-fuzzing-more-AI-friendly...origin/... [gone]
-bash: /home/.../logs/hosts/76326ac211757bfa/2026-08-03.tsv: No such file or directory
```

Two defects behind that one line.

## 1. The error should never have been visible

The per-command write was:

```bash
printf ... >>"$__woswoar_logdir/$day.tsv" 2>/dev/null
```

Redirections are applied **left to right**. bash tries the append first, fails,
and reports it to a stderr it has not redirected yet — the terminal. The
`2>/dev/null` only ever covered `printf`'s own stderr, which never fails.
Demonstrated:

```console
$ bash -c 'printf "x\n" >>"/tmp/nope/day.tsv" 2>/dev/null'
bash: line 1: /tmp/nope/day.tsv: No such file or directory
$ bash -c 'printf "x\n" 2>/dev/null >>"/tmp/nope/day.tsv"'
$
```

Recording is meant to fail silently — the hook is written that way throughout —
or it stops being a hook and becomes a liability at every prompt.

## 2. And it should have healed

The log directory is created when the **shell starts**, and a shell outlives a
lot: an uninstall, a home directory moved, a work machine's cleanup. Once it is
gone, every command in every open shell writes into nothing until each one is
restarted.

It is remade on the once-a-day branch, inside the subshell already forked there
— so the per-command path is untouched and CI's no-fork assertion still holds.
Under the same `umask 077`, or an uninstall followed by a day boundary would
quietly downgrade the permissions on everything recorded afterwards. That is its
own test.

## What this does not explain

**Why the directory vanished on your machine.** Nothing in woswoar deletes it,
and I could not reproduce a cause. The fix is that the hook survives it either
way — but if you know what happened there (an uninstall attempt, a cleanup job,
the home directory being remounted), it is worth knowing, because that is a
different bug.

Worth checking on that machine: `woswoar doctor`, and whether
`~/.local/share/woswoar/logs/` still holds the days it should. Anything recorded
between the directory going and this landing is genuinely gone — the hook had
nowhere to put it.

## Tests

Driven through a real bash, as this file's other tests are: `rm -rf` the log
directory mid-session and assert the shell says nothing, then turn the day over
and assert recording resumes into a 0700 directory.

Mutation-tested, all three caught:

```
caught  the redirect goes back before 2>/dev/null, so bash reports it at the prompt
caught  the log directory is never remade, so a shell stays broken until restarted
caught  it is remade under the ambient umask, downgrading the permissions
```