### PR TITLE
release: 0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ names the one command to run next, if there is one:
 
 ```console
 $ woswoar
-woswoar 0.5.0 — 54,804 commands from 3 machines
+woswoar 0.5.1 — 54,804 commands from 3 machines
 
 1 machine(s) waiting to be accepted here:
     'martin@laptop'
@@ -59,7 +59,7 @@ one machine.
 > **The same line upgrades an existing install** — run it again whenever you want
 > the latest release. `stable` tracks the most recent tag, so the command never
 > changes and you never edit a version number on five machines. Swap `@stable`
-> for `@main` to track the tip, or `@v0.5.0` to pin exactly.
+> for `@main` to track the tip, or `@v0.5.1` to pin exactly.
 
 **Needs:** bash 5.0+ (Linux) · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) ·

--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
Cuts v0.5.1. Two commits since v0.5.0.

**Patch:** a fix on a path every user hits, plus a new way in that takes nothing
away.

## The shell hook stopped talking at your prompt

Reported from a real machine on v0.4.1, after an ordinary command:

```
-bash: /home/.../logs/hosts/76326ac.../2026-08-03.tsv: No such file or directory
```

Two defects behind it (#126):

- **It should never have been visible.** The per-command write was
  `printf … >>"$file" 2>/dev/null`, and redirections apply left to right — bash
  tries the append first and reports the failure to a stderr it has not
  redirected yet. The `2>/dev/null` only ever covered `printf`'s own stderr,
  which never fails. Recording is meant to fail silently.
- **It should have healed.** The log directory is created when the *shell*
  starts, so once it is gone every command in every open shell writes into
  nothing until each is restarted. It is remade on the once-a-day path, in the
  subshell already forked there — the per-command path is untouched and still
  forkless — under the same `umask 077`.

**If you are on an affected machine:** restarting the shell restores recording
immediately, on any version. Anything typed between the directory disappearing
and the shell restarting is gone; the hook had nowhere to put it.

## `woswoar` on its own

The single entry point (#125). On a machine with nothing installed it sets up;
otherwise it says where you stand and names the one command to run next:

```console
$ woswoar
woswoar 0.5.1 — 54,804 commands from 3 machines

1 machine(s) waiting to be accepted here:
    'martin@laptop'

Next:  woswoar accept
```

It reads only local state — no network — and it does **not** offer to grant,
trust or accept. Those widen who can read your whole history, and folding them
in would hand the timing to whoever can push to the repository: enrol a machine,
and the next `woswoar` typed for any reason has a consent prompt in it. It names
the command; deciding stays something you go and do.

Every existing command is unchanged.

## Upgrade path

Nothing. No format change.

## Still not done

**The end-to-end shakedown on a real install.** It is the oldest outstanding
item, and this release is the argument for it: the hook bug was found by
somebody typing `git s`, not by CI, and it had been shipping since the
redirection was written.