### PR TITLE
tests: two shells on one machine, which nothing was checking

### DIFF
--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -21,7 +21,7 @@ import unittest
 from pathlib import Path
 from typing import ClassVar
 
-from woswoar import cache, store
+from woswoar import cache, search, store
 from woswoar.entry import MAX_CMD_CHARS, TRUNCATION_MARKER, Entry, escape, unescape
 
 from .credential_shapes import DOCUMENTED_GAPS, INNOCENT_SHAPES, SECRET_SHAPES
@@ -972,3 +972,41 @@ class TestALostLogDirectory(ShellHookTestCase):
             """
         )
         self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o700)
+
+
+@requires_bash5
+class TestTwoShellsOnOneMachine(ShellHookTestCase):
+    """A second shell sees the first one's commands, with nothing in between.
+
+    Asked directly: "when I have two different shells open on the same computer,
+    shouldn't one shell immediately pick up the history of the other?" It should
+    and it does -- both write to the same per-host, per-day log, and every Ctrl-R
+    is a fresh process that re-reads the tail of it. There was no test for it,
+    which for the thing woswoar exists to do is an odd gap: every other test of
+    this runs one shell.
+    """
+
+    def test_the_second_shell_sees_the_first_ones_commands(self) -> None:
+        self.run_shell("echo from_the_first_shell\n")
+        self.run_shell("echo from_the_second_shell\n")
+
+        # Global is what Ctrl-R opens in -- `${WOSWOAR_SCOPE:-global}` in the
+        # hook -- so this is what the second shell's picker actually shows.
+        shown = [search.command_from_line(line) for line in search.lines_for("global")]
+        self.assertIn("echo from_the_first_shell", shown)
+        self.assertIn("echo from_the_second_shell", shown)
+
+    def test_no_sync_or_other_step_is_needed_in_between(self) -> None:
+        """One machine, one log file. Nothing has to be exchanged with anything:
+        the second shell is reading the same file the first one appended to."""
+        self.run_shell("echo written_by_one_shell\n")
+        recorded = self.by_cmd()["echo written_by_one_shell"]
+        self.assertEqual(recorded.host, MACHINE_ID, "both shells are the same host")
+
+    def test_each_shell_still_has_its_own_session(self) -> None:
+        """Which is what `--scope session` is for, and what would be broken by
+        making them share history the crude way."""
+        self.run_shell("echo first_shell\n")
+        self.run_shell("echo second_shell\n")
+        sessions = {e.session for e in self.recorded()}
+        self.assertEqual(len(sessions), 2, f"the two shells shared a session: {sessions}")


### PR DESCRIPTION
> I wonder when I have two different shells open on the same computer, shouldn't
> one shell immediately pick up the history of the other shell? I don't think
> that happens

**It should, and it does.** Measured on the real hook, two real bash processes:

```
  after shell A:            ['echo from_shell_A']
  after shell B:            ['echo from_shell_B', 'echo from_shell_A']
  scope=global   ['echo from_shell_B', 'echo from_shell_A']
  scope=host     ['echo from_shell_B', 'echo from_shell_A']
  scope=session  []
```

Both shells append to the same per-host, per-day log, and every Ctrl-R is a
fresh process that re-reads the tail of it. Nothing has to be synced or
exchanged — it is one file. Ctrl-R opens in `global`
(`${WOSWOAR_SCOPE:-global}` in the hook), so that is what the picker shows.

**But nothing was asserting it.** Every other hook test runs a single shell,
which for the thing woswoar exists to do is an odd gap. This adds two real bash
processes and pins three things: the second shell sees the first one's commands,
no step happens in between, and the two still have *distinct* sessions — which
is what `--scope session` is for, and what sharing history the crude way would
quietly break.

Mutation-tested, both caught:

```
caught  each shell writes to a log of its own, so neither sees the other
caught  both shells share one session id
```

## So why did you not see it?

Nothing here is broken, so the likely answer is on the machine, and the first
candidate is the bug you reported an hour ago: if
`logs/hosts/<id>/2026-08-03.tsv` could not be written, **neither shell recorded
anything** — there was nothing for the other to pick up. That machine was
printing `No such file or directory` on every command.

Worth checking there, on v0.5.1:

```sh
woswoar doctor
woswoar stats
echo $WOSWOAR_SCOPE      # if this is 'session', Ctrl-R only shows this shell
```

The third is the other candidate: `WOSWOAR_SCOPE=session` in an rcfile or
exported somewhere makes Ctrl-R open scoped to the current shell alone, and
everything above would still be true while looking exactly like the symptom you
describe.

One genuine limitation either way, which is bash's behaviour rather than
woswoar's: a command is recorded when it **finishes**, at the next prompt. A
long-running command in one shell is not in the other's history until it
returns.