### PR TITLE
release: 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ names the one command to run next, if there is one:
 
 ```console
 $ woswoar
-woswoar 0.5.1 — 54,804 commands from 3 machines
+woswoar 0.6.0 — 54,804 commands from 3 machines
 
 1 machine(s) waiting to be accepted here:
     'martin@laptop'
@@ -63,7 +63,7 @@ one machine.
 > **The same line upgrades an existing install** — run it again whenever you want
 > the latest release. `stable` tracks the most recent tag, so the command never
 > changes and you never edit a version number on five machines. Swap `@stable`
-> for `@main` to track the tip, or `@v0.5.1` to pin exactly.
+> for `@main` to track the tip, or `@v0.6.0` to pin exactly.
 
 **Needs:** bash 5.0+ (Linux) · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) ·

--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"


### PR DESCRIPTION
Cuts v0.6.0. Three commits since v0.5.1, all in the picker.

**Minor:** the Ctrl-R list looks different.

## Failed commands are dim red (#129)

The exit status has been in the cache since the beginning and nothing showed it.
A command that exited non-zero is now dimmed red — dim rather than plain, so a
screen of failures does not shout.

This required giving fzf `--ansi`, which the code had deliberately avoided:
*"fzf only happens to strip escapes when it is not given `--ansi`."* That is
answered rather than ignored — `make_inert` removes every C0 byte, ESC included,
from a command on its way into the cache, so no history from any machine can
carry escapes of its own. There is a test that records a command containing
`\x1b[1A\x1b[2K` and asserts it arrives with no escape left.

Off by default: `woswoar list | grep docker` stays plain text.

## The machine that ran it, in the line (#130)

```
  woswoar (global) > docker
   2m  laptop   docker compose up -d --build
   3h  desktop  docker logs -f api
   6d  laptop   docker system prune -af
```

Which is also how you filter by machine: fzf matches from the second field on,
so typing `desktop` narrows to it. No new key, no new mode. The column appears
only when there is more than one machine, so a single-machine install is
unchanged.

The machine *name* comes from a peer's `name.age` — anyone who can push chooses
it — and is now made inert before it reaches the line. With `--ansi` newly on,
that combination would otherwise have let a peer erase the line above; the two
changes are only safe together, and both landed here.

## Two shells on one machine (#128)

No behaviour change: it always worked. But nothing asserted it, which for the
thing woswoar exists to do was an odd gap. Two real bash processes now check
that the second shell sees the first one's commands with nothing in between —
and that they still have distinct sessions, which `--scope session` needs.

## Upgrade path

Nothing. The cache and repository formats are unchanged; only the display line
is different, and it is rebuilt every time.

## Still open

- **Ctrl-R cycling the scope**, the last of the four ideas. It needs fzf's
  `transform` action (0.45+) plus a fallback for older fzf.
- **The end-to-end shakedown on a real install**, still the oldest item.