### PR TITLE
search: labels that tell machines apart, and Ctrl-R to cycle the scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,17 @@ when you need that one command from last Tuesday, on the other machine.
 
 ```
   woswoar (global) > docker
-   2m  laptop   docker compose up -d --build
-   3h  desktop  docker logs -f api
-   6d  laptop   docker system prune -af
-  ctrl-g global | ctrl-h host | ctrl-s session
+   2m  thinkpad  docker compose up -d --build
+   3h  DT-24YYQ3 docker logs -f api
+   6d  thinkpad  docker system prune -af
+  ctrl-r cycles | ctrl-g global | ctrl-h host | ctrl-s session
 ```
 
 The machine column appears once you have more than one, and fzf matches on it —
-so typing `desktop` narrows to that machine. A command that exited non-zero is
-dimmed red.
+so typing `thinkpad` narrows to that machine. It shows the *host* part of each
+machine's name, because that is usually what differs between your own machines.
+A command that exited non-zero is dimmed red, and <kbd>Ctrl</kbd>+<kbd>R</kbd>
+again cycles global → host → session.
 
 ## Quick start
 
@@ -64,6 +66,18 @@ one machine.
 > the latest release. `stable` tracks the most recent tag, so the command never
 > changes and you never edit a version number on five machines. Swap `@stable`
 > for `@main` to track the tip, or `@v0.6.0` to pin exactly.
+>
+> If `--force` fails with **"A virtual environment already exists"**, your pipx
+> is using `uv` as its backend and cannot reuse the old venv. Either
+> `UV_VENV_CLEAR=1 pipx install --force …`, or the version that always works:
+>
+> ```bash
+> pipx uninstall woswoar
+> pipx install "git+https://github.com/martinus/woswoar.git@stable"
+> ```
+>
+> Neither touches your history: it lives in `~/.local/share/woswoar`, not in the
+> venv.
 
 **Needs:** bash 5.0+ (Linux) · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) ·

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -433,6 +433,10 @@ class TestThePickerAppearsBeforeTheHistoryIsBuilt(WoswoarTestCase):
         with (
             mock.patch("subprocess.Popen", Spawned),
             mock.patch.object(search, "lines_for", slow_lines),
+            # The version probe would otherwise be caught by the fake `Popen`
+            # above -- `subprocess.run` uses it. This test is about the order of
+            # two things, not about which fzf is installed.
+            mock.patch.object(search, "fzf_supports_transform", return_value=False),
         ):
             search.interactive("global")
 
@@ -604,3 +608,120 @@ class TestTheMachineColumn(WoswoarTestCase):
         is a way to erase the line above, so it is neutralised here."""
         store.write_atomic(store.name_file(self.OTHER), b"ok\x1b[1A\x1b[2K\n")
         self.assertNotIn("\x1b", search.host_label(self.OTHER))
+
+
+class TestCtrlRCyclesTheScope(unittest.TestCase):
+    """Ctrl-R inside the picker moves global -> host -> session -> global.
+
+    fzf holds no variables, so the binding reads the current scope back out of
+    the prompt fzf is already showing. What is asserted here is that shell
+    script, run the way fzf runs it: the decision it makes is the part that can
+    be wrong, and it needs no terminal.
+
+    The keypress itself is not driven here -- fzf needs a tty and the result was
+    not something I could assert reliably. The binding's *shape* is checked
+    against a real fzf's acceptance by `TestRealFzfRanking`, which runs one.
+    """
+
+    def next_scope(self, prompt: str) -> str:
+        binding = search._cycle_binding("woswoar", "", " --host-width 0")
+        script = binding.split("transform:", 1)[1]
+        out = subprocess.run(
+            ["sh", "-c", script],
+            capture_output=True,
+            text=True,
+            env={"FZF_PROMPT": prompt, "PATH": "/usr/bin:/bin"},
+            check=True,
+        ).stdout
+        return out.split("--scope ", 1)[1].split(")", 1)[0].strip()
+
+    def test_it_goes_round(self) -> None:
+        self.assertEqual(self.next_scope("woswoar (global) "), "host")
+        self.assertEqual(self.next_scope("woswoar (host) "), "session")
+        self.assertEqual(self.next_scope("woswoar (session) "), "global")
+
+    def test_it_repaints_the_prompt_it_reads_back(self) -> None:
+        """`change-prompt` is not decoration: the next press reads it."""
+        binding = search._cycle_binding("woswoar", "", " --host-width 0")
+        script = binding.split("transform:", 1)[1]
+        out = subprocess.run(
+            ["sh", "-c", script],
+            capture_output=True,
+            text=True,
+            env={"FZF_PROMPT": "woswoar (global) ", "PATH": "/usr/bin:/bin"},
+            check=True,
+        ).stdout
+        self.assertIn("change-prompt(woswoar (host) )", out)
+
+    def test_the_reload_keeps_the_colour_and_the_width(self) -> None:
+        """A cycle that dropped either would change the layout mid-picker, and
+        `command_from_line` slices at a width decided when it opened."""
+        self.assertIn(
+            "--colour --host-width 7",
+            search._cycle_binding("woswoar", "", " --host-width 7"),
+        )
+
+    def test_an_older_fzf_is_offered_nothing_it_cannot_do(self) -> None:
+        """An unknown action in a `--bind` makes fzf refuse to start, so this
+        cannot be offered optimistically: the cost of guessing wrong is no
+        picker at all."""
+        with mock.patch.object(search, "fzf_supports_transform", return_value=False):
+            argv = search._fzf_argv("global", "", True, 0)
+        self.assertFalse([a for a in argv if "ctrl-r:" in a])
+        self.assertNotIn("ctrl-r cycles", " ".join(argv))
+
+    def test_a_new_enough_fzf_gets_it(self) -> None:
+        with mock.patch.object(search, "fzf_supports_transform", return_value=True):
+            argv = search._fzf_argv("global", "", True, 0)
+        self.assertTrue([a for a in argv if a.startswith("--bind=ctrl-r:transform:")])
+        self.assertIn("ctrl-r cycles", " ".join(argv))
+
+    def test_the_version_gate_reads_a_version(self) -> None:
+        for version, wanted in (("0.44.1 (Fedora)", False), ("0.45.0", True), ("0.73.1", True)):
+            with self.subTest(version=version):
+                done = subprocess.CompletedProcess([], 0, stdout=version, stderr="")
+                with mock.patch("subprocess.run", return_value=done):
+                    self.assertEqual(search.fzf_supports_transform(), wanted)
+
+    def test_an_fzf_that_says_nothing_useful_is_treated_as_old(self) -> None:
+        """Erring towards the picker still opening."""
+        done = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        with mock.patch("subprocess.run", return_value=done):
+            self.assertFalse(search.fzf_supports_transform())
+
+
+class TestLabelsStayDifferent(WoswoarTestCase):
+    """Reported: two machines showing as `martinleitnerank` and
+    `martinus@DT-24YY`, both cut at sixteen, neither saying which machine.
+
+    A name is `user@host`, and on one person's machines the user is usually the
+    same while the host is what differs -- and it is the host that a long
+    username pushes off the end.
+    """
+
+    A, B = "aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"
+
+    def named(self, **names: str) -> dict[str, str]:
+        for host, name in names.items():
+            store.write_atomic(store.name_file(getattr(self, host)), f"{name}\n".encode())
+        return search.host_labels({self.A, self.B})
+
+    def test_the_reported_case(self) -> None:
+        labels = self.named(A="martinleitnerankerl@thinkpad", B="martinus@DT-24YYQ3")
+        self.assertEqual(labels[self.A], "thinkpad")
+        self.assertEqual(labels[self.B], "DT-24YYQ3")
+
+    def test_the_full_name_comes_back_when_hosts_would_collide(self) -> None:
+        """Two accounts on one machine, or the same hostname twice: the host
+        half no longer distinguishes, so it is not used."""
+        labels = self.named(A="martin@box", B="root@box")
+        self.assertEqual({labels[self.A], labels[self.B]}, {"martin@box", "root@box"})
+
+    def test_something_too_long_keeps_its_end(self) -> None:
+        labels = self.named(A="x@" + "a" * 40, B="y@short")
+        self.assertTrue(labels[self.A].startswith("…"), labels[self.A])
+        self.assertEqual(len(labels[self.A]), search._HOST_WIDTH)
+
+    def test_the_column_is_only_as_wide_as_the_labels(self) -> None:
+        self.named(A="martinleitnerankerl@thinkpad", B="martinus@DT-24YYQ3")
+        self.assertEqual(search.host_width_for({self.A, self.B}), len("DT-24YYQ3"))

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -66,13 +66,20 @@ def relative_time(ts: int, now: int | None = None) -> str:
     return f"{years}y" if years < 100 else "old"
 
 
-#: Widest a host name may be in the picker. Long enough for `martin@work-laptop`
-#: to survive, short enough that the commands still start near the left.
-_HOST_WIDTH = 16
+#: Widest a machine label may be. Generous, because it is only ever as wide as
+#: the longest label actually present, and a column of ellipses distinguishes
+#: nothing -- which is what a tight cap produced: `martinleitnerank` and
+#: `martinus@DT-24YY`, both cut, from two machines that share neither.
+_HOST_WIDTH = 20
+
+#: Cut here rather than at the end. A name is `user@host`, and the *host* is
+#: what tells two of your machines apart -- it is also the part a long username
+#: pushes off the end.
+_ELLIPSIS = "\u2026"
 
 
 def host_label(host_id: str) -> str:
-    """What to show for a machine, in a form safe to put on a coloured line.
+    """What to show for one machine, in a form safe to put on a coloured line.
 
     `make_inert` because this is *another machine's* text: `_merge_name` writes
     whatever decrypted out of its `name.age` straight to disk, and sealing one
@@ -85,10 +92,32 @@ def host_label(host_id: str) -> str:
     is what the host directory is called.
     """
     name = make_inert(store.host_name(host_id)).strip()
-    # A short slice of the id when no name has arrived -- the full 16 hex
-    # characters would be a wide column of nothing anyone can read, and the
-    # first eight already tell two machines apart.
-    return (name or host_id[:8])[:_HOST_WIDTH]
+    return name or host_id[:8]
+
+
+def host_labels(hosts: set[str]) -> dict[str, str]:
+    """A short label per machine, chosen so that they stay *different*.
+
+    Names are `user@host` by default, and on one person's machines the user is
+    usually the same and the host is what differs -- so the host half is tried
+    first. It is dropped only if two machines would then look alike, because a
+    column that cannot tell them apart is worse than a long one.
+
+    Reported: two machines showing as `martinleitnerank` and
+    `martinus@DT-24YY`, both cut at sixteen characters, neither saying which
+    machine it was.
+    """
+    full = {host: host_label(host) for host in hosts}
+    short = {host: label.rsplit("@", 1)[-1] or label for host, label in full.items()}
+    chosen = short if len(set(short.values())) == len(short) else full
+    return {host: _clip(label) for host, label in chosen.items()}
+
+
+def _clip(label: str) -> str:
+    """Trim to `_HOST_WIDTH`, keeping the end -- see `_ELLIPSIS`."""
+    if len(label) <= _HOST_WIDTH:
+        return label
+    return _ELLIPSIS + label[-(_HOST_WIDTH - 1) :]
 
 
 def command_from_line(line: str, host_width: int = 0) -> str:
@@ -206,7 +235,7 @@ def render_rows(
     """
     if now is None:
         now = int(time.time())
-    labels = {host: host_label(host) for host in {row[3] for row in rows}} if host_width else {}
+    labels = host_labels({row[3] for row in rows}) if host_width else {}
 
     out = []
     for ts, cmd, code, host in rows:
@@ -228,7 +257,7 @@ def host_width_for(hosts: set[str]) -> int:
     """
     if len(hosts) < 2:
         return 0
-    return min(_HOST_WIDTH, max(len(host_label(host)) for host in hosts))
+    return max(len(label) for label in host_labels(hosts).values())
 
 
 def _self_command() -> str:
@@ -239,6 +268,49 @@ def _self_command() -> str:
     if found:
         return found
     return f"{sys.executable} -m woswoar"
+
+
+def fzf_supports_transform() -> bool:
+    """Whether this fzf has the `transform` action, added in 0.45.
+
+    Needed because an unknown *action* in a `--bind` makes fzf refuse to start,
+    so this cannot be offered optimistically -- an older fzf would get no picker
+    at all rather than no Ctrl-R cycling. One `fzf --version`, on a path that is
+    already forking fzf.
+    """
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["fzf", "--version"], capture_output=True, text=True, timeout=5, check=False
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return False
+    digits = out.strip().split()[0].split(".") if out.strip() else []
+    try:
+        major, minor = int(digits[0]), int(digits[1])
+    except (IndexError, ValueError):
+        return False
+    return (major, minor) >= (0, 45)
+
+
+def _cycle_binding(self_cmd: str, dedup_flag: str, width: str) -> str:
+    """Ctrl-R inside the picker moves to the next scope.
+
+    fzf holds no variables, so the current scope is read back out of the prompt
+    it is already showing -- which is why `change-prompt` is not cosmetic. The
+    order matches the header: global, host, session, round again.
+    """
+    reload = f"{self_cmd} list --colour{width} --scope"
+    script = (
+        'case "$FZF_PROMPT" in '
+        "*global*) n=host ;; "
+        "*host*) n=session ;; "
+        "*) n=global ;; "
+        "esac; "
+        f'printf "reload({reload} $n{dedup_flag})+change-prompt(woswoar ($n) )"'
+    )
+    return f"--bind=ctrl-r:transform:{script}"
 
 
 def _fzf_argv(scope: Scope, query: str, dedup: bool, host_width: int) -> list[str]:
@@ -277,8 +349,13 @@ def _fzf_argv(scope: Scope, query: str, dedup: bool, host_width: int) -> list[st
         "--tiebreak=index",
         f"--query={query}",
         f"--prompt=woswoar ({scope}) ",
-        "--header=ctrl-g global | ctrl-h host | ctrl-s session",
+        "--header=ctrl-r cycles | ctrl-g global | ctrl-h host | ctrl-s session",
     ]
+    if fzf_supports_transform():
+        argv.append(_cycle_binding(self_cmd, dedup_flag, width))
+    else:
+        # Say what is on offer, rather than advertising a key that does nothing.
+        argv[-1] = "--header=ctrl-g global | ctrl-h host | ctrl-s session"
     for key, target in (("ctrl-g", "global"), ("ctrl-h", "host"), ("ctrl-s", "session")):
         argv.append(
             f"--bind={key}:reload({self_cmd} list --colour{width} --scope {target}{dedup_flag})"


### PR DESCRIPTION
All three of the things you hit.

## 1. The labels distinguished nothing

> martinleitnerank
> martinus@DT-24YY

Both cut at sixteen. A name is `user@host`, and on your own machines the user is
usually the same while the **host** is what differs — and a long username pushes
the host off the end, which is exactly what you saw.

The host half is used when it keeps the machines distinct, and the full name
when it would not:

| names | labels | width |
|---|---|---|
| `martinleitnerankerl@thinkpad`, `martinus@DT-24YYQ3` | `thinkpad`, `DT-24YYQ3` | 9 |
| `martin@box`, `root@box` | `martin@box`, `root@box` | 10 |
| `x@aaaa…40 chars`, `y@short` | `…aaaaaaaaaaaaaaaaaaa`, `short` | 20 |

Anything still over the cap keeps its **end**, because that is the part that
distinguishes. The cap went 16 → 20, which costs nothing: the column is only
ever as wide as the longest label actually present.

## 2. Ctrl-R cycles

global → host → session → global, alongside the existing ctrl-g/h/s. The header
says so.

fzf holds no variables, so the binding reads the current scope back out of the
prompt fzf is already showing — which makes `change-prompt` load-bearing rather
than decoration. It needs fzf's `transform` action (0.45+), and an unknown
action in a `--bind` makes fzf **refuse to start at all**, so it is gated on one
`fzf --version` rather than offered optimistically: the cost of guessing wrong
is no picker.

**What I did not manage to test:** the keypress end to end. fzf needs a terminal
and I could not get a pty-driven assertion I trusted. What is tested is the
shell script that decides the next scope, executed the way fzf executes it with
`FZF_PROMPT` set — the part that can actually be wrong — plus the version gate
and that an older fzf is offered nothing it cannot do.

## 3. `pipx install --force` fails on a uv-backed pipx

```
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at: .
```

Not woswoar's bug — it is pipx delegating to `uv`, which will not reuse the
existing venv — but it *is* woswoar's documented upgrade line, so the README now
says what to do:

```bash
pipx uninstall woswoar
pipx install "git+https://github.com/martinus/woswoar.git@stable"
```

or `UV_VENV_CLEAR=1 pipx install --force …` for the one-liner. With the note
that neither touches your history: it lives in `~/.local/share/woswoar`, not in
the venv. **That is the one you need to get onto v0.6.0 at all.**

## Mutation-tested, all five caught

```
caught  labels go back to the whole user@host, cut at the end
caught  the host half is used even when two machines would look alike
caught  clipping keeps the start, losing the part that distinguishes
caught  ctrl-r is bound on an fzf too old to understand it
caught  the cycle goes the wrong way round
```