### PR TITLE
release: 0.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ names the one command to run next, if there is one:
 
 ```console
 $ woswoar
-woswoar 0.6.0 — 54,804 commands from 3 machines
+woswoar 0.6.1 — 54,804 commands from 3 machines
 
 1 machine(s) waiting to be accepted here:
     'martin@laptop'
@@ -65,7 +65,7 @@ one machine.
 > **The same line upgrades an existing install** — run it again whenever you want
 > the latest release. `stable` tracks the most recent tag, so the command never
 > changes and you never edit a version number on five machines. Swap `@stable`
-> for `@main` to track the tip, or `@v0.6.0` to pin exactly.
+> for `@main` to track the tip, or `@v0.6.1` to pin exactly.
 >
 > If `--force` fails with **"A virtual environment already exists"**, your pipx
 > is using `uv` as its backend and cannot reuse the old venv. Either

--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"


### PR DESCRIPTION
Cuts v0.6.1. One commit since v0.6.0, fixing what v0.6.0 got wrong plus the
last of the four picker ideas.

**Patch:** the machine column shipped yesterday and was unreadable; this is that
fix, not a new feature.

## The machine column now tells machines apart

Reported straight after v0.6.0: two machines showing as `martinleitnerank` and
`martinus@DT-24YY`, both cut at sixteen characters, neither saying which machine
it was.

A name is `user@host`, and on one person's machines the user is usually the same
while the **host** is what differs — and a long username pushes the host off the
end. The host half is used when it keeps the machines distinct, the full name
when it would not:

| names | labels |
|---|---|
| `martinleitnerankerl@thinkpad`, `martinus@DT-24YYQ3` | `thinkpad`, `DT-24YYQ3` |
| `martin@box`, `root@box` | `martin@box`, `root@box` |

Anything still too long keeps its **end**, since that is what distinguishes.

## Ctrl-R cycles the scope

global → host → session → global, alongside ctrl-g/h/s. Gated on `fzf --version`
because it needs the `transform` action (fzf 0.45+) and an unknown action in a
`--bind` makes fzf refuse to start at all — an older fzf gets the picker it
always had.

## Upgrading, if `--force` fails

Not a woswoar bug, but it is woswoar's documented upgrade line. On a pipx backed
by `uv`:

```
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at: .
```

The README now gives the version that always works:

```bash
pipx uninstall woswoar
pipx install "git+https://github.com/martinus/woswoar.git@stable"
```

Neither touches your history — it lives in `~/.local/share/woswoar`, not in the
venv.

## Upgrade path

Nothing. Display only.

## Still open

**The end-to-end shakedown on a real install**, now the only outstanding item
and by a long way the oldest. The case for it keeps making itself: the machine
column shipped in v0.6.0 and was unusable within a day, found by someone looking
at it rather than by any test.