### PR TITLE
progress: stop the counter swallowing the first line a command prints

### DIFF
--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -9,6 +9,7 @@ not a cosmetic regression.
 from __future__ import annotations
 
 import io
+import sys
 import unittest
 from unittest import mock
 
@@ -24,6 +25,31 @@ class Fake(io.StringIO):
 
     def isatty(self) -> bool:
         return self._tty
+
+
+def rendered(raw: str) -> list[str]:
+    """The lines a terminal would be showing, having been sent `raw`.
+
+    A real cursor, because the bug this exists for is invisible in the byte
+    stream: every character of both the counter and the command's output is
+    present and correct, and they are simply on the same line. Overwriting
+    rather than truncating at `\\r` matters too -- that is how the counter's
+    pad-to-previous-width erases a longer line behind a shorter one.
+    """
+    lines: list[str] = []
+    line, column = "", 0
+    for char in raw:
+        if char == "\r":
+            column = 0
+        elif char == "\n":
+            lines.append(line.rstrip())
+            line, column = "", 0
+        else:
+            line = line[:column] + char + line[column + 1 :]
+            column += 1
+    if line.strip():
+        lines.append(line.rstrip())
+    return lines
 
 
 class TestItStaysQuietWhenItShould(unittest.TestCase):
@@ -112,6 +138,125 @@ class TestItSpeaksWhenTheWaitIsLong(unittest.TestCase):
                 progress.tick(i, 5000, "days")
         # One write got through; the rest were inside the interval.
         self.assertLess(self.out.getvalue().count("days"), 5)
+
+
+class TestTheCommandsOwnOutputIsNotDamaged(unittest.TestCase):
+    """One terminal, written by the counter and by the command at once.
+
+    The counter is rewritten in place and so never ends in a newline, and
+    `to_terminal` wraps the whole command -- so before this, the first thing a
+    slow command printed landed on the end of the counter:
+
+        merging... 3/5 days (60%)Merged 12 commands from 2 machines
+
+    Reported from a real install as output that "doesn't properly print a
+    newline when done". Only the first line is damaged, so it reads as
+    intermittent.
+    """
+
+    def setUp(self) -> None:
+        self.term = Fake(tty=True)
+        # Zero, so what these test is where the clearing happens rather than
+        # whether the wait was long enough -- which is TestItSpeaksWhenTheWait-
+        # IsLong's job. With the real values nothing prints at all and every
+        # assertion below would pass against any implementation.
+        for name in ("PATIENCE", "INTERVAL"):
+            patched = mock.patch.object(progress, name, 0.0)
+            patched.start()
+            self.addCleanup(patched.stop)
+        # The command's stdout *is* the terminal. That sharing is the whole
+        # mechanism: two streams, one screen.
+        patched_out = mock.patch.object(sys, "stdout", self.term)
+        patched_out.start()
+        self.addCleanup(patched_out.stop)
+
+    def test_a_line_printed_mid_command_starts_its_own_line(self) -> None:
+        with progress.to_terminal(self.term):
+            progress.phase("merging other machines")
+            progress.tick(3, 5, "days")
+            print("Merged 12 commands from 2 machines")
+        self.assertEqual(rendered(self.term.getvalue()), ["Merged 12 commands from 2 machines"])
+
+    def test_the_counter_comes_back_after_the_command_has_spoken(self) -> None:
+        """Clearing must not end the reporting: `sync` prints what it resealed
+        and then carries on merging, and the wait after that needs a counter
+        just as much as the wait before it did."""
+        with progress.to_terminal(self.term):
+            progress.phase("merging")
+            progress.tick(1, 5, "days")
+            print("Resealed 3 days")
+            progress.tick(4, 5, "days")
+            shown = rendered(self.term.getvalue())
+        self.assertEqual(shown[0], "Resealed 3 days")
+        self.assertIn("4/5 days", shown[-1])
+
+    def test_nothing_of_the_counter_survives_under_the_output(self) -> None:
+        """The counter is padded to the previous width, so a careless clear
+        leaves trailing spaces that a short output line does not cover."""
+        with progress.to_terminal(self.term):
+            progress.phase("merging a great many other machines")
+            progress.tick(1234, 5678, "days")
+            print("ok")
+        self.assertEqual(rendered(self.term.getvalue()), ["ok"])
+
+    def test_a_warning_on_stderr_starts_its_own_line_too(self) -> None:
+        """The counter goes to stderr, so this is where a collision shows most
+        plainly -- and `init` prints "joined, but the first sync failed" there
+        partway through, which is a slow command by definition."""
+        with mock.patch.object(sys, "stderr", self.term), progress.to_terminal(self.term):
+            progress.phase("cloning")
+            progress.tick(1, 3, "days")
+            print("joined, but the first sync failed", file=sys.stderr)
+        self.assertEqual(rendered(self.term.getvalue()), ["joined, but the first sync failed"])
+
+    def test_a_reporter_writing_through_the_wrapper_does_not_recurse(self) -> None:
+        """A wrapped write calls `clear`, and `clear` writes -- so a reporter
+        whose own stream is the wrapper is a loop unless the flag is lowered
+        before the write rather than after it.
+
+        `to_terminal` builds its reporter on the raw stream, so today only a
+        nested call reaches this. It is a `RecursionError` when it happens,
+        which is a stack trace instead of whatever the command was saying.
+        """
+        with mock.patch.object(sys, "stderr", self.term), progress.to_terminal(self.term):
+            progress.phase("outer")
+            progress.tick(1, 2, "days")
+            with progress.to_terminal():  # picks up the wrapped sys.stderr
+                progress.phase("inner")
+                progress.tick(1, 2, "days")
+                print("still here")
+        self.assertIn("still here", rendered(self.term.getvalue()))
+
+    def test_both_streams_are_left_exactly_as_they_were_found(self) -> None:
+        out, err = sys.stdout, sys.stderr
+        with progress.to_terminal(self.term):
+            self.assertIsNot(sys.stdout, out, "precondition: stdout was borrowed")
+            self.assertIsNot(sys.stderr, err, "precondition: stderr was borrowed")
+        self.assertIs(sys.stdout, out)
+        self.assertIs(sys.stderr, err)
+
+    def test_a_pipe_gets_its_stdout_back_untouched(self) -> None:
+        """`woswoar list` writes tens of thousands of rows into fzf through
+        here, and with no counter on screen there is nothing to clear."""
+        with progress.to_terminal(Fake(tty=False)):
+            self.assertIs(sys.stdout, self.term)
+
+
+class TestBorrowingStdoutChangesNothingElse(unittest.TestCase):
+    def test_it_still_answers_isatty_for_the_stream_underneath(self) -> None:
+        """`doctor`'s tick marks and `list --colour` decide on colour by asking
+        stdout (`__main__.py:253`). A wrapper answering for itself would turn
+        colour off for exactly the slow commands that install a reporter."""
+        for tty in (True, False):
+            with self.subTest(tty=tty):
+                shared = progress._Shared(Fake(tty=tty))
+                self.assertEqual(shared.isatty(), tty)
+
+    def test_what_is_written_arrives_unchanged(self) -> None:
+        underneath = Fake(tty=True)
+        shared = progress._Shared(underneath)
+        shared.write("one\ntwo\n")
+        self.assertEqual(underneath.getvalue(), "one\ntwo\n")
 
 
 if __name__ == "__main__":

--- a/woswoar/progress.py
+++ b/woswoar/progress.py
@@ -36,7 +36,7 @@ import sys
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Protocol, TextIO
+from typing import Any, Protocol, TextIO, cast
 
 #: How long a command may run before it owes the user a word. Below this,
 #: printing costs more attention than it saves: an idle sync is ~10 ms, and the
@@ -57,6 +57,13 @@ class Reporter(Protocol):
 
     def tick(self, done: int, total: int, noun: str) -> None:
         """Report position within the current phase."""
+
+    def clear(self) -> None:
+        """Give the line back, without ending the run.
+
+        Called before anything else writes to the terminal, and possibly many
+        times. A later `tick` may redraw.
+        """
 
     def finish(self) -> None:
         """Leave the line as it was found."""
@@ -105,11 +112,19 @@ class _Terminal:
         share = f" ({done * 100 // total}%)" if total > 0 else ""
         self._write(f"  {self._label}... {done}/{total} {noun}{share}")
 
+    def clear(self) -> None:
+        if not self._showing:
+            return
+        # Lowered before the write, not after: the write goes to a stream that
+        # `_sharing_the_screen` may have wrapped, and a wrapped write calls back
+        # in here. Clearing the flag first makes that second call a no-op rather
+        # than an unbounded recursion.
+        self._showing = False
+        self._stream.write("\r" + " " * self._width + "\r")
+        self._stream.flush()
+
     def finish(self) -> None:
-        if self._showing:
-            self._stream.write("\r" + " " * self._width + "\r")
-            self._stream.flush()
-            self._showing = False
+        self.clear()
 
 
 class _Recorder:
@@ -123,6 +138,14 @@ class _Recorder:
 
     def tick(self, done: int, total: int, noun: str) -> None:
         self.said.append(f"tick:{done}/{total} {noun}")
+
+    def clear(self) -> None:
+        """Nothing to give back: a recorder never held the line.
+
+        Deliberately unrecorded. It fires on every write to stdout, so recording
+        it would bury what a test is actually asserting on under one entry per
+        printed line.
+        """
 
     def finish(self) -> None:
         self.said.append("finish")
@@ -143,6 +166,53 @@ def tick(done: int, total: int, noun: str) -> None:
         _current.tick(done, total, noun)
 
 
+def clear() -> None:
+    """Take the progress line off the screen before something else uses it."""
+    if _current is not None:
+        _current.clear()
+
+
+class _Shared:
+    """An output stream, with the progress line cleared out of the way first.
+
+    The counter is rewritten in place and so ends in no newline, and
+    `to_terminal` wraps the *whole* command -- so a command that prints while it
+    is still working prints onto the counter:
+
+        merging other machines... 3/5 days (60%)Merged 12 commands
+
+    Reported from a real install as output that "doesn't properly print a
+    newline when done". Only the first such line is damaged, which is what makes
+    it look intermittent: after it the cursor is on a fresh line again.
+
+    Done here rather than by calling `clear` before each `print` because the
+    commands that print mid-run are not a closed set -- `sync` reports resealing
+    and newcomers, `doctor` prints a line per check -- and a rule every future
+    command has to remember is one a future command will forget.
+
+    Both streams are wrapped, not just stdout. The counter goes to stderr, so
+    stderr is where a collision is most obvious, and `init` prints "joined, but
+    the first sync failed" there (`__main__.py:489`) partway through exactly the
+    kind of slow command that has a counter running.
+    """
+
+    def __init__(self, stream: TextIO) -> None:
+        self._stream = stream
+
+    def write(self, text: str) -> int:
+        # Empty writes reach here from `print`'s separator handling, and must
+        # not disturb a counter that is mid-redraw.
+        if text:
+            clear()
+        return self._stream.write(text)
+
+    def __getattr__(self, name: str) -> Any:
+        # `isatty` above all: `doctor`'s tick marks and `list --colour` decide
+        # on colour by asking stdout, and a wrapper that answered for itself
+        # would turn the colour off whenever progress was installed.
+        return getattr(self._stream, name)
+
+
 @contextmanager
 def _install(reporter: Reporter | None) -> Iterator[None]:
     global _current
@@ -157,17 +227,40 @@ def _install(reporter: Reporter | None) -> Iterator[None]:
 
 
 @contextmanager
+def _sharing_the_screen() -> Iterator[None]:
+    """Route both output streams through `_Shared` for the duration.
+
+    The reporter keeps the raw stream it was built with, so its own writes do
+    not recurse back through here.
+    """
+    before_out, before_err = sys.stdout, sys.stderr
+    sys.stdout = cast(TextIO, _Shared(before_out))
+    sys.stderr = cast(TextIO, _Shared(before_err))
+    try:
+        yield
+    finally:
+        sys.stdout, sys.stderr = before_out, before_err
+
+
+@contextmanager
 def to_terminal(stream: TextIO | None = None) -> Iterator[None]:
     """Report progress, if there is a terminal to report it to.
 
     Wrapped around the *whole* command rather than each slow part, so the
     patience clock measures what the user is waiting for rather than what any
-    one loop is doing.
+    one loop is doing. Which is also why stdout is borrowed for that whole time:
+    the command keeps printing while progress is showing.
     """
     out = sys.stderr if stream is None else stream
     watched = out.isatty()
     with _install(_Terminal(out) if watched else None):
-        yield
+        if not watched:
+            # Nothing holds the line, so nothing has to give it back -- and
+            # `list` piped into fzf writes every row through here.
+            yield
+        else:
+            with _sharing_the_screen():
+                yield
 
 
 @contextmanager


### PR DESCRIPTION
Reported from a real install: *"some output lines don't properly print a newline when done, after the output that is shown when commands take a while."*

## What was wrong

The progress counter is rewritten in place with `\r`, so it deliberately ends in no newline, and `to_terminal` wraps the **whole** command (`__main__.py:1607`) — `finish()`, which erases the line, doesn't run until the command returns. So anything a command printed *while* the counter was showing landed on the counter's line:

```
merging other machines... 3/5 days (60%)Merged 12 commands from 2 machines
Exported 4 days
```

Only the *first* such line is damaged — after it the cursor is on a fresh line again — which is what made it look intermittent.

Reachable on both streams. `sync` prints what it resealed and which machines are new while it is still merging; `init` prints `joined, but the first sync failed` to stderr (`__main__.py:489`) partway through a clone, which is a slow command by definition.

## The fix

Both output streams are borrowed for the duration of a command and give the line back before they write. `clear()` is separate from `finish()`: it releases the line without ending the run, so the counter comes back for the work that follows.

At the stream rather than by calling `clear()` before each `print` because the commands that print mid-run are not a closed set — and a rule every future command has to remember is one a future command will forget.

Notes on the parts that are easy to get wrong:

- **`isatty` is forwarded** to the stream underneath. `doctor`'s tick marks and `list --colour` decide on colour by asking stdout (`__main__.py:253`); a wrapper answering for itself would have turned colour off for exactly the slow commands that install a reporter.
- **Nothing is wrapped when nobody is watching**, so `woswoar list` piped into fzf is untouched. `__main__.py:124` writes the whole list in one call anyway, so even when it is wrapped the cost is one no-op check.
- **`_showing` is lowered before the write, not after.** A wrapped write calls back into `clear()`, and `clear()` writes — an unbounded recursion otherwise. Only a nested `to_terminal` reaches it today, but the failure mode is a stack trace in place of whatever the command was saying.

## Verification

`tools/mutate.py`, seven mutations, all caught:

```
caught    stdout no longer clears the progress line before writing
caught    stdout is not borrowed at all, so nothing can clear the line
caught    stderr is left unwrapped, so a warning still lands on the counter
caught    clearing is read as 'stop reporting', so no counter ever comes back
caught    the showing flag is lowered after the write again, as it was
caught    the wrapper answers isatty for itself instead of the real stream
caught    stdout is borrowed even when nobody is watching
```

The tests assert on what a terminal would be *showing*, not on the byte stream: `rendered()` applies `\r` and `\n` against a real cursor. That matters here, because in the byte stream every character of both the counter and the output is present and correct — they are merely on the same line, so a substring assertion would have passed against the bug.

`PATIENCE` and `INTERVAL` are zeroed in those tests. At their real values nothing prints at all inside a unit test, and every assertion would have passed against any implementation.

Full preflight green: `ruff check`, `ruff format --check`, `mypy`, `shellcheck`, 588 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)