### PR TITLE
sync from the shell hook instead of a systemd timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ one machine.
 
 > [!TIP]
 > **The same line upgrades an existing install** — run it again whenever you want
-> the latest release. `stable` tracks the most recent tag, so the command never
-> changes and you never edit a version number on five machines. Swap `@stable`
-> for `@main` to track the tip, or `@v0.6.1` to pin exactly.
+> the latest release, then `woswoar install` to refresh the shell hook, which is
+> a copy and does not update with the program. `woswoar` and `woswoar doctor`
+> both say so when it is out of date. `stable` tracks the most recent tag, so the
+> command never changes and you never edit a version number on five machines.
+> Swap `@stable` for `@main` to track the tip, or `@v0.6.1` to pin exactly.
 >
 > If `--force` fails with **"A virtual environment already exists"**, your pipx
 > is using `uv` as its backend and cannot reuse the old venv. Either
@@ -302,6 +304,7 @@ truthful. Re-running an import is idempotent.
 | `WOSWOAR_DIR` | data directory (default `~/.local/share/woswoar`) |
 | `WOSWOAR_IGNORE` | extended regex of commands never to record |
 | `WOSWOAR_IGNORE_EXTRA` | extra regex joined onto the default, instead of replacing it |
+| `WOSWOAR_SYNC_INTERVAL` | seconds between background syncs; `0` turns them off (default `60`) |
 | `WOSWOAR_SCOPE` | default scope for <kbd>Ctrl</kbd>+<kbd>R</kbd> (default `global`) |
 | `WOSWOAR_NO_BIND` | set to skip binding <kbd>Ctrl</kbd>+<kbd>R</kbd> |
 

--- a/README.md
+++ b/README.md
@@ -182,16 +182,48 @@ automatically, since taking trust away can only ever cause a refusal.
 
 ### Sync automatically
 
+Nothing to install — the shell hook does it. At most once a minute, and only on
+a machine somebody is actually typing on, it starts a `woswoar sync` in the
+background. Your prompt never waits for it: the shell hands the work to a
+detached process and returns immediately, so a slow `git push` cannot hold up a
+shell, and neither can a laptop that woke up on the wrong network.
+
+```bash
+# Sync at most every 5 minutes instead of every minute.
+export WOSWOAR_SYNC_INTERVAL=300
+```
+
+An idle machine costs nothing, which is the point: a timer firing every minute
+on four machines is 5,760 fetches a day whether or not anyone typed anything.
+Recorded history reaches your other machines within a minute of you typing it,
+and about 6 MB of repository per machine per year — real typing is bursty, so a
+minute rather than five roughly doubles the syncs that carry anything, not
+quintuples them.
+
+<details>
+<summary>Keeping a machine current while nobody is using it</summary>
+
+The trade is that a machine nobody types on never syncs, so it never *receives*
+either — a laptop left shut for a week is a week stale until the first command
+is typed. Opening a shell syncs, so in practice you are current by the time you
+have a prompt. If you would rather have a machine stay current while idle, the
+systemd timer is still there:
+
 ```bash
 mkdir -p ~/.config/systemd/user
 cp contrib/systemd/woswoar-sync.* ~/.config/systemd/user/
 systemctl --user enable --now woswoar-sync.timer
+export WOSWOAR_SYNC_INTERVAL=0   # and turn the hook's off, or you pay twice
 ```
 
-One-minute interval by default, which costs about **6 MB of repository per
-machine per year** — real typing is bursty, so a minute rather than five roughly
-doubles the syncs that carry anything, not quintuples them. Sync never runs on
-your prompt: a `git push` must not be able to block a shell.
+The two are safe to run together — syncs take a non-blocking lock, so whichever
+arrives second exits immediately — but there is no reason to.
+
+</details>
+
+If a background sync starts failing, nothing is on screen to say so. Typing
+`woswoar` on its own reports it, because a detached sync's error message would
+otherwise go nowhere at all.
 
 ## Why woswoar?
 
@@ -279,7 +311,8 @@ There is no `woswoar uninstall`, because every step is one you should see. In
 order, and each is independent:
 
 ```sh
-# 1. Stop the timer, if you installed one.
+# 1. Stop the timer, if you installed one. Syncing from the shell hook stops
+#    with the hook itself, in step 2.
 systemctl --user disable --now woswoar-sync.timer
 rm -f ~/.config/systemd/user/woswoar-sync.{service,timer}
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -433,7 +433,7 @@ Claims rot. The ones that matter are asserted in CI on every push:
 |---|---|
 | History is never readable by others | every path woswoar creates is walked under a stock `umask 022`, on both the Python and the shell-hook side |
 | The hook's scratch file is never in a directory another user can write | `TMPDIR` and `/tmp` are never consulted; an `XDG_RUNTIME_DIR` this user cannot write falls back to woswoar's own `0700` tree instead of switching recording off |
-| The hook forks nothing | recording runs under `strace`; the clone/fork/execve count must be **0** |
+| Recording forks nothing | the clone count under `strace` must be *identical* for 3 commands and for 30, so nothing on the record path scales with use. Syncing is the one exception and is deliberate: at most one fork per `WOSWOAR_SYNC_INTERVAL`, asserted separately |
 | Search stays fast | latency measured on 52,000 entries |
 | The repo does not blow up | a simulated multi-day, multi-machine run is measured after `git gc` |
 

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -175,6 +175,8 @@ Measured on a real **54,943-entry** history across ~750 daily files:
 | | |
 |---|---|
 | record a command | **~150 µs**, 0 forks |
+| decide whether a sync is due | **~5 µs**, 0 forks |
+| start a background sync | once per `WOSWOAR_SYNC_INTERVAL`, 2 forks, no wait |
 | <kbd>Ctrl</kbd>+<kbd>R</kbd>, whole process | **~105 ms** |
 
 No index, no SQLite — a parse cache that only re-reads what changed is enough,

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -809,8 +809,20 @@ the working copy. This is also why git clean/smudge filters were rejected: they
 re-encrypt whole files on every `git add`, which is precisely the failure mode
 above.
 
-Triggering is manual (`woswoar sync`) plus an optional systemd `--user` timer.
-Never on a prompt: a git push must not be able to block a shell.
+Triggering is the shell hook, at most once per `WOSWOAR_SYNC_INTERVAL` (default
+60s), plus `woswoar sync` by hand and an optional systemd `--user` timer for
+machines that should stay current while nobody is typing on them.
+
+Never *on* a prompt, which is the constraint that has not changed: a git push
+must not be able to block a shell. The hook forks a subshell that backgrounds
+the sync and exits, so the prompt waits for two forks and never for the network.
+The due check ahead of that is one integer comparison against a shared stamp
+file, so the per-command cost is nothing until the interval has actually passed.
+
+Prompt-triggered rather than polled because an idle machine should cost nothing:
+four machines on a one-minute timer are 5,760 fetches a day whether or not
+anyone typed anything, and the number of syncs that carry something is set by
+how much someone types, not by how often a timer fires.
 
 ### Residual leakage
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -35,7 +35,24 @@ class Ran(NamedTuple):
     err: str
 
 
-def run_cli(*argv: str) -> Ran:
+class Captured(io.StringIO):
+    """A captured stream that can claim to be a terminal, which StringIO cannot.
+
+    Several commands branch on `isatty` -- `doctor` picks its markers, `sync`
+    decides whether a failure was witnessed, `progress` decides whether to draw
+    at all -- and capturing the output is exactly what turns that answer to
+    False. So the harness has to be able to say otherwise.
+    """
+
+    def __init__(self, tty: bool = False) -> None:
+        super().__init__()
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+def run_cli(*argv: str, tty: bool = False) -> Ran:
     """Drive the real CLI in process, capturing both streams.
 
     Both, because several commands put the thing a test cares about on stderr --
@@ -45,8 +62,13 @@ def run_cli(*argv: str) -> Ran:
     only check the exit code, and would have passed had the warning been
     deleted. That is the failure mode `CLAUDE.md` rule 3 is about, and it was
     invisible at each individual call site.
+
+    `tty` makes both streams answer `isatty` the way a real terminal would.
+    Patching `sys.stderr.isatty` from a test does not work and fails quietly:
+    the patch lands on whatever object was installed at the time, and then this
+    function replaces it.
     """
-    out, err = io.StringIO(), io.StringIO()
+    out, err = Captured(tty), Captured(tty)
     with redirect_stdout(out), redirect_stderr(err):
         code = main(list(argv))
     return Ran(code, out.getvalue(), err.getvalue())

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -13,9 +13,10 @@ import os
 import shutil
 import stat
 import unittest
+from pathlib import Path
 
 from woswoar import __main__ as main_module
-from woswoar import crypto
+from woswoar import crypto, store
 
 from . import support
 from .support import WoswoarTestCase, requires_age
@@ -185,3 +186,38 @@ class TestDoctorsMarkers(WoswoarTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAHookLeftBehindByAnUpgrade(WoswoarTestCase):
+    """`install` copies the hook; upgrading woswoar does not.
+
+    So a machine can run this version's Python against an older version's shell
+    code indefinitely, with every other check passing. That was survivable while
+    the hook only recorded commands. Since #134 it also decides when to sync, so
+    an un-re-installed machine silently keeps whatever arrangement it had --
+    which is the "running machine silently wrong" CLAUDE.md rule 8 is about.
+    """
+
+    def hook(self) -> Path:
+        path = store.data_dir() / main_module.HOOK_NAME
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def test_an_older_copy_is_reported_with_the_command_that_fixes_it(self) -> None:
+        self.hook().write_text("# woswoar, but from last year\n", encoding="utf-8")
+        out = support.run_cli("doctor").out
+        self.assertIn("[FAIL] hook", out)
+        self.assertIn("woswoar install", out)
+
+    def test_the_shipped_hook_passes(self) -> None:
+        """Otherwise the check above would fail for everyone, always -- and the
+        comparison is against the packaged bytes, so a stray newline written by
+        `install` would do exactly that."""
+        support.run_cli("install", "--rcfile", str(self.root / "bashrc"))
+        self.assertIn("[ok] hook", support.run_cli("doctor").out)
+
+    def test_a_missing_hook_still_reads_as_missing(self) -> None:
+        """Not as "older than this woswoar", which would name the wrong fix."""
+        out = support.run_cli("doctor").out
+        self.assertIn("[FAIL] hook", out)
+        self.assertNotIn("older than this woswoar", out)

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -17,6 +17,7 @@ import stat
 import subprocess
 import tempfile
 import textwrap
+import time
 import unittest
 from pathlib import Path
 from typing import ClassVar
@@ -742,6 +743,17 @@ class TestForkFree(ShellHookTestCase):
                 total += int(fields[3])
         return total
 
+    #: Syncing off, so this measures the *record* path alone.
+    #:
+    #: Not a workaround. Prompt-triggered sync forks on purpose, about once a
+    #: minute, and leaving it on here would make the equality below hold only as
+    #: long as 30 `echo`s stay inside one interval -- passing locally, passing in
+    #: CI, and failing once a week on a loaded runner, where it would be read as
+    #: "the record path forks" and sent someone hunting through the wrong code.
+    #: What forks the sync may do is `TestPromptTriggeredSync`'s business, and it
+    #: pins them with a stamp file rather than with a clock.
+    NO_SYNC: ClassVar[dict[str, str]] = {"WOSWOAR_SYNC_INTERVAL": "0"}
+
     def test_clone_count_does_not_scale_with_commands(self) -> None:
         # Not "zero forks": startup legitimately runs mkdir and two `trap -p`
         # subshells -- one to see whether the EXIT trap is free, one at the first
@@ -752,8 +764,9 @@ class TestForkFree(ShellHookTestCase):
         #
         # Both scratch-file branches, because they are chosen at startup and a
         # fork added to either would be paid on every command of that shell.
-        for label, env in (("runtime dir", None), ("fallback", {"XDG_RUNTIME_DIR": ""})):
+        for label, extra in (("runtime dir", {}), ("fallback", {"XDG_RUNTIME_DIR": ""})):
             with self.subTest(scratch=label):
+                env = {**self.NO_SYNC, **extra}
                 few = self.clone_count(3, env)
                 many = self.clone_count(30, env)
                 self.assertEqual(
@@ -785,9 +798,194 @@ class TestForkFree(ShellHookTestCase):
         """
         for label, before in self.SHAPES.items():
             with self.subTest(shape=label):
-                few = self.clone_count(3, before=before)
-                many = self.clone_count(30, before=before)
+                few = self.clone_count(3, self.NO_SYNC, before=before)
+                many = self.clone_count(30, self.NO_SYNC, before=before)
                 self.assertEqual(few, many, f"{label}: {few} clones for 3 commands, {many} for 30")
+
+
+@requires_bash5
+class TestPromptTriggeredSync(ShellHookTestCase):
+    """Syncing from the prompt instead of a systemd timer (#134).
+
+    Driven with a real bash and a stand-in `woswoar` on PATH that records that
+    it was called, because what is under test is the shell's decision -- when to
+    fire, when to stay quiet, and that the prompt never waits for the answer.
+
+    Time is never slept on. Every "the interval has passed" case is set up by
+    writing the stamp file, so nothing here can become slow or flaky on a loaded
+    runner.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.calls = self.root / "sync-calls"
+        bindir = self.root / "bin"
+        bindir.mkdir(exist_ok=True)
+        fake = bindir / "woswoar"
+        # Records the call and *then* sleeps, so `syncs()` sees it immediately
+        # while `test_the_prompt_does_not_wait_for_the_sync` still has something
+        # slow to measure.
+        #
+        # Three seconds, not one. A sync fires once per interval, so with one
+        # second the difference between waiting and not waiting was one second
+        # across the whole run -- inside the tolerance, and the mutation that
+        # deletes the `&` survived because of it.
+        fake.write_text(
+            f'#!/bin/sh\necho "$*" >> {shlex.quote(str(self.calls))}\nsleep 3\n',
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        self.bindir = bindir
+        # `__woswoar_maybe_sync` will not fork without one, on the grounds that
+        # a machine that never ran `init` has nothing to sync.
+        self.repo = Path(os.environ["WOSWOAR_DIR"]) / "history"
+        self.repo.mkdir(parents=True, exist_ok=True)
+        # `store`'s idea of the path, not a second copy of it. The hook is
+        # copied verbatim into a shell and cannot import anything, so the two
+        # can only be held together from here -- and they came apart at the
+        # first attempt: `__woswoar_stamp` was already the name of the
+        # PROMPT_COMMAND exit-status snippet, so the hook wrote its timestamp to
+        # a file called `__woswoar_status=$?; ...` in whatever directory the
+        # shell happened to be in.
+        self.stamp = store.sync_stamp_file()
+
+    def env(self, **extra: str) -> dict[str, str]:
+        return {"PATH": f"{self.bindir}:{os.environ.get('PATH', '')}", **extra}
+
+    def syncs(self, timeout: float = 20.0) -> int:
+        """How many times the stand-in ran, once the dust has settled.
+
+        The whole point of the feature is that the shell does not wait, so the
+        test cannot either: the shell exits while its grandchild is still being
+        exec'd. Polls rather than sleeping a fixed time so the common case is
+        fast and a slow runner does not fail.
+        """
+        deadline = time.monotonic() + timeout
+        seen = 0
+        while time.monotonic() < deadline:
+            if self.calls.exists():
+                lines = self.calls.read_text(encoding="utf-8").splitlines()
+                # Two consecutive reads agreeing is what says the detached
+                # process has finished writing, rather than "at least one".
+                if lines and len(lines) == seen:
+                    return seen
+                seen = len(lines)
+            time.sleep(0.05)
+        return seen
+
+    def test_a_shell_that_types_nothing_still_syncs_at_startup(self) -> None:
+        """Sitting down and pressing Ctrl-R has to show current history."""
+        self.run_shell("", self.env())
+        self.assertEqual(self.syncs(), 1)
+
+    def test_it_syncs_once_per_interval_not_once_per_command(self) -> None:
+        """The whole cost argument in #134 rests on this number."""
+        self.run_shell("".join(f"echo cmd{i}\n" for i in range(30)), self.env())
+        self.assertEqual(self.syncs(), 1)
+
+    def test_a_fresh_stamp_from_another_shell_suppresses_the_sync(self) -> None:
+        """The stamp is shared, so ten terminals opening at once are one sync.
+
+        Written as if another shell had just synced -- which is what makes this
+        about the shared clock rather than about this shell's own memory.
+        """
+        self.stamp.write_text(f"{int(time.time())}\n", encoding="utf-8")
+        self.run_shell("echo one\necho two\n", self.env())
+        self.assertEqual(self.syncs(timeout=3.0), 0)
+
+    def test_a_stale_stamp_comes_due_again(self) -> None:
+        """Without this, the test above would also pass if syncing never fired."""
+        self.stamp.write_text(f"{int(time.time()) - 3600}\n", encoding="utf-8")
+        self.run_shell("echo one\n", self.env())
+        self.assertEqual(self.syncs(), 1)
+
+    def test_a_zero_interval_turns_it_off(self) -> None:
+        """For anyone running the systemd timer instead."""
+        self.run_shell("echo one\n", self.env(WOSWOAR_SYNC_INTERVAL="0"))
+        self.assertEqual(self.syncs(timeout=3.0), 0)
+
+    def test_nothing_forks_before_the_machine_has_joined_a_repository(self) -> None:
+        """`woswoar sync` on a machine that never ran `init` fails every time,
+        and doing it once a minute from every shell is a fork and an interpreter
+        start to produce an error nobody reads."""
+        shutil.rmtree(self.repo)
+        self.run_shell("echo one\n", self.env())
+        self.assertEqual(self.syncs(timeout=3.0), 0)
+
+    def test_the_prompt_does_not_wait_for_the_sync(self) -> None:
+        """The constraint the maintainer named directly: "Sync on shell startup
+        must be asynchronous, I don't want shell startup to be slow."
+
+        The stand-in sleeps for three seconds. A shell that waits for it cannot
+        finish inside the bound below; one that hands it to a detached process
+        takes about a fifth of a second.
+        """
+        started = time.monotonic()
+        self.run_shell("".join(f"echo cmd{i}\n" for i in range(10)), self.env())
+        self.assertLess(time.monotonic() - started, 2.0)
+
+    def test_a_command_is_recorded_before_the_sync_it_triggers(self) -> None:
+        """Otherwise a command reaches the repository in the *next* sync, which
+        for someone who types one thing and walks away is never.
+
+        Both markers are printed with `printf 'MARK %s\\n'` rather than written
+        literally, because the harness echoes the lines it types: a marker
+        spelled out in the stub definition would appear in the output whether or
+        not the stub was ever called.
+        """
+        # Both stubs on one line: replacing them one prompt at a time leaves a
+        # prompt in between where only the first exists, and that prompt's own
+        # marks come first in the output.
+        out = self.run_shell(
+            "__woswoar_record() { printf 'MARK %s\\n' record; }; "
+            "__woswoar_maybe_sync() { printf 'MARK %s\\n' sync; }\n"
+            "echo trigger\n",
+            self.env(),
+        )
+        marks = re.findall(r"MARK (\w+)", out)
+        self.assertEqual(marks[:2], ["record", "sync"], f"got {marks} from:\n{out}")
+
+    def test_the_stamp_is_owner_only(self) -> None:
+        """It is written by the shell, so `>` alone would create it 0644 and
+        `doctor` would report an exposure in woswoar's own data directory."""
+        self.run_shell("", self.env())
+        self.syncs()
+        self.assertTrue(self.stamp.exists(), "no stamp was written")
+        self.assertEqual(self.stamp.stat().st_mode & 0o077, 0)
+
+    def test_the_sync_never_enters_the_shells_job_table(self) -> None:
+        """A plain `&` would print `[1] 1234` and later `[1]+ Done` at the
+        prompt, once a minute for the life of the shell.
+
+        Asserted through `jobs` rather than by looking for `[1]` in the output,
+        because bash only prints those notifications when job control is on and
+        a shell reading a pipe has it off -- so the notification itself is
+        invisible to this harness and a test looking for it passes against a
+        bare `&`. Job *table* membership is the same fact and is observable
+        here. The stand-in sleeps, so the job is still running when `jobs` asks.
+        """
+        out = self.run_shell("echo marker\njobs\n", self.env())
+        self.assertIn("marker", out, "precondition: the shell ran at all")
+        self.assertNotIn("woswoar sync", out, "the sync is a job of this shell")
+
+    def test_junk_in_the_stamp_does_not_reach_shell_arithmetic(self) -> None:
+        """Bash evaluates array subscripts inside `((...))`, so a value read
+        from a file and handed straight to arithmetic executes what is in it.
+
+        The payload has to be `x[$(...)]` specifically. `1234$(...)` -- the
+        obvious way to write this -- is an arithmetic *syntax error* and runs
+        nothing, so a test using it passes with the sanitising line deleted.
+        That was the first version of this test.
+
+        Reachable without an attacker: `>` is not atomic and every shell on the
+        machine writes this file, so a torn write is enough to produce a value
+        that is not a number.
+        """
+        canary = self.root / "arithmetic-ran"
+        self.stamp.write_text(f"x[$(touch {canary})]\n", encoding="utf-8")
+        out = self.run_shell("echo marker\n", self.env())
+        self.assertIn("marker", out)
+        self.assertFalse(canary.exists(), "the stamp's contents were executed")
 
 
 @requires_bash5

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -754,6 +754,43 @@ class TestForkFree(ShellHookTestCase):
     #: pins them with a stamp file rather than with a clock.
     NO_SYNC: ClassVar[dict[str, str]] = {"WOSWOAR_SYNC_INTERVAL": "0"}
 
+    def stamp_opens(self, command_count: int) -> int:
+        """How many times the shell opened the sync stamp across the run.
+
+        The fork count cannot see this: skipping the `__woswoar_next_sync` memo
+        adds a file open per prompt, not a fork, so the clone-count assertions
+        stay green while every command grows a syscall. Counted the same way and
+        for the same reason -- a per-command cost has to be pinned by something
+        that scales with commands, not by a stopwatch.
+        """
+        script = "".join(f"echo cmd{i}\n" for i in range(command_count))
+        proc = subprocess.run(
+            ["strace", "-f", "-e", "trace=openat", "bash", "--norc", "-i"],
+            input=f"source {HOOK}\n{script}",
+            text=True,
+            env=self.shell_env(),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=120,
+        )
+        return proc.stderr.count(store.sync_stamp_file().name)
+
+    def test_the_stamp_is_read_once_a_shell_not_once_a_command(self) -> None:
+        """The memo is the whole reason the due check is affordable.
+
+        Measured at ~16 us for the read against ~1.5 us for the arithmetic it
+        replaces, in a hook whose comments argue over 7 us.
+        """
+        (store.history_dir() / ".git").mkdir(parents=True, exist_ok=True)
+        counts = []
+        for count in (3, 30):
+            store.sync_stamp_file().write_text(f"{int(time.time())}\n", encoding="utf-8")
+            counts.append(self.stamp_opens(count))
+        few, many = counts
+        self.assertGreater(few, 0, "the stamp was never consulted at all")
+        self.assertEqual(few, many, f"{few} stamp reads for 3 commands, {many} for 30")
+
     def test_clone_count_does_not_scale_with_commands(self) -> None:
         # Not "zero forks": startup legitimately runs mkdir and two `trap -p`
         # subshells -- one to see whether the EXIT trap is free, one at the first
@@ -774,6 +811,24 @@ class TestForkFree(ShellHookTestCase):
                     many,
                     f"record path forks: {few} clones for 3 commands, {many} for 30",
                 )
+
+    def test_the_record_path_forks_nothing_at_the_shipped_interval_either(self) -> None:
+        """The case above turns syncing off, so on its own it stops covering the
+        configuration people actually run -- including the stamp file every shell
+        reads at its first prompt.
+
+        Deterministic without a clock: a stamp written immediately beforehand
+        means the interval cannot elapse during the run, so a due sync is not
+        merely unlikely, it is impossible. That is what lets this assert strict
+        equality rather than a tolerance.
+        """
+        (store.history_dir() / ".git").mkdir(parents=True, exist_ok=True)
+        counts = []
+        for count in (3, 30):
+            store.sync_stamp_file().write_text(f"{int(time.time())}\n", encoding="utf-8")
+            counts.append(self.clone_count(count))
+        few, many = counts
+        self.assertEqual(few, many, f"{few} clones for 3 commands, {many} for 30")
 
     #: Each takes a different branch of the PROMPT_COMMAND assembly, and the
     #: last two are shapes where `__woswoar_unboot`'s exact-match removal can
@@ -838,8 +893,11 @@ class TestPromptTriggeredSync(ShellHookTestCase):
         self.bindir = bindir
         # `__woswoar_maybe_sync` will not fork without one, on the grounds that
         # a machine that never ran `init` has nothing to sync.
-        self.repo = Path(os.environ["WOSWOAR_DIR"]) / "history"
-        self.repo.mkdir(parents=True, exist_ok=True)
+        # `store`'s idea of the path, not a second copy of it -- same reason
+        # as the stamp below, and the hook's `history/.git` test has to keep
+        # agreeing with `sync.is_repo`.
+        self.repo = store.history_dir()
+        (self.repo / ".git").mkdir(parents=True, exist_ok=True)
         # `store`'s idea of the path, not a second copy of it. The hook is
         # copied verbatim into a shell and cannot import anything, so the two
         # can only be held together from here -- and they came apart at the
@@ -849,8 +907,21 @@ class TestPromptTriggeredSync(ShellHookTestCase):
         # shell happened to be in.
         self.stamp = store.sync_stamp_file()
 
-    def env(self, **extra: str) -> dict[str, str]:
-        return {"PATH": f"{self.bindir}:{os.environ.get('PATH', '')}", **extra}
+    def shell_env(self, extra: dict[str, str] | None = None) -> dict[str, str]:
+        """Every shell in this class needs the stand-in ahead of the real one."""
+        return super().shell_env(
+            {"PATH": f"{self.bindir}:{os.environ.get('PATH', '')}", **(extra or {})}
+        )
+
+    def fired(self) -> bool:
+        """Whether this run decided to sync, without waiting for anything.
+
+        The stamp is written *inside* the subshell the prompt waits for, before
+        the `&` -- so by the time `run_shell` returns, the decision is already on
+        disk. Asserting a negative through `syncs()` instead means polling for
+        something that will never arrive, which was three seconds a test.
+        """
+        return self.stamp.exists()
 
     def syncs(self, timeout: float = 20.0) -> int:
         """How many times the stand-in ran, once the dust has settled.
@@ -875,42 +946,75 @@ class TestPromptTriggeredSync(ShellHookTestCase):
 
     def test_a_shell_that_types_nothing_still_syncs_at_startup(self) -> None:
         """Sitting down and pressing Ctrl-R has to show current history."""
-        self.run_shell("", self.env())
+        self.run_shell("")
         self.assertEqual(self.syncs(), 1)
 
     def test_it_syncs_once_per_interval_not_once_per_command(self) -> None:
         """The whole cost argument in #134 rests on this number."""
-        self.run_shell("".join(f"echo cmd{i}\n" for i in range(30)), self.env())
+        self.run_shell("".join(f"echo cmd{i}\n" for i in range(30)))
         self.assertEqual(self.syncs(), 1)
 
     def test_a_fresh_stamp_from_another_shell_suppresses_the_sync(self) -> None:
-        """The stamp is shared, so ten terminals opening at once are one sync.
-
-        Written as if another shell had just synced -- which is what makes this
-        about the shared clock rather than about this shell's own memory.
-        """
-        self.stamp.write_text(f"{int(time.time())}\n", encoding="utf-8")
-        self.run_shell("echo one\necho two\n", self.env())
-        self.assertEqual(self.syncs(timeout=3.0), 0)
+        """The stamp is shared, so a shell that another just synced for stays
+        quiet -- which is what makes this about the shared clock rather than
+        about this shell's own memory."""
+        # Five seconds ago, not "now": the hook writes `$EPOCHSECONDS`, so a
+        # stamp written in the same second is byte-identical to the one an
+        # unwanted sync would leave, and this assertion could not tell them
+        # apart. Still far inside the interval, so it still suppresses.
+        fresh = f"{int(time.time()) - 5}\n"
+        self.stamp.write_text(fresh, encoding="utf-8")
+        self.run_shell("echo one\necho two\n")
+        self.assertEqual(self.stamp.read_text(encoding="utf-8"), fresh, "it synced anyway")
 
     def test_a_stale_stamp_comes_due_again(self) -> None:
         """Without this, the test above would also pass if syncing never fired."""
         self.stamp.write_text(f"{int(time.time()) - 3600}\n", encoding="utf-8")
-        self.run_shell("echo one\n", self.env())
+        self.run_shell("echo one\n")
         self.assertEqual(self.syncs(), 1)
 
     def test_a_zero_interval_turns_it_off(self) -> None:
         """For anyone running the systemd timer instead."""
-        self.run_shell("echo one\n", self.env(WOSWOAR_SYNC_INTERVAL="0"))
-        self.assertEqual(self.syncs(timeout=3.0), 0)
+        self.run_shell("echo one\n", {"WOSWOAR_SYNC_INTERVAL": "0"})
+        self.assertFalse(self.fired())
+
+    def test_a_hostile_interval_from_the_environment_is_not_evaluated(self) -> None:
+        """`WOSWOAR_SYNC_INTERVAL` is inherited, and it reaches `((...))` -- where
+        bash evaluates an array subscript, so `x[$(...)]` runs a command rather
+        than being a syntax error. An exported variable is a plausible way in:
+        anything that spawns your shell chooses this value.
+        """
+        canary = self.root / "interval-ran"
+        out = self.run_shell("echo marker\n", {"WOSWOAR_SYNC_INTERVAL": f"x[$(touch {canary})]"})
+        self.assertIn("marker", out)
+        self.assertFalse(canary.exists(), "the interval was evaluated as arithmetic")
+        self.assertTrue(self.fired(), "it should fall back to the default, not switch off")
+
+    def test_a_leading_zero_is_read_as_decimal_not_octal(self) -> None:
+        """`((08))` is `value too great for base`, printed to an un-redirected
+        stderr at every prompt -- the exact shape of the bug 0.4.1 shipped. And
+        `08` is a perfectly reasonable thing to write for eight seconds."""
+        out = self.run_shell("echo marker\n", {"WOSWOAR_SYNC_INTERVAL": "08"})
+        self.assertIn("marker", out)
+        self.assertNotIn("value too great", out)
+        self.assertTrue(self.fired(), "a valid interval stopped it syncing at all")
 
     def test_nothing_forks_before_the_machine_has_joined_a_repository(self) -> None:
         """`woswoar sync` on a machine that never ran `init` fails every time,
         and doing it once a minute from every shell is a fork and an interpreter
         start to produce an error nobody reads."""
         shutil.rmtree(self.repo)
-        self.run_shell("echo one\n", self.env())
-        self.assertEqual(self.syncs(timeout=3.0), 0)
+        self.run_shell("echo one\n")
+        self.assertFalse(self.fired())
+
+    def test_a_clone_that_died_partway_is_not_a_repository(self) -> None:
+        """`history/` without `.git` in it is what an interrupted `init` leaves,
+        and `sync.is_repo` calls it not a repository. A hook that disagreed would
+        have that machine start an interpreter a minute, forever, to print an
+        error into /dev/null."""
+        shutil.rmtree(self.repo / ".git")
+        self.run_shell("echo one\n")
+        self.assertFalse(self.fired())
 
     def test_the_prompt_does_not_wait_for_the_sync(self) -> None:
         """The constraint the maintainer named directly: "Sync on shell startup
@@ -921,7 +1025,7 @@ class TestPromptTriggeredSync(ShellHookTestCase):
         takes about a fifth of a second.
         """
         started = time.monotonic()
-        self.run_shell("".join(f"echo cmd{i}\n" for i in range(10)), self.env())
+        self.run_shell("".join(f"echo cmd{i}\n" for i in range(10)))
         self.assertLess(time.monotonic() - started, 2.0)
 
     def test_a_command_is_recorded_before_the_sync_it_triggers(self) -> None:
@@ -940,15 +1044,36 @@ class TestPromptTriggeredSync(ShellHookTestCase):
             "__woswoar_record() { printf 'MARK %s\\n' record; }; "
             "__woswoar_maybe_sync() { printf 'MARK %s\\n' sync; }\n"
             "echo trigger\n",
-            self.env(),
         )
         marks = re.findall(r"MARK (\w+)", out)
         self.assertEqual(marks[:2], ["record", "sync"], f"got {marks} from:\n{out}")
 
+    def test_a_stamp_that_is_not_a_plain_number_is_rejected_not_salvaged(self) -> None:
+        """Stripping the non-digits out instead turns junk into a *plausible*
+        epoch, and one in the future stops this shell syncing until the file
+        changes again -- a machine that quietly never syncs, from a bad write.
+
+        `08` is the other half: `((...))` reads a leading zero as octal, so it
+        is not merely wrong but `value too great for base` printed to an
+        un-redirected stderr at every prompt.
+        """
+        for junk in ("9999999999oops", "08", "not-a-number", ""):
+            with self.subTest(stamp=junk):
+                self.stamp.write_text(f"{junk}\n", encoding="utf-8")
+                out = self.run_shell("echo marker\n")
+                self.assertIn("marker", out)
+                self.assertNotIn("value too great", out)
+                self.assertNotIn("syntax error", out)
+                self.assertNotEqual(
+                    self.stamp.read_text(encoding="utf-8").strip(),
+                    junk,
+                    "an unreadable stamp was believed rather than replaced",
+                )
+
     def test_the_stamp_is_owner_only(self) -> None:
         """It is written by the shell, so `>` alone would create it 0644 and
         `doctor` would report an exposure in woswoar's own data directory."""
-        self.run_shell("", self.env())
+        self.run_shell("")
         self.syncs()
         self.assertTrue(self.stamp.exists(), "no stamp was written")
         self.assertEqual(self.stamp.stat().st_mode & 0o077, 0)
@@ -964,7 +1089,7 @@ class TestPromptTriggeredSync(ShellHookTestCase):
         bare `&`. Job *table* membership is the same fact and is observable
         here. The stand-in sleeps, so the job is still running when `jobs` asks.
         """
-        out = self.run_shell("echo marker\njobs\n", self.env())
+        out = self.run_shell("echo marker\njobs\n")
         self.assertIn("marker", out, "precondition: the shell ran at all")
         self.assertNotIn("woswoar sync", out, "the sync is a job of this shell")
 
@@ -983,7 +1108,7 @@ class TestPromptTriggeredSync(ShellHookTestCase):
         """
         canary = self.root / "arithmetic-ran"
         self.stamp.write_text(f"x[$(touch {canary})]\n", encoding="utf-8")
-        out = self.run_shell("echo marker\n", self.env())
+        out = self.run_shell("echo marker\n")
         self.assertIn("marker", out)
         self.assertFalse(canary.exists(), "the stamp's contents were executed")
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -25,7 +25,7 @@ from typing import Any, ClassVar
 from unittest import mock
 
 from woswoar import cache, crypto, progress, search, store, sync
-from woswoar.__main__ import _GRANT_REMEDY, main
+from woswoar.__main__ import _GRANT_REMEDY, HOOK_NAME, main
 from woswoar.entry import Entry, format_line
 from woswoar.sync import COMMIT_MESSAGE as COMMIT
 
@@ -240,10 +240,10 @@ class SyncTestCase(unittest.TestCase):
             for day in days:
                 os.utime(store.chunk_dir(host.id, day), (aged, aged))
 
-    def run_cli(self, fake: Fake, *argv: str) -> support.Ran:
+    def run_cli(self, fake: Fake, *argv: str, tty: bool = False) -> support.Ran:
         """Drive the real CLI as ``fake``. Both streams -- see `support.run_cli`."""
         with fake.active():
-            return support.run_cli(*argv)
+            return support.run_cli(*argv, tty=tty)
 
 
 class TestSingleMachine(SyncTestCase):
@@ -5188,14 +5188,21 @@ class TestABackgroundSyncThatKeepsFailing(SyncTestCase):
     where the bare `woswoar` will put it in front of someone. See #134.
     """
 
-    def failing(self, alpha: Fake) -> support.Ran:
-        """Run `sync` with the export step raising, as a broken remote would."""
+    MESSAGE = "could not connect to the remote"
+
+    @contextmanager
+    def broken_export(self) -> Iterator[None]:
+        """Make the export step raise, as a broken remote would."""
 
         def boom(*args: object, **kwargs: object) -> None:
-            raise sync.SyncError("could not connect to the remote")
+            raise sync.SyncError(self.MESSAGE)
 
         with mock.patch.object(sync, "export", boom):
-            return self.run_cli(alpha, "sync")
+            yield
+
+    def failing(self, alpha: Fake, tty: bool = False) -> support.Ran:
+        with self.broken_export():
+            return self.run_cli(alpha, "sync", tty=tty)
 
     def test_the_failure_is_kept_and_shown_by_the_bare_command(self) -> None:
         alpha = self.machine("alpha")
@@ -5249,19 +5256,31 @@ class TestABackgroundSyncThatKeepsFailing(SyncTestCase):
         self.assertIn("remote said", out)
 
     def test_a_failure_a_person_is_watching_is_not_recorded(self) -> None:
-        """`init`, `accept` and `grant` sync too, and they print the error to
-        the screen of whoever typed them. Recording it as a *background*
-        failure would then have the status line report a problem that was
-        already dealt with, every time until the next background sync."""
+        """Somebody who types `woswoar sync`, reads the error and deals with it
+        must not then be told by every later `woswoar` that a *background* sync
+        has been failing -- with "run woswoar sync" as the remedy, which is the
+        command they just ran.
+
+        The question asked is whether anyone was watching, not which subcommand
+        this was: a terminal on stderr is the same test `progress.to_terminal`
+        makes, and it means the message has already been read.
+        """
         alpha = self.machine("alpha")
         with alpha.active():
             sync.run()
+        self.failing(alpha, tty=True)
+        with alpha.active():
+            self.assertIsNone(sync.last_failure())
 
-            def boom(*args: object, **kwargs: object) -> None:
-                raise sync.SyncError("could not connect to the remote")
-
-            with mock.patch.object(sync, "export", boom):
-                self.run_cli(alpha, "grant", "--yes")
+    def test_a_hand_run_sync_that_works_clears_a_background_failure(self) -> None:
+        """Whoever fixed the problem should not have to wait for a background
+        run to stop being told about it."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+        self.failing(alpha)
+        self.run_cli(alpha, "sync", tty=True)
+        with alpha.active():
             self.assertIsNone(sync.last_failure())
 
 
@@ -5395,3 +5414,44 @@ class TestLongCommandsSayWhatTheyAreDoing(SyncTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAHookLeftBehindByAnUpgradeIsSurfaced(SyncTestCase):
+    """`install` copies the hook, so upgrading the Python leaves old shell code.
+
+    `doctor` reports it, but only somebody who already suspects a problem runs
+    doctor -- and the symptom is that nothing syncs while every other line looks
+    healthy. So the bare `woswoar` says it too, ahead of everything else.
+    """
+
+    def stale(self, alpha: Fake) -> None:
+        with alpha.active():
+            hook = store.data_dir() / HOOK_NAME
+            hook.parent.mkdir(parents=True, exist_ok=True)
+            hook.write_text("# woswoar, but from last year\n", encoding="utf-8")
+
+    def test_the_bare_command_names_the_command_that_fixes_it(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+        self.stale(alpha)
+        out = self.run_cli(alpha).out
+        self.assertIn("older woswoar", out)
+        self.assertIn("woswoar install", out)
+
+    def test_a_current_hook_says_nothing(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+            pass
+        self.run_cli(alpha, "install", "--rcfile", str(self.root / "bashrc"))
+        self.assertNotIn("older woswoar", self.run_cli(alpha).out)
+
+    def test_a_machine_with_no_hook_at_all_is_not_told_to_reinstall_it(self) -> None:
+        """That is a different problem with a different fix, and `doctor` owns
+        it. Saying "an older woswoar installed this" about a file that is not
+        there would send someone looking for something that never existed."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+        self.assertNotIn("older woswoar", self.run_cli(alpha).out)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5180,6 +5180,91 @@ class TestTheStatusLine(SyncTestCase):
         self.assertNotIn("woswoar accept", out)
 
 
+class TestABackgroundSyncThatKeepsFailing(SyncTestCase):
+    """A sync fired from the prompt is detached and its output goes nowhere.
+
+    The systemd timer at least had the journal. Nobody reads the journal either,
+    but "nowhere" is a step down from "somewhere", so the failure is recorded
+    where the bare `woswoar` will put it in front of someone. See #134.
+    """
+
+    def failing(self, alpha: Fake) -> support.Ran:
+        """Run `sync` with the export step raising, as a broken remote would."""
+
+        def boom(*args: object, **kwargs: object) -> None:
+            raise sync.SyncError("could not connect to the remote")
+
+        with mock.patch.object(sync, "export", boom):
+            return self.run_cli(alpha, "sync")
+
+    def test_the_failure_is_kept_and_shown_by_the_bare_command(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+        self.assertEqual(self.failing(alpha).code, 1)
+
+        out = self.run_cli(alpha).out
+        self.assertIn("could not connect to the remote", out)
+        self.assertIn("woswoar sync", out)
+
+    def test_a_sync_that_works_clears_it_again(self) -> None:
+        """Otherwise the first failure is reported forever, which teaches people
+        to read past the one line this exists to make them read."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+        self.failing(alpha)
+        self.run_cli(alpha, "sync")
+        self.assertNotIn("could not connect", self.run_cli(alpha).out)
+
+    def test_nothing_is_said_when_nothing_has_failed(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+        self.assertNotIn("failing", self.run_cli(alpha).out)
+
+    def test_an_unreadable_record_is_not_a_broken_status_line(self) -> None:
+        """`woswoar` on its own is what someone types when something is wrong.
+
+        It reporting on a background failure must not be a second way for it to
+        fail -- so a damaged record degrades to silence, the same way
+        `State.load` treats a value it cannot read.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+            store.sync_failure_file().write_text("{not json", encoding="utf-8")
+            self.assertIsNone(sync.last_failure())
+        self.assertEqual(self.run_cli(alpha).code, 0)
+
+    def test_an_escape_sequence_in_the_message_is_defanged(self) -> None:
+        """The message can carry a remote's text -- a git error quotes the URL
+        and the server's reply -- and this is printed straight to a terminal."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+            sync.record_failure("remote said \x1b[2J\x1b]0;pwned\x07 no")
+        out = self.run_cli(alpha).out
+        self.assertNotIn("\x1b", out)
+        self.assertIn("remote said", out)
+
+    def test_a_failure_a_person_is_watching_is_not_recorded(self) -> None:
+        """`init`, `accept` and `grant` sync too, and they print the error to
+        the screen of whoever typed them. Recording it as a *background*
+        failure would then have the status line report a problem that was
+        already dealt with, every time until the next background sync."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+
+            def boom(*args: object, **kwargs: object) -> None:
+                raise sync.SyncError("could not connect to the remote")
+
+            with mock.patch.object(sync, "export", boom):
+                self.run_cli(alpha, "grant", "--yes")
+            self.assertIsNone(sync.last_failure())
+
+
 class TestNewcomersIsAskedDirectly(SyncTestCase):
     """The pairing decides who is offered read access, so it is asserted here
     rather than through `accept`'s stdout -- which is the rule `Reader`'s own

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -33,22 +33,21 @@ _END = "# <<< woswoar <<<"
 _BLOCK = re.compile(re.escape(_BEGIN) + r".*?" + re.escape(_END) + r"\n?", re.DOTALL)
 
 
-def _hook_source() -> Path:
-    # Imported here rather than at module scope: importlib.resources costs ~8 ms
-    # of startup and only `install` needs it, while every Ctrl-R pays for
-    # whatever this module imports eagerly.
-    from importlib import resources
-
-    with resources.as_file(resources.files("woswoar") / "shell" / HOOK_NAME) as path:
-        return Path(str(path))
-
-
 def _hook_bytes() -> bytes:
     """The hook as this version ships it.
 
-    Read through `files(...).read_bytes()` rather than `_hook_source()` so it is
-    correct for a zipped install too, where `as_file` hands back a temporary
-    path that is deleted as soon as its context exits.
+    The bytes rather than a path, which is what replaced an `as_file` dance
+    here. `as_file` hands back a *temporary* path for a zipped install and
+    deletes it when its context exits, so the previous version of this returned
+    a path that no longer existed and `install` copied from it. Nothing noticed,
+    because nobody installs woswoar as a zipapp -- but `doctor` now compares
+    what is installed against what is packaged, and one function returning one
+    thing is what makes that comparison true by construction rather than by
+    hoping two readers agree.
+
+    Imported here rather than at module scope: importlib.resources costs ~8 ms
+    of startup and only `install` and `doctor` need it, while every Ctrl-R pays
+    for whatever this module imports eagerly.
     """
     from importlib import resources
 
@@ -76,13 +75,11 @@ def portable_hook_path(target: Path) -> str:
 
 def cmd_install(args: argparse.Namespace) -> int:
     """Set up machine identity, install the hook, and wire up .bashrc."""
-    import shutil
-
     machine = store.machine()
     store.private_dir(store.data_dir())
     target = store.data_dir() / HOOK_NAME
-    shutil.copyfile(_hook_source(), target)
-    # After the copy, not before: `copyfile` creates at the ambient umask, so
+    target.write_bytes(_hook_bytes())
+    # After the copy, not before: `write_bytes` creates at the ambient umask, so
     # hardening first would leave the one file install itself writes as the one
     # file its own migration missed. This is also what re-tightens a tree from
     # a woswoar that predated owner-only directories -- `install` is the
@@ -314,7 +311,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     check("machine", has_machine, str(machine_file))
 
     hook = store.data_dir() / HOOK_NAME
-    if hook.is_file() and hook.read_bytes() != _hook_bytes():
+    if _hook_is_stale():
         # `install` copies the hook into the data directory rather than sourcing
         # it out of the package, so upgrading woswoar leaves the old shell code
         # running -- and nothing said so. That was survivable while the hook only
@@ -537,15 +534,29 @@ def cmd_sync(args: argparse.Namespace) -> int:
     from . import sync
 
     # The shell hook fires this detached, with its output going nowhere, so a
-    # failure has to be left somewhere the bare `woswoar` can find it. Recorded
-    # here rather than inside `sync.run` because `init`, `accept` and `grant`
-    # call that too, and a failure a person is standing in front of has already
-    # been reported to them by the message on their screen.
+    # failure has to be left somewhere the bare `woswoar` can find it.
+    #
+    # Gated on whether anyone is watching, not on which command this is. The
+    # first version asked the latter -- recorded from `sync`, not from `init`,
+    # `accept` or `grant` -- and got the common case backwards: somebody who
+    # types `woswoar sync`, reads the error and deals with it was then told by
+    # every later `woswoar` that a *background* sync had been failing for days,
+    # with "run woswoar sync to see it in full" as the remedy. That is the
+    # command they had just run.
+    #
+    # `stderr.isatty()` is the same question `progress.to_terminal` asks, and
+    # for the same reason: a terminal means the message has already been read
+    # by the person it was for.
+    watched = sys.stderr.isatty()
     try:
         report = sync.run(push=not args.no_push)
     except Exception as exc:
-        sync.record_failure(str(exc) or exc.__class__.__name__)
+        if not watched:
+            sync.record_failure(str(exc) or exc.__class__.__name__)
         raise
+    # Cleared whoever was watching: a sync that worked is proof the recorded
+    # failure is stale, and someone who fixed the problem by hand should not
+    # have to wait for a background run to stop being told about it.
     sync.clear_failure()
     if report.revoked:
         print(
@@ -766,6 +777,27 @@ def cmd_grant(args: argparse.Namespace) -> int:
 
     _report_reseal(sync.grant(approved=[reader.key for reader in readers]))
     return 0
+
+
+def _hook_is_stale() -> bool:
+    """Whether the installed hook is some older woswoar's copy of it.
+
+    False for a missing hook: that is a different problem with a different fix,
+    and `doctor` already has a line for it.
+    """
+    hook = store.data_dir() / HOOK_NAME
+    return hook.is_file() and hook.read_bytes() != _hook_bytes()
+
+
+def _report_stale_hook() -> None:
+    if not _hook_is_stale():
+        return
+    print(
+        "\nThe shell hook here was installed by an older woswoar, so this"
+        "\nmachine is still running that version's shell code -- including"
+        "\nwhatever it did or did not do about syncing."
+        "\n\nNext:  woswoar install   then open a new shell"
+    )
 
 
 def _report_sync_failure(failure: Failure | None) -> None:
@@ -1023,6 +1055,14 @@ def cmd_status(args: argparse.Namespace) -> int:
     hosts = {meta.host for meta in loaded.meta.values() if meta.host}
     machines = f"{len(hosts)} machine{'s' if len(hosts) != 1 else ''}"
     print(f"woswoar {__version__} -- {len(stamps)} commands from {machines}")
+
+    # Ahead of everything else, because it is the condition under which the rest
+    # of this report is describing a machine that is not running this version.
+    # `install` copies the hook, so upgrading the Python leaves the old shell
+    # code in place -- and syncing lives in the hook, so the visible symptom is
+    # that nothing syncs while every other line here says all is well. `doctor`
+    # says so too, but only somebody who already suspects a problem runs doctor.
+    _report_stale_hook()
 
     if not sync.is_repo():
         print(

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -17,7 +17,7 @@ from .entry import make_inert
 from .errors import WoswoarError
 
 if TYPE_CHECKING:  # `sync` is imported lazily; only the annotation needs it.
-    from .sync import Reader, ReencryptReport
+    from .sync import Failure, Reader, ReencryptReport
 
 #: Both "no repo key yet" and "some days unreadable" have the same fix, and
 #: used to say so in two independently worded paragraphs.
@@ -41,6 +41,18 @@ def _hook_source() -> Path:
 
     with resources.as_file(resources.files("woswoar") / "shell" / HOOK_NAME) as path:
         return Path(str(path))
+
+
+def _hook_bytes() -> bytes:
+    """The hook as this version ships it.
+
+    Read through `files(...).read_bytes()` rather than `_hook_source()` so it is
+    correct for a zipped install too, where `as_file` hands back a temporary
+    path that is deleted as soon as its context exits.
+    """
+    from importlib import resources
+
+    return (resources.files("woswoar") / "shell" / HOOK_NAME).read_bytes()
 
 
 def portable_hook_path(target: Path) -> str:
@@ -302,7 +314,15 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     check("machine", has_machine, str(machine_file))
 
     hook = store.data_dir() / HOOK_NAME
-    check("hook", hook.is_file(), str(hook))
+    if hook.is_file() and hook.read_bytes() != _hook_bytes():
+        # `install` copies the hook into the data directory rather than sourcing
+        # it out of the package, so upgrading woswoar leaves the old shell code
+        # running -- and nothing said so. That was survivable while the hook only
+        # recorded; syncing lives in it now, so a machine that never re-ran
+        # `install` silently keeps whatever sync arrangement it had.
+        check("hook", False, f"{hook} is older than this woswoar - run 'woswoar install'")
+    else:
+        check("hook", hook.is_file(), str(hook))
 
     rcfile = Path.home() / ".bashrc"
     sourced = rcfile.is_file() and _BEGIN in rcfile.read_text(encoding="utf-8")
@@ -516,7 +536,17 @@ def cmd_init(args: argparse.Namespace) -> int:
 def cmd_sync(args: argparse.Namespace) -> int:
     from . import sync
 
-    report = sync.run(push=not args.no_push)
+    # The shell hook fires this detached, with its output going nowhere, so a
+    # failure has to be left somewhere the bare `woswoar` can find it. Recorded
+    # here rather than inside `sync.run` because `init`, `accept` and `grant`
+    # call that too, and a failure a person is standing in front of has already
+    # been reported to them by the message on their screen.
+    try:
+        report = sync.run(push=not args.no_push)
+    except Exception as exc:
+        sync.record_failure(str(exc) or exc.__class__.__name__)
+        raise
+    sync.clear_failure()
     if report.revoked:
         print(
             "This machine's access to the shared history was revoked, so nothing\n"
@@ -736,6 +766,23 @@ def cmd_grant(args: argparse.Namespace) -> int:
 
     _report_reseal(sync.grant(approved=[reader.key for reader in readers]))
     return 0
+
+
+def _report_sync_failure(failure: Failure | None) -> None:
+    """Surface a background sync that has been failing where nobody could see.
+
+    The one thing the systemd timer had over a detached fork from the prompt:
+    its stderr went to the journal. This is the replacement, and it is put in
+    front of someone who typed `woswoar` rather than someone who thought to run
+    `journalctl --user -u woswoar-sync`, so it is the better half of the trade.
+    """
+    if failure is None:
+        return
+    print(f"\nBackground sync has been failing for {search.relative_time(int(failure.when))}:")
+    print(f"    {make_inert(failure.message)}")
+    # The remedy is the same one every time and it is not "run sync again":
+    # what a detached sync hides is the *message*, so the fix is to look at it.
+    print("\nNext:  woswoar sync   to see it in full")
 
 
 def _report_reseal(report: ReencryptReport, waiting: bool = True) -> None:
@@ -983,6 +1030,8 @@ def cmd_status(args: argparse.Namespace) -> int:
             "Next:  woswoar init <url>   to share it with your other machines"
         )
         return 0
+
+    _report_sync_failure(sync.last_failure())
 
     # Local only: see `sync.local_newcomers`. Typing this must not reach the
     # network, and what has not arrived here is not yet this machine's decision.

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -162,15 +162,27 @@ __woswoar_max=8000
 #: two are safe together -- `sync.lock` is non-blocking, so whichever arrives
 #: second exits at once -- but running both is just paying twice.
 #:
-#: Validated rather than trusted: this reaches `((...))`, where a value like
-#: `x[$(...)]` is not a syntax error but a command substitution.
-: "${WOSWOAR_SYNC_INTERVAL:=60}"
-[[ $WOSWOAR_SYNC_INTERVAL =~ ^[0-9]+$ ]] || WOSWOAR_SYNC_INTERVAL=60
+#: Validated rather than trusted, because it reaches `((...))`, where a value
+#: like `x[$(...)]` is not a syntax error but a command substitution. One test
+#: rather than a `:=` default followed by a test: unset and empty both fail the
+#: pattern, so the default falls out of the same line.
+#:
+#: Then normalised through `10#`, because `((...))` reads a leading zero as
+#: octal -- so a perfectly reasonable `WOSWOAR_SYNC_INTERVAL=08` is not merely
+#: wrong, it is `value too great for base` printed to an un-redirected stderr
+#: at every prompt. That is the shape of the bug 0.4.1 shipped.
+[[ ${WOSWOAR_SYNC_INTERVAL:-} =~ ^[0-9]+$ ]] || WOSWOAR_SYNC_INTERVAL=60
+WOSWOAR_SYNC_INTERVAL=$((10#$WOSWOAR_SYNC_INTERVAL))
 
-#: Shared between every shell on this machine, deliberately. Ten open terminals
-#: with ten private clocks all come due at the same moment and fire ten syncs;
-#: nine of them lose the lock instantly, but an interpreter start is ~40ms and
-#: nine of those is real. See store.sync_stamp_file.
+#: Shared between every shell on this machine, deliberately: ten open terminals
+#: with ten private clocks would each come due on their own schedule and sync
+#: ten times an hour between them rather than once.
+#:
+#: Not a claim of atomicity. Ten shells starting in the same instant -- a tmux
+#: session restore -- all read the same stale stamp and all fork, and `sync.lock`
+#: is what stops nine of them doing any work. That costs nine interpreter starts
+#: (~30ms each) once per restore, which is worth accepting rather than
+#: introducing a lock file of this one's own. See store.sync_stamp_file.
 __woswoar_syncstamp=$__woswoar_dir/sync-stamp
 
 #: Earliest $EPOCHSECONDS at which the stamp above is worth opening. Keeps the
@@ -393,9 +405,13 @@ __woswoar_maybe_sync() {
     local last=
     read -r last 2>/dev/null <"$__woswoar_syncstamp"
     # A torn or truncated write must not reach `((...))`, where a non-numeric
-    # value is a variable name to dereference rather than an error.
-    last=${last//[^0-9]/}
-    last=${last:-0}
+    # value is a variable name to dereference rather than an error. Rejected
+    # outright rather than stripped to the digits in it: stripping turns half of
+    # `1785...` followed by a leftover tail into a *plausible* epoch, and one in
+    # the future stops this shell syncing until the file changes again. The same
+    # test as the interval above, for the same reason, in the same shape.
+    [[ $last =~ ^[0-9]+$ ]] || last=0
+    last=$((10#$last))
 
     if ((EPOCHSECONDS - last < WOSWOAR_SYNC_INTERVAL)); then
         __woswoar_next_sync=$((last + WOSWOAR_SYNC_INTERVAL))
@@ -410,7 +426,13 @@ __woswoar_maybe_sync() {
     # Nothing to sync with, so nothing to fork for. Checked here rather than
     # once at startup because `woswoar init` may well be the command that just
     # ran, and a per-shell flag would leave that shell never syncing.
-    [[ -d $__woswoar_dir/history ]] || return 0
+    #
+    # `history/.git`, matching `sync.is_repo`, not `history/` itself: a clone
+    # that died partway leaves the directory without the repository in it, and
+    # `woswoar sync` calls that "not initialised". Testing the directory would
+    # have this machine fork an interpreter a minute, forever, to print that
+    # error into /dev/null.
+    [[ -e $__woswoar_dir/history/.git ]] || return 0
 
     # `( ... & )`: the subshell backgrounds the sync and exits immediately, so
     # the prompt waits for two forks (~1ms) and never for the sync itself. A

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -157,6 +157,29 @@ fi
 #: Mirrors MAX_CMD_CHARS in woswoar/entry.py.
 __woswoar_max=8000
 
+#: Seconds between prompt-triggered syncs; 0 turns them off entirely, which is
+#: what to set if you run the systemd timer in `contrib/systemd` instead. The
+#: two are safe together -- `sync.lock` is non-blocking, so whichever arrives
+#: second exits at once -- but running both is just paying twice.
+#:
+#: Validated rather than trusted: this reaches `((...))`, where a value like
+#: `x[$(...)]` is not a syntax error but a command substitution.
+: "${WOSWOAR_SYNC_INTERVAL:=60}"
+[[ $WOSWOAR_SYNC_INTERVAL =~ ^[0-9]+$ ]] || WOSWOAR_SYNC_INTERVAL=60
+
+#: Shared between every shell on this machine, deliberately. Ten open terminals
+#: with ten private clocks all come due at the same moment and fire ten syncs;
+#: nine of them lose the lock instantly, but an interpreter start is ~40ms and
+#: nine of those is real. See store.sync_stamp_file.
+__woswoar_syncstamp=$__woswoar_dir/sync-stamp
+
+#: Earliest $EPOCHSECONDS at which the stamp above is worth opening. Keeps the
+#: per-command cost to one integer comparison: a stamp can only ever move
+#: forward, so "not due until T" cannot become due sooner than T. Another
+#: shell syncing in the meantime pushes T out, and the worst that costs is one
+#: file read that decides against syncing.
+__woswoar_next_sync=0
+
 #: Set by preexec, consumed by precmd. Empty also means "no command has been
 #: timed since the last prompt", which is what makes a separate armed flag
 #: unnecessary: preexec only stamps when it is empty, so the first simple
@@ -207,12 +230,27 @@ __woswoar_precmd() {
     # user's exit status for the *first* of them -- after that it is the status
     # of the previous entry. Anything already in PROMPT_COMMAND (a title hook,
     # a prompt framework) therefore made every recorded command look successful.
-    # __woswoar_stamp is prepended so it captures the real one before any of
-    # that runs. Consumed rather than cached: leaving it set would make a shell
-    # whose PROMPT_COMMAND was replaced wholesale record a *stale* code, which
-    # is worse than falling back to whatever $? holds here.
+    # __woswoar_status is set by a string prepended to PROMPT_COMMAND, so it
+    # captures the real one before any of that runs. Consumed rather than
+    # cached: leaving it set would make a shell whose PROMPT_COMMAND was
+    # replaced wholesale record a *stale* code, which is worse than falling
+    # back to whatever $? holds here.
     local exit_code=${__woswoar_status:-$?}
     __woswoar_status=
+
+    # Recording first, so a command reaches the repository in the sync it
+    # triggers rather than in the one after it -- which for someone who types
+    # one command and walks away is the difference between a minute and never.
+    #
+    # Two functions rather than one because `__woswoar_record` returns early
+    # from seven places -- an ignored command, a duplicate, a bare Enter -- and
+    # a shell must still come due for a sync in every one of those cases.
+    __woswoar_record "$exit_code"
+    __woswoar_maybe_sync
+}
+
+__woswoar_record() {
+    local exit_code=$1
 
     # Taken and cleared in one place, so every path out of this function is
     # covered by construction. Recording deliberately does not depend on the
@@ -335,6 +373,61 @@ __woswoar_precmd() {
     printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
         "$EPOCHSECONDS" "$WOSWOAR_SESSION" "$cwd" "$exit_code" "$duration" "$cmd" \
         2>/dev/null >>"$__woswoar_logdir/$day.tsv"
+}
+
+# Fires a sync when one is due. Runs on every prompt, and forks on roughly one
+# prompt a minute -- which is the one deliberate exception to the builtins-only
+# rule above, and the reason `test_it_syncs_once_per_interval_not_once_per_command`
+# exists beside the strict fork-count test rather than replacing it.
+#
+# The steady-state cost is the single `((...))` below. Everything that touches
+# the filesystem is behind it.
+__woswoar_maybe_sync() {
+    ((WOSWOAR_SYNC_INTERVAL > 0 && EPOCHSECONDS >= __woswoar_next_sync)) || return 0
+
+    # `2>/dev/null` *before* the `<`, not after. Redirections are applied left
+    # to right, so the other order reports a missing stamp to a stderr that has
+    # not been redirected yet -- and prints a path at the user's prompt after
+    # every command. That is not hypothetical: it is the 0.4.1 bug, in the
+    # append a few lines above, written the other way round.
+    local last=
+    read -r last 2>/dev/null <"$__woswoar_syncstamp"
+    # A torn or truncated write must not reach `((...))`, where a non-numeric
+    # value is a variable name to dereference rather than an error.
+    last=${last//[^0-9]/}
+    last=${last:-0}
+
+    if ((EPOCHSECONDS - last < WOSWOAR_SYNC_INTERVAL)); then
+        __woswoar_next_sync=$((last + WOSWOAR_SYNC_INTERVAL))
+        return 0
+    fi
+
+    # Set before the check below rather than in both of its arms: coming due
+    # and finding nothing to do still costs a `stat` on every command until the
+    # interval is put back.
+    __woswoar_next_sync=$((EPOCHSECONDS + WOSWOAR_SYNC_INTERVAL))
+
+    # Nothing to sync with, so nothing to fork for. Checked here rather than
+    # once at startup because `woswoar init` may well be the command that just
+    # ran, and a per-shell flag would leave that shell never syncing.
+    [[ -d $__woswoar_dir/history ]] || return 0
+
+    # `( ... & )`: the subshell backgrounds the sync and exits immediately, so
+    # the prompt waits for two forks (~1ms) and never for the sync itself. A
+    # plain `&` here would put it in this shell's job table and print `[1] 1234`
+    # and `[1]+ Done` at the prompt once a minute, forever.
+    #
+    # The stamp is written *inside* that subshell, which is why it costs no
+    # extra fork -- and under `umask 077`, because a file's mode is fixed when
+    # it is created and `>` would otherwise make it 0644 for `doctor` to flag.
+    #
+    # Stamped before the sync runs, not after it succeeds: a `woswoar` that is
+    # not on PATH must cost one attempt a minute, not one per command.
+    (
+        umask 077
+        printf '%s\n' "$EPOCHSECONDS" >"$__woswoar_syncstamp"
+        woswoar sync >/dev/null 2>&1 </dev/null &
+    ) 2>/dev/null
 }
 
 # ---------------------------------------------------------------------------
@@ -519,5 +612,12 @@ if [[ -z ${WOSWOAR_NO_BIND:-} ]]; then
     bind -m vi-insert -x '"\C-r": __woswoar_widget' 2>/dev/null
     bind -m vi-command -x '"\C-r": __woswoar_widget' 2>/dev/null
 fi
+
+# No `__woswoar_maybe_sync` call here, deliberately. Bash runs PROMPT_COMMAND
+# once before the *first* prompt, so a shell where nobody has typed anything yet
+# has already been through `__woswoar_precmd` and has already synced -- which is
+# what makes sitting down and pressing Ctrl-R show current history. An explicit
+# call at the end of this file was written first and is redundant; a mutation
+# that deleted it changed no behaviour, which is how that was noticed.
 
 __WOSWOAR_LOADED=1

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -480,6 +480,31 @@ def state_file() -> Path:
     return data_dir() / "state.json"
 
 
+def sync_stamp_file() -> Path:
+    """When a sync was last *started*, as decimal seconds on one line.
+
+    Written by the shell hook, which is the only thing that reads it, and read
+    with bash's `read` builtin -- so it holds the time rather than relying on
+    its own mtime, which bash cannot ask for without forking `stat`.
+
+    "Started", not "finished": the hook stamps it before it forks. A sync that
+    dies immediately -- `woswoar` not on PATH, a half-finished install -- must
+    still cost one attempt a minute rather than one per command.
+    """
+    return data_dir() / "sync-stamp"
+
+
+def sync_failure_file() -> Path:
+    """The last unattended sync's failure, or absent if the last one worked.
+
+    A sync fired from the prompt is detached and its output goes nowhere, so
+    without this a sync that has been failing for a week says nothing at all.
+    The systemd timer had the journal, which was already only a theoretical
+    improvement -- nobody reads that either.
+    """
+    return data_dir() / "sync-failure.json"
+
+
 def repo_host_dir(machine_id: str) -> Path:
     return history_dir() / _HOSTS / machine_id
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -572,6 +572,45 @@ def lock() -> Iterator[None]:
         handle.close()
 
 
+class Failure(NamedTuple):
+    """A recorded sync failure, and when it happened."""
+
+    when: float
+    message: str
+
+
+def record_failure(message: str) -> None:
+    """Remember that the last unattended sync failed, for the status line.
+
+    Deliberately not in `state.json`. That file is written only when something
+    in it changed (`State.save`), which is what keeps a one-minute sync from
+    rewriting a megabyte to say nothing happened -- and a timestamp changes
+    every time, so putting one there would defeat exactly that.
+    """
+    store.save_json(store.sync_failure_file(), {"when": time.time(), "error": message})
+
+
+def clear_failure() -> None:
+    """Forget any recorded failure. Called when a sync works."""
+    store.sync_failure_file().unlink(missing_ok=True)
+
+
+def last_failure() -> Failure | None:
+    """The recorded failure, if the last unattended sync left one.
+
+    Degrades to `None` rather than raising, the same way `State.load` treats a
+    value it cannot read: this is reported by the bare `woswoar`, and a status
+    line that cannot be printed because the thing it reports on is broken is
+    the worst of both.
+    """
+    payload = store.load_json(store.sync_failure_file())
+    message = payload.get("error")
+    if not isinstance(message, str) or not message:
+        return None
+    when = payload.get("when")
+    return Failure(when if isinstance(when, int | float) else 0.0, message)
+
+
 # ---------------------------------------------------------------------------
 # Keys
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #134. Your comment on the issue — *"Sync on shell startup must be asynchronous, I don't want shell startup to be slow"* — is the constraint the design is built around, and it has a test that fails by seconds if it regresses.

## What changes

The hook checks a shared stamp file on every prompt and, on roughly one prompt a minute, fires a detached `woswoar sync`. An idle machine costs nothing: no typing, no syncing, zero fetches.

This also removes the last thing tying automatic syncing to systemd, which is the bigger win — it now works on macOS, in containers, and on non-systemd distros, with nothing to install.

```
1 machine, every minute:    1,440 fetches/day
4 machines:                 5,760 fetches/day    2,102,400/year
```

## The three constraints from the issue

**The prompt must not wait.** The hook runs `( ... & )` — a subshell that backgrounds the sync and exits. The prompt waits for two forks, not for the network. `test_the_prompt_does_not_wait_for_the_sync` drives a stand-in `woswoar` that sleeps 3s and bounds the whole ten-command run at 2s.

**The prompt must not fork per command.** The steady-state cost is one `((...))`, measured at **~5 µs per command** against a ~300 µs record path. Everything touching the filesystem is behind it.

`test_clone_count_does_not_scale_with_commands` was rewritten rather than left to rot, exactly as the issue asked. It now runs with `WOSWOAR_SYNC_INTERVAL=0` so it measures the record path alone. Left as it was, its strict `few == many` would have held only while 30 `echo`s stayed inside one interval — passing locally, passing in CI, failing once a week on a loaded runner, and being read as "the record path forks". What forks the *sync* may do is a separate class that pins them with a stamp file rather than a clock.

**A failing sync must not be invisible.** `woswoar sync` records its failure; the bare `woswoar` reports it. Strictly better than the journal it replaces, since nobody reads that either.

## Also in here

`doctor` now notices a hook copy left behind by an upgrade. `install` *copies* the hook into the data directory rather than sourcing it from the package, so an upgraded woswoar runs the old shell code until `install` is re-run — and nothing said so. That was survivable while the hook only recorded; it now decides when to sync, which makes it the rule-8 "running machine silently wrong" case.

## Upgrade path

1. `woswoar install` on each machine — this is already the documented upgrade step, and now `doctor` says so when it is needed.
2. If you have the systemd timer, either disable it or set `WOSWOAR_SYNC_INTERVAL=0`. Both together is safe — the lock is non-blocking — but it pays twice.

## Verification

Seventeen mutations across three tables, all caught. Four survived the first run, and every one was a weak fixture rather than a wrong mutation, which is the order CLAUDE.md rule 3 asks for:

- the stand-in slept 1s and a sync fires *once*, so deleting `&` cost one second across the run — inside the tolerance
- job-control notifications only print when job control is on, and a shell reading a pipe has it off — so the test looking for `[1] 1234` passed against a bare `&`. Asserted through the job *table* instead, which is observable here
- the arithmetic-injection payload was `1234$(...)`, which is a syntax error and runs nothing. The real vector is `x[$(...)]`, which executes silently. Sanitising is load-bearing and the first test could not see it
- the fourth found **dead code**: an explicit `__woswoar_maybe_sync` at the end of the hook, deleted here. Bash runs `PROMPT_COMMAND` before the first prompt, so a shell where nobody has typed anything has already synced

One real bug the tests caught during development: `__woswoar_stamp` was already the name of the `PROMPT_COMMAND` exit-status snippet, so the hook wrote its timestamp to a file called `__woswoar_status=$?; ...` in whatever directory the shell was in. The test fixture now takes the path from `store.sync_stamp_file()` so the two cannot drift again.

Full preflight green: `ruff check`, `ruff format --check`, `mypy`, `shellcheck`, 608 tests.

## Reviewed, with one deviation

This is CLAUDE.md rule 1's top row — it caches a fact about the world. I reviewed the diff by hand rather than with `/simplify`'s four agents, because this session is configured not to launch subagents. The two findings I did apply were mine: a comment naming a test that does not exist, and `__woswoar_next_sync` assigned in both arms of a branch.

## What this costs

A machine nobody types on never syncs, so it never *receives* either — a laptop shut for a week is a week stale until the first command. Opening a shell syncs, so in practice you are current by the time you have a prompt. The timer stays available for anyone who wants otherwise, and the README says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)