### PR TITLE
release: 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ names the one command to run next, if there is one:
 
 ```console
 $ woswoar
-woswoar 0.6.1 — 54,804 commands from 3 machines
+woswoar 0.7.0 — 54,804 commands from 3 machines
 
 1 machine(s) waiting to be accepted here:
     'martin@laptop'
@@ -67,7 +67,7 @@ one machine.
 > a copy and does not update with the program. `woswoar` and `woswoar doctor`
 > both say so when it is out of date. `stable` tracks the most recent tag, so the
 > command never changes and you never edit a version number on five machines.
-> Swap `@stable` for `@main` to track the tip, or `@v0.6.1` to pin exactly.
+> Swap `@stable` for `@main` to track the tip, or `@v0.7.0` to pin exactly.
 >
 > If `--force` fails with **"A virtual environment already exists"**, your pipx
 > is using `uv` as its backend and cannot reuse the old venv. Either

--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"


### PR DESCRIPTION
Version bump only. `main` is protected, so this arrives as a PR; pushing `v0.7.0` afterwards is what actually cuts the release and moves `stable`.

**Minor, not patch.** Automatic syncing moved out of the systemd timer and into the shell hook, which changes what an existing installation has to do to keep syncing.

## What is in it

**#136 — sync from the shell hook instead of a systemd timer.** The hook fires a detached `woswoar sync` at most once a minute, and only on a machine somebody is typing on. An idle machine costs nothing; four machines no longer make 5,760 fetches a day regardless of use. Automatic syncing needs no systemd, so it now works on macOS, in containers, and on non-systemd distros.

Also in #136: `WOSWOAR_SYNC_INTERVAL` (0 turns it off), a background sync's failure recorded where the bare `woswoar` reports it, and `doctor` plus `woswoar` both noticing a shell hook left behind by an upgrade.

**#135 — the progress counter no longer swallows the first line a command prints.** `merging... 3/5 days (60%)Merged 12 commands` was reaching real terminals.

## Upgrading

1. `pipx install --force "git+https://github.com/martinus/woswoar.git@stable"`
2. **`woswoar install`** — the hook is a copy and does not update with the program, and this release puts syncing in it. `woswoar` and `woswoar doctor` both say so if it is skipped.
3. Open a new shell.
4. If you run the systemd timer, either disable it or set `WOSWOAR_SYNC_INTERVAL=0`. Both together is safe — the sync lock is non-blocking — but it pays twice.

No data migration: nothing about the record format, the repository layout, `state.json` or the day-key scheme changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)