### PR TITLE
the shell hook brings itself up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,16 @@ one machine.
 
 > [!TIP]
 > **The same line upgrades an existing install** — run it again whenever you want
-> the latest release, then `woswoar install` to refresh the shell hook, which is
-> a copy and does not update with the program. `woswoar` and `woswoar doctor`
-> both say so when it is out of date. `stable` tracks the most recent tag, so the
-> command never changes and you never edit a version number on five machines.
-> Swap `@stable` for `@main` to track the tip, or `@v0.7.0` to pin exactly.
+> the latest release. The shell hook is a copy rather than the packaged file, but
+> it brings itself up to date on the next background sync, so there is nothing
+> else to run; open a new shell to pick it up. `stable` tracks the most recent
+> tag, so the command never changes and you never edit a version number on five
+> machines. Swap `@stable` for `@main` to track the tip, or `@v0.7.0` to pin
+> exactly.
+>
+> **Coming from 0.6.x or earlier, run `woswoar install` once.** Those versions
+> had no background sync, so there is nothing running that could notice.
+> `woswoar` and `woswoar doctor` both say so if it is skipped.
 >
 > If `--force` fails with **"A virtual environment already exists"**, your pipx
 > is using `uv` as its backend and cannot reuse the old venv. Either

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -221,3 +221,18 @@ class TestAHookLeftBehindByAnUpgrade(WoswoarTestCase):
         out = support.run_cli("doctor").out
         self.assertIn("[FAIL] hook", out)
         self.assertNotIn("older than this woswoar", out)
+
+
+class TestReadingThePackagedHook(unittest.TestCase):
+    def test_the_fast_path_and_the_fallback_agree(self) -> None:
+        """`_hook_bytes` reads the file beside the module and only falls back to
+        `importlib.resources` when there is none -- 8.7 ms saved on a sync that
+        now runs once a minute. Two routes to one file is two chances to read a
+        different one, and the fallback is exercised by nothing else here: it is
+        for a zipapp, which nothing in CI builds.
+        """
+        from importlib import resources
+
+        via_resources = (resources.files("woswoar") / "shell" / main_module.HOOK_NAME).read_bytes()
+        self.assertEqual(main_module._hook_bytes(), via_resources)
+        self.assertTrue(via_resources.startswith(b"# woswoar"), "that is not the hook")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -26,6 +26,7 @@ from unittest import mock
 
 from woswoar import cache, crypto, progress, search, store, sync
 from woswoar.__main__ import _GRANT_REMEDY, HOOK_NAME, main
+from woswoar.__main__ import _hook_bytes as main_hook_bytes
 from woswoar.entry import Entry, format_line
 from woswoar.sync import COMMIT_MESSAGE as COMMIT
 
@@ -5455,3 +5456,76 @@ class TestAHookLeftBehindByAnUpgradeIsSurfaced(SyncTestCase):
         with alpha.active():
             sync.run()
         self.assertNotIn("older woswoar", self.run_cli(alpha).out)
+
+
+class TestTheHookKeepsItselfUpToDate(SyncTestCase):
+    """An upgrade should not need a second command (#136 follow-up).
+
+    `install` copies the hook, so upgrading the program leaves the old shell
+    code running. The hook now starts a `woswoar sync` about once a minute, so
+    that sync is what notices -- an upgrade heals itself within a minute.
+    """
+
+    def install(self, alpha: Fake) -> Path:
+        self.run_cli(alpha, "install", "--rcfile", str(self.root / "bashrc"))
+        with alpha.active():
+            return store.data_dir() / HOOK_NAME
+
+    def test_a_stale_hook_is_brought_up_to_date_by_a_sync(self) -> None:
+        alpha = self.machine("alpha")
+        hook = self.install(alpha)
+        hook.write_text("# woswoar, but from last year\n", encoding="utf-8")
+        self.run_cli(alpha, "sync")
+        self.assertEqual(hook.read_bytes(), main_hook_bytes())
+
+    def test_the_bare_command_stops_reporting_it_afterwards(self) -> None:
+        """The report and the repair have to agree, or somebody is told to run
+        a command that has already been run for them."""
+        alpha = self.machine("alpha")
+        hook = self.install(alpha)
+        hook.write_text("# older\n", encoding="utf-8")
+        self.assertIn("older woswoar", self.run_cli(alpha).out)
+        self.run_cli(alpha, "sync")
+        self.assertNotIn("older woswoar", self.run_cli(alpha).out)
+
+    def test_a_machine_with_no_hook_does_not_get_one(self) -> None:
+        """It never ran `install`, so its `.bashrc` sources nothing. Writing a
+        file nothing references would be a confusing way to say that."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            hook = store.data_dir() / HOOK_NAME
+            self.assertFalse(hook.exists(), "precondition: no hook installed")
+        self.run_cli(alpha, "sync")
+        with alpha.active():
+            self.assertFalse(hook.exists())
+
+    def test_an_unreachable_remote_does_not_keep_the_hook_stale(self) -> None:
+        """The two have nothing to do with each other, and a machine that
+        cannot reach its remote is exactly one nobody is attending to."""
+        alpha = self.machine("alpha")
+        hook = self.install(alpha)
+        hook.write_text("# older\n", encoding="utf-8")
+
+        def boom(*args: object, **kwargs: object) -> None:
+            raise sync.SyncError("could not connect to the remote")
+
+        with mock.patch.object(sync, "export", boom):
+            self.assertEqual(self.run_cli(alpha, "sync").code, 1)
+        self.assertEqual(hook.read_bytes(), main_hook_bytes())
+
+    def test_a_current_hook_is_left_exactly_alone(self) -> None:
+        """Rewriting an identical file once a minute is a pointless write, and
+        it would reset the mtime every time on a file `doctor` reports on."""
+        alpha = self.machine("alpha")
+        hook = self.install(alpha)
+        before = hook.stat().st_mtime_ns
+        self.run_cli(alpha, "sync")
+        self.assertEqual(hook.stat().st_mtime_ns, before)
+
+    def test_a_read_only_data_directory_does_not_stop_the_sync(self) -> None:
+        """Repairing the hook is a courtesy; syncing is the job."""
+        alpha = self.machine("alpha")
+        hook = self.install(alpha)
+        hook.write_text("# older\n", encoding="utf-8")
+        with mock.patch.object(Path, "write_bytes", side_effect=OSError("read-only")):
+            self.assertEqual(self.run_cli(alpha, "sync").code, 0)

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -45,10 +45,17 @@ def _hook_bytes() -> bytes:
     thing is what makes that comparison true by construction rather than by
     hoping two readers agree.
 
-    Imported here rather than at module scope: importlib.resources costs ~8 ms
-    of startup and only `install` and `doctor` need it, while every Ctrl-R pays
-    for whatever this module imports eagerly.
+    Beside this file first, and `importlib.resources` only if that is not
+    there. `resources` costs a measured 8.7 ms to import -- a fifth of an idle
+    sync, which now runs once a minute and calls this every time -- while the
+    package layout puts the hook next to this module in every install that has
+    a filesystem at all, wheel or editable. The fallback is for a zipapp, where
+    `__file__` is a path inside the archive and nothing can open it.
     """
+    beside = Path(__file__).resolve().parent / "shell" / HOOK_NAME
+    if beside.is_file():
+        return beside.read_bytes()
+
     from importlib import resources
 
     return (resources.files("woswoar") / "shell" / HOOK_NAME).read_bytes()
@@ -533,6 +540,11 @@ def cmd_init(args: argparse.Namespace) -> int:
 def cmd_sync(args: argparse.Namespace) -> int:
     from . import sync
 
+    # Before the sync, not after: a remote that is unreachable must not be able
+    # to keep the hook out of date, and these two have nothing to do with each
+    # other beyond both being things this command is well placed to do.
+    _refresh_hook()
+
     # The shell hook fires this detached, with its output going nowhere, so a
     # failure has to be left somewhere the bare `woswoar` can find it.
     #
@@ -787,6 +799,46 @@ def _hook_is_stale() -> bool:
     """
     hook = store.data_dir() / HOOK_NAME
     return hook.is_file() and hook.read_bytes() != _hook_bytes()
+
+
+def _refresh_hook() -> bool:
+    """Bring the installed hook up to this version, if it is behind.
+
+    `install` copies the hook rather than sourcing it out of the package, so
+    upgrading the program used to leave the old shell code running until
+    somebody re-ran `install`. Since the hook now starts a `woswoar sync` about
+    once a minute, that sync is the thing best placed to notice -- an upgrade
+    heals itself within a minute and the reinstall step goes away.
+
+    Deliberately *not* a symlink into the installed package, which was the first
+    idea and is worse. That path contains the Python version
+    (`.../lib/python3.14/site-packages/...`), so a distribution's Python bump or
+    a `pipx reinstall` leaves it dangling -- and a dangling `source` prints an
+    error at every shell start and switches recording off, where a merely stale
+    hook still records and still searches. It would also make `doctor` report
+    the packaged file's mode as an exposure, because its permission walk uses
+    `stat`, which follows links.
+
+    Only ever *re*-writes. A machine with no hook at all has not run `install`,
+    its `.bashrc` sources nothing, and writing a file it does not reference
+    would be a confusing way to say so.
+    """
+    if not _hook_is_stale():
+        return False
+    hook = store.data_dir() / HOOK_NAME
+    # The mode was set when `install` created it and `write_bytes` truncates
+    # rather than recreates, so it survives -- and the hook is public code
+    # anyway. Failure is not fatal: a read-only data directory is a real
+    # situation and it must not stop the sync this command exists for.
+    try:
+        hook.write_bytes(_hook_bytes())
+    except OSError:
+        return False
+    # Shells already running keep the code they sourced, exactly as they do
+    # after a hand-run `install`. New ones get this. Nothing to do about the
+    # difference, and nothing anyone needs to do.
+    print(f"updated the shell hook at {hook} to {__version__}")
+    return True
 
 
 def _report_stale_hook() -> None:


### PR DESCRIPTION
Answers the maintainer's question: *"would it be better if the installed bash script is a symlink to the latest installed one? then I don't need to reinstall the hook"* — right goal, and there is a safer way to reach it.

## Why not a symlink

Two things measured before deciding, both of which make it worse than the problem:

**A dangling symlink is worse than a stale hook.** The packaged path is `~/.local/share/pipx/venvs/woswoar/lib/python3.14/site-packages/woswoar/shell/woswoar.bash` — it contains the Python version, so it dies on a distribution's Python bump, on `pipx reinstall`, and on uninstall-then-reinstall. `source` on a missing file prints `bash: ...: No such file or directory` at **every** shell start and recording is off entirely; a stale hook still records and still searches.

**It would break `doctor`.** The permission walk uses `stat()`, which follows symlinks — measured returning `0o644` for the linked-to file against `0o777` for `lstat`. It would report the packaged file as world-readable inside woswoar's own data directory: a false alarm in the one check that must never cry wolf.

There is also no filesystem path at all in a zipapp, so a copy fallback would be needed regardless.

## What this does instead

Since 0.7.0 the hook starts a `woswoar sync` about once a minute, so that sync is what notices. An upgrade heals itself within a minute; no reinstall, no dangling target, and the hook stays a self-contained file that survives the venv being deleted.

Shape, and why:

- **Only ever re-writes.** A machine with no hook has not run `install` and its `.bashrc` sources nothing, so writing a file it does not reference would be a confusing way to say so.
- **Before the sync, not after.** An unreachable remote must not be able to keep the hook out of date, and a machine that cannot reach its remote is exactly one nobody is attending to.
- **A failed write is not fatal.** Repairing the hook is a courtesy; syncing is the job.
- **An identical hook is left alone**, asserted on `st_mtime_ns` — otherwise this rewrites a file once a minute forever.

## Cost

`_hook_bytes` now reads the file beside the module, falling back to `importlib.resources` only when there is none (zipapp). That import measured **8.7 ms** — a fifth of an idle sync, called once a minute:

| | best of 7 |
|---|---|
| interpreter + `import woswoar.__main__` | 26.2 ms |
| ... `+ _hook_bytes()` via `importlib.resources` | 34.7 ms |
| ... `+ _hook_bytes()` reading beside the module | **26.4 ms** |

Both routes are pinned to return the same bytes by a test, since the fallback is exercised by nothing else here — nothing in CI builds a zipapp.

## What still needs a manual step

**0.6.x and earlier.** Those versions have no background sync, so nothing is running that could notice. `woswoar install` once, as 0.7.0's release notes say; `woswoar` and `woswoar doctor` both report it if skipped. Every upgrade from 0.7.0 onward is automatic.

## Verification

Six mutations, all caught. One needed re-aiming: pointing the fast path at a non-existent file fell through to the fallback and returned the correct bytes, so it tested nothing — the real regression is a fast path that reads a *different existing* file, and that is what the mutation now does.

Full preflight green: `ruff check`, `ruff format --check`, `mypy`, `shellcheck`, 624 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)