### PR TITLE
status: tell three unnamed machines apart, and say what is missing

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5529,3 +5529,115 @@ class TestTheHookKeepsItselfUpToDate(SyncTestCase):
         hook.write_text("# older\n", encoding="utf-8")
         with mock.patch.object(Path, "write_bytes", side_effect=OSError("read-only")):
             self.assertEqual(self.run_cli(alpha, "sync").code, 0)
+
+
+class TestTheStatusLineOnAMachineThatCannotReadYet(SyncTestCase):
+    """The screen a new machine actually gets, reported from a real install:
+
+        3 machine(s) waiting to be accepted here:
+            '(unnamed)'
+            '(unnamed)'
+            '(unnamed)'
+
+    A name lives in `hosts/<id>/name.age`, sealed to the recipients, so a
+    machine nobody has granted yet cannot open one of them. That part is
+    working as designed -- but three identical placeholders distinguish
+    nothing, and `accept` here does not get that machine any history.
+    """
+
+    def joined_but_not_granted(self) -> tuple[Fake, list[Fake]]:
+        """A newcomer, and the machines that have not accepted it yet."""
+        others = []
+        for name in ("alpha", "beta"):
+            machine = self.machine(name, display=f"martin@{name}")
+            with machine.active():
+                machine.record("2023-11-14", 1_700_000_001, f"{name} history")
+                sync.run()
+            others.append(machine)
+        newcomer = self.machine("newcomer", display="martin@newcomer")
+        with newcomer.active():
+            newcomer.record("2023-11-15", 1_700_100_001, "its own history")
+            sync.run()
+        return newcomer, others
+
+    def test_each_machine_is_told_apart_by_its_fingerprint(self) -> None:
+        newcomer, _ = self.joined_but_not_granted()
+        out = self.run_cli(newcomer).out
+        lines = [line for line in out.splitlines() if "(unnamed)" in line]
+        self.assertEqual(len(lines), 2, f"expected two unnamed machines:\n{out}")
+        self.assertEqual(len(set(lines)), 2, f"the two lines are identical:\n{out}")
+
+    def test_it_says_why_they_have_no_names_and_what_is_missing(self) -> None:
+        """`accept` on this machine changes nothing about what it can read, and
+        a screen that only says `Next: woswoar accept` sends someone to it."""
+        newcomer, _ = self.joined_but_not_granted()
+        out = self.run_cli(newcomer).out
+        self.assertIn("sealed", out, "it does not say why they have no names")
+        self.assertIn("already use", out, "the other-machine step is missing")
+        # Both, and in that order: the explanation has to come before the
+        # commands, or "Next: woswoar accept" is immediately contradicted.
+        self.assertLess(out.index("sealed"), out.index("Next:"))
+
+    def test_a_machine_that_can_read_is_not_lectured(self) -> None:
+        """Once granted, the names resolve and the explanation would be noise --
+        and worse, wrong."""
+        newcomer, others = self.joined_but_not_granted()
+        for machine in others:
+            self.run_cli(machine, "accept", "--yes")
+        with newcomer.active():
+            sync.run()
+        out = self.run_cli(newcomer).out
+        self.assertNotIn("already use", out)
+        self.assertNotIn("sealed", out)
+        self.assertIn("Next:  woswoar accept", out, "it still has to name the step")
+
+    def test_the_fingerprint_is_the_one_accept_will_ask_about(self) -> None:
+        """Two screens describing one decision have to name it the same way, or
+        checking the first against the second proves nothing.
+
+        Asserted against `candidate.fingerprint` -- the signing key, which is
+        what `accept` prints and what `ssh-keygen -lf` reproduces on the machine
+        itself -- and not against `Newcomer.fingerprint`. The first version did
+        the latter, which is the same expression the code under test uses: both
+        sides moved together, and a mutation swapping in the *reader's*
+        fingerprint went unnoticed.
+        """
+        newcomer, _ = self.joined_but_not_granted()
+        status = self.run_cli(newcomer).out
+        with newcomer.active():
+            pending = sync.local_newcomers().machines
+        self.assertTrue(pending, "precondition: something is pending")
+        for machine in pending:
+            candidate = machine.candidate
+            assert candidate is not None, "these machines all publish a signer"
+            self.assertIn(candidate.fingerprint, status)
+            self.assertTrue(
+                candidate.fingerprint.startswith("SHA256:"),
+                "that is not the signing fingerprint accept shows",
+            )
+
+    def test_a_peer_calling_itself_unnamed_does_not_look_unreadable(self) -> None:
+        """`(unnamed)` is a string a peer can put in its own `name.age`, which
+        sealing needs no secret to write -- so "has this name been read" cannot
+        be answered by comparing against the placeholder's text. See `Name`.
+
+        The cost of getting it wrong is that a machine which *can* read its
+        peers is told it cannot, and pointed at a step it has already done.
+        """
+        others = []
+        for name, display in (("alpha", sync.UNNAMED), ("beta", sync.UNNAMED)):
+            machine = self.machine(name, display=display)
+            with machine.active():
+                machine.record("2023-11-14", 1_700_000_001, f"{name} history")
+                sync.run()
+            others.append(machine)
+        newcomer = self.machine("newcomer", display="martin@newcomer")
+        with newcomer.active():
+            sync.run()
+        for machine in others:
+            self.run_cli(machine, "accept", "--yes")
+        with newcomer.active():
+            sync.run()
+
+        out = self.run_cli(newcomer).out
+        self.assertNotIn("sealed", out, "a readable name was read as unreadable")

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -1137,8 +1137,34 @@ def cmd_status(args: argparse.Namespace) -> int:
     if waiting:
         print(f"\n{len(waiting)} machine(s) waiting to be accepted here:")
         for machine in waiting:
-            print(f"    {machine.display_name()}")
-        print("\nNext:  woswoar accept")
+            # Fingerprint first, then the name, matching `_show_readers`: it is
+            # the only part of the line the repository cannot choose. It also
+            # has to be here at all, because on a machine that has not been
+            # granted yet *every* name is unreadable -- reported from a fresh
+            # install as three consecutive lines reading `'(unnamed)'`, which
+            # is not a list of three machines so much as a list of nothing.
+            print(f"    {machine.fingerprint}  {machine.display_name()}")
+        if any(machine.named for machine in waiting):
+            print("\nNext:  woswoar accept")
+        else:
+            # Why they have no names, and the half of the job that happens
+            # somewhere else. `init` says this once and then nobody sees it
+            # again, which is exactly when it is needed.
+            #
+            # Both commands named in one breath, and the explanation before
+            # rather than after them: an earlier version printed the ordinary
+            # `Next: woswoar accept` and *then* said accepting here changes
+            # nothing about what this machine can read, which reads as a
+            # contradiction and leaves someone unsure which half to believe.
+            print(
+                "\nNone of them could be named here: a name is sealed to the machines"
+                "\nthat can read this history, and nothing has granted that to this one"
+                "\nyet. So it takes the same command in two places --"
+                "\n\nNext:  woswoar accept   here, so they can read what this machine"
+                "\n                        publishes"
+                "\n       woswoar accept   on a machine you already use, so this one can"
+                "\n                        read the history from before it joined"
+            )
     if changed:
         print(
             f"\n{len(changed)} machine(s) changed their signing key, which is either a"

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -2541,6 +2541,36 @@ class Newcomer(NamedTuple):
         """
         return self.reader is not None and self.reader.shares_name
 
+    @property
+    def host_id(self) -> str | None:
+        """The host directory it publishes under, when it has published one."""
+        return self.candidate.host_id if self.candidate is not None else None
+
+    @property
+    def named(self) -> bool:
+        """Whether this machine's name could actually be read here.
+
+        A name lives in `hosts/<id>/name.age`, sealed to the recipients, so a
+        machine that has not been granted yet cannot open a single one of them
+        and reads every peer as `(unnamed)`. Asked through `name_for` rather
+        than by comparing `label` against `UNNAMED`, for the reason `Name`
+        gives: sealing a `name.age` needs no secret, so a peer can spell the
+        placeholder itself.
+        """
+        return name_for(self.host_id).known
+
+    @property
+    def fingerprint(self) -> str:
+        """The part of this machine's identity the repository cannot choose.
+
+        Which is the whole reason it is worth printing beside an unreadable
+        name: three lines reading `(unnamed)` distinguish nothing, and the
+        fingerprint was always the thing being consented to.
+        """
+        if self.candidate is not None:
+            return self.candidate.fingerprint
+        return self._reader.fingerprint
+
     def display_name(self) -> str:
         """See `Reader.display_name`: never print `label` directly."""
         return repr(self.label)


### PR DESCRIPTION
Reported from a fresh install:

```
$ woswoar
woswoar 0.7.0 -- 4184 commands from 1 machine

3 machine(s) waiting to be accepted here:
    '(unnamed)'
    '(unnamed)'
    '(unnamed)'

Next:  woswoar accept
```

## What was actually happening

Nothing was broken. A name lives in `hosts/<id>/name.age`, **sealed to the recipients**, so a machine nobody has granted yet cannot open a single one of them. The maintainer confirmed this by running `accept` on another machine, after which all three names appeared.

Two things were wrong with the screen in the meantime.

**Three identical placeholders are not a list of three machines.** The fingerprint now leads each line, exactly as `_show_readers` already does and for the reason its comment gives — it is the only part of the line the repository cannot choose. It is also what `accept` will ask about and what `ssh-keygen -lf` reproduces on the machine itself, so it is the thing you would compare.

**`Next: woswoar accept` was, on its own, the wrong instruction.** Running it here lets the other machines read what this one publishes; it gives this machine nothing to read. The step that does happens on a machine that is already enrolled — which `init` prints once, at the moment nobody needs it yet, and which is never shown again.

## After

```
2 machine(s) waiting to be accepted here:
    SHA256:H4TuypFBYxLmZ+ZrvNAfqx9cyorQYXTzLRuHMz2IUqo  '(unnamed)'
    SHA256:0e5+Dn+UmvPz5H1g04CmyonTK+zZELmkuYlhJo6tpro  '(unnamed)'

None of them could be named here: a name is sealed to the machines
that can read this history, and nothing has granted that to this one
yet. So it takes the same command in two places --

Next:  woswoar accept   here, so they can read what this machine
                        publishes
       woswoar accept   on a machine you already use, so this one can
                        read the history from before it joined
```

The explanation comes **before** the commands. An earlier draft kept the ordinary `Next: woswoar accept` and then said accepting here changes nothing about what this machine can read — which reads as a contradiction and leaves you unsure which half to believe.

A machine that can already read its peers sees none of this; it gets the old one-line `Next:` unchanged.

## Verification

Five mutations, all caught — after two survived and both turned out to be my fixtures:

- **A tautology I wrote.** `test_the_fingerprint_is_the_one_accept_will_ask_about` asserted `machine.fingerprint in status`, which is the same expression the code under test uses — both sides moved together, and a mutation swapping in the *reader's* fingerprint went unnoticed. It now asserts against `candidate.fingerprint` and that it is the `SHA256:` form `accept` prints.
- **A hazard the codebase already documents.** `Name`'s docstring warns that a peer can put the literal `(unnamed)` in its own `name.age`, since sealing one needs no secret — so "has this name been read" cannot be answered by comparing text. `named` asks `name_for(...).known`, but nothing had a machine that named itself the placeholder. Now something does; getting it wrong tells a machine that *can* read its peers that it cannot, and points it at a step it has already done.

Full preflight green: `ruff check`, `ruff format --check`, `mypy`, `shellcheck`, 629 tests.

Branched from `main`, so it is independent of #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)