### PR TITLE
release: 0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ names the one command to run next, if there is one:
 
 ```console
 $ woswoar
-woswoar 0.7.0 — 54,804 commands from 3 machines
+woswoar 0.7.1 — 54,804 commands from 3 machines
 
 1 machine(s) waiting to be accepted here:
     'martin@laptop'
@@ -67,7 +67,7 @@ one machine.
 > it brings itself up to date on the next background sync, so there is nothing
 > else to run; open a new shell to pick it up. `stable` tracks the most recent
 > tag, so the command never changes and you never edit a version number on five
-> machines. Swap `@stable` for `@main` to track the tip, or `@v0.7.0` to pin
+> machines. Swap `@stable` for `@main` to track the tip, or `@v0.7.1` to pin
 > exactly.
 >
 > **Coming from 0.6.x or earlier, run `woswoar install` once.** Those versions

--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"


### PR DESCRIPTION
Version bump only. `main` is protected, so this arrives as a PR; pushing `v0.7.1` afterwards is what cuts the release and moves `stable`.

Both fixes came from the maintainer setting up a new machine.

## What is in it

**#138 — the shell hook brings itself up to date.** `install` copies the hook rather than sourcing the packaged file, so upgrading the program left the old shell code running until somebody re-ran `install`. Since 0.7.0 the hook starts a `woswoar sync` about once a minute, so that sync is what notices: an upgrade now heals itself within a minute.

Deliberately not a symlink into the installed package, which was the first idea and is worse — that path contains the Python version, so a distribution's Python bump leaves it dangling, and a dangling `source` switches recording off at every shell start rather than merely leaving it a version behind.

**#139 — the status line on a machine that cannot read yet.** A new machine showed three consecutive lines reading `'(unnamed)'`, which is not a list of three machines. Names are sealed to the recipients, so a machine nobody has granted cannot read one. Each line now leads with the fingerprint — the part the repository cannot choose, and the one `accept` asks about — and when no name can be read, the screen says why and names both halves of the job, including the one that has to happen on a machine you already use.

## Upgrading

```bash
pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
```

**From 0.7.0:** nothing else. The hook updates itself on the next background sync; open a new shell to pick it up.

**From 0.6.x or earlier:** `woswoar install` once, as 0.7.0 said. Those versions have no background sync, so nothing is running that could notice. This is the last release that will ever need it.

No data migration: nothing about the record format, the repository layout, `state.json` or the day-key scheme changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)