### PR TITLE
search: mark only known failures, and only the age column

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import os
+import re
 import sqlite3
 import subprocess
 import unittest
@@ -506,22 +507,70 @@ class TestThePickerAppearsBeforeTheHistoryIsBuilt(WoswoarTestCase):
         self.assertEqual(chosen, f"cmd {search._CHUNK * 2 + 6}", "a chunk went missing")
 
 
+#: What fzf hands back with `--ansi`: the line, with every escape removed.
+_ESCAPES = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def unstyled(line: str) -> str:
+    return _ESCAPES.sub("", line)
+
+
 class TestFailedCommandsAreMarked(WoswoarTestCase):
     """Colour by exit status, which the picker can show and a pipe must not."""
 
-    def rows(self) -> list[str]:
+    def rows(self, codes: tuple[int, int] = (0, 1)) -> list[str]:
+        good, bad = codes
         with store.private_append(store.log_file(MACHINE_ID, "2026-07-29")) as handle:
-            for ts, code, cmd in ((NOW - 1, 0, "worked"), (NOW, 1, "failed")):
+            for ts, code, cmd in ((NOW - 1, good, "worked"), (NOW, bad, "failed")):
                 handle.write(format_line(Entry(ts, MACHINE_ID, "s1", "~", code, 1, cmd)) + "\n")
         return search.lines_for("global", colour=True)
 
     def test_a_failure_is_marked_and_a_success_is_not(self) -> None:
         failed, worked = self.rows()
         self.assertIn("failed", failed)
-        self.assertTrue(failed.startswith("\x1b["), f"not marked: {failed!r}")
-        self.assertTrue(failed.endswith("\x1b[0m"), "the colour is never reset")
+        self.assertIn(search._FAILED, failed, f"not marked: {failed!r}")
+        self.assertIn(search._RESET, failed, "the colour is never reset")
+        self.assertFalse(failed.endswith(search._RESET), "the whole line is coloured again")
         self.assertIn("worked", worked)
         self.assertNotIn("\x1b[", worked, "a command that succeeded was marked")
+
+    def test_only_the_age_is_coloured_not_the_whole_line(self) -> None:
+        """Reported as "a bit much if the whole line is red" -- and on a history
+        with any real proportion of failures, a mark covering half the lines has
+        stopped marking anything."""
+        (failed, _) = self.rows()
+        before, _, after = failed.partition(search._RESET)
+        self.assertNotIn("failed", before, "the command itself is inside the colour")
+        self.assertIn("failed", after)
+        # The escapes wrap the age and nothing else, so what they contain is
+        # exactly what `relative_time` produced, padding included.
+        self.assertEqual(before.removeprefix(search._FAILED).strip(), "now")
+
+    def test_the_columns_still_line_up(self) -> None:
+        """The escapes go outside the padding, so a coloured line and a plain
+        one are the same width once fzf has stripped them."""
+        failed, worked = self.rows()
+        self.assertEqual(len(unstyled(failed)) - len("failed"), len(worked) - len("worked"))
+
+    def test_an_unknown_exit_code_is_not_a_failure(self) -> None:
+        """`~/.bash_history` and `~/.zsh_history` carry no exit codes at all, so
+        `importer` records -1. Treating "anything but 0" as failure painted a
+        freshly imported history entirely red, which is what this is for."""
+        for unknown in (-1, -2):
+            with self.subTest(code=unknown):
+                self.setUp()
+                failed, worked = self.rows(codes=(unknown, unknown))
+                for line in (failed, worked):
+                    self.assertNotIn("\x1b[", line, f"an unknown code was marked: {line!r}")
+
+    def test_what_counts_as_failure_is_decided_in_one_place(self) -> None:
+        """So a fourth caller cannot invent a fifth answer."""
+        self.assertFalse(search.is_failure("0"))
+        self.assertFalse(search.is_failure(""))
+        self.assertFalse(search.is_failure("-1"))
+        self.assertFalse(search.is_failure("not-a-number"))
+        self.assertTrue(search.is_failure("1"))
+        self.assertTrue(search.is_failure("130"))
 
     def test_plain_by_default_so_a_pipe_stays_plain(self) -> None:
         """`woswoar list | grep` is a documented thing to do."""
@@ -534,8 +583,7 @@ class TestFailedCommandsAreMarked(WoswoarTestCase):
         prefix `command_from_line` slices is unchanged -- but if that ever stops
         being true, this is where it shows."""
         failed, _ = self.rows()
-        stripped = failed.removeprefix(search._FAILED).removesuffix(search._RESET)
-        self.assertEqual(search.command_from_line(stripped), "failed")
+        self.assertEqual(search.command_from_line(unstyled(failed)), "failed")
 
     def test_a_command_cannot_smuggle_its_own_escapes(self) -> None:
         """The whole reason `--ansi` is safe. `make_inert` removes every C0

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -38,8 +38,31 @@ Row = tuple[int, str, str, str]
 #: Dim red for a command that failed. Dim rather than plain red so a screen of
 #: failures does not shout, and so it reads as "this one did not work" rather
 #: than as an error message woswoar is producing now.
-_FAILED = "\x1b[2;31m"
+#: Plain red rather than the dim red this started as. Dim was the right choice
+#: while the whole line carried it -- a screen of dim red is legible where a
+#: screen of bright red is not -- but it now marks the age column alone, and
+#: dim red on three characters is close to not being there at all.
+_FAILED = "\x1b[31m"
 _RESET = "\x1b[0m"
+
+
+def is_failure(code: str) -> bool:
+    """Whether a recorded exit code is a *known* failure.
+
+    Unknown is not failure, and that distinction is the whole function.
+    `~/.bash_history` and `~/.zsh_history` record no exit codes whatsoever, so
+    `importer` stores -1 for "never knew" -- and "anything but 0" painted every
+    imported command red, which on a freshly imported history is the entire
+    screen. Reported as "I think bash import marks all lines as red?".
+
+    Parsed rather than string-compared against a list of the codes seen so far:
+    the same bug would come back for any other sentinel, and the cache holds
+    these as text only because it is columnar.
+    """
+    try:
+        return int(code) > 0
+    except ValueError:
+        return False
 
 
 def relative_time(ts: int, now: int | None = None) -> str:
@@ -240,11 +263,22 @@ def render_rows(
     out = []
     for ts, cmd, code, host in rows:
         when = f"{relative_time(ts, now):>{_TIME_WIDTH}}"
+        if colour and is_failure(code):
+            # The age column only. Colouring the whole line was the first
+            # version and was reported as "a bit much" -- on a history with any
+            # real proportion of failures it is most of the screen in red, and a
+            # mark that covers half the lines has stopped marking anything.
+            #
+            # Wrapped *after* the padding, so the escapes are outside the width
+            # and every column still lines up. fzf renders them as zero-width
+            # and strips them from what it hands back, so `command_from_line`
+            # slices the same fixed prefix it always did.
+            when = f"{_FAILED}{when}{_RESET}"
         if host_width:
             line = f"{when}  {labels[host]:<{host_width}}  {escape(cmd)}"
         else:
             line = f"{when}  {escape(cmd)}"
-        out.append(f"{_FAILED}{line}{_RESET}" if colour and code not in ("0", "") else line)
+        out.append(line)
     return out
 
 


### PR DESCRIPTION
Two things, both reported from a real install: *"is it possible to just color the time in red? it's a bit much if the whole line is red — also, I think bash import marks all lines as red?"*

The second one is a defect, and it is the one that matters.

## Bash and zsh imports were entirely red

Neither `~/.bash_history` nor `~/.zsh_history` records exit codes at all, so `importer` stores `-1` for "never knew" (`importer.py:532`). The renderer marked anything that was not `"0"`:

```python
out.append(f"{_FAILED}{line}{_RESET}" if colour and code not in ("0", "") else line)
```

So every imported command was red. On the maintainer's machine that is 4,184 commands — a screen of red that means nothing, and which also drowns the handful of lines that genuinely failed.

`is_failure` now parses the code and answers `True` only for a known non-zero one. Parsed rather than compared against a growing list of sentinels, so the same bug cannot come back for the next one.

| code | source | marked |
|---|---|---|
| `0` | ran, succeeded | no |
| `1`, `130` | ran, failed | **yes** |
| `-1` | imported from bash/zsh, never recorded | no |
| `""` | malformed | no |

## Only the age column

```
  now  git status
> now< cargo build --release        <- only the age is red
  now  ls -la
> now< sleep 100
  now  imported from bash, exit code never recorded
```

The escapes wrap the age *after* padding, so they sit outside the column width. Every column still lines up, fzf renders them zero-width, and `command_from_line` slices the same fixed prefix once fzf has stripped them — which now has a test of its own rather than being argued for in a comment.

Colour changed from dim red to plain red. Dim was the right call while the whole line carried it — a screen of dim red is legible where bright red is not — but on three characters dim red is close to not being there. Easy to change back if it reads as too loud.

## Verification

Six mutations, all caught, including the two that matter most: `code not in ("0", "")` restored (imports go red again) and the escapes moved inside the padding (columns shift).

Full preflight green: `ruff check`, `ruff format --check`, `mypy`, `shellcheck`, 633 tests.

## Not changed

`importer` still stores `-1`. It is the honest value — the exit code genuinely is not known — and changing what is on disk would need a migration under CLAUDE.md rule 8 to fix something that is purely a rendering decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)