### PR TITLE
search: say that ^name filters to one machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,20 @@ when you need that one command from last Tuesday, on the other machine.
    2m  thinkpad  docker compose up -d --build
    3h  DT-24YYQ3 docker logs -f api
    6d  thinkpad  docker system prune -af
-  ctrl-r cycles | ctrl-g global | ctrl-h host | ctrl-s session
+  ctrl-r cycles | ctrl-g global | ctrl-h host | ctrl-s session | ^name one machine
 ```
 
 The machine column appears once you have more than one, and fzf matches on it —
 so typing `thinkpad` narrows to that machine. It shows the *host* part of each
 machine's name, because that is usually what differs between your own machines.
-A command that exited non-zero is dimmed red, and <kbd>Ctrl</kbd>+<kbd>R</kbd>
+The age of a command that exited non-zero is red, and <kbd>Ctrl</kbd>+<kbd>R</kbd>
 again cycles global → host → session.
+
+**A short machine name is also an ordinary word.** If yours is `box`, typing it
+finds `sandbox` and `~/dropbox` too — so anchor it: **`^box`** matches only the
+machine, because the search starts at the machine column and `^` sticks to the
+front of it. It composes with everything else, so `^box docker` is "docker, on
+box" and `^box !docker` is "on box, but not docker".
 
 ## Quick start
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import io
 import os
 import re
+import shutil
 import sqlite3
 import subprocess
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
+from typing import ClassVar
 from unittest import mock
 
 from woswoar import search, store
@@ -773,3 +775,93 @@ class TestLabelsStayDifferent(WoswoarTestCase):
     def test_the_column_is_only_as_wide_as_the_labels(self) -> None:
         self.named(A="martinleitnerankerl@thinkpad", B="martinus@DT-24YYQ3")
         self.assertEqual(search.host_width_for({self.A, self.B}), len("DT-24YYQ3"))
+
+
+class TestSayingHowToFilterByMachine(WoswoarTestCase):
+    """`^box` matches only the machine called box.
+
+    It works because `--nth=2..` starts the searched region at the machine name
+    and fzf anchors `^` to the start of that region, not of the line -- so this
+    needed no new key, no new mode, and no change to the line. It needed saying.
+
+    Reported as "I have a host named box and that is short enough to also be
+    part of a few commands", which is exactly what an unanchored query cannot
+    tell apart.
+    """
+
+    def test_the_hint_appears_once_there_is_a_column_to_filter_on(self) -> None:
+        header = search._header(host_width=8)
+        self.assertIn("^name", header)
+
+    def test_a_single_machine_is_not_told_about_it(self) -> None:
+        """There is no machine column on a one-machine install, so the hint
+        would describe something that is not on screen."""
+        self.assertNotIn("^name", search._header(host_width=0))
+
+    def test_the_scope_keys_are_still_listed(self) -> None:
+        for width in (0, 8):
+            with self.subTest(host_width=width):
+                header = search._header(host_width=width)
+                for key in ("ctrl-g", "ctrl-h", "ctrl-s"):
+                    self.assertIn(key, header)
+
+    def test_ctrl_r_is_listed_only_where_it_works(self) -> None:
+        """`transform` needs fzf 0.45+, and a header naming a key that does
+        nothing is worse than one that stays quiet about it."""
+        for supported in (True, False):
+            with (
+                self.subTest(transform=supported),
+                mock.patch.object(search, "fzf_supports_transform", return_value=supported),
+            ):
+                self.assertEqual("ctrl-r" in search._header(8), supported)
+
+    def test_the_header_reaches_fzf(self) -> None:
+        """A header nothing passes on is a string in a unit test."""
+        argv = search._fzf_argv("global", "", dedup=True, host_width=8)
+        self.assertIn(f"--header={search._header(8)}", argv)
+
+    ROWS: ClassVar[list[str]] = [
+        "  2m  box       docker run sandbox",
+        "  3h  thinkpad  docker ps",
+        "  6d  box       ls",
+        "  1d  at1i-ws07 echo box",
+    ]
+
+    def fzf_filter(self, query: str) -> str:
+        """Run the real fzf with the matching flags the picker actually passes.
+
+        `--nth` is taken out of `_fzf_argv` rather than written again here. The
+        claim under test is about how fzf resolves `^` against *that* field
+        range, so a test spelling its own range has quietly stopped testing the
+        code: with the value hardcoded, changing it to `--nth=1..` -- which
+        anchors `^` to the age column and breaks the feature outright -- left
+        every assertion below passing.
+        """
+        argv = search._fzf_argv("global", "", dedup=True, host_width=8)
+        matching = [arg for arg in argv if arg.startswith("--nth=") or arg == "--ansi"]
+        self.assertTrue(matching, "no matching flags found; _fzf_argv changed shape")
+        return subprocess.run(
+            ["fzf", "--filter", query, *matching],
+            input="\n".join(self.ROWS),
+            text=True,
+            capture_output=True,
+            check=False,
+        ).stdout
+
+    @unittest.skipUnless(shutil.which("fzf"), "fzf required")
+    def test_the_anchor_really_does_restrict_to_the_machine(self) -> None:
+        """Driven through the real fzf, because the whole claim is about how fzf
+        resolves `^` against a field range -- which no assertion about our own
+        strings can check."""
+        got = self.fzf_filter("^box")
+        chosen = sorted(line.split()[1] for line in got.splitlines() if line.strip())
+        self.assertEqual(chosen, ["box", "box"], "the anchor did not restrict to the machine")
+
+    @unittest.skipUnless(shutil.which("fzf"), "fzf required")
+    def test_it_composes_with_an_ordinary_search(self) -> None:
+        """Filtering to a machine is worth little if it cannot then be searched,
+        and that is two terms in one query rather than a mode to leave."""
+        got = self.fzf_filter("^box docker")
+        self.assertIn("docker run sandbox", got)
+        self.assertNotIn("docker ps", got, "another machine survived the anchor")
+        self.assertNotIn("  ls", got, "the second term was ignored")

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -347,6 +347,29 @@ def _cycle_binding(self_cmd: str, dedup_flag: str, width: str) -> str:
     return f"--bind=ctrl-r:transform:{script}"
 
 
+def _header(host_width: int) -> str:
+    """The line above the prompt: what the keys do, and how to pick a machine.
+
+    `^box` restricts a search to the machine called `box`, and has since the
+    column existed -- `--nth=2..` starts the searched region at the machine
+    name, and fzf anchors `^` to the start of that region rather than of the
+    line. Nothing said so, which made it a feature only its author knew about:
+    reported as "I have a host named box and that is short enough to also be
+    part of a few commands", which is the exact case it solves.
+
+    Only with a column to filter on. On a single-machine install there is no
+    machine name in the line and the hint would describe nothing.
+
+    Ctrl-R is listed only where it works: `transform` needs fzf 0.45+, and
+    advertising a key that does nothing is worse than staying quiet about it.
+    """
+    hints = ["ctrl-r cycles"] if fzf_supports_transform() else []
+    hints += ["ctrl-g global", "ctrl-h host", "ctrl-s session"]
+    if host_width:
+        hints.append("^name one machine")
+    return " | ".join(hints)
+
+
 def _fzf_argv(scope: Scope, query: str, dedup: bool, host_width: int) -> list[str]:
     self_cmd = _self_command()
     dedup_flag = "" if dedup else " --no-dedup"
@@ -383,13 +406,10 @@ def _fzf_argv(scope: Scope, query: str, dedup: bool, host_width: int) -> list[st
         "--tiebreak=index",
         f"--query={query}",
         f"--prompt=woswoar ({scope}) ",
-        "--header=ctrl-r cycles | ctrl-g global | ctrl-h host | ctrl-s session",
+        f"--header={_header(host_width)}",
     ]
     if fzf_supports_transform():
         argv.append(_cycle_binding(self_cmd, dedup_flag, width))
-    else:
-        # Say what is on offer, rather than advertising a key that does nothing.
-        argv[-1] = "--header=ctrl-g global | ctrl-h host | ctrl-s session"
     for key, target in (("ctrl-g", "global"), ("ctrl-h", "host"), ("ctrl-s", "session")):
         argv.append(
             f"--bind={key}:reload({self_cmd} list --colour{width} --scope {target}{dedup_flag})"


### PR DESCRIPTION
Asked as: *"I have a host named `box` and that is short enough to also be part of a few commands."*

Typing `box` finds `sandbox` and `~/dropbox` too, because the machine column and the command share one search space.

## It already works

`^box` restricts a search to that machine, and has since the column existed. `--nth=2..` starts the searched region at the machine name, and fzf anchors `^` to the front of *that region*, not of the line:

```
query "box"      → 4 matches   box×2, "echo box", "cd ~/dropbox"
query "^box"     → 2 matches   only the machine
```

It composes with everything else, so both of these read like what they do:

```
^box docker      docker, on box
^box !docker     on box, but not docker
```

Nothing said so anywhere, which made it a feature only its author knew about.

## So this adds no mechanism

No new key, no new mode, no change to the line — a hint in the header, and only where there is a machine column to filter on:

```
ctrl-r cycles | ctrl-g global | ctrl-h host | ctrl-s session | ^name one machine
```

A single-machine install has no machine column, so it does not get the hint.

The README gains the example, and loses a claim #141 made stale — the whole line is no longer dimmed red, the age is.

## Verification

Six mutations, all caught — after one survived and found a genuinely weak fixture.

The two tests that drive the real fzf spelled `--nth=2..` in their own argv rather than taking it from `_fzf_argv`. Changing the code to `--nth=1..` — which anchors `^` to the age column and breaks the feature outright — left every assertion passing, because the tests were exercising their own hardcoded flag. They now pull the matching flags out of `_fzf_argv`, so the mutation is caught. That is the difference between testing fzf and testing what woswoar tells fzf.

Full preflight green: `ruff check`, `ruff format --check`, `mypy`, `shellcheck`, 639 tests.

## Considered and not done

Prefixing the column with `@` (so `@box` is unambiguous without knowing fzf's syntax) would be more discoverable, but it costs a column of width, changes what `command_from_line` slices, and `@` is common in commands anyway — `user@host`, `npm i @scope/pkg`, git URLs. Worth revisiting if `^` proves too obscure in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)