### PR TITLE
search: ctrl-t unfolds the timeline around a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ when you need that one command from last Tuesday, on the other machine.
    2m  thinkpad  docker compose up -d --build
    3h  DT-24YYQ3 docker logs -f api
    6d  thinkpad  docker system prune -af
-  ctrl-r cycles | ctrl-t timeline | ctrl-g global | ctrl-h host | ctrl-s session | ^name one machine
+  ctrl-r global → host → session, or ctrl-g/h/s | ctrl-t timeline | ^name one machine
 ```
 
 The machine column appears once you have more than one, and fzf matches on it —

--- a/README.md
+++ b/README.md
@@ -38,23 +38,24 @@ box" and `^box !docker` is "on box, but not docker".
 Half of what you want from history is not a command but the *next* one — you
 remember running the migration, and what you actually need is what you ran after
 it. Find anything, press <kbd>Ctrl</kbd>+<kbd>T</kbd>, and the list becomes the
-timeline either side of it, oldest at the top, with the cursor still on what you
-found:
+timeline either side of it, with the cursor still on what you found:
 
 ```
   woswoar (timeline global) >
-   4h  cd ~/proj
-   4h  cargo build
+   3h  git commit -m wip
+   3h  git add -A
    4h  cargo test
    4h  vim src/lib.rs          <- where you were
    4h  cargo test
-   3h  git add -A
-   3h  git commit -m wip
+   4h  cargo build
+   4h  cd ~/proj
 ```
 
-Scroll up into what led there, down into what came next, and press
-<kbd>Enter</kbd> on any of them. Repeats are kept — running `cargo test` twice
-is the shape of what happened, and the deduplicated search list hides it.
+Newest first, like every other list here. Scroll up into what came next, down
+into what led there, and press <kbd>Enter</kbd> on any of them. The search box
+is cleared, so typing now filters *the timeline* rather than repeating the search
+that got you here. Repeats are kept — running `cargo test` twice is the shape of
+what happened, and the deduplicated search list hides it.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ when you need that one command from last Tuesday, on the other machine.
    3h  DT-24YYQ3 docker logs -f api
    6d  thinkpad  docker system prune -af
   ctrl-r cycles | ctrl-g global | ctrl-h host | ctrl-s session | ^name one machine
+  ctrl-r cycles | ctrl-t timeline | ctrl-g global | ctrl-h host | ctrl-s session
 ```
 
 The machine column appears once you have more than one, and fzf matches on it —
@@ -33,6 +34,28 @@ finds `sandbox` and `~/dropbox` too — so anchor it: **`^box`** matches only th
 machine, because the search starts at the machine column and `^` sticks to the
 front of it. It composes with everything else, so `^box docker` is "docker, on
 box" and `^box !docker` is "on box, but not docker".
+### Find one command, then read around it
+
+Half of what you want from history is not a command but the *next* one — you
+remember running the migration, and what you actually need is what you ran after
+it. Find anything, press <kbd>Ctrl</kbd>+<kbd>T</kbd>, and the list becomes the
+timeline either side of it, oldest at the top, with the cursor still on what you
+found:
+
+```
+  woswoar (timeline global) >
+   4h  cd ~/proj
+   4h  cargo build
+   4h  cargo test
+   4h  vim src/lib.rs          <- where you were
+   4h  cargo test
+   3h  git add -A
+   3h  git commit -m wip
+```
+
+Scroll up into what led there, down into what came next, and press
+<kbd>Enter</kbd> on any of them. Repeats are kept — running `cargo test` twice
+is the shape of what happened, and the deduplicated search list hides it.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ when you need that one command from last Tuesday, on the other machine.
    2m  thinkpad  docker compose up -d --build
    3h  DT-24YYQ3 docker logs -f api
    6d  thinkpad  docker system prune -af
-  ctrl-r cycles | ctrl-g global | ctrl-h host | ctrl-s session | ^name one machine
-  ctrl-r cycles | ctrl-t timeline | ctrl-g global | ctrl-h host | ctrl-s session
+  ctrl-r cycles | ctrl-t timeline | ctrl-g global | ctrl-h host | ctrl-s session | ^name one machine
 ```
 
 The machine column appears once you have more than one, and fzf matches on it —

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -14,6 +14,7 @@ import shutil
 import stat
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from woswoar import __main__ as main_module
 from woswoar import crypto, store
@@ -236,3 +237,57 @@ class TestReadingThePackagedHook(unittest.TestCase):
         via_resources = (resources.files("woswoar") / "shell" / main_module.HOOK_NAME).read_bytes()
         self.assertEqual(main_module._hook_bytes(), via_resources)
         self.assertTrue(via_resources.startswith(b"# woswoar"), "that is not the hook")
+
+
+class TestDoctorReportsWhatFzfCanDo(WoswoarTestCase):
+    """Not just that fzf is there, but which keys it can offer.
+
+    An fzf below 0.45 gets a working picker with no Ctrl-R cycling and no
+    Ctrl-T timeline. That is correct and deliberate -- an unknown action in a
+    `--bind` makes fzf refuse to start, so the keys cannot be offered
+    optimistically -- but it is also silent, and indistinguishable from a bug
+    unless something says so. Reported from a fleet running 0.73 on one machine
+    and Debian's 0.44.1 on another.
+    """
+
+    def fzf_line(self, said: str, parsed: tuple[int, int] | None) -> str:
+        from woswoar import search
+
+        with (
+            mock.patch.object(search, "fzf_version", return_value=(said, parsed)),
+            mock.patch.object(
+                search,
+                "fzf_supports_transform",
+                return_value=parsed is not None and parsed >= search.TRANSFORM_SINCE,
+            ),
+        ):
+            out = support.run_cli("doctor").out
+        return next(line for line in out.splitlines() if " fzf " in line)
+
+    def test_a_new_enough_fzf_just_shows_its_version(self) -> None:
+        line = self.fzf_line("0.73.1 (Fedora)", (0, 73))
+        self.assertIn("0.73.1", line)
+        self.assertNotIn("need", line, "a capable fzf was told what it is missing")
+
+    def test_an_old_fzf_is_told_exactly_what_it_is_missing(self) -> None:
+        line = self.fzf_line("0.44.1 (debian)", (0, 44))
+        self.assertIn("0.44.1", line)
+        for named in ("ctrl-r", "ctrl-t", "0.45+"):
+            self.assertIn(named, line, f"{named} is not mentioned")
+
+    def test_an_old_fzf_is_not_reported_as_a_failure(self) -> None:
+        """Search works perfectly there. A red cross would say the machine is
+        broken, and the next one would be read as noise too."""
+        self.assertIn("[ok]", self.fzf_line("0.44.1 (debian)", (0, 44)))
+
+    def test_a_version_it_cannot_parse_does_not_go_blank(self) -> None:
+        line = self.fzf_line("", None)
+        self.assertIn("version unknown", line)
+
+    def test_a_missing_fzf_still_says_how_to_get_one(self) -> None:
+        """The other branch, and the one that is an actual problem."""
+        with mock.patch.object(shutil, "which", return_value=None):
+            out = support.run_cli("doctor").out
+        line = next(line for line in out.splitlines() if " fzf " in line)
+        self.assertIn("[FAIL]", line)
+        self.assertIn("not found", line)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -934,11 +934,20 @@ class TestTheTimelineAroundACommand(WoswoarTestCase):
 
     def test_the_cursor_lands_on_the_command_that_was_found(self) -> None:
         """`pos` is 1-based. Without it fzf resets to the top of the window and
-        the command you searched for is forty rows below the cursor."""
-        row = self.row_of("vim")
-        at = search.anchor_position(row, "global")
-        found = search.lines_for("global", around=row)
-        self.assertEqual(search.command_from_line(found[at - 1]), "vim src/lib.rs")
+        the command you searched for is forty rows below the cursor.
+
+        Checked at the ends as well as the middle, and that is not padding: the
+        first version only asked about a command in the *centre* of the window,
+        where the position before reversing and the position after it are the
+        same number. A mutation that dropped the reversal from the arithmetic
+        went unnoticed until an off-centre anchor was asked about.
+        """
+        for needle in ("cd ~/proj", "vim src/lib.rs", "git commit -m wip"):
+            with self.subTest(command=needle):
+                row = self.row_of(needle)
+                at = search.anchor_position(row, "global")
+                found = search.lines_for("global", around=row)
+                self.assertEqual(search.command_from_line(found[at - 1]), needle)
 
     def test_the_anchor_sits_mid_window_once_there_is_history_either_side(self) -> None:
         """With fewer commands than the span there is nothing above, and the

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -982,10 +982,23 @@ class TestTheTimelineAroundACommand(WoswoarTestCase):
         self.assertNotIn("not mine", " ".join(found))
 
     def test_the_picker_binds_it_and_says_so(self) -> None:
-        argv = search._fzf_argv("global", "", dedup=True, host_width=0)
+        # `transform` is fzf 0.45+, and the binding is not offered without it.
+        # Forced rather than skipped: the runner's fzf decides whether this test
+        # runs at all otherwise, which is how a green pull request failed while
+        # cutting a release once already.
+        with mock.patch.object(search, "fzf_supports_transform", return_value=True):
+            argv = search._fzf_argv("global", "", dedup=True, host_width=0)
         binds = " ".join(a for a in argv if a.startswith("--bind="))
         self.assertIn("ctrl-t:", binds)
         for piece in ("--around {n}", "--print-anchor", "+pos($p)", "reload("):
             self.assertIn(piece, binds, f"the ctrl-t binding is missing {piece}")
         header = next(a for a in argv if a.startswith("--header="))
         self.assertIn("ctrl-t timeline", header, "the key is bound but never mentioned")
+
+    def test_the_key_is_not_advertised_on_an_fzf_that_cannot_do_it(self) -> None:
+        with mock.patch.object(search, "fzf_supports_transform", return_value=False):
+            argv = search._fzf_argv("global", "", dedup=True, host_width=0)
+        binds = " ".join(a for a in argv if a.startswith("--bind="))
+        self.assertNotIn("ctrl-t:", binds)
+        header = next(a for a in argv if a.startswith("--header="))
+        self.assertNotIn("ctrl-t", header, "a key that does nothing here is named anyway")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -910,14 +910,19 @@ class TestTheTimelineAroundACommand(WoswoarTestCase):
         ]
 
     def test_it_shows_what_came_before_and_after(self) -> None:
+        """Both directions, which is the whole feature: the list you arrived
+        from could only ever show you the command itself."""
         found = self.timeline("vim")
-        self.assertEqual(found[found.index("vim src/lib.rs") - 1], "cargo test")
-        self.assertEqual(found[found.index("vim src/lib.rs") + 1], "cargo test")
+        at = found.index("vim src/lib.rs")
+        self.assertEqual(found[at + 1 :], ["cargo test", "cargo build", "cd ~/proj"])
+        self.assertEqual(found[:at], ["git commit -m wip", "git add -A", "cargo test"])
 
-    def test_it_reads_oldest_first_so_scrolling_down_goes_forward(self) -> None:
-        """The opposite of every other list here, and deliberately: you find the
-        command you remember and read *down* into what you did next."""
-        self.assertEqual(self.timeline("vim"), self.SESSION_CMDS)
+    def test_it_reads_newest_first_like_every_other_list(self) -> None:
+        """This started out reversed, on the theory that a timeline should read
+        downwards into the future. Wrong in use: every other screen here puts
+        the recent thing at the top, and one screen that does not is a screen
+        you have to stop and reorient on."""
+        self.assertEqual(self.timeline("vim"), self.SESSION_CMDS[::-1])
 
     def test_repeats_are_not_collapsed(self) -> None:
         """A timeline with the repeats removed is not a timeline. Running
@@ -990,7 +995,11 @@ class TestTheTimelineAroundACommand(WoswoarTestCase):
             argv = search._fzf_argv("global", "", dedup=True, host_width=0)
         binds = " ".join(a for a in argv if a.startswith("--bind="))
         self.assertIn("ctrl-t:", binds)
-        for piece in ("--around {n}", "--print-anchor", "+pos($p)", "reload("):
+        # `reload-sync`, not `reload`: the asynchronous one lets `pos` run
+        # against the list still on screen, which put the cursor anywhere but
+        # on what was found. `clear-query` so that typing next filters the
+        # timeline rather than re-applying the search that got you here.
+        for piece in ("--around {n}", "--print-anchor", "+pos($p)", "reload-sync(", "clear-query"):
             self.assertIn(piece, binds, f"the ctrl-t binding is missing {piece}")
         header = next(a for a in argv if a.startswith("--header="))
         self.assertIn("ctrl-t timeline", header, "the key is bound but never mentioned")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -727,6 +727,29 @@ class TestCtrlRCyclesTheScope(unittest.TestCase):
         header = next(a for a in argv if a.startswith("--header="))
         self.assertIn("ctrl-r", header, "the key is bound but never mentioned")
 
+    def test_the_version_is_reported_as_well_as_judged(self) -> None:
+        """`doctor` shows a person the string fzf printed while the gate below
+        compares numbers, so both come from one call -- deriving either from the
+        other at each call site is how the two would come to disagree."""
+        cases = [
+            ("0.73.1 (Fedora)", ("0.73.1 (Fedora)", (0, 73))),
+            ("0.44.1 (debian)", ("0.44.1 (debian)", (0, 44))),
+            ("nonsense", ("nonsense", None)),
+            ("", ("", None)),
+        ]
+        for printed, wanted in cases:
+            with self.subTest(version=printed):
+                done = subprocess.CompletedProcess([], 0, stdout=printed, stderr="")
+                with mock.patch("subprocess.run", return_value=done):
+                    self.assertEqual(search.fzf_version(), wanted)
+
+    def test_an_fzf_that_cannot_be_run_is_not_an_exception(self) -> None:
+        """It is a machine without fzf, which `doctor` reports and the picker
+        has to survive rather than crash on."""
+        with mock.patch("subprocess.run", side_effect=OSError("no such file")):
+            self.assertEqual(search.fzf_version(), ("", None))
+            self.assertFalse(search.fzf_supports_transform())
+
     def test_the_version_gate_reads_a_version(self) -> None:
         for version, wanted in (("0.44.1 (Fedora)", False), ("0.45.0", True), ("0.73.1", True)):
             with self.subTest(version=version):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -718,13 +718,14 @@ class TestCtrlRCyclesTheScope(unittest.TestCase):
         with mock.patch.object(search, "fzf_supports_transform", return_value=False):
             argv = search._fzf_argv("global", "", True, 0)
         self.assertFalse([a for a in argv if "ctrl-r:" in a])
-        self.assertNotIn("ctrl-r cycles", " ".join(argv))
+        self.assertNotIn("ctrl-r", " ".join(argv), "a key that does nothing here is named anyway")
 
     def test_a_new_enough_fzf_gets_it(self) -> None:
         with mock.patch.object(search, "fzf_supports_transform", return_value=True):
             argv = search._fzf_argv("global", "", True, 0)
         self.assertTrue([a for a in argv if a.startswith("--bind=ctrl-r:transform:")])
-        self.assertIn("ctrl-r cycles", " ".join(argv))
+        header = next(a for a in argv if a.startswith("--header="))
+        self.assertIn("ctrl-r", header, "the key is bound but never mentioned")
 
     def test_the_version_gate_reads_a_version(self) -> None:
         for version, wanted in (("0.44.1 (Fedora)", False), ("0.45.0", True), ("0.73.1", True)):
@@ -798,12 +799,37 @@ class TestSayingHowToFilterByMachine(WoswoarTestCase):
         would describe something that is not on screen."""
         self.assertNotIn("^name", search._header(host_width=0))
 
-    def test_the_scope_keys_are_still_listed(self) -> None:
-        for width in (0, 8):
-            with self.subTest(host_width=width):
-                header = search._header(host_width=width)
-                for key in ("ctrl-g", "ctrl-h", "ctrl-s"):
-                    self.assertIn(key, header)
+    def test_every_scope_is_named_and_every_key_reachable(self) -> None:
+        """The three direct keys share one segment where Ctrl-R names the
+        scopes, because `g`, `h` and `s` are the initials of the words beside
+        them -- but all three still have to be *findable*, and so does each
+        scope, or the compaction has quietly dropped one."""
+        for supported in (True, False):
+            for width in (0, 8):
+                with (
+                    self.subTest(transform=supported, host_width=width),
+                    mock.patch.object(search, "fzf_supports_transform", return_value=supported),
+                ):
+                    header = search._header(host_width=width)
+                    for scope in ("global", "host", "session"):
+                        self.assertIn(scope, header, f"{scope} is not named")
+                    for key in ("g", "h", "s"):
+                        self.assertRegex(header, rf"ctrl-(\w+/)*{key}\b|ctrl-{key}\b")
+
+    def test_the_cycle_says_which_order_it_goes_in(self) -> None:
+        """`ctrl-r cycles` said that it cycled and not through what, so the
+        only way to learn the order was to press it three times."""
+        with mock.patch.object(search, "fzf_supports_transform", return_value=True):
+            header = search._header(host_width=0)
+        self.assertIn("global \u2192 host \u2192 session", header)
+
+    def test_the_timeline_comes_after_the_scopes(self) -> None:
+        """Ordered by how far each takes you from an ordinary search: change
+        what is listed, then change the kind of list, then narrow it."""
+        with mock.patch.object(search, "fzf_supports_transform", return_value=True):
+            header = search._header(host_width=8)
+        self.assertLess(header.index("ctrl-r"), header.index("ctrl-t"))
+        self.assertLess(header.index("ctrl-t"), header.index("^name"))
 
     def test_ctrl_r_is_listed_only_where_it_works(self) -> None:
         """`transform` needs fzf 0.45+, and a header naming a key that does

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -865,3 +865,127 @@ class TestSayingHowToFilterByMachine(WoswoarTestCase):
         self.assertIn("docker run sandbox", got)
         self.assertNotIn("docker ps", got, "another machine survived the anchor")
         self.assertNotIn("  ls", got, "the second term was ignored")
+
+
+class TestTheTimelineAroundACommand(WoswoarTestCase):
+    """Find a command, then read what happened either side of it.
+
+    Asked for as: "use fzf search to find a particular command, then press
+    ctrl-t to switch to timeline mode, the commands above and below unfold and
+    I can scroll up and down and choose the surrounding ones."
+
+    So it is one fzf session throughout -- `reload` swaps the list underneath a
+    picker that never closes, and `pos` puts the cursor back on the command that
+    was found, without which the surrounding commands unfold forty rows away
+    from where you are looking.
+    """
+
+    SESSION_CMDS: ClassVar[list[str]] = [
+        "cd ~/proj",
+        "cargo build",
+        "cargo test",
+        "vim src/lib.rs",
+        "cargo test",
+        "git add -A",
+        "git commit -m wip",
+    ]
+
+    def setUp(self) -> None:
+        super().setUp()
+        with store.private_append(store.log_file(MACHINE_ID, "2026-07-29")) as handle:
+            for i, cmd in enumerate(self.SESSION_CMDS):
+                entry = Entry(NOW + i * 60, MACHINE_ID, "s1", "~", 0, 1, cmd)
+                handle.write(format_line(entry) + "\n")
+
+    def ranked(self) -> list[str]:
+        return search.lines_for("global")
+
+    def row_of(self, needle: str) -> int:
+        return next(i for i, line in enumerate(self.ranked()) if needle in line)
+
+    def timeline(self, needle: str) -> list[str]:
+        return [
+            search.command_from_line(line)
+            for line in search.lines_for("global", around=self.row_of(needle))
+        ]
+
+    def test_it_shows_what_came_before_and_after(self) -> None:
+        found = self.timeline("vim")
+        self.assertEqual(found[found.index("vim src/lib.rs") - 1], "cargo test")
+        self.assertEqual(found[found.index("vim src/lib.rs") + 1], "cargo test")
+
+    def test_it_reads_oldest_first_so_scrolling_down_goes_forward(self) -> None:
+        """The opposite of every other list here, and deliberately: you find the
+        command you remember and read *down* into what you did next."""
+        self.assertEqual(self.timeline("vim"), self.SESSION_CMDS)
+
+    def test_repeats_are_not_collapsed(self) -> None:
+        """A timeline with the repeats removed is not a timeline. Running
+        `cargo test` twice while fixing something is the shape of what
+        happened, and the deduped list this was reached from shows it once."""
+        self.assertEqual(self.timeline("vim").count("cargo test"), 2)
+        listed = [search.command_from_line(line) for line in self.ranked()]
+        self.assertEqual(listed.count("cargo test"), 1)
+
+    def test_the_cursor_lands_on_the_command_that_was_found(self) -> None:
+        """`pos` is 1-based. Without it fzf resets to the top of the window and
+        the command you searched for is forty rows below the cursor."""
+        row = self.row_of("vim")
+        at = search.anchor_position(row, "global")
+        found = search.lines_for("global", around=row)
+        self.assertEqual(search.command_from_line(found[at - 1]), "vim src/lib.rs")
+
+    def test_the_anchor_sits_mid_window_once_there_is_history_either_side(self) -> None:
+        """With fewer commands than the span there is nothing above, and the
+        cursor is near the top -- which is correct, and is also why the position
+        cannot be a constant fzf could be told once."""
+        long_day = [f"cmd {i}" for i in range(search.TIMELINE_SPAN * 3)]
+        with store.private_append(store.log_file(MACHINE_ID, "2026-07-30")) as handle:
+            for i, cmd in enumerate(long_day):
+                entry = Entry(NOW + 10_000 + i * 60, MACHINE_ID, "s1", "~", 0, 1, cmd)
+                handle.write(format_line(entry) + "\n")
+        middle = self.row_of(f"cmd {search.TIMELINE_SPAN + 5}")
+        self.assertEqual(search.anchor_position(middle, "global"), search.TIMELINE_SPAN + 1)
+
+    def test_an_index_past_the_end_of_the_list_gives_nothing(self) -> None:
+        """The index comes from fzf and a background sync can merge commands
+        between the picker opening and the key being pressed. Showing the wrong
+        moment in history confidently is worse than showing none."""
+        self.assertEqual(search.lines_for("global", around=9999), [])
+        self.assertEqual(search.anchor_position(9999, "global"), 0)
+
+    def test_an_anchor_that_is_not_in_the_history_gives_nothing(self) -> None:
+        """The other way the anchor can be lost, and the one an out-of-range
+        index does not reach: a row that is *in* the ranked list but not in the
+        rows the timeline is built from.
+
+        Reached by making `rank_rows` return something the data does not
+        contain, because by construction today it cannot -- both come from the
+        same columns. That is exactly why this needs a test rather than a
+        comment: the branch is unreachable until the day the two stop agreeing,
+        and then it is the difference between an empty timeline and a
+        confidently wrong one.
+        """
+        invented = (NOW + 999_999, "never ran this", "0", MACHINE_ID)
+        with mock.patch.object(search, "rank_rows", return_value=[invented]):
+            self.assertEqual(search.lines_for("global", around=0), [])
+            self.assertEqual(search.anchor_position(0, "global"), 0)
+
+    def test_the_scope_is_kept(self) -> None:
+        """A timeline of another machine's evening is not what ctrl-t on a
+        host-scoped list means."""
+        with store.private_append(store.log_file("ffffffffffffffff", "2026-07-29")) as handle:
+            entry = Entry(NOW + 200, "ffffffffffffffff", "elsewhere", "~", 0, 1, "not mine")
+            handle.write(format_line(entry) + "\n")
+        row = next(i for i, line in enumerate(search.lines_for("host")) if "vim" in line)
+        found = search.lines_for("host", around=row)
+        self.assertNotIn("not mine", " ".join(found))
+
+    def test_the_picker_binds_it_and_says_so(self) -> None:
+        argv = search._fzf_argv("global", "", dedup=True, host_width=0)
+        binds = " ".join(a for a in argv if a.startswith("--bind="))
+        self.assertIn("ctrl-t:", binds)
+        for piece in ("--around {n}", "--print-anchor", "+pos($p)", "reload("):
+            self.assertIn(piece, binds, f"the ctrl-t binding is missing {piece}")
+        header = next(a for a in argv if a.startswith("--header="))
+        self.assertIn("ctrl-t timeline", header, "the key is bound but never mentioned")

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -318,7 +318,26 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     check("bash", major >= 5, f"{version or 'not found'} (5.0+ required)")
 
     fzf = shutil.which("fzf")
-    check("fzf", fzf is not None, fzf or f"not found - {deps.advice([deps.FZF])}")
+    if fzf is None:
+        check("fzf", False, f"not found - {deps.advice([deps.FZF])}")
+    else:
+        # Which keys this fzf can actually offer, not just that it is there.
+        # An fzf below 0.45 gets a working picker with no Ctrl-R cycling and no
+        # Ctrl-T timeline -- correct, silent, and impossible to tell from a bug
+        # unless something says so. Reported from a fleet running 0.73 on one
+        # machine and Debian's 0.44.1 on another.
+        said, _ = search.fzf_version()
+        shown = said or "version unknown"
+        if search.fzf_supports_transform():
+            check("fzf", True, f"{fzf}  ({shown})")
+        else:
+            floor = ".".join(str(part) for part in search.TRANSFORM_SINCE)
+            check(
+                "fzf",
+                True,
+                f"{fzf}  ({shown} - searching works; ctrl-r cycling and the"
+                f" ctrl-t timeline need {floor}+)",
+            )
 
     machine_file = store.machine_file()
     # Read before anything calls store.machine(), which would create it.

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -129,12 +129,20 @@ def cmd_install(args: argparse.Namespace) -> int:
 
 
 def cmd_list(args: argparse.Namespace) -> int:
+    if args.print_anchor:
+        # Where fzf should park the cursor once it has unfolded the timeline.
+        # A separate invocation because `transform` composes `reload(...)` and
+        # `pos(...)` in one string, so the position has to be known before the
+        # reload it belongs to has run.
+        print(search.anchor_position(args.around or 0, args.scope, dedup=not args.no_dedup))
+        return 0
     lines = search.lines_for(
         args.scope,
         dedup=not args.no_dedup,
         limit=args.limit,
         colour=args.colour,
         host_width=args.host_width,
+        around=args.around,
     )
     if lines:
         sys.stdout.write("\n".join(lines) + "\n")
@@ -1495,6 +1503,14 @@ def build_parser() -> argparse.ArgumentParser:
     # Passed by the picker's reload bindings so both sides lay the line out the
     # same way. Not something to type by hand, hence no help text.
     p_list.add_argument("--host-width", type=int, default=None, help=argparse.SUPPRESS)
+    p_list.add_argument(
+        "--around",
+        type=int,
+        default=None,
+        help="show the timeline either side of this row of the list, oldest first",
+    )
+    # Both passed by the picker's ctrl-t binding rather than typed.
+    p_list.add_argument("--print-anchor", action="store_true", help=argparse.SUPPRESS)
     p_list.add_argument(
         "--colour",
         "--color",

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -460,9 +460,23 @@ def _header(host_width: int) -> str:
     Ctrl-R and Ctrl-T are listed only where they work: both need `transform`,
     which is fzf 0.45+, and advertising a key that does nothing is worse than
     staying quiet about it.
+
+    Ordered by how far each takes you from an ordinary search: change what is
+    listed, then change the *kind* of list, then narrow the one you have.
     """
-    hints = ["ctrl-r cycles", "ctrl-t timeline"] if fzf_supports_transform() else []
-    hints += ["ctrl-g global", "ctrl-h host", "ctrl-s session"]
+    if fzf_supports_transform():
+        # Naming the scopes in the order Ctrl-R visits them is what lets the
+        # three direct keys collapse into one segment: `g`, `h` and `s` are the
+        # initials of the words right beside them, so spelling each out again
+        # was three quarters of the line saying the same thing twice.
+        #
+        # `ctrl-` in full rather than the usual `^r`, because `^` already means
+        # something else on this line: `^name` is fzf's anchor, not a key.
+        hints = ["ctrl-r global \u2192 host \u2192 session, or ctrl-g/h/s", "ctrl-t timeline"]
+    else:
+        # Neither key exists here, and with no cycle to name the scopes the
+        # three that do have to introduce themselves.
+        hints = ["ctrl-g global", "ctrl-h host", "ctrl-s session"]
     if host_width:
         hints.append("^name one machine")
     return " | ".join(hints)

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -245,10 +245,11 @@ TIMELINE_SPAN = 40
 def _window_around(anchor: Row | None, columns: Columns) -> tuple[list[Row], int]:
     """Everything either side of `anchor`, oldest first.
 
-    Oldest first, unlike every other list here, because that is the direction
-    the question runs: you find the command you remember and then read *down*
-    into what you did next. Reversing that would make "scroll down" mean "go
-    back in time", which is the opposite of every log anyone has ever read.
+    Newest first, like every other list here. This started out reversed, on
+    the theory that a timeline should read downwards into the future -- and
+    that was wrong in use: every other screen in woswoar puts the recent thing
+    at the top, and one screen that does not is a screen you have to stop and
+    reorient on. Reported as "I think it's bad that it reverses order".
 
     Never deduplicated, also unlike every other list. A timeline with the
     repeats collapsed is not a timeline -- running `cargo test` four times
@@ -275,7 +276,12 @@ def _window_around(anchor: Row | None, columns: Columns) -> tuple[list[Row], int
     except ValueError:
         return [], 0
     start = max(0, at - TIMELINE_SPAN)
-    return chronological[start : at + TIMELINE_SPAN + 1], at - start + 1
+    window = chronological[start : at + TIMELINE_SPAN + 1]
+    # Reversed at the end rather than sorted that way, because the window is
+    # defined by what surrounds the anchor *in time* -- taking the neighbours
+    # first and the direction second keeps those two decisions apart.
+    offset = at - start
+    return window[::-1], len(window) - offset
 
 
 def anchor_position(index: int, scope: Scope, dedup: bool = True) -> int:
@@ -487,7 +493,17 @@ def _timeline_binding(self_cmd: str, dedup_flag: str, width: str) -> str:
         # `pos` has to be composed into the same action string as the `reload`
         # it applies to, so it cannot be read out of the reload's own output.
         f"p=$({reload} $s{dedup_flag} --around {{n}} --print-anchor); "
-        f'printf "reload({reload} $s{dedup_flag} --around {{n}})'
+        # `reload-sync`, not `reload`: a plain reload is asynchronous, so `pos`
+        # ran against the list that was still on screen and the cursor was
+        # wherever the new one happened to leave it. Reported as "it seems to
+        # jump to the bottom always and not to the selection".
+        #
+        # `clear-query` because the query that found the command is not the one
+        # you want against its neighbours -- leaving it filters the timeline
+        # down to the same match you started from, which is an empty gesture.
+        # Asked for directly: "it should clear the filter, that way it's
+        # filtering the timeline".
+        f'printf "clear-query+reload-sync({reload} $s{dedup_flag} --around {{n}})'
         '+pos($p)+change-prompt(woswoar (timeline $s) )"'
     )
     return f"--bind=ctrl-t:transform:{script}"

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -35,9 +35,6 @@ _STAMP = itemgetter(0)
 #: One display row: when, what, how it ended, and which machine ran it.
 Row = tuple[int, str, str, str]
 
-#: Dim red for a command that failed. Dim rather than plain red so a screen of
-#: failures does not shout, and so it reads as "this one did not work" rather
-#: than as an error message woswoar is producing now.
 #: Plain red rather than the dim red this started as. Dim was the right choice
 #: while the whole line carried it -- a screen of dim red is legible where a
 #: screen of bright red is not -- but it now marks the age column alone, and
@@ -155,14 +152,68 @@ def command_from_line(line: str, host_width: int = 0) -> str:
     return make_inert(unescape(line[_PREFIX + (host_width + 2 if host_width else 0) :]))
 
 
+#: The four parallel columns a display line is built from.
+Columns = tuple[list[str], list[str], list[str], list[str]]
+
+
+def _columns_for(scope: Scope) -> tuple[cache.Cache, Columns | None]:
+    """The rows a scope is about, straight out of the cache's columns.
+
+    Split out of `lines_for` so a timeline can start from exactly the same set
+    -- asking the same question twice and getting different answers is how the
+    anchor `{n}` names would stop meaning what fzf thinks it means.
+    """
+    loaded = cache.load_columns()
+    if scope == "host":
+        return loaded, loaded.display_columns({store.machine().id})
+    if scope == "session":
+        session = os.environ.get("WOSWOAR_SESSION", "")
+        if not session:
+            # Not an error: this is what a shell without the hook loaded looks like.
+            return loaded, None
+        stamps, commands, codes, hosts = loaded.display_columns()
+        # The one column that is per entry rather than per file, so it is the
+        # one scope that cannot be answered by dropping whole files.
+        wanted = [i for i, value in enumerate(loaded.sessions()) if value == session]
+        return loaded, (
+            [stamps[i] for i in wanted],
+            [commands[i] for i in wanted],
+            [codes[i] for i in wanted],
+            [hosts[i] for i in wanted],
+        )
+    return loaded, loaded.display_columns()
+
+
+def _rows_for(columns: Columns, dedup: bool, around: int | None) -> tuple[list[Row], int]:
+    """The rows to display, and where the cursor belongs among them.
+
+    The second value is 1-based for fzf's `pos()` and is 0 when there is no
+    anchor to sit on -- which is every ordinary list, and also a timeline whose
+    anchor has gone.
+    """
+    stamps, commands, codes, hosts = columns
+    ranked = rank_rows(stamps, commands, codes, hosts, dedup=dedup)
+    if around is None:
+        return ranked, 0
+    anchor = ranked[around] if 0 <= around < len(ranked) else None
+    return _window_around(anchor, columns)
+
+
 def lines_for(
     scope: Scope,
     dedup: bool = True,
     limit: int | None = None,
     colour: bool = False,
     host_width: int | None = None,
+    around: int | None = None,
 ) -> list[str]:
     """The full pipeline: load, filter, rank, render.
+
+    With `around`, the answer is not a ranked list at all but the *timeline*
+    either side of one of its rows -- see `_window_around`. The row is named by
+    its position in the ranked list because that is what fzf can tell us: `{n}`
+    is the index of the highlighted item, and the list it indexes into is the
+    one this same function produced a moment earlier.
 
     The two columns a line is made of come straight out of the cache, without
     an `Entry` in between. On a real 54,804-command history that is 39 ms of
@@ -174,31 +225,71 @@ def lines_for(
     fetches one more column. `host` needs none: it is a property of the file,
     so the cache filters whole files out before a single row is looked at.
     """
-    loaded = cache.load_columns()
-    if scope == "host":
-        stamps, commands, codes, hosts = loaded.display_columns({store.machine().id})
-    elif scope == "session":
-        session = os.environ.get("WOSWOAR_SESSION", "")
-        if not session:
-            # Not an error: this is what a shell without the hook loaded looks like.
-            return []
-        stamps, commands, codes, hosts = loaded.display_columns()
-        # The one column that is per entry rather than per file, so it is the
-        # one scope that cannot be answered by dropping whole files.
-        wanted = [i for i, value in enumerate(loaded.sessions()) if value == session]
-        stamps = [stamps[i] for i in wanted]
-        commands = [commands[i] for i in wanted]
-        codes = [codes[i] for i in wanted]
-        hosts = [hosts[i] for i in wanted]
-    else:
-        stamps, commands, codes, hosts = loaded.display_columns()
-
-    rows = rank_rows(stamps, commands, codes, hosts, dedup=dedup)
+    loaded, columns = _columns_for(scope)
+    if columns is None:
+        return []
+    rows, _ = _rows_for(columns, dedup=dedup, around=around)
     if limit is not None:
         rows = rows[:limit]
     if host_width is None:
         host_width = host_width_for({meta.host for meta in loaded.meta.values() if meta.host})
     return render_rows(rows, colour=colour, host_width=host_width)
+
+
+#: How many commands a timeline shows either side of the one it is centred on.
+#: A screenful each way: enough that the thing you were looking for is usually
+#: already on it, few enough that the picker still opens instantly.
+TIMELINE_SPAN = 40
+
+
+def _window_around(anchor: Row | None, columns: Columns) -> tuple[list[Row], int]:
+    """Everything either side of `anchor`, oldest first.
+
+    Oldest first, unlike every other list here, because that is the direction
+    the question runs: you find the command you remember and then read *down*
+    into what you did next. Reversing that would make "scroll down" mean "go
+    back in time", which is the opposite of every log anyone has ever read.
+
+    Never deduplicated, also unlike every other list. A timeline with the
+    repeats collapsed is not a timeline -- running `cargo test` four times
+    while fixing something is the shape of what happened, and it is exactly
+    what you came here to see.
+
+    An anchor that is no longer in the list gives an empty window rather than a
+    wrong one. The index comes from fzf, and a background sync can merge new
+    commands between the picker opening and the key being pressed; showing the
+    wrong point in history confidently is worse than showing none.
+    """
+    if anchor is None:
+        return [], 0
+    stamps, commands, codes, hosts = columns
+    chronological = sorted(
+        zip((int(s) for s in stamps), commands, codes, hosts, strict=True),
+        key=_STAMP,
+    )
+    try:
+        # By identity of the whole row, not by timestamp: two machines can
+        # record in the same second, and `sorted` is stable but not meaningful
+        # between them.
+        at = chronological.index(anchor)
+    except ValueError:
+        return [], 0
+    start = max(0, at - TIMELINE_SPAN)
+    return chronological[start : at + TIMELINE_SPAN + 1], at - start + 1
+
+
+def anchor_position(index: int, scope: Scope, dedup: bool = True) -> int:
+    """Where fzf should put the cursor after unfolding a timeline.
+
+    Its own entry point because the answer has to reach fzf *before* the
+    reload it applies to: `transform` runs a shell command and prints the
+    actions to perform, so the position has to be known while composing
+    `reload(...)+pos(...)`, not after.
+    """
+    _, columns = _columns_for(scope)
+    if columns is None:
+        return 0
+    return _rows_for(columns, dedup=dedup, around=index)[1]
 
 
 def rank_rows(
@@ -360,14 +451,46 @@ def _header(host_width: int) -> str:
     Only with a column to filter on. On a single-machine install there is no
     machine name in the line and the hint would describe nothing.
 
-    Ctrl-R is listed only where it works: `transform` needs fzf 0.45+, and
-    advertising a key that does nothing is worse than staying quiet about it.
+    Ctrl-R and Ctrl-T are listed only where they work: both need `transform`,
+    which is fzf 0.45+, and advertising a key that does nothing is worse than
+    staying quiet about it.
     """
-    hints = ["ctrl-r cycles"] if fzf_supports_transform() else []
+    hints = ["ctrl-r cycles", "ctrl-t timeline"] if fzf_supports_transform() else []
     hints += ["ctrl-g global", "ctrl-h host", "ctrl-s session"]
     if host_width:
         hints.append("^name one machine")
     return " | ".join(hints)
+
+
+def _timeline_binding(self_cmd: str, dedup_flag: str, width: str) -> str:
+    """Ctrl-T shows what happened either side of the highlighted command.
+
+    `{n}` is fzf's index of that item, and the list it indexes into is the one
+    `woswoar list` just produced -- so the anchor needs nothing added to the
+    line and the display format is untouched.
+
+    The scope is read back out of the prompt, exactly as `_cycle_binding` does
+    and for the same reason: fzf holds no variables. It is carried into the
+    timeline's own prompt (`woswoar (timeline host)`) so that pressing this
+    again recentres without silently changing scope, and so that ctrl-g/h/s/r
+    still read a scope out of it on the way back out.
+    """
+    reload = f"{self_cmd} list --colour{width} --scope"
+    script = (
+        'case "$FZF_PROMPT" in '
+        "*global*) s=global ;; "
+        "*host*) s=host ;; "
+        "*session*) s=session ;; "
+        "*) s=global ;; "
+        "esac; "
+        # One extra invocation, on a keypress rather than on the prompt path:
+        # `pos` has to be composed into the same action string as the `reload`
+        # it applies to, so it cannot be read out of the reload's own output.
+        f"p=$({reload} $s{dedup_flag} --around {{n}} --print-anchor); "
+        f'printf "reload({reload} $s{dedup_flag} --around {{n}})'
+        '+pos($p)+change-prompt(woswoar (timeline $s) )"'
+    )
+    return f"--bind=ctrl-t:transform:{script}"
 
 
 def _fzf_argv(scope: Scope, query: str, dedup: bool, host_width: int) -> list[str]:
@@ -410,6 +533,7 @@ def _fzf_argv(scope: Scope, query: str, dedup: bool, host_width: int) -> list[st
     ]
     if fzf_supports_transform():
         argv.append(_cycle_binding(self_cmd, dedup_flag, width))
+        argv.append(_timeline_binding(self_cmd, dedup_flag, width))
     for key, target in (("ctrl-g", "global"), ("ctrl-h", "host"), ("ctrl-s", "session")):
         argv.append(
             f"--bind={key}:reload({self_cmd} list --colour{width} --scope {target}{dedup_flag})"

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -401,6 +401,38 @@ def _self_command() -> str:
     return f"{sys.executable} -m woswoar"
 
 
+#: The fzf that gained the `transform` action, which Ctrl-R cycling and the
+#: Ctrl-T timeline are both built on.
+TRANSFORM_SINCE = (0, 45)
+
+
+def fzf_version() -> tuple[str, tuple[int, int] | None]:
+    """What `fzf --version` says, and the (major, minor) parsed out of it.
+
+    Both halves, because they answer different questions: `doctor` shows a
+    person the string fzf printed, and the gate below compares numbers. Deriving
+    one from the other at each call site is how they would come to disagree.
+
+    The version is `None` when fzf is absent or says something unparseable, and
+    that reads as "too old" everywhere -- the safe direction, since an unknown
+    *action* in a `--bind` makes fzf refuse to start, so a wrong guess costs the
+    picker entirely rather than one key.
+    """
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["fzf", "--version"], capture_output=True, text=True, timeout=5, check=False
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return "", None
+    digits = out.split()[0].split(".") if out else []
+    try:
+        return out, (int(digits[0]), int(digits[1]))
+    except (IndexError, ValueError):
+        return out, None
+
+
 def fzf_supports_transform() -> bool:
     """Whether this fzf has the `transform` action, added in 0.45.
 
@@ -409,20 +441,8 @@ def fzf_supports_transform() -> bool:
     at all rather than no Ctrl-R cycling. One `fzf --version`, on a path that is
     already forking fzf.
     """
-    import subprocess
-
-    try:
-        out = subprocess.run(
-            ["fzf", "--version"], capture_output=True, text=True, timeout=5, check=False
-        ).stdout
-    except (OSError, subprocess.SubprocessError):
-        return False
-    digits = out.strip().split()[0].split(".") if out.strip() else []
-    try:
-        major, minor = int(digits[0]), int(digits[1])
-    except (IndexError, ValueError):
-        return False
-    return (major, minor) >= (0, 45)
+    _, parsed = fzf_version()
+    return parsed is not None and parsed >= TRANSFORM_SINCE
 
 
 def _cycle_binding(self_cmd: str, dedup_flag: str, width: str) -> str:


### PR DESCRIPTION
> use fzf search to find a particular command, then press ctrl-t to switch to timeline mode, the commands above and below unfold and I can scroll up and down and choose the surrounding ones

That, exactly. Half of what you want from history is not a command but the *next* one — you remember running the migration, and what you need is what you ran after it.

```
  woswoar (timeline global) >
   4h  cd ~/proj
   4h  cargo build
   4h  cargo test
   4h  vim src/lib.rs          <- cursor stays where you were
   4h  cargo test
   3h  git add -A
   3h  git commit -m wip
```

## It stays inside fzf

`reload` swaps the list underneath a picker that never closes, so you keep scrolling and press <kbd>Enter</kbd> on any neighbour. Ctrl-G/H/S/R still work and take you back out to an ordinary list.

**The cursor position is the part that makes it feel right.** Without fzf's `pos()`, a reload resets to the top of the window and the command you searched for is forty rows below — the surrounding commands unfold somewhere you are not looking. `pos()` needs the anchor's index in the *new* list, and `transform` composes `reload(...)+pos(...)` in one string, so the position has to be known before the reload it applies to has run. Hence `--print-anchor`: one extra invocation, on a keypress rather than on the prompt path.

**The anchor is fzf's `{n}`** — the index of the highlighted item — which indexes into the list `woswoar list` produced a moment earlier. So the display format is untouched and nothing had to be smuggled into the line to identify a row.

## Two deliberate differences from every other list

**Oldest first.** That is the direction the question runs: you find the command you remember and read *down* into what you did next. Reversing it would make "scroll down" mean "go back in time", which is the opposite of every log anyone has read.

**Never deduplicated.** Running `cargo test` four times while fixing something *is* the shape of what happened — and it is exactly what the deduplicated search list you arrived from was hiding.

## Verification

Eight mutations, all caught. Two survived first and both were mine to fix:

- The dedup mutation was **mis-aimed**: I mutated `rank_rows(dedup=...)`, but the timeline never goes through `rank_rows` at all — it is undeduplicated by construction. Re-aimed at the chronological list it actually builds.
- `test_an_anchor_that_has_gone...` used an out-of-range index, which returns before ever reaching the `ValueError` branch it claimed to cover. That branch is unreachable today — the anchor and the timeline come from the same columns — so it is now reached by making `rank_rows` return a row the data does not contain. Which is the point: it is the difference between an empty timeline and a confidently wrong one on the day those two stop agreeing.

Full preflight green: `ruff check`, `ruff format --check`, `mypy`, `shellcheck`, 641 tests.

## Note on ordering

Touches the same header string as #142, so whichever lands second needs a one-line conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)