### PR TITLE
release: 0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ names the one command to run next, if there is one:
 
 ```console
 $ woswoar
-woswoar 0.7.1 — 54,804 commands from 3 machines
+woswoar 0.7.2 — 54,804 commands from 3 machines
 
 1 machine(s) waiting to be accepted here:
     'martin@laptop'
@@ -96,7 +96,7 @@ one machine.
 > it brings itself up to date on the next background sync, so there is nothing
 > else to run; open a new shell to pick it up. `stable` tracks the most recent
 > tag, so the command never changes and you never edit a version number on five
-> machines. Swap `@stable` for `@main` to track the tip, or `@v0.7.1` to pin
+> machines. Swap `@stable` for `@main` to track the tip, or `@v0.7.2` to pin
 > exactly.
 >
 > **Coming from 0.6.x or earlier, run `woswoar install` once.** Those versions

--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"


### PR DESCRIPTION
Version bump only. Pushing `v0.7.2` afterwards is what cuts the release and moves `stable`.

Everything here came from the maintainer using it on a four-machine fleet.

## What is in it

**#143 — <kbd>Ctrl</kbd>+<kbd>T</kbd> unfolds the timeline around a command.** Find anything, press Ctrl-T, and the list becomes what happened either side of it, cursor still on what you found. Scroll into what led there or what came next and press Enter on any of them. Repeats are kept — running `cargo test` twice is the shape of what happened, and the deduplicated search list hides it.

The same PR reworked the help line, which now says what the keys do rather than that they do something:

```
ctrl-r global → host → session, or ctrl-g/h/s | ctrl-t timeline | ^name one machine
```

And `doctor` now reports which keys the local fzf can offer. An fzf below 0.45 gets a working picker with no Ctrl-R cycling and no Ctrl-T timeline — deliberate, since an unknown action in a `--bind` makes fzf refuse to start, but silent and indistinguishable from a bug:

```
[ok] fzf   /usr/bin/fzf  (0.44.1 (debian) - searching works; ctrl-r cycling
                          and the ctrl-t timeline need 0.45+)
```

**#142 — `^name` filters to one machine.** It always worked, because `--nth=2..` starts the searched region at the machine column and fzf anchors `^` to the front of it. Nothing said so. Asked for as "I have a host named `box` and that is short enough to also be part of a few commands".

**#141 — only *known* failures are marked, and only the age.** `~/.bash_history` records no exit codes, so `importer` stores -1 — and "anything but 0" painted every imported command red. On a freshly imported history that was the whole screen.

## Upgrading

```bash
pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
```

**From 0.7.1: nothing else.** The hook updates itself on the next background sync. Nothing in this release changes the hook anyway.

**From 0.6.x or earlier:** `woswoar install` once. Those versions have no background sync, so nothing is running that could notice.

No data migration: nothing about the record format, the repository layout, `state.json` or the day-key scheme changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)