### PR TITLE
Let users verify that nothing readable leaves their machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ editing, never executed behind your back.
 | ⚡ **~150 µs per command, zero forks** | the hook is pure bash; Python never runs on your prompt |
 | 🔎 **fzf as the UI** | the fuzzy finder you already know, not a bespoke TUI |
 | 🚚 **Imports what you have** | bash, zsh and atuin histories, idempotently |
-| 🧱 **~3500 lines of implementation** | small enough to read in an afternoon |
+| 🧱 **~4300 lines of implementation** | small enough to read in an afternoon |
+| 🐤 **Verifiable on your machine** | `woswoar doctor --prove` demonstrates, not asserts — see [verify it yourself](docs/verify.md) |
 
 > [!NOTE]
 > woswoar is a lighter alternative to [atuin](https://github.com/atuinsh/atuin).
@@ -294,8 +295,16 @@ and woswoar's wrapper is a few dozen lines of `subprocess`.
 Your **local** history is plaintext, though, and metadata like "how many machines
 and how often they sync" is visible to anyone holding the repo.
 
+None of that has to be taken on faith. `woswoar doctor --prove` records a
+canary command in a throwaway sandbox, syncs it, and shows you that it reaches
+the remote unreadable — and that is only the first of the checks you can run
+yourself, decrypting a chunk with stock `age` and no woswoar in the pipeline
+among them.
+
 📖 **[The full security model](docs/security.md)** — what is protected, what is
 not, and the guarantees CI asserts on every push.
+🐤 **[Verify it yourself](docs/verify.md)** — checks you run on your own
+machine, none of which ask you to believe a document.
 
 ## Coming from atuin
 
@@ -326,6 +335,7 @@ truthful. Re-running an import is idempotent.
 | `woswoar import bash\|zsh\|atuin` | import an existing history |
 | `woswoar stats` | entry counts, date range, most-used commands |
 | `woswoar doctor` | check the installation and the tools it needs |
+| `woswoar doctor --prove` | demonstrate in a sandbox that nothing readable is published |
 | `woswoar init [url]` | create or join an encrypted history repo |
 | `woswoar sync` | exchange history with the remote |
 | `woswoar accept` | add a machine you own: `grant` and `trust` at once |

--- a/docs/security.md
+++ b/docs/security.md
@@ -376,7 +376,11 @@ install from your distribution.
 
 ## ✅ Guarantees pinned by tests, not by prose
 
-Claims rot. The ones that matter are asserted in CI on every push:
+Claims rot. The ones that matter are asserted in CI on every push — and the
+central one does not even ask you to trust CI: `woswoar doctor --prove` walks
+a canary command through a sandboxed install on *your* machine and shows it
+reaching the remote unreadable. [Verify it yourself](verify.md) has that and
+every other check you can run without believing anyone.
 
 **Nobody else can put history in yours**
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -1,0 +1,179 @@
+# Verify it yourself
+
+[The security model](security.md) states what woswoar guarantees, and CI pins
+each claim with a test. This page is for the moment before you believe any of
+that: every section is a check **you run, on your machine, against the copy of
+woswoar you actually installed**. None of them asks you to trust a document,
+a badge, or the person who wrote this sentence.
+
+First, be clear about what there is to verify. The entire thing you are
+trusting is:
+
+- **this repository** — about 4,300 lines of implementation (twice that
+  counting its deliberately dense comments), readable in an afternoon, with
+  [zero runtime dependencies](../pyproject.toml): no PyPI packages, no
+  transitive tree, no post-install scripts;
+- **four system binaries** you install from your distribution and that
+  woswoar merely runs: `age`, `git`, `ssh-keygen`, `fzf`. All of the
+  cryptography happens inside the first three; woswoar composes no primitive
+  of its own.
+
+That is a small enough surface that "verify" can mean something. The checks
+below are ordered by effort, starting at one command.
+
+## 🐤 The one-command proof
+
+```console
+$ woswoar doctor --prove
+[--] sandbox      /tmp/woswoar-prove-... - a throwaway install; your real history is not touched
+[ok] recorded     the canary 'woswoar-canary-52bc...' sits in the sandbox's plaintext log, exactly as logs/ holds your own
+[ok] published    1 line(s) sealed into 1 chunk(s) and pushed to the sandbox's remote
+[ok] sealed       the pushed chunk decrypts back to the canary -- with the sandbox's private key, which never left this machine
+[ok] unreadable   the canary appears in none of the 35,308 bytes on the remote
+[ok] anonymous    neither is any of: 'you@yourhost', 'you', 'yourhost'
+```
+
+This builds a complete throwaway installation in a temporary directory — its
+own identity, signing key, and a bare git "remote" that is just another
+directory — records one canary command, syncs, and then walks the round trip:
+
+- **recorded**: the canary is in the sandbox's plaintext log, because
+  [local logs are plaintext](security.md#%EF%B8%8F-what-is-not-protected) and
+  pretending otherwise would be the opposite of this page;
+- **sealed**: the chunk that reached the remote decrypts back to the canary,
+  so the proof is about your history, not about an empty repository;
+- **unreadable** and **anonymous**: neither the canary nor this machine's
+  username or hostname appears in *any* byte on the remote — including every
+  git object, decompressed, which is where committed bytes actually live.
+
+It runs the installed code, needs no network, and touches nothing of your real
+installation. A `FAIL` is a defect in woswoar itself — please
+[report it](https://github.com/martinus/woswoar/issues). Re-run it after every
+upgrade; it is the upgrade you are re-deciding to trust.
+
+## 🕵️ The same thing by hand, on your real history
+
+The sandbox proves the code. Your own repository is the thing you care about,
+and the same canary walk works there — type a marker, sync, and search every
+byte your repo holds:
+
+```console
+$ echo woswoar-canary-look-for-me
+$ woswoar sync
+$ grep -r woswoar-canary ~/.local/share/woswoar/logs
+.../2026-08-04.tsv:1785843371	s1	~	0	1	echo woswoar-canary-look-for-me
+$ git -C ~/.local/share/woswoar/history cat-file --batch-all-objects --batch | grep -a woswoar-canary
+$
+```
+
+The first search finds the plaintext log, which is local, `0600`, and
+documented. The second inflates **every git object in the repository** — every
+byte a `git push` has ever sent or will send — and finds nothing.
+
+`cat-file --batch-all-objects` rather than `grep -r`, because git stores
+objects zlib-compressed: a raw byte scan of the repository would come back
+clean *even if your history were committed in plaintext*. Inflating the
+objects first is the difference between a scan and a ritual.
+
+## 🔓 Read your history without woswoar
+
+The strongest evidence that the encryption is real, standard age — and that
+your data is not held hostage by this tool — is decrypting a chunk with no
+woswoar in the pipeline:
+
+```sh
+H=~/.local/share/woswoar/history
+ID=$(sed -n 's/^id=//p' ~/.config/woswoar/machine)          # this machine's opaque host id
+KEY=$(sed -n 's/^identity=//p' ~/.config/woswoar/machine)   # the identity it decrypts with
+DAY=$(date +%F)
+
+for chunk in "$H/hosts/$ID/$DAY/"*.age; do
+  age -d -i <(age -d -i "$KEY" "$H/hosts/$ID/keys/$DAY.age") "$chunk" |
+    python3 -c 'import sys,zlib; sys.stdout.buffer.write(zlib.decompress(sys.stdin.buffer.read()))'
+done
+```
+
+That prints today's commands as tab-separated plaintext, and everything in the
+pipeline is somebody else's audited tool. The two `age -d` calls are the two
+layers of [the design](security.md): each day has its own key, sealed to your
+machines' keys — the inner call opens the day key, the outer opens the chunk
+with it. The `zlib` line exists because chunks are compressed *before*
+sealing; ciphertext does not compress, so it is then or never.
+
+Nothing above needed woswoar installed at all. If this project is abandoned
+tomorrow, that loop — or the plain TSV files in `logs/` — is your history.
+
+## 🔌 It cannot phone home if there is no phone
+
+woswoar has no server and no account; the only thing that ever touches a
+network is `git` talking to the remote *you* configured. A remote can be a
+directory, so the whole system runs with no network at all — which you can
+make a hard fact rather than a claim:
+
+```console
+$ unshare -rn woswoar sync        # a network namespace with no interfaces
+in sync with the remote
+```
+
+Or watch the syscalls: against a directory remote, a full sync makes **zero**
+`connect()` calls —
+
+```console
+$ strace -f -e trace=connect -o /tmp/trace woswoar sync && grep -c connect /tmp/trace
+0
+```
+
+With a remote on a git host, every connection you see in that trace is git
+reaching the address you gave `woswoar init`, and nothing else.
+
+## 🧪 Run the guarantee suite where you can watch
+
+The tables in [security.md](security.md#-guarantees-pinned-by-tests) —
+forged history is refused, tampering is refused, a revoked machine stays
+revoked — are each backed by a test, and the suite runs anywhere:
+
+```sh
+git clone https://github.com/martinus/woswoar && cd woswoar
+python -m tools.run_tests
+```
+
+The tests drive real `age`, real `git` and a real `bash` rather than mocks —
+two simulated machines exchanging history through a bare repository, attacks
+mounted and refused. A claim you can watch fail when you break the code is a
+different thing from a claim in prose.
+
+## 📦 Know what you installed
+
+woswoar is pure Python installed from a git checkout — no build step, no
+binary artifact between the code you can read and the code that runs. So the
+two can be compared directly:
+
+```sh
+SRC=$(pipx runpip woswoar show woswoar | sed -n 's/^Location: //p')
+VERSION=$(pipx runpip woswoar show woswoar | sed -n 's/^Version: //p')
+git clone -q --branch "v$VERSION" https://github.com/martinus/woswoar /tmp/woswoar-src
+diff -r -x __pycache__ "$SRC/woswoar" /tmp/woswoar-src/woswoar && echo identical
+```
+
+The install line in the README tracks `stable`, a branch the release workflow
+fast-forwards — convenient, and it means whoever controls the GitHub
+repository controls what your next upgrade installs. If that is a trade you
+do not want, pin the exact commit you audited; a full commit hash is a handle
+nobody can quietly move:
+
+```sh
+pipx install --force "git+https://github.com/martinus/woswoar.git@<full 40-character sha>"
+```
+
+## ⚠️ What none of this can show
+
+Honesty about limits is part of the story, here as in
+[the security model](security.md#%EF%B8%8F-what-is-not-protected). These
+checks demonstrate what this install did on the paths you exercised. They
+cannot prove the absence of a channel that hides deliberately — behavior that
+triggers on a date, a hostname, the thousandth sync. No black-box test can;
+that assurance only comes from reading the code, which is why the size of the
+trust surface is the load-bearing fact on this page. What the checks do is
+shrink the leap of faith to: *these few thousand dependency-free lines, whose
+observable behavior I just tested, do not contain a bomb.* For a local tool,
+that is as good as verifiable trust gets.

--- a/tests/support.py
+++ b/tests/support.py
@@ -97,16 +97,11 @@ def make_entry(ts: int, cmd: str, host: str = MACHINE_ID, session: str = "s1") -
     return Entry(ts=ts, host=host, session=session, cwd="/tmp", exit_code=0, duration_ms=1, cmd=cmd)
 
 
-#: Every environment variable store.py consults. Shared with tests/test_sync.py
-#: so a new one cannot be isolated in one place and leak in the other.
-ENV_KEYS = (
-    "WOSWOAR_DIR",
-    "WOSWOAR_SESSION",
-    "XDG_CONFIG_HOME",
-    "XDG_CACHE_HOME",
-    "XDG_DATA_HOME",
-    "XDG_RUNTIME_DIR",
-)
+#: Every environment variable store.py consults, from the module that owns the
+#: list -- so a variable added there cannot be isolated here and leak in
+#: `prove`'s sandbox, or the reverse. This alias keeps the suite's historical
+#: import path working.
+ENV_KEYS = store.ENV_KEYS
 
 
 class WoswoarTestCase(unittest.TestCase):

--- a/tests/test_prove.py
+++ b/tests/test_prove.py
@@ -1,0 +1,125 @@
+"""`doctor --prove` must catch the leak it exists to catch.
+
+The proof is fault injection: strip the sealing out from under the real sync
+and watch the scan go red. A prove that stays green with encryption disabled
+would be decoration -- on the one command whose entire job is to be believed.
+
+The machine name is pinned to ``canaryuser@canaryhost`` throughout, because the
+sandbox otherwise names itself after the account running the suite, and whether
+that name is searchable (length, collision with woswoar's own boilerplate)
+would then vary by machine -- the anonymity assertions here must not.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import zlib
+from pathlib import Path
+from unittest import mock
+
+from woswoar import crypto, prove, store, sync
+
+from . import support
+from .support import WoswoarTestCase, requires_age, requires_git, requires_ssh_keygen
+
+
+@requires_age
+@requires_git
+@requires_ssh_keygen
+class ProveTestCase(WoswoarTestCase):
+    def prove(self) -> support.Ran:
+        with mock.patch.object(
+            store, "default_machine_name", return_value="canaryuser@canaryhost"
+        ):
+            return support.run_cli("doctor", "--prove")
+
+
+class TestACleanInstallProves(ProveTestCase):
+    def test_every_check_passes(self) -> None:
+        ran = self.prove()
+        self.assertEqual(ran.code, 0, ran.out + ran.err)
+        for label in ("recorded", "published", "sealed", "unreadable", "anonymous"):
+            self.assertIn(f"[ok] {label}", ran.out)
+        # Both name halves were really searched, not quietly skipped.
+        self.assertIn("'canaryuser'", ran.out)
+        self.assertIn("'canaryhost'", ran.out)
+        self.assertNotIn("not searched", ran.out)
+
+    def test_the_real_installation_is_not_touched(self) -> None:
+        """The sandbox must be a world of its own, and must be gone afterwards.
+
+        `mkdtemp` is watched rather than the temp directory listed, because
+        other suites run in parallel and their sandboxes come and go.
+        """
+        made: list[str] = []
+        real_mkdtemp = tempfile.mkdtemp
+
+        def watched(prefix: str = "") -> str:
+            path = real_mkdtemp(prefix=prefix)
+            made.append(path)
+            return path
+
+        saved = {key: os.environ.get(key) for key in prove._ENV_KEYS}
+        with mock.patch.object(tempfile, "mkdtemp", side_effect=watched):
+            ran = self.prove()
+
+        self.assertEqual(ran.code, 0, ran.out + ran.err)
+        self.assertEqual(saved, {key: os.environ.get(key) for key in prove._ENV_KEYS})
+        self.assertEqual(len(made), 1)
+        self.assertFalse(Path(made[0]).exists())
+        # This test environment's own store: prove created nothing in it.
+        self.assertFalse(store.history_dir().exists())
+        self.assertFalse(store.logs_dir().exists())
+
+
+class TestAPlantedLeakIsCaught(ProveTestCase):
+    """Encryption stripped out from under the real pipeline.
+
+    Chunks, day keys and the sealed machine name all reach the remote as
+    plaintext -- through the real export, the real git, the real push. The scan
+    of the remote's decompressed objects is the only thing left standing
+    between that and a green run, which is exactly the claim under test.
+    """
+
+    def test_readable_bytes_on_the_remote_go_red(self) -> None:
+        with (
+            mock.patch.object(crypto, "encrypt_to", lambda data, recipient: data),
+            mock.patch.object(crypto, "encrypt_to_recipients", lambda data, recipients: data),
+            mock.patch.object(sync, "pack", lambda data: data),
+        ):
+            ran = self.prove()
+        self.assertEqual(ran.code, 1, ran.out + ran.err)
+        self.assertIn("[FAIL] unreadable", ran.out)
+        self.assertIn("[FAIL] anonymous", ran.out)
+
+
+class TestNothingPublishedGoesRed(ProveTestCase):
+    """An export that silently does nothing must not leave an absence proof
+    standing: a repo that never held the canary proves nothing by lacking it."""
+
+    def test_an_empty_sync_cannot_pass(self) -> None:
+        with mock.patch.object(sync, "export", lambda known, state, report, now: False):
+            ran = self.prove()
+        self.assertEqual(ran.code, 1, ran.out + ran.err)
+        self.assertIn("[FAIL] published", ran.out)
+
+
+class TestAWrongChunkGoesRed(ProveTestCase):
+    """Chunks that seal, push and decrypt perfectly -- holding the wrong bytes.
+
+    Catches a `sealed` check that trusts the plumbing instead of reading what
+    came back: every step of the pipeline succeeds here except the one fact the
+    check is supposed to establish.
+    """
+
+    def test_a_chunk_without_the_canary_fails_sealed(self) -> None:
+        with mock.patch.object(
+            sync, "pack", lambda data: zlib.compress(b"1700000000\tprove\t~\t0\t1\tnot it\n")
+        ):
+            ran = self.prove()
+        self.assertEqual(ran.code, 1, ran.out + ran.err)
+        self.assertIn("[FAIL] sealed", ran.out)
+        # The canary genuinely never reached the remote, so the absence scans
+        # still hold; only the presence proof may be what failed.
+        self.assertIn("[ok] unreadable", ran.out)

--- a/tests/test_prove.py
+++ b/tests/test_prove.py
@@ -13,7 +13,11 @@ would then vary by machine -- the anonymity assertions here must not.
 from __future__ import annotations
 
 import os
+import re
+import subprocess
 import tempfile
+import time
+import unittest
 import zlib
 from pathlib import Path
 from unittest import mock
@@ -21,15 +25,15 @@ from unittest import mock
 from woswoar import crypto, prove, store, sync
 
 from . import support
-from .support import WoswoarTestCase, requires_age, requires_git, requires_ssh_keygen
+from .support import WoswoarTestCase, requires_age, requires_bash, requires_git, requires_ssh_keygen
 
 
 @requires_age
 @requires_git
 @requires_ssh_keygen
 class ProveTestCase(WoswoarTestCase):
-    def prove(self) -> support.Ran:
-        with mock.patch.object(store, "default_machine_name", return_value="canaryuser@canaryhost"):
+    def prove(self, name: str = "canaryuser@canaryhost") -> support.Ran:
+        with mock.patch.object(store, "default_machine_name", return_value=name):
             return support.run_cli("doctor", "--prove")
 
 
@@ -121,3 +125,100 @@ class TestAWrongChunkGoesRed(ProveTestCase):
         # The canary genuinely never reached the remote, so the absence scans
         # still hold; only the presence proof may be what failed.
         self.assertIn("[ok] unreadable", ran.out)
+
+
+class TestACollidingNameIsSkippedNotFailed(ProveTestCase):
+    """A user or host that collides with woswoar's own boilerplate.
+
+    `hosts/` and `keys/` sit in every tree object, "localhost" is in the commit
+    email -- a machine actually named after any of those must not be told the
+    proof failed and to file a bug. The token is skipped, *said* to be skipped,
+    and the full `user@host` form is searched regardless. This is the branch
+    the pinned fixture name everywhere else deliberately avoids.
+    """
+
+    def test_boilerplate_and_short_tokens_are_reported_not_searched(self) -> None:
+        ran = self.prove(name="keys@localhost")
+        self.assertEqual(ran.code, 0, ran.out + ran.err)
+        self.assertIn("[ok] anonymous", ran.out)
+        self.assertIn("'keys@localhost'", ran.out)
+        self.assertIn("'keys' was not searched for", ran.out)
+        self.assertIn("'localhost' was not searched for", ran.out)
+
+    def test_a_short_token_is_reported_not_searched(self) -> None:
+        ran = self.prove(name="ab@canaryhost")
+        self.assertEqual(ran.code, 0, ran.out + ran.err)
+        self.assertIn("'ab' was not searched for", ran.out)
+        self.assertIn("'canaryhost'", ran.out)
+
+
+@requires_age
+@requires_git
+@requires_ssh_keygen
+@requires_bash
+class TestTheDocsRecipeStillDecrypts(unittest.TestCase):
+    """docs/verify.md's "read your history without woswoar" block, executed.
+
+    The recipe hardcodes the repo layout -- `hosts/<id>/keys/<day>.age`, the
+    `machine` kv file, the zlib step -- because its whole point is to work with
+    no woswoar in the pipeline. Nothing else would notice that layout moving
+    under it, and a silently broken recipe is the worst outcome for a page
+    whose premise is that you should not have to trust the page.
+    """
+
+    @staticmethod
+    def _recipe() -> str:
+        text = (Path(__file__).parent.parent / "docs" / "verify.md").read_text(encoding="utf-8")
+        blocks: list[str] = [
+            b for b in re.findall(r"```sh\n(.*?)```", text, re.S) if "for chunk in" in b
+        ]
+        assert len(blocks) == 1, "expected exactly one decrypt recipe in docs/verify.md"
+        return blocks[0]
+
+    def test_the_recipe_prints_the_recorded_command(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="woswoar-docs-") as tmp:
+            root = Path(tmp)
+            (root / "home").mkdir()
+            (root / "home" / ".gitconfig").write_text(prove.QUIET_MAINTENANCE, encoding="utf-8")
+            saved = {key: os.environ.get(key) for key in prove._ENV_KEYS}
+            try:
+                # Only HOME is set: the recipe spells paths as `~/...`, so the
+                # fixture must resolve them the way a stock install would.
+                for key in prove._ENV_KEYS:
+                    os.environ.pop(key, None)
+                os.environ["HOME"] = str(root / "home")
+                origin = root / "origin.git"
+                subprocess.run(
+                    ["git", "init", "--quiet", "--bare", "--template=", str(origin)],
+                    check=True,
+                    timeout=60,
+                )
+                sync.initialise(remote=str(origin), new_identity=True)
+                known = store.machine()
+
+                # Twice at most: the recipe reads `date +%F` on its own clock,
+                # so a run that straddles midnight records into yesterday's
+                # chunk and finds nothing. Re-recording is then enough; a
+                # recipe that is genuinely broken fails both times.
+                for _ in range(2):
+                    entry = support.make_entry(
+                        int(time.time()), "echo docs-recipe-canary", host=known.id
+                    )
+                    store.append_entries(known.id, [entry])
+                    sync.run()
+                    ran = subprocess.run(
+                        ["bash", "-euo", "pipefail", "-c", self._recipe()],
+                        capture_output=True,
+                        text=True,
+                        timeout=120,
+                    )
+                    if ran.returncode == 0 and "echo docs-recipe-canary" in ran.stdout:
+                        break
+                self.assertEqual(ran.returncode, 0, ran.stdout + ran.stderr)
+                self.assertIn("echo docs-recipe-canary", ran.stdout)
+            finally:
+                for key, value in saved.items():
+                    if value is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = value

--- a/tests/test_prove.py
+++ b/tests/test_prove.py
@@ -29,9 +29,7 @@ from .support import WoswoarTestCase, requires_age, requires_git, requires_ssh_k
 @requires_ssh_keygen
 class ProveTestCase(WoswoarTestCase):
     def prove(self) -> support.Ran:
-        with mock.patch.object(
-            store, "default_machine_name", return_value="canaryuser@canaryhost"
-        ):
+        with mock.patch.object(store, "default_machine_name", return_value="canaryuser@canaryhost"):
             return support.run_cli("doctor", "--prove")
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 from unittest import mock
 
-from woswoar import cache, crypto, progress, search, store, sync
+from woswoar import cache, crypto, progress, prove, search, store, sync
 from woswoar.__main__ import _GRANT_REMEDY, HOOK_NAME, main
 from woswoar.__main__ import _hook_bytes as main_hook_bytes
 from woswoar.entry import Entry, format_line
@@ -53,7 +53,11 @@ _ENV = (*support.ENV_KEYS, "HOME")
 #: new each time teaches people to re-run it rather than read it. What makes the
 #: *clone* safe is `--no-local`, which has its own test; this only stops git's
 #: housekeeping showing up as whichever test was unlucky.
-QUIET_MAINTENANCE = "[gc]\n\tauto = 0\n\tautoDetach = false\n[receive]\n\tautogc = false\n"
+#:
+#: The constant itself lives in `prove`, which builds the same kind of
+#: short-lived repository for users and would show the same flakes as a failed
+#: proof; one copy, so a knob learned here reaches there and back.
+QUIET_MAINTENANCE = prove.QUIET_MAINTENANCE
 
 
 class Fake:
@@ -271,7 +275,13 @@ class TestSingleMachine(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "sudo rm -rf /very-secret-path")
             sync.run()
-            blob = b"".join(p.read_bytes() for p in store.history_dir().rglob("*") if p.is_file())
+            # Through the same scanner `doctor --prove` ships, so the suite and
+            # the user-facing proof cannot disagree about what "no readable
+            # byte" means. It inflates the git objects too: a raw walk cannot
+            # see into a superseded revision of a rewritten file, which lives
+            # only zlib-compressed under `objects/` -- and is pushed all the
+            # same.
+            blob = b"".join(data for _, data in prove._published_bytes(store.history_dir()))
         self.assertNotIn(b"very-secret-path", blob)
         self.assertNotIn(b"sudo", blob)
 
@@ -2888,13 +2898,13 @@ class TestRecipientsPublishNoNames(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "git status")
             sync.run()
-            # `.git` included, deliberately: it is where git would record an
-            # author identity, so leaving it out would skip the weakest link in
-            # the claim. `_ensure_repo_config` pins the author to a constant,
-            # and this is what keeps that true.
-            committed = b"".join(
-                path.read_bytes() for path in store.history_dir().rglob("*") if path.is_file()
-            )
+            # Through `doctor --prove`'s scanner: it walks `.git` -- where git
+            # would record an author identity, kept constant by
+            # `_ensure_repo_config` -- and additionally inflates every object,
+            # where a name in a *superseded* revision of `recipients.txt`
+            # would hide from a raw walk and still be pushed. That rewritten
+            # file is exactly how #22 leaked names in the first place.
+            committed = b"".join(data for _, data in prove._published_bytes(store.history_dir()))
         self.assertNotIn(b"secret-box", committed)
         self.assertNotIn(b"zqoperator", committed)
 

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -300,6 +300,20 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         """Context that cannot fail, kept visually distinct from a real check."""
         print(f"{marker['info']} {label:<12} {detail}")
 
+    if args.prove:
+        from . import prove
+
+        prove.run(check, info)
+        if not ok:
+            # Unlike the checks below, nothing here is the user's to fix: the
+            # sandbox is built from scratch, so a FAIL can only be woswoar
+            # publishing something it promised not to.
+            print(
+                "\nA FAIL above is a defect in woswoar itself, not in your setup."
+                "\nPlease report it: https://github.com/martinus/woswoar/issues"
+            )
+        return 0 if ok else 1
+
     bash = shutil.which("bash")
     version = ""
     if bash:
@@ -1634,8 +1648,15 @@ def build_parser() -> argparse.ArgumentParser:
         and the state of the history repo -- and prints what to do about each
         failure rather than only that it failed.
 
-        Changes nothing.
+        Changes nothing. With --prove it instead demonstrates, in a throwaway
+        sandbox that never touches your real history, that a recorded command
+        reaches the remote unreadable: see docs/verify.md.
         """,
+    )
+    p_doctor.add_argument(
+        "--prove",
+        action="store_true",
+        help="record a canary in a sandbox, sync it, and prove nothing readable was published",
     )
     p_doctor.set_defaults(func=cmd_doctor)
 

--- a/woswoar/prove.py
+++ b/woswoar/prove.py
@@ -34,7 +34,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from . import crypto, deps, store, sync
-from .entry import Entry, format_line
+from .entry import Entry
 from .errors import WoswoarError
 
 #: Print one pass/fail line, in whatever shape the caller renders checks.
@@ -42,37 +42,44 @@ Check = Callable[[str, bool, str], None]
 #: Print one line of context that cannot fail.
 Info = Callable[[str, str], None]
 
-#: Everything that decides where woswoar -- and git -- read and write. All
-#: redirected into the sandbox: HOME because git reads ``~/.gitconfig``, whose
-#: hooks and filters must neither run against the sandbox nor colour the proof.
-_ENV_KEYS = (
-    "HOME",
-    "WOSWOAR_DIR",
-    "WOSWOAR_SESSION",
-    "XDG_CONFIG_HOME",
-    "XDG_CACHE_HOME",
-    "XDG_DATA_HOME",
-    "XDG_RUNTIME_DIR",
-)
+#: `store.ENV_KEYS` is everything woswoar itself resolves paths from; HOME is
+#: for git, which reads ``~/.gitconfig``, whose hooks and filters must neither
+#: run against the sandbox nor colour the proof.
+_ENV_KEYS = (*store.ENV_KEYS, "HOME")
 
 #: git's background `gc --auto` detaches and keeps repacking after the command
-#: that triggered it returns -- so it would still be rewriting the origin while
-#: the scan below reads it and the cleanup deletes it. Same setting, same
-#: reason, as the sync test suite.
-_QUIET_MAINTENANCE = "[gc]\n\tauto = 0\n\tautoDetach = false\n[receive]\n\tautogc = false\n"
+#: that triggered it returns -- so it would still be rewriting a short-lived
+#: repository while a scan reads it and the cleanup deletes it. The sync test
+#: suite met that as five separate red mains in three disguises before pinning
+#: it down (see tests/test_sync.py, which imports this); here it would surface
+#: as a randomly failed proof.
+QUIET_MAINTENANCE = "[gc]\n\tauto = 0\n\tautoDetach = false\n[receive]\n\tautogc = false\n"
 
-#: Strings woswoar itself writes into every repository. A username or hostname
-#: that happens to be one of them cannot be told from this boilerplate by
-#: searching bytes, so it is reported as not searchable rather than searched
-#: and wrongly failed. Two real shapes, met on the first two machines this ran
-#: on: a machine named "localhost" collides with the commit email, and a user
-#: sharing a name with the maintainer collides with the repository URL in the
-#: committed README.
+#: Strings woswoar itself writes into every repository -- commit boilerplate,
+#: the committed files, and every path component a tree object carries. A
+#: username or hostname that happens to be one of them cannot be told from
+#: this boilerplate by searching bytes, so it is reported as not searchable
+#: rather than searched and wrongly failed. Two real shapes, met on the first
+#: two machines this ran on: a machine named "localhost" collides with the
+#: commit email, and a user sharing a name with the maintainer collides with
+#: the repository URL in the committed README.
 _BOILERPLATE = (
     sync.COMMIT_NAME,
     sync.COMMIT_EMAIL,
     sync.COMMIT_MESSAGE,
     store.README_CONTENT,
+    store.GITATTRIBUTES_CONTENT,
+    store.README,
+    store.GITATTRIBUTES,
+    store.RECIPIENTS,
+    # The repo-layout names, from the module that owns them: tree objects
+    # spell out every directory and file name under `hosts/`.
+    store._HOSTS,
+    store._KEYS,
+    store._MANIFESTS,
+    store.signer_public("x").name,
+    store.name_seal("x").name,
+    # git's own vocabulary in refs and config.
     "main",
     "master",
     "origin",
@@ -91,15 +98,16 @@ def _sandbox() -> Iterator[Path]:
     Restoring the environment in ``finally`` is what makes this safe to run
     from inside a live installation: every store path is resolved from the
     environment on each call, so nothing read or written in here can land in
-    the real one.
+    the real one. Only ``home`` is created up front -- the write below does
+    not make parents -- everything else woswoar creates itself, owner-only,
+    exactly as it would on a real machine.
     """
     saved = {key: os.environ.get(key) for key in _ENV_KEYS}
     tmp = tempfile.mkdtemp(prefix="woswoar-prove-")
     try:
         root = Path(tmp)
-        for name in ("data", "conf", "cache", "home"):
-            (root / name).mkdir()
-        (root / "home" / ".gitconfig").write_text(_QUIET_MAINTENANCE, encoding="utf-8")
+        (root / "home").mkdir()
+        (root / "home" / ".gitconfig").write_text(QUIET_MAINTENANCE, encoding="utf-8")
         for key in _ENV_KEYS:
             os.environ.pop(key, None)
         os.environ.update(
@@ -121,9 +129,9 @@ def _sandbox() -> Iterator[Path]:
         shutil.rmtree(tmp, ignore_errors=True)
 
 
-def _git_bytes(*args: str) -> bytes:
+def _git_bytes(*args: str, cwd: Path | None = None) -> bytes:
     """git output as raw bytes; `sync.git` decodes, and objects are not text."""
-    done = subprocess.run(["git", *args], capture_output=True, check=False, timeout=60)
+    done = subprocess.run(["git", *args], capture_output=True, check=False, timeout=60, cwd=cwd)
     if done.returncode != 0:
         raise WoswoarError(
             f"git {args[0]} failed in the sandbox:\n{done.stderr.decode('utf-8', 'replace')}"
@@ -131,24 +139,33 @@ def _git_bytes(*args: str) -> bytes:
     return done.stdout
 
 
-def _published_bytes(origin: Path) -> list[tuple[str, bytes]]:
-    """Every byte the sandbox pushed, by name, decompressed where git compresses.
+def _published_bytes(repo: Path) -> list[tuple[str, bytes]]:
+    """Every byte ``repo`` holds, by name, decompressed where git compresses.
 
-    Two passes over the same repository, because each is blind where the other
-    sees. The raw files cover refs, config and packed-refs -- but a leak inside
-    a *committed* file lives zlib-compressed in ``objects/``, where no byte
-    scan can recognise it. ``cat-file --batch-all-objects`` prints every
-    object inflated: blobs, and also the trees and commits that carry paths,
+    Two passes, because each is blind where the other sees. The raw files
+    cover refs, config, packed-refs and any working tree -- but a committed
+    byte lives zlib-compressed under ``objects/``, where no byte scan can
+    recognise it, so that directory is skipped raw and read through
+    ``cat-file --batch-all-objects`` instead, which prints every object
+    inflated: blobs, and also the trees and commits that carry paths,
     directory names and author lines.
     """
+    git_dir = Path(_git_bytes("rev-parse", "--absolute-git-dir", cwd=repo).decode().strip())
+    objects = git_dir / "objects"
     streams = [
-        (str(path.relative_to(origin)), path.read_bytes())
-        for path in sorted(origin.rglob("*"))
-        if path.is_file()
+        (str(path.relative_to(repo)), path.read_bytes())
+        for path in sorted(repo.rglob("*"))
+        if path.is_file() and objects not in path.parents
     ]
-    inflated = _git_bytes("-C", str(origin), "cat-file", "--batch-all-objects", "--batch")
+    inflated = _git_bytes("cat-file", "--batch-all-objects", "--batch", cwd=repo)
     streams.append(("every git object, decompressed", inflated))
     return streams
+
+
+def _find(streams: list[tuple[str, bytes]], text: str) -> list[str]:
+    """The stream names in which ``text``'s bytes appear."""
+    needle = text.encode("utf-8")
+    return [where for where, data in streams if needle in data]
 
 
 def _pushed_plaintext(origin: Path, known: store.Machine, day: str) -> bytes:
@@ -157,41 +174,41 @@ def _pushed_plaintext(origin: Path, known: store.Machine, day: str) -> bytes:
     Read from the origin's objects, not from the local checkout: the claim
     being proven is about what *left* the machine, so that is what is opened.
     """
-    tip = _git_bytes("-C", str(origin), "rev-list", "--all", "-n", "1").decode().strip()
+    tip = _git_bytes("rev-list", "--all", "-n", "1", cwd=origin).decode().strip()
     if not tip:
         raise WoswoarError("the sandbox remote holds no commit")
     history = store.history_dir()
     sealed_rel = store.day_key(known.id, day).relative_to(history)
-    sealed = _git_bytes("-C", str(origin), "cat-file", "blob", f"{tip}:{sealed_rel}")
-    day_secret = crypto.decrypt_with_file(sealed, sync.identity_path(known)).decode("utf-8")
+    sealed = _git_bytes("cat-file", "blob", f"{tip}:{sealed_rel}", cwd=origin)
+    day_secret = sync.open_day_key_bytes(known, sealed)
 
     chunk_rel = store.chunk_dir(known.id, day).relative_to(history)
-    listing = _git_bytes(
-        "-C", str(origin), "ls-tree", "-r", "--name-only", tip, str(chunk_rel)
-    ).decode("utf-8")
-    plaintext = b""
+    listing = _git_bytes("ls-tree", "-r", "--name-only", tip, str(chunk_rel), cwd=origin).decode(
+        "utf-8"
+    )
+    pieces = []
     for name in listing.splitlines():
-        blob = _git_bytes("-C", str(origin), "cat-file", "blob", f"{tip}:{name}")
-        plaintext += sync.unpack(crypto.decrypt_with_secret(blob, day_secret))
-    return plaintext
+        blob = _git_bytes("cat-file", "blob", f"{tip}:{name}", cwd=origin)
+        pieces.append(sync.unpack(crypto.decrypt_with_secret(blob, day_secret)))
+    return b"".join(pieces)
 
 
-def _name_tokens(name: str) -> tuple[list[str], list[str]]:
+def _name_tokens(name: str) -> tuple[list[str], list[tuple[str, str]]]:
     """Split ``user@host`` into what can be searched for and what cannot.
 
     The full name is always searchable -- ``@`` keeps it out of any encoding a
     repository legitimately contains. The halves are searched one by one so a
     leak of either alone is still caught, except where a byte search cannot
-    mean anything: a token short enough to appear in ciphertext by chance, or
-    one that woswoar's own boilerplate already contains everywhere.
+    mean anything; those come back as ``(token, why not)`` pairs, said to the
+    user rather than silently narrowing the claim.
     """
     user, _, host = name.partition("@")
     searchable, unsearchable = [name], []
     for token in (user, host):
         if len(token) < _MIN_TOKEN:
-            unsearchable.append(f"{token!r} (short enough to appear in ciphertext by chance)")
+            unsearchable.append((token, "short enough to appear in ciphertext by chance"))
         elif any(token in text for text in _BOILERPLATE):
-            unsearchable.append(f"{token!r} (woswoar's own boilerplate happens to contain it)")
+            unsearchable.append((token, "woswoar's own boilerplate happens to contain it"))
         else:
             searchable.append(token)
     return searchable, unsearchable
@@ -205,15 +222,23 @@ def run(check: Check, info: Info) -> None:
     """
     crypto.require()
     crypto.require_signing()
-    if shutil.which("git") is None:
-        raise WoswoarError(f"git is required - {deps.advice([deps.GIT])}")
+    if not deps.GIT.present:
+        raise WoswoarError(deps.report([deps.GIT]))
 
     # Long enough that finding it anywhere is a fact, not a coincidence.
     marker = f"woswoar-canary-{secrets.token_hex(12)}"
 
     with _sandbox() as root:
         origin = root / "origin.git"
-        _git_bytes("init", "--quiet", "--bare", str(origin))
+        # `--template=` keeps git from copying its ~27 KB of sample hooks into
+        # the "remote": they would dominate the byte count reported below, and
+        # none of them was published by anything.
+        _git_bytes("init", "--quiet", "--bare", "--template=", str(origin))
+        # Belt and braces beside the sandbox HOME: a push's `receive-pack`
+        # runs on the origin side, and the origin's own config governs it
+        # wherever it inherits its environment from.
+        with (origin / "config").open("a", encoding="utf-8") as handle:
+            handle.write(QUIET_MAINTENANCE)
         info("sandbox", f"{root} - a throwaway install; your real history is not touched")
 
         sync.initialise(remote=str(origin), new_identity=True)
@@ -230,8 +255,7 @@ def run(check: Check, info: Info) -> None:
             duration_ms=1,
             cmd=f"echo {marker}",
         )
-        with store.private_append(store.log_file(known.id, day)) as handle:
-            handle.write(format_line(entry) + "\n")
+        store.append_entries(known.id, [entry])
 
         logged = store.log_file(known.id, day).read_bytes()
         check(
@@ -264,7 +288,7 @@ def run(check: Check, info: Info) -> None:
 
         streams = _published_bytes(origin)
         total = sum(len(data) for _, data in streams)
-        hits = [where for where, data in streams if marker.encode("utf-8") in data]
+        hits = _find(streams, marker)
         check(
             "unreadable",
             not hits,
@@ -274,14 +298,7 @@ def run(check: Check, info: Info) -> None:
         )
 
         searchable, unsearchable = _name_tokens(known.name)
-        named = sorted(
-            {
-                token
-                for token in searchable
-                for where, data in streams
-                if token.encode("utf-8") in data
-            }
-        )
+        named = [token for token in searchable if _find(streams, token)]
         check(
             "anonymous",
             not named,
@@ -289,5 +306,5 @@ def run(check: Check, info: Info) -> None:
             if not named
             else f"readable on the remote: {', '.join(repr(t) for t in named)}",
         )
-        for token in unsearchable:
-            info("", f"{token} was not searched for; the full name above still was")
+        for token, why in unsearchable:
+            info("", f"{token!r} was not searched for ({why}); the full name above still was")

--- a/woswoar/prove.py
+++ b/woswoar/prove.py
@@ -222,7 +222,12 @@ def run(check: Check, info: Info) -> None:
         now = int(time.time())
         day = store.day_for(now)
         entry = Entry(
-            ts=now, host=known.id, session="prove", cwd="~", exit_code=0, duration_ms=1,
+            ts=now,
+            host=known.id,
+            session="prove",
+            cwd="~",
+            exit_code=0,
+            duration_ms=1,
             cmd=f"echo {marker}",
         )
         with store.private_append(store.log_file(known.id, day)) as handle:

--- a/woswoar/prove.py
+++ b/woswoar/prove.py
@@ -1,0 +1,288 @@
+"""A proof the user can run: nothing readable leaves this machine.
+
+docs/security.md pins its claims with tests, but those run in CI -- somebody
+else's machine, on somebody else's history. The gap this module closes is the
+question a stranger evaluating woswoar actually has: *does the copy installed
+here, today, publish anything I could regret?* No document answers that. A
+round trip they can watch does.
+
+So `woswoar doctor --prove` builds a complete throwaway installation in a
+temporary directory -- its own config, identity, signing key, and a bare git
+"remote" that is just another directory -- records one canary command, syncs,
+and then demonstrates four things about the bytes that reached the remote:
+
+- the canary went in (a proof against an empty repo would be vacuous),
+- it comes back out with the sandbox's private key,
+- it appears in no published byte, decompressed git objects included,
+- and neither does this machine's username or hostname.
+
+Everything runs against the installed code and a directory-shaped remote, so
+it needs no network and touches nothing of the real installation. A FAIL here
+is a defect in woswoar itself, not in the user's setup.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import shutil
+import subprocess
+import tempfile
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from . import crypto, deps, store, sync
+from .entry import Entry, format_line
+from .errors import WoswoarError
+
+#: Print one pass/fail line, in whatever shape the caller renders checks.
+Check = Callable[[str, bool, str], None]
+#: Print one line of context that cannot fail.
+Info = Callable[[str, str], None]
+
+#: Everything that decides where woswoar -- and git -- read and write. All
+#: redirected into the sandbox: HOME because git reads ``~/.gitconfig``, whose
+#: hooks and filters must neither run against the sandbox nor colour the proof.
+_ENV_KEYS = (
+    "HOME",
+    "WOSWOAR_DIR",
+    "WOSWOAR_SESSION",
+    "XDG_CONFIG_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_DATA_HOME",
+    "XDG_RUNTIME_DIR",
+)
+
+#: git's background `gc --auto` detaches and keeps repacking after the command
+#: that triggered it returns -- so it would still be rewriting the origin while
+#: the scan below reads it and the cleanup deletes it. Same setting, same
+#: reason, as the sync test suite.
+_QUIET_MAINTENANCE = "[gc]\n\tauto = 0\n\tautoDetach = false\n[receive]\n\tautogc = false\n"
+
+#: Strings woswoar itself writes into every repository. A username or hostname
+#: that happens to be one of them cannot be told from this boilerplate by
+#: searching bytes, so it is reported as not searchable rather than searched
+#: and wrongly failed. Two real shapes, met on the first two machines this ran
+#: on: a machine named "localhost" collides with the commit email, and a user
+#: sharing a name with the maintainer collides with the repository URL in the
+#: committed README.
+_BOILERPLATE = (
+    sync.COMMIT_NAME,
+    sync.COMMIT_EMAIL,
+    sync.COMMIT_MESSAGE,
+    store.README_CONTENT,
+    "main",
+    "master",
+    "origin",
+)
+
+#: Below this, a hit in ciphertext by chance is likelier than a real leak: an
+#: age recipient line is ~60 characters of lowercase bech32, so a three-letter
+#: name has fair odds of appearing in one honestly.
+_MIN_TOKEN = 4
+
+
+@contextmanager
+def _sandbox() -> Iterator[Path]:
+    """A directory that is, for the duration, the whole world.
+
+    Restoring the environment in ``finally`` is what makes this safe to run
+    from inside a live installation: every store path is resolved from the
+    environment on each call, so nothing read or written in here can land in
+    the real one.
+    """
+    saved = {key: os.environ.get(key) for key in _ENV_KEYS}
+    tmp = tempfile.mkdtemp(prefix="woswoar-prove-")
+    try:
+        root = Path(tmp)
+        for name in ("data", "conf", "cache", "home"):
+            (root / name).mkdir()
+        (root / "home" / ".gitconfig").write_text(_QUIET_MAINTENANCE, encoding="utf-8")
+        for key in _ENV_KEYS:
+            os.environ.pop(key, None)
+        os.environ.update(
+            {
+                "HOME": str(root / "home"),
+                "WOSWOAR_DIR": str(root / "data"),
+                "XDG_CONFIG_HOME": str(root / "conf"),
+                "XDG_CACHE_HOME": str(root / "cache"),
+                "XDG_DATA_HOME": str(root / "data"),
+            }
+        )
+        yield root
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _git_bytes(*args: str) -> bytes:
+    """git output as raw bytes; `sync.git` decodes, and objects are not text."""
+    done = subprocess.run(["git", *args], capture_output=True, check=False, timeout=60)
+    if done.returncode != 0:
+        raise WoswoarError(
+            f"git {args[0]} failed in the sandbox:\n{done.stderr.decode('utf-8', 'replace')}"
+        )
+    return done.stdout
+
+
+def _published_bytes(origin: Path) -> list[tuple[str, bytes]]:
+    """Every byte the sandbox pushed, by name, decompressed where git compresses.
+
+    Two passes over the same repository, because each is blind where the other
+    sees. The raw files cover refs, config and packed-refs -- but a leak inside
+    a *committed* file lives zlib-compressed in ``objects/``, where no byte
+    scan can recognise it. ``cat-file --batch-all-objects`` prints every
+    object inflated: blobs, and also the trees and commits that carry paths,
+    directory names and author lines.
+    """
+    streams = [
+        (str(path.relative_to(origin)), path.read_bytes())
+        for path in sorted(origin.rglob("*"))
+        if path.is_file()
+    ]
+    inflated = _git_bytes("-C", str(origin), "cat-file", "--batch-all-objects", "--batch")
+    streams.append(("every git object, decompressed", inflated))
+    return streams
+
+
+def _pushed_plaintext(origin: Path, known: store.Machine, day: str) -> bytes:
+    """What ``day``'s chunks on the remote decrypt to, using the sandbox's key.
+
+    Read from the origin's objects, not from the local checkout: the claim
+    being proven is about what *left* the machine, so that is what is opened.
+    """
+    tip = _git_bytes("-C", str(origin), "rev-list", "--all", "-n", "1").decode().strip()
+    if not tip:
+        raise WoswoarError("the sandbox remote holds no commit")
+    history = store.history_dir()
+    sealed_rel = store.day_key(known.id, day).relative_to(history)
+    sealed = _git_bytes("-C", str(origin), "cat-file", "blob", f"{tip}:{sealed_rel}")
+    day_secret = crypto.decrypt_with_file(sealed, sync.identity_path(known)).decode("utf-8")
+
+    chunk_rel = store.chunk_dir(known.id, day).relative_to(history)
+    listing = _git_bytes(
+        "-C", str(origin), "ls-tree", "-r", "--name-only", tip, str(chunk_rel)
+    ).decode("utf-8")
+    plaintext = b""
+    for name in listing.splitlines():
+        blob = _git_bytes("-C", str(origin), "cat-file", "blob", f"{tip}:{name}")
+        plaintext += sync.unpack(crypto.decrypt_with_secret(blob, day_secret))
+    return plaintext
+
+
+def _name_tokens(name: str) -> tuple[list[str], list[str]]:
+    """Split ``user@host`` into what can be searched for and what cannot.
+
+    The full name is always searchable -- ``@`` keeps it out of any encoding a
+    repository legitimately contains. The halves are searched one by one so a
+    leak of either alone is still caught, except where a byte search cannot
+    mean anything: a token short enough to appear in ciphertext by chance, or
+    one that woswoar's own boilerplate already contains everywhere.
+    """
+    user, _, host = name.partition("@")
+    searchable, unsearchable = [name], []
+    for token in (user, host):
+        if len(token) < _MIN_TOKEN:
+            unsearchable.append(f"{token!r} (short enough to appear in ciphertext by chance)")
+        elif any(token in text for text in _BOILERPLATE):
+            unsearchable.append(f"{token!r} (woswoar's own boilerplate happens to contain it)")
+        else:
+            searchable.append(token)
+    return searchable, unsearchable
+
+
+def run(check: Check, info: Info) -> None:
+    """Record a canary in a sandbox, publish it, and prove what the remote saw.
+
+    The checks print in the order the bytes travel: plaintext log, sealed
+    chunk on the remote, back to plaintext under the key, and nowhere else.
+    """
+    crypto.require()
+    crypto.require_signing()
+    if shutil.which("git") is None:
+        raise WoswoarError(f"git is required - {deps.advice([deps.GIT])}")
+
+    # Long enough that finding it anywhere is a fact, not a coincidence.
+    marker = f"woswoar-canary-{secrets.token_hex(12)}"
+
+    with _sandbox() as root:
+        origin = root / "origin.git"
+        _git_bytes("init", "--quiet", "--bare", str(origin))
+        info("sandbox", f"{root} - a throwaway install; your real history is not touched")
+
+        sync.initialise(remote=str(origin), new_identity=True)
+        known = store.machine()
+
+        now = int(time.time())
+        day = store.day_for(now)
+        entry = Entry(
+            ts=now, host=known.id, session="prove", cwd="~", exit_code=0, duration_ms=1,
+            cmd=f"echo {marker}",
+        )
+        with store.private_append(store.log_file(known.id, day)) as handle:
+            handle.write(format_line(entry) + "\n")
+
+        logged = store.log_file(known.id, day).read_bytes()
+        check(
+            "recorded",
+            marker.encode("utf-8") in logged,
+            f"the canary '{marker}' sits in the sandbox's plaintext log,"
+            " exactly as logs/ holds your own",
+        )
+
+        report = sync.run()
+        check(
+            "published",
+            report.lines_exported >= 1 and report.pushed,
+            f"{report.lines_exported} line(s) sealed into {report.chunks_written} chunk(s)"
+            " and pushed to the sandbox's remote",
+        )
+
+        # Presence first: an absence proof over a repo that never held the
+        # canary would pass while proving nothing.
+        try:
+            plaintext = _pushed_plaintext(origin, known, day)
+            opened = marker.encode("utf-8") in plaintext
+            detail = (
+                "the pushed chunk decrypts back to the canary -- with the sandbox's"
+                " private key, which never left this machine"
+            )
+        except (WoswoarError, OSError, subprocess.SubprocessError, ValueError) as exc:
+            opened, detail = False, f"could not open what was published: {exc}"
+        check("sealed", opened, detail)
+
+        streams = _published_bytes(origin)
+        total = sum(len(data) for _, data in streams)
+        hits = [where for where, data in streams if marker.encode("utf-8") in data]
+        check(
+            "unreadable",
+            not hits,
+            f"the canary appears in none of the {total:,} bytes on the remote"
+            if not hits
+            else f"the canary is readable in: {', '.join(hits)}",
+        )
+
+        searchable, unsearchable = _name_tokens(known.name)
+        named = sorted(
+            {
+                token
+                for token in searchable
+                for where, data in streams
+                if token.encode("utf-8") in data
+            }
+        )
+        check(
+            "anonymous",
+            not named,
+            f"neither is any of: {', '.join(repr(t) for t in searchable)}"
+            if not named
+            else f"readable on the remote: {', '.join(repr(t) for t in named)}",
+        )
+        for token in unsearchable:
+            info("", f"{token} was not searched for; the full name above still was")

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -87,6 +87,22 @@ class Machine(NamedTuple):
     identity: str = ""
 
 
+#: Every environment variable this module consults when resolving paths. One
+#: authoritative list, owned by the module the variables belong to: the test
+#: suite redirects all of them into throwaway roots, and `prove` builds its
+#: sandbox from them -- a variable added here but missed in a hand-kept copy
+#: would silently point a "sandbox" at the real installation, with nothing
+#: failing. Three copies of this tuple existed before it moved here.
+ENV_KEYS = (
+    "WOSWOAR_DIR",
+    "WOSWOAR_SESSION",
+    "XDG_CONFIG_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_DATA_HOME",
+    "XDG_RUNTIME_DIR",
+)
+
+
 def _xdg(env_var: str, default: str) -> Path:
     value = os.environ.get(env_var)
     base = Path(value) if value else Path.home() / default

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -886,6 +886,17 @@ def open_day_key(known: Machine, host_id: str, day: str) -> str:
         sealed = sealed_path.read_bytes()
     except OSError as exc:
         raise SyncError(f"missing day key {sealed_path}") from exc
+    return open_day_key_bytes(known, sealed)
+
+
+def open_day_key_bytes(known: Machine, sealed: bytes) -> str:
+    """The identity inside a sealed day key, wherever the bytes came from.
+
+    Split from `open_day_key` so that `prove`, which reads the sealed bytes
+    out of a git object rather than the working tree, opens them through the
+    same code -- a change to how day keys are sealed then has one reader to
+    update, not two.
+    """
     return crypto.decrypt_with_file(sealed, identity_path(known)).decode("utf-8")
 
 


### PR DESCRIPTION
## What

A stranger evaluating woswoar has one question no document can answer: *does the copy installed here, today, publish anything I could regret?* This PR gives them a round trip they can watch instead of a claim to believe.

- **`woswoar doctor --prove`** (new `woswoar/prove.py`): builds a complete throwaway installation in a temp directory — own identity, signing key, and a bare git "remote" that is just a directory — records one canary command, syncs, and proves: the canary is in the plaintext log, it decrypts back out of the pushed chunk with the sandbox's key, and neither it nor the machine's username/hostname appears in *any* byte on the remote, decompressed git objects included. No network, nothing of the real installation touched; a FAIL is a woswoar defect by construction.
- **`docs/verify.md`**: checks the user runs by hand — the canary walk on their real repo, decrypting a chunk with stock `age` and a `zlib` one-liner (no woswoar in the pipeline), `unshare -rn`/`strace` offline proofs, running the guarantee suite, and diffing the installed files against the tag. **Every command was executed against a scratch install before being written down**; the decrypt recipe is additionally pinned by a test that extracts it from the doc and runs it, so the repo layout cannot move under it silently.
- **README / security.md**: link the above; the security page now points out that its central claim can be re-proven locally.

## Worth knowing

- The very first `--prove` run caught a real (benign) subtlety: the maintainer's GitHub handle in the committed README URL collides with a user also named `martinus`. That shaped the design — tokens woswoar's own boilerplate contains are *reported as not searchable* rather than searched and wrongly failed, and that branch has its own tests.
- Both CI leak scans (`test_nothing_readable_leaks_into_the_repo`, `test_nothing_in_the_repo_names_the_machine`) now go through the same scanner `--prove` ships, which inflates git objects. The old raw walk could not see into a superseded revision of a rewritten file (exactly how #22 leaked names), though those bytes are pushed all the same.
- Drive-by: README's "~3500 lines of implementation" had drifted; measured (tokenizer, comments/docstrings excluded) it is ~4300.

## Review (working agreement rule 1, top row)

Full four-angle `/simplify` ran before this PR opened; the applied findings are commit `beea317`. Skipped, deliberately:

- *Fold `_git_bytes` into `sync.git`*: would put a `str | bytes` return polymorphism on a core helper for two call sites; kept a 7-line prove-local wrapper (with `cwd=` and honest error naming per the same review).
- *Batch the per-chunk `cat-file` forks / overlap scan and inflation with `Popen`*: a one-shot diagnostic saving ~2 forks / ~3 ms; clarity wins.
- *Merge the two clean-install tests*: costs ~0.4 s but keeps "it passes" and "it leaves nothing behind" separately diagnosable.
- *Make `--prove` its own subcommand*: it is a diagnostic and lives under `doctor` deliberately; the doctor description documents it, and nothing else of doctor's semantics applies to it either way.
- *Derive the boilerplate skip-list from a control run instead of enumerating*: doubles runtime and still needs the length floor (short tokens hit ciphertext by chance), so it removes less than it costs; the enumeration is now sourced from the owning constants and test-covered instead.
- One efficiency-agent premise corrected rather than applied: an eighth mutation "scanner stops inflating objects, CI tests catch it" is impossible — the CI tests assert *absence*, which a weakened scanner still finds. Only the fault-injection prove test can catch scanner weakening, and it does (mutation 1).

## Mutation testing (rule 3)

`python -m tools.mutate` on the final tree:

```
caught    the scan no longer decompresses git objects, where pushed bytes actually live
caught    the published check passes without anything having been exported
caught    the sealed check trusts the plumbing instead of reading what came back
caught    the unreadable check passes without consulting the scan
caught    the anonymous check passes without consulting the scan
caught    the sandbox is left on disk
caught    the canary is never actually written to the log
```

## Preflight

`ruff check` / `ruff format --check` / `mypy` / `shellcheck` / `python -m tools.run_tests`: all green (309 tests, benchmarks skipped as designed). A live `woswoar doctor --prove` on this machine passes with the boilerplate-collision path exercised for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)