### PR TITLE
release: 0.8.0

### DIFF
--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.7.2"
+__version__ = "0.8.0"


### PR DESCRIPTION
Version bump for the release carrying #145 (`doctor --prove` and docs/verify.md). Tag `v0.8.0` follows once this is merged, per the documented release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)