### PR TITLE
release: attest build provenance for every artefact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 
 permissions:
   contents: write # create the release, and move `stable`
+  id-token: write # prove to Sigstore which workflow is signing
+  attestations: write # store the provenance attestation
 
 jobs:
   release:
@@ -79,6 +81,19 @@ jobs:
           # artefacts cannot serve that; a PEP 508 direct reference supplies the
           # project name instead, which is what makes the arbitrary name legal.
           cp dist/woswoar-*.tar.gz dist/woswoar.tar.gz
+
+      - name: attest what was built
+        # Binds each artefact to this repository, this workflow file and this
+        # commit, signed via Sigstore with the run's own OIDC identity -- no
+        # key exists that could be lost or stolen. Anyone can then check a
+        # downloaded file with
+        #   gh attestation verify woswoar.tar.gz --repo martinus/woswoar
+        # which turns "this tarball came from the audited release pipeline"
+        # from a claim into something docs/verify.md can tell people to run.
+        # Before `publish`, so nothing unattested is ever offered for download.
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/*
 
       - name: publish the release
         env:

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -155,6 +155,25 @@ git clone -q --branch "v$VERSION" https://github.com/martinus/woswoar /tmp/woswo
 diff -r -x __pycache__ "$SRC/woswoar" /tmp/woswoar-src/woswoar && echo identical
 ```
 
+Release artefacts (the `.tar.gz` and `.whl` on each GitHub release, from
+v0.8.1 on) additionally carry a **build provenance attestation**: a
+Sigstore-backed statement, signed by the release workflow's own identity,
+that these exact bytes were built by this repository's public pipeline at
+this commit — the pipeline that refuses a tag not on the protected branch and
+re-runs the whole suite first. There is no key anyone holds, so there is no
+key anyone can lose. Verify a download with:
+
+```console
+$ gh attestation verify woswoar.tar.gz --repo martinus/woswoar
+✓ Verification succeeded
+```
+
+What that does not prove is intent: anyone with push access to the
+repository could cut a release through the same pipeline, and it would attest
+cleanly. It rules out the quieter failures — an asset replaced after
+publication, or a tarball built on somebody's compromised laptop rather than
+in the audited workflow.
+
 The install line in the README tracks `stable`, a branch the release workflow
 fast-forwards — convenient, and it means whoever controls the GitHub
 repository controls what your next upgrade installs. If that is a trade you


### PR DESCRIPTION
Implements option 1 from the signed-releases discussion: GitHub build provenance attestations on every release artefact, including the fixed-name `woswoar.tar.gz` that the stable download URL serves.

- `release.yml` gains `id-token: write` + `attestations: write` and an `actions/attest-build-provenance@v4` step (latest major, checked against the action's releases) after `build`, **before** `publish` — so a failure blocks the release with nothing published and `stable` unmoved, never the reverse.
- `docs/verify.md` documents `gh attestation verify woswoar.tar.gz --repo martinus/woswoar` and states the limit honestly: attestation proves the bytes came from this repo's public pipeline at a given commit, not that the maintainer meant it.

Cannot be exercised without cutting a release; the step's failure mode was reviewed instead (fails closed, ahead of publish). Takes effect from the next tag — the doc says "from v0.8.1 on" accordingly. Signed tags (option 2) and a `v*` tag ruleset remain open, and need actions only the maintainer can take (uploading a signing key, repo settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)