### PR TITLE
release: 0.8.1

### DIFF
--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"


### PR DESCRIPTION
Version bump for the release carrying #147. This will be the first release whose artefacts are attested, which `docs/verify.md` already announces as "from v0.8.1 on" — tagging `v0.8.1` after this merges is also what exercises the new workflow step for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)