### PR TITLE
search: two-unit ages in the picker (3h42m, 6mo12d)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ when you need that one command from last Tuesday, on the other machine.
 
 ```
   woswoar (global) > docker
-   2m  thinkpad  docker compose up -d --build
-   3h  DT-24YYQ3 docker logs -f api
-   6d  thinkpad  docker system prune -af
+       2m  thinkpad  docker compose up -d --build
+    3h12m  DT-24YYQ3 docker logs -f api
+     6d4h  thinkpad  docker system prune -af
   ctrl-r global → host → session, or ctrl-g/h/s | ctrl-t timeline | ^name one machine
 ```
 
@@ -42,13 +42,13 @@ timeline either side of it, with the cursor still on what you found:
 
 ```
   woswoar (timeline global) >
-   3h  git commit -m wip
-   3h  git add -A
-   4h  cargo test
-   4h  vim src/lib.rs          <- where you were
-   4h  cargo test
-   4h  cargo build
-   4h  cd ~/proj
+    3h41m  git commit -m wip
+    3h44m  git add -A
+    3h58m  cargo test
+     4h2m  vim src/lib.rs          <- where you were
+    4h15m  cargo test
+    4h15m  cargo build
+    4h17m  cd ~/proj
 ```
 
 Newest first, like every other list here. Scroll up into what came next, down

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -31,25 +31,50 @@ class TestRelativeTime(unittest.TestCase):
             (60, "1m"),
             (59 * 60, "59m"),
             (3600, "1h"),
-            (23 * 3600, "23h"),
+            (3600 + 60, "1h1m"),
+            (23 * 3600 + 59 * 60, "23h59m"),
             (86400, "1d"),
-            (29 * 86400, "29d"),
+            (86400 + 3600, "1d1h"),
+            (29 * 86400 + 23 * 3600, "29d23h"),
             (30 * 86400, "1mo"),
-            (349 * 86400, "11mo"),
-            (350 * 86400, "1y"),
+            (42 * 86400, "1mo12d"),
+            (359 * 86400, "11mo29d"),
+            (360 * 86400, "1y"),
             (365 * 86400, "1y"),
-            (900 * 86400, "2y"),
+            (729 * 86400, "1y11mo"),
+            (730 * 86400, "2y"),
+            (900 * 86400, "2y5mo"),
         ]
         for delta, expected in cases:
+            with self.subTest(delta=delta):
+                self.assertEqual(search.relative_time(NOW - delta, NOW), expected)
+
+    def test_a_second_unit_of_zero_is_dropped(self) -> None:
+        # "3h", never "3h0m": the padding absorbs the difference either way,
+        # but a written zero is noise on every round-hour row.
+        for delta, expected in [(3 * 3600, "3h"), (12 * 86400, "12d"), (6 * 30 * 86400, "6mo")]:
             with self.subTest(delta=delta):
                 self.assertEqual(search.relative_time(NOW - delta, NOW), expected)
 
     def test_never_exceeds_the_column_width(self) -> None:
         # command_from_line() slices at a fixed offset, so an over-wide label
         # would silently eat the first characters of the command.
-        for delta in [0, 1, 59, 61, 3599, 90000, 86400 * 29, 86400 * 364, 86400 * 365 * 40]:
+        for delta in [
+            0,
+            1,
+            59,
+            61,
+            3599,
+            90000,
+            86400 * 29 + 86399,
+            86400 * 359,
+            86400 * 364,
+            86400 * 729,
+            86400 * 365 * 40,
+            86400 * 365 * 200,
+        ]:
             with self.subTest(delta=delta):
-                self.assertLessEqual(len(search.relative_time(NOW - delta, NOW)), 4)
+                self.assertLessEqual(len(search.relative_time(NOW - delta, NOW)), search._TIME_WIDTH)
 
     def test_clock_skew_from_another_machine_is_tolerated(self) -> None:
         self.assertEqual(search.relative_time(NOW + 500, NOW), "now")
@@ -431,7 +456,7 @@ class TestThePickerAppearsBeforeTheHistoryIsBuilt(WoswoarTestCase):
 
         def slow_lines(*args: object, **kwargs: object) -> list[str]:
             order.append("history")
-            return ["  1s  cmd 0"]
+            return ["     1s  cmd 0"]
 
         with (
             mock.patch("subprocess.Popen", Spawned),
@@ -620,8 +645,8 @@ class TestTheMachineColumn(WoswoarTestCase):
         self.record(MACHINE_ID, "git status")
         self.assertEqual(search.host_width_for({MACHINE_ID}), 0)
         (line,) = search.lines_for("global")
-        # The time column is right-aligned in four, so "now" leaves one space.
-        self.assertEqual(line, " now  git status")
+        # The time column is right-aligned in seven, so "now" leaves four.
+        self.assertEqual(line, "    now  git status")
 
     def test_two_machines_get_one(self) -> None:
         self.record(MACHINE_ID, "mine")
@@ -870,10 +895,10 @@ class TestSayingHowToFilterByMachine(WoswoarTestCase):
         self.assertIn(f"--header={search._header(8)}", argv)
 
     ROWS: ClassVar[list[str]] = [
-        "  2m  box       docker run sandbox",
-        "  3h  thinkpad  docker ps",
-        "  6d  box       ls",
-        "  1d  at1i-ws07 echo box",
+        "     2m  box       docker run sandbox",
+        "  3h12m  thinkpad  docker ps",
+        "   6d4h  box       ls",
+        "   1d2h  at1i-ws07 echo box",
     ]
 
     def fzf_filter(self, query: str) -> str:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -74,7 +74,9 @@ class TestRelativeTime(unittest.TestCase):
             86400 * 365 * 200,
         ]:
             with self.subTest(delta=delta):
-                self.assertLessEqual(len(search.relative_time(NOW - delta, NOW)), search._TIME_WIDTH)
+                self.assertLessEqual(
+                    len(search.relative_time(NOW - delta, NOW)), search._TIME_WIDTH
+                )
 
     def test_clock_skew_from_another_machine_is_tolerated(self) -> None:
         self.assertEqual(search.relative_time(NOW + 500, NOW), "now")

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -23,10 +23,13 @@ from .entry import escape, make_inert, unescape
 Scope = Literal["global", "host", "session"]
 SCOPES: tuple[Scope, ...] = ("global", "host", "session")
 
-#: Every display line is ``"<4-char relative time><2 spaces><escaped command>"``.
+#: Every display line is ``"<7-char relative time><2 spaces><escaped command>"``.
 #: The prefix is a fixed width so recovering the command from what fzf prints
-#: back is an exact slice rather than a parse.
-_TIME_WIDTH = 4
+#: back is an exact slice rather than a parse. Seven fits the widest age
+#: `relative_time` can produce (``11mo29d``, ``99y11mo``); recent commands --
+#: most of any screen -- still render two or three characters and the rest is
+#: padding, so the width is only actually spent on rows old enough to need it.
+_TIME_WIDTH = 7
 _PREFIX = _TIME_WIDTH + 2
 
 #: Sort key for a row. In C, rather than a lambda.
@@ -66,6 +69,13 @@ def relative_time(ts: int, now: int | None = None) -> str:
     """Render a timestamp as an age, at most :data:`_TIME_WIDTH` characters.
 
     Computed at display time rather than stored, so it never goes stale.
+
+    Two adjacent units from hours upward -- ``3h42m``, ``12d5h``, ``6mo12d``,
+    ``1y3mo`` -- because one unit is off by up to half of itself, and a bare
+    ``6mo`` hiding a fortnight was reported as too coarse to be useful. Below
+    an hour a single unit is already within a minute, and those rows are most
+    of any screen, so they stay as narrow as they were. A second unit of zero
+    is dropped rather than written: ``3h``, not ``3h0m``.
     """
     delta = (int(time.time()) if now is None else now) - ts
     if delta < 0:
@@ -75,15 +85,28 @@ def relative_time(ts: int, now: int | None = None) -> str:
     if delta < 3600:
         return f"{delta // 60}m"
     if delta < 86400:
-        return f"{delta // 3600}h"
-    if delta < 86400 * 30:
-        return f"{delta // 86400}d"
-    if delta < 86400 * 350:
-        # Cut over before the month count could reach 12, which would be both
-        # wider than the column and sillier than saying "1y".
-        return f"{delta // (86400 * 30)}mo"
-    years = max(1, delta // (86400 * 365))
-    return f"{years}y" if years < 100 else "old"
+        big, small = divmod(delta // 60, 60)
+        units = "h", "m"
+    elif delta < 86400 * 30:
+        big, small = divmod(delta // 3600, 24)
+        units = "d", "h"
+    elif delta < 86400 * 360:
+        # Cut over exactly where the month count would reach 12, which would
+        # be both wider than the column and sillier than saying "1y".
+        big, small = divmod(delta // 86400, 30)
+        units = "mo", "d"
+    else:
+        big = max(1, delta // (86400 * 365))
+        if big >= 100:
+            return "old"
+        # Clamped: 360-364 days is short of one year but says "1y" rather than
+        # inventing a negative month, and day 364 of any year would otherwise
+        # round to a twelfth month the column has no room for.
+        small = min(11, max(0, (delta // 86400 - big * 365) // 30))
+        units = "y", "mo"
+    if small == 0:
+        return f"{big}{units[0]}"
+    return f"{big}{units[0]}{small}{units[1]}"
 
 
 #: Widest a machine label may be. Generous, because it is only ever as wide as


### PR DESCRIPTION
"just seeing 6mo is quite inaccurate" — a single unit is off by up to half of itself, and at months that hides a fortnight.

Ages now show two adjacent units from hours upward: `3h42m`, `12d5h`, `6mo12d`, `1y3mo`, with a zero second unit dropped (`3h`, never `3h0m`). Sub-hour rows — most of any real screen — stay exactly as narrow as before (`42s`, `5m`), so the added precision lands only where it was missing. The column is right-aligned in 7 (was 4), which fits the widest possible value (`11mo29d`); recent rows spend the difference on padding, not text.

Nothing else had to move: the fixed-slice command recovery and fzf's `--nth=2..` both derive from `_TIME_WIDTH`/whitespace fields, and compound ages contain no spaces. README's picker mocks updated to match real output.

Mutation run per rule 3:

```
caught    the second unit is never shown, reverting to the old single-unit display
caught    hours never carry minutes
caught    the clamp protecting the year boundary is gone
caught    the column width no longer fits the widest age
```

The year-boundary clamp exists because 360–364 days would otherwise render a negative month (`1y-1mo`), and day 364 of any year would round to a twelfth month the column has no room for; both are pinned in `test_scales`.

Preflight (ruff, format, mypy, shellcheck, full suite) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)