### PR TITLE
tests: a pty harness, so Ctrl-R landing on the prompt is actually asserted

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import fcntl
 import io
 import os
+import pty
+import select
 import shutil
+import signal
+import struct
 import tempfile
+import termios
+import time
 import unittest
-from contextlib import redirect_stderr, redirect_stdout
+from collections.abc import Sequence
+from contextlib import redirect_stderr, redirect_stdout, suppress
 from pathlib import Path
 from typing import NamedTuple
 
@@ -72,6 +80,120 @@ def run_cli(*argv: str, tty: bool = False) -> Ran:
     with redirect_stdout(out), redirect_stderr(err):
         code = main(list(argv))
     return Ran(code, out.getvalue(), err.getvalue())
+
+
+class Typed(NamedTuple):
+    """One exchange with a program running under a terminal.
+
+    ``send`` is typed at it verbatim -- control characters included, so a
+    keypress is just ``"\\x12"`` -- and then output is read until ``until``
+    shows up. Reading to a marker rather than for a fixed time is what keeps
+    this from being a sleep race: a step that never produces its marker fails
+    with the whole transcript rather than passing on an empty read.
+
+    ``until`` must be a string the program *prints*, not one the harness typed:
+    a terminal echoes what you type back at you, so waiting for your own input
+    is satisfied instantly and asserts nothing. `CLAUDE.md` rule 3, fourth
+    bullet. The trick used here and in the tests is `echo MAR''KER` -- typed
+    with the quotes, printed without.
+    """
+
+    send: str
+    until: str
+
+
+def run_in_pty(
+    argv: Sequence[str],
+    steps: Sequence[Typed],
+    *,
+    env: dict[str, str],
+    size: tuple[int, int] = (40, 120),
+    timeout: float = 30.0,
+) -> list[str]:
+    """Drive ``argv`` under a real pseudo-terminal, one exchange at a time.
+
+    Returns what the program wrote during each step, in order, so a test can
+    assert about the state of the screen *between* two keypresses -- which is
+    where "the recalled command is sitting on the prompt and has not run" lives.
+    ``timeout`` is per step, not for the run.
+
+    A pty rather than pipes because the things worth testing about a shell only
+    exist when it has a terminal: readline does no line editing without one, and
+    the Ctrl-R widget reads its picker's input from `/dev/tty`, which a pipe
+    cannot provide. `pty.fork` rather than `pty.openpty` plus `Popen` because it
+    also makes the slave the child's *controlling* terminal, and a GitHub runner
+    has none to inherit.
+
+    The window size is set explicitly and before the exec, because a pty starts
+    at 0x0 and a program that believes it has no room draws almost nothing --
+    fzf, which #152 will drive through here, renders into three lines. Readline
+    covers for it by falling back to 80x24, so no test that only runs bash could
+    notice this going missing; `TestThePtyHarness` asserts it directly instead.
+    """
+    rows, cols = size
+    pid, master = pty.fork()
+    if pid == 0:  # pragma: no cover - the child execs or dies
+        # Nothing here may raise back into the test process: after the fork
+        # there are two of those, and the second one continuing to run the suite
+        # would be a mess to even diagnose.
+        try:
+            fcntl.ioctl(0, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+            os.execvpe(argv[0], list(argv), env)
+        except BaseException:
+            pass
+        os._exit(127)
+
+    transcript: list[str] = []
+    try:
+        for index, step in enumerate(steps):
+            if step.send:
+                os.write(master, step.send.encode())
+            transcript.append(_read_until(master, step.until, timeout, index, transcript))
+        return transcript
+    finally:
+        os.close(master)
+        # SIGKILL, not SIGTERM: an interactive bash ignores SIGTERM, and a test
+        # that leaves one running holds a worker of the parallel runner forever.
+        with suppress(ProcessLookupError):
+            os.kill(pid, signal.SIGKILL)
+        os.waitpid(pid, 0)
+
+
+def _read_until(fd: int, marker: str, timeout: float, index: int, before: list[str]) -> str:
+    """Read from ``fd`` until ``marker`` appears, or fail with what did appear.
+
+    An `AssertionError` rather than a `TimeoutError`, and carrying every step's
+    output rather than this one's: a terminal test that goes wrong says nothing
+    about *why* from its exception alone, and the answer is almost always
+    several steps back -- a prompt that never came, a shell that died at the
+    line before.
+    """
+    deadline = time.monotonic() + timeout
+    buffer = b""
+    needle = marker.encode()
+
+    def stalled(reason: str) -> AssertionError:
+        seen = [*before, buffer.decode("utf-8", "replace")]
+        return AssertionError(
+            f"step {index} waited for {marker!r} and {reason}. Transcript:\n" + "\n---\n".join(seen)
+        )
+
+    while needle not in buffer:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise stalled("timed out")
+        if not select.select([fd], [], [], remaining)[0]:
+            continue
+        try:
+            chunk = os.read(fd, 65536)
+        except OSError:
+            # EIO on Linux is how a pty reports that the child is gone; it is an
+            # ordinary end of stream here, not a fault of its own.
+            chunk = b""
+        if not chunk:
+            raise stalled("the program exited")
+        buffer += chunk
+    return buffer.decode("utf-8", "replace")
 
 
 def loose_paths() -> list[str]:

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -26,7 +26,7 @@ from woswoar import cache, search, store
 from woswoar.entry import MAX_CMD_CHARS, TRUNCATION_MARKER, Entry, escape, unescape
 
 from .credential_shapes import DOCUMENTED_GAPS, INNOCENT_SHAPES, SECRET_SHAPES
-from .support import MACHINE_ID, WoswoarTestCase
+from .support import MACHINE_ID, Typed, WoswoarTestCase, requires_bash, run_in_pty
 
 HOOK = Path(__file__).resolve().parent.parent / "woswoar" / "shell" / "woswoar.bash"
 
@@ -1333,3 +1333,129 @@ class TestTwoShellsOnOneMachine(ShellHookTestCase):
         self.run_shell("echo second_shell\n")
         sessions = {e.session for e in self.recorded()}
         self.assertEqual(len(sessions), 2, f"the two shells shared a session: {sessions}")
+
+
+@requires_bash
+class TestThePtyHarness(unittest.TestCase):
+    """One assertion about the harness, for the trap it is built to avoid.
+
+    A pty's window is 0x0 until somebody says otherwise, and a program that
+    believes it has no room draws almost nothing -- every assertion against that
+    output then passes or fails for reasons unconnected to the code under test.
+
+    It is checked here rather than left to the tests that use the harness,
+    because readline hides it: it falls back to 80x24 when the window is zero,
+    so the Ctrl-R test below stays green with `TIOCSWINSZ` removed. fzf does not
+    fall back, and #152 and #158 are built on this helper. A fixture too weak to
+    tell the two answers apart is invisible in the test's own text, which is why
+    this one is about the fixture and nothing else.
+    """
+
+    def test_the_window_size_reaches_the_child(self) -> None:
+        # Not the helper's default: a size that matched it would still pass if
+        # the ioctl were dropped and the caller's argument ignored.
+        chunks = run_in_pty(
+            ["bash", "--norc", "-i"],
+            [Typed("", "ps> "), Typed("stty size\n", "41 123")],
+            env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "PS1": "ps> ", "TERM": "xterm"},
+            size=(41, 123),
+        )
+        self.assertIn("41 123", chunks[1])
+
+
+@requires_bash5
+class TestCtrlRLandsOnThePrompt(ShellHookTestCase):
+    """The one property that keeps a recalled command from running by itself.
+
+    Every other test of the widget checks a piece of it from the outside: what
+    the picker would print, what the cycle binding decides. None of them press
+    the key, because the key does nothing without a terminal -- `bind -x` is
+    readline, and readline does no line editing on a pipe. So the claim the
+    whole feature rests on, that a selection arrives *on the prompt for editing*
+    and is never executed, was guarded by nothing at all.
+
+    Here it is driven: a real bash, a real readline, a real pty, the real hook.
+    What is stubbed is the picker itself -- the widget's contract with it is one
+    line on stdout, and fzf choosing that line needs its own test rather than a
+    share of this one.
+    """
+
+    #: What the picker hands back, and what running it would print. Two strings
+    #: on purpose. A terminal echoes what you type at it, so if the recalled
+    #: text and the executed output were spelled the same, "it did not run"
+    #: would be satisfied by the harness's own echo of the line -- `CLAUDE.md`
+    #: rule 3, fourth bullet, which is a trap this test would otherwise walk
+    #: into head first. The empty `''` is removed by the shell that runs the
+    #: line and by nothing else: `RAN''MARK` can only be the buffer on screen,
+    #: `RANMARK` can only be something having executed it.
+    SELECTION = "echo RAN''MARK"
+    IF_EXECUTED = "RANMARK"
+
+    #: Handed to bash in the environment, so the harness waits for a string it
+    #: has never typed. It doubles as the "readline is listening" signal:
+    #: readline puts the terminal into raw mode *before* it draws the prompt, so
+    #: a prompt on screen means the next keypress reaches the widget rather than
+    #: the kernel's line discipline. Typing before that was the first way this
+    #: test failed -- Ctrl-R came back as an echoed `^R` and nothing ran.
+    PROMPT = "ps> "
+
+    def picker_env(self) -> dict[str, str]:
+        """A sandbox whose `woswoar` on PATH is a fixed answer to `search`."""
+        bin_dir = self.root / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        fake = bin_dir / "woswoar"
+        fake.write_text(
+            "#!/bin/sh\n"
+            # Anything but `search` exits quietly. The hook reaches for
+            # `woswoar sync` too, and a stub that complained about the
+            # subcommand would put its complaint on the terminal this test
+            # reads, in the middle of the screen it is asserting about.
+            '[ "$1" = search ] || exit 0\n'
+            "printf '%s\\n' \"$WOSWOAR_TEST_SELECTION\"\n",
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        return self.shell_env(
+            {
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+                # Not `dumb`, which the rest of this file uses: this is the one
+                # test that wants readline to behave as it does for a person.
+                "TERM": "xterm",
+                # Bash only defaults PS1 when it is unset, so handing it in is
+                # enough -- and it means the harness never *types* the string it
+                # waits for to know the shell is up.
+                "PS1": self.PROMPT,
+                "WOSWOAR_TEST_SELECTION": self.SELECTION,
+            }
+        )
+
+    def test_the_selection_arrives_for_editing_and_does_not_run(self) -> None:
+        steps = [
+            Typed("", self.PROMPT),
+            Typed(f"source {HOOK}; echo LOAD''ED\n", "LOADED"),
+            # `LOADED` is printed while bash is still running the line; the
+            # prompt after it is what says readline has the terminal back.
+            Typed("", self.PROMPT),
+            # Ctrl-R, and then wait for the recalled text. That text is a marker
+            # the harness has not typed, so its only possible source is readline
+            # redrawing the buffer the widget just filled in.
+            Typed("\x12", self.SELECTION),
+            # Typed where the widget left the cursor, so it lands *after* the
+            # recalled command rather than in front of it, and then Enter. A
+            # READLINE_POINT of 0 would run `EXTRAecho ...` instead, and this
+            # step would time out with the transcript.
+            Typed(" EXTRA\r", f"{self.IF_EXECUTED} EXTRA"),
+        ]
+        # Named rather than indexed: the two that matter are the last two, and a
+        # step inserted above must not silently move an assertion onto the wrong
+        # screen.
+        *_, after_keypress, after_enter = run_in_pty(
+            ["bash", "--norc", "-i"], steps, env=self.picker_env()
+        )
+
+        self.assertNotIn(
+            self.IF_EXECUTED,
+            after_keypress,
+            "the keypress executed the selection instead of offering it for editing",
+        )
+        self.assertIn(f"{self.IF_EXECUTED} EXTRA", after_enter, "the edited line is what ran")


### PR DESCRIPTION
Closes #153.

`tests/test_search.py` recorded the gap: *"fzf needs a tty and the result was not
something I could assert reliably"*. So the property the whole picker rests on --
that a selection **lands on the prompt for editing and is never executed** -- was
guarded by nothing. This adds the machinery to press the key, and one test that
presses it.

No production code changes.

## `run_in_pty` in `tests/support.py`

Stdlib only (`pty`, `fcntl`, `termios`, `select`), so no new dependency. It takes
a list of `Typed(send, until)` exchanges: type this, read until that shows up,
and return **what the program wrote during each step separately**. That last part
is the point -- "the command is sitting on the prompt and has not run" is a claim
about the screen *between* two keypresses, and a single blob of output cannot
express it.

`pty.fork` rather than `pty.openpty` + `Popen`, because it also makes the slave
the child's *controlling* terminal, which a GitHub runner has none of to inherit.
A step that never sees its marker raises an `AssertionError` carrying every
step's transcript, not just its own; when a terminal test goes wrong the answer
is usually several steps back.

## The two fixture traps from the issue

**The window size.** Set with `TIOCSWINSZ` before the exec. It is asserted
directly by `TestThePtyHarness`, and that is deliberate rather than tidy: readline
falls back to 80x24 when a pty is left at 0x0, so the Ctrl-R test below stays
green with the ioctl removed — I checked. fzf does not fall back, and #152 and
#158 are built on this helper, so the guard is put where it can actually fail.

**The marker must not be the harness's own echo.** `TestCtrlRLandsOnThePrompt`
uses two different strings: the picker returns `echo RAN''MARK`, and running that
prints `RANMARK`. Neither contains the other. So "the recalled text is on screen"
can only be readline redrawing the buffer, and "nothing ran" cannot be satisfied
by the terminal echoing what was typed. The same trick (`echo LOAD''ED`) is how
each setup step knows it finished.

The last step is what pins `READLINE_POINT`: it types ` EXTRA` and presses Enter,
and expects `RANMARK EXTRA`. With the cursor left at 0 the line would be
`EXTRAecho RAN''MARK` and nothing would print.

One more thing worth recording, since it is the first way this test failed:
nothing may be typed before a prompt is on screen. Readline puts the terminal in
raw mode *before* it draws the prompt, so a prompt is the signal that the next
keypress reaches the widget rather than the kernel's line discipline. Ctrl-R sent
too early came back as an echoed `^R` and ran nothing.

## Verification

`python -m tools.mutate`, as rule 3 asks. Three mutations break the widget, one
breaks the harness:

```
  caught    the selection never reaches the buffer
  caught    the cursor is left in front of the recalled command
  caught    the widget runs the selection instead of offering it (zle accept-line)
  caught    the pty is left at its default 0x0 window
```

The third is the issue's suggested check -- the bash equivalent of `zle
accept-line`, `eval "$selection"` after the assignment.

Flake check, since a pty test that is flaky on a runner should be dropped rather
than lived with: 25 consecutive local runs of both classes, 25 green. CI is the
other half of that answer and is reported below.

Full suite: 671 tests, green. Preflight (`ruff`, `mypy`, `shellcheck`,
`tools.run_tests`) clean.

## Review

Rule 1, bottom row: tests only, no production change, nothing that reaches disk
differently. Re-read the diff myself rather than running agents on it. Two things
came out of that and are in the branch: the assertions were indexing `chunks[3]`
and `chunks[4]`, which a step inserted above would silently move onto the wrong
screen, and `_read_until` grew a clearer failure path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
