### PR TITLE
search: a dir scope -- commands from this directory and below

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,16 @@ when you need that one command from last Tuesday, on the other machine.
        2m  thinkpad  docker compose up -d --build
     3h12m  DT-24YYQ3 docker logs -f api
      6d4h  thinkpad  docker system prune -af
-  ctrl-r global → host → session, or ctrl-g/h/s | ctrl-t timeline | ^name one machine
+  ctrl-r global → host → session → dir, or ctrl-g/h/s, ctrl-o dir | ctrl-t timeline | ^name one machine
 ```
 
 The machine column appears once you have more than one, and fzf matches on it —
 so typing `thinkpad` narrows to that machine. It shows the *host* part of each
 machine's name, because that is usually what differs between your own machines.
 The age of a command that exited non-zero is red, and <kbd>Ctrl</kbd>+<kbd>R</kbd>
-again cycles global → host → session.
+again cycles global → host → session → dir — where **dir** is this directory and
+everything below it, on every machine, because `~/src/woswoar` on your laptop and
+on your desktop is the same project.
 
 **A short machine name is also an ordinary word.** If yours is `box`, typing it
 finds `sandbox` and `~/dropbox` too — so anchor it: **`^box`** matches only the
@@ -349,7 +351,7 @@ truthful. Re-running an import is idempotent.
 | `WOSWOAR_IGNORE` | extended regex of commands never to record |
 | `WOSWOAR_IGNORE_EXTRA` | extra regex joined onto the default, instead of replacing it |
 | `WOSWOAR_SYNC_INTERVAL` | seconds between background syncs; `0` turns them off (default `60`) |
-| `WOSWOAR_SCOPE` | default scope for <kbd>Ctrl</kbd>+<kbd>R</kbd> (default `global`) |
+| `WOSWOAR_SCOPE` | default scope for <kbd>Ctrl</kbd>+<kbd>R</kbd>: `global`, `host`, `session` or `dir` (default `global`) |
 | `WOSWOAR_NO_BIND` | set to skip binding <kbd>Ctrl</kbd>+<kbd>R</kbd> |
 
 ## Uninstalling

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -55,6 +55,18 @@ Switch scope without leaving the picker:
 | <kbd>Ctrl</kbd>+<kbd>G</kbd> | **global** — every machine |
 | <kbd>Ctrl</kbd>+<kbd>H</kbd> | **host** — this machine |
 | <kbd>Ctrl</kbd>+<kbd>S</kbd> | **session** — this shell |
+| <kbd>Ctrl</kbd>+<kbd>O</kbd> | **dir** — this directory and below |
+
+<kbd>Ctrl</kbd>+<kbd>R</kbd> inside the picker walks the same four in that order.
+
+**`dir` spans machines, and that is deliberate.** `~/src/woswoar` on your laptop
+and on your desktop is the same project, and that cross-machine question is the
+one woswoar exists to answer — so the directory scope does *not* also narrow to
+this machine. The machine column names where each row came from. (The scopes do
+not compose, so making `dir` imply `host` would remove the only way to ask it.)
+
+It matches what was *recorded*, which is the logical path: after `cd` through a
+symlink the hook stores the path you typed, and so does the lookup.
 
 `WOSWOAR_NO_BIND=1` skips the <kbd>Ctrl</kbd>+<kbd>R</kbd> binding entirely if
 you would rather keep another tool's.

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -10,6 +10,7 @@ from woswoar.entry import (
     Entry,
     escape,
     format_line,
+    home_relative,
     parse_line,
     truncate,
     unescape,
@@ -142,3 +143,39 @@ class TestParsedCommandsAreBounded(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestHomeRelative(unittest.TestCase):
+    """The `~` rule, which three implementations now have to agree on.
+
+    The hook writes it in shell, the importer applies it to this machine's own
+    rows, and `search`'s `dir` scope rebuilds it to compare against. It moved
+    here from `importer` when the third caller arrived: `search` must not import
+    `importer`, whose weight on the scope-switch path `credentials` documents as
+    a measured cost.
+    """
+
+    HOME = "/home/martinus"
+
+    def test_the_home_directory_itself(self) -> None:
+        self.assertEqual(home_relative(self.HOME, self.HOME), "~")
+
+    def test_a_path_below_home(self) -> None:
+        self.assertEqual(home_relative(f"{self.HOME}/src/woswoar", self.HOME), "~/src/woswoar")
+
+    def test_a_sibling_that_starts_the_same_is_left_alone(self) -> None:
+        """The trap in `${PWD/#$HOME/~}`, which rewrites this to `~copy`. The
+        hook spells the rule out in shell for the same reason, and
+        `test_shell_hook.test_sibling_of_home_is_not_mangled` pins that half."""
+        self.assertEqual(home_relative("/home/martinuscopy", self.HOME), "/home/martinuscopy")
+
+    def test_a_path_outside_home(self) -> None:
+        self.assertEqual(home_relative("/etc", self.HOME), "/etc")
+
+    def test_no_home_leaves_every_path_absolute(self) -> None:
+        """A machine with `$HOME` unset, where every path is honestly absolute
+        -- not a guess to be made on its behalf."""
+        self.assertEqual(home_relative("/home/martinus/src", ""), "/home/martinus/src")
+
+    def test_an_empty_path_stays_empty(self) -> None:
+        self.assertEqual(home_relative("", self.HOME), "")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -9,7 +9,7 @@ import shutil
 import sqlite3
 import subprocess
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import ClassVar
 from unittest import mock
@@ -18,7 +18,7 @@ from woswoar import search, store
 from woswoar.__main__ import main
 from woswoar.entry import Entry, format_line
 
-from .support import MACHINE_ID, WoswoarTestCase, requires_fzf
+from .support import MACHINE_ID, Captured, WoswoarTestCase, requires_fzf, run_cli
 
 NOW = 1_800_000_000
 
@@ -134,6 +134,33 @@ class TestRenderRoundTrip(unittest.TestCase):
                 self.assertEqual(search.command_from_line(line), cmd)
 
 
+def recalled(scope: search.Scope) -> list[str]:
+    """Every command a scope shows, as the picker recovers them.
+
+    One width, decided once and used for both halves -- which is the rule
+    `command_from_line` exists to enforce, and the reason this is one function
+    rather than a copy per test class: the picker's reload runs in another
+    process, so a machine arriving in between must not be able to make the two
+    sides disagree and slice somebody's command in the wrong place.
+    """
+    width = search.host_width_for(set(store.host_names()))
+    return [
+        search.command_from_line(line, width) for line in search.lines_for(scope, host_width=width)
+    ]
+
+
+#: Every scope's direct key, spelled as fzf takes it. Hand-written rather than
+#: read out of `search.KEYS`: a test that derived the key the way the code does
+#: would agree with it about a wrong one. Asserted against `search.SCOPES` so a
+#: scope added there without a key fails here.
+SCOPE_KEYS: dict[str, str] = {
+    "global": "ctrl-g",
+    "host": "ctrl-h",
+    "session": "ctrl-s",
+    "dir": "ctrl-o",
+}
+
+
 class TestScope(WoswoarTestCase):
     """Driven through `lines_for`, which is the path Ctrl-R takes.
 
@@ -154,14 +181,7 @@ class TestScope(WoswoarTestCase):
         self.record(2, "mine, other shell", session="elsewhere")
         self.record(3, "another machine", host="ffffffffffffffff", session="remote")
 
-    @staticmethod
-    def commands(scope: search.Scope) -> list[str]:
-        """As the picker does it: one width, decided once, used for both."""
-        width = search.host_width_for(set(store.host_names()))
-        return [
-            search.command_from_line(line, width)
-            for line in search.lines_for(scope, host_width=width)
-        ]
+    commands = staticmethod(recalled)
 
     def test_global_keeps_everything(self) -> None:
         self.assertEqual(len(self.commands("global")), 3)
@@ -187,12 +207,22 @@ class TestFzfArgv(unittest.TestCase):
     def test_scope_keys_reload_the_right_scope(self) -> None:
         argv = search._fzf_argv("global", "", True, 0)
         binds = " ".join(a for a in argv if a.startswith("--bind="))
-        for key, scope in (("ctrl-g", "global"), ("ctrl-h", "host"), ("ctrl-s", "session")):
-            self.assertIn(f"{key}:reload(", binds)
+        self.assertEqual(sorted(SCOPE_KEYS), sorted(search.SCOPES), "a scope with no direct key")
+        for scope in search.SCOPES:
+            self.assertIn(f"{SCOPE_KEYS[scope]}:reload(", binds)
             # `--colour` too: the reload's output goes back into fzf, which was
             # started with `--ansi`, so a scope switch that dropped it would
             # silently stop marking failures.
             self.assertIn(f"list --colour --host-width 0 --scope {scope}", binds)
+
+    def test_the_dir_key_is_one_fzf_has_not_taken(self) -> None:
+        """An fzf default binding would win, so the key would do fzf's thing and
+        never woswoar's. `ctrl-d` is the one this rules out by name: it is fzf's
+        `delete-char/eof`, which *aborts the picker* on an empty query."""
+        binds = " ".join(a for a in search._fzf_argv("global", "", True, 0) if "--bind=" in a)
+        self.assertIn("ctrl-o:reload(", binds)
+        for taken in ("ctrl-a", "ctrl-b", "ctrl-d", "ctrl-e", "ctrl-f", "ctrl-k", "ctrl-u"):
+            self.assertNotIn(f"{taken}:", binds, f"{taken} is one of fzf's own")
 
     def test_no_dedup_propagates_into_the_reload_command(self) -> None:
         argv = search._fzf_argv("global", "", False, 0)
@@ -688,7 +718,7 @@ class TestTheMachineColumn(WoswoarTestCase):
 
 
 class TestCtrlRCyclesTheScope(unittest.TestCase):
-    """Ctrl-R inside the picker moves global -> host -> session -> global.
+    """Ctrl-R inside the picker moves global -> host -> session -> dir -> global.
 
     fzf holds no variables, so the binding reads the current scope back out of
     the prompt fzf is already showing. What is asserted here is that shell
@@ -713,9 +743,44 @@ class TestCtrlRCyclesTheScope(unittest.TestCase):
         return out.split("--scope ", 1)[1].split(")", 1)[0].strip()
 
     def test_it_goes_round(self) -> None:
-        self.assertEqual(self.next_scope("woswoar (global) "), "host")
-        self.assertEqual(self.next_scope("woswoar (host) "), "session")
-        self.assertEqual(self.next_scope("woswoar (session) "), "global")
+        """Every scope's successor, driven off `SCOPES` so the two cannot drift.
+
+        Written out as three assertions before, which is how `session -> global`
+        stayed correct by *accident*: it was falling through the catch-all
+        rather than being decided, so the arm it needed once something followed
+        it was never missed."""
+        for index, scope in enumerate(search.SCOPES):
+            with self.subTest(scope=scope):
+                nxt = search.SCOPES[(index + 1) % len(search.SCOPES)]
+                self.assertEqual(self.next_scope(f"woswoar ({scope}) "), nxt)
+
+    def test_an_unrecognised_prompt_degrades_to_global(self) -> None:
+        """Which is what the catch-all is for, and why `session` needed an arm
+        of its own rather than keeping the fall-through it used to have."""
+        self.assertEqual(self.next_scope(""), "global")
+
+    def test_the_prompt_carries_nothing_but_the_scope(self) -> None:
+        """The `case` arms are substring matches over the *whole* prompt, so any
+        user text in it is a way to misroute the cycle. A prompt that named the
+        directory -- `woswoar (dir ~/src/session-manager)` -- reads as `session`
+        and goes to `dir` instead of round to `global`. If the matcher below is
+        ever made exact, the test that pins that misrouting is where to record
+        that this constraint has been lifted.
+
+        Asserted on the prompt fzf is actually given, and on the one the cycle
+        repaints, because those are the two places the text could get in."""
+        for scope in search.SCOPES:
+            with self.subTest(scope=scope):
+                argv = search._fzf_argv(scope, "", True, 0)
+                self.assertIn(f"--prompt=woswoar ({scope}) ", argv)
+        binding = search._cycle_binding("woswoar", "", " --host-width 0")
+        self.assertIn("change-prompt(woswoar ($n) )", binding)
+
+    def test_a_directory_in_the_prompt_would_misroute(self) -> None:
+        """The reason for the test above, made concrete rather than asserted
+        about in prose: this is what the substring matcher does with a path in
+        the prompt, and it is silent."""
+        self.assertEqual(self.next_scope("woswoar (dir ~/src/session-manager) "), "dir")
 
     def test_it_repaints_the_prompt_it_reads_back(self) -> None:
         """`change-prompt` is not decoration: the next press reads it."""
@@ -850,10 +915,15 @@ class TestSayingHowToFilterByMachine(WoswoarTestCase):
         self.assertNotIn("^name", search._header(host_width=0))
 
     def test_every_scope_is_named_and_every_key_reachable(self) -> None:
-        """The three direct keys share one segment where Ctrl-R names the
+        """The first three direct keys share one segment where Ctrl-R names the
         scopes, because `g`, `h` and `s` are the initials of the words beside
-        them -- but all three still have to be *findable*, and so does each
-        scope, or the compaction has quietly dropped one."""
+        them -- but all four still have to be *findable*, and so does each
+        scope, or the compaction has quietly dropped one.
+
+        Driven off `search.SCOPES` rather than a list written here, because a
+        scope added there and forgotten in the header is exactly the failure
+        this is for: the list used to be hardcoded, and it had already fallen
+        one behind by the time `dir` arrived."""
         for supported in (True, False):
             for width in (0, 8):
                 with (
@@ -861,9 +931,9 @@ class TestSayingHowToFilterByMachine(WoswoarTestCase):
                     mock.patch.object(search, "fzf_supports_transform", return_value=supported),
                 ):
                     header = search._header(host_width=width)
-                    for scope in ("global", "host", "session"):
+                    for scope in search.SCOPES:
                         self.assertIn(scope, header, f"{scope} is not named")
-                    for key in ("g", "h", "s"):
+                        key = SCOPE_KEYS[scope].removeprefix("ctrl-")
                         self.assertRegex(header, rf"ctrl-(\w+/)*{key}\b|ctrl-{key}\b")
 
     def test_the_cycle_says_which_order_it_goes_in(self) -> None:
@@ -871,7 +941,7 @@ class TestSayingHowToFilterByMachine(WoswoarTestCase):
         only way to learn the order was to press it three times."""
         with mock.patch.object(search, "fzf_supports_transform", return_value=True):
             header = search._header(host_width=0)
-        self.assertIn("global \u2192 host \u2192 session", header)
+        self.assertIn(" \u2192 ".join(search.SCOPES), header)
 
     def test_the_timeline_comes_after_the_scopes(self) -> None:
         """Ordered by how far each takes you from an ordinary search: change
@@ -1096,3 +1166,263 @@ class TestTheTimelineAroundACommand(WoswoarTestCase):
         self.assertNotIn("ctrl-t:", binds)
         header = next(a for a in argv if a.startswith("--header="))
         self.assertNotIn("ctrl-t", header, "a key that does nothing here is named anyway")
+
+    def test_it_carries_every_scope_through(self) -> None:
+        """Ctrl-T reads the scope back out of the prompt, exactly as the cycle
+        does, so a scope with no arm of its own silently becomes `global` -- a
+        timeline of the wrong list, with no error and a prompt that says
+        `timeline dir` while showing everything.
+
+        Driven as the real `sh`, because what is under test is that snippet's
+        decision. `--print-anchor` is stubbed out of the way: this is about the
+        scope it chooses, and the anchor needs a history to look at."""
+        script = search._timeline_binding("true", "", " --host-width 0").split("transform:", 1)[1]
+        for scope in search.SCOPES:
+            with self.subTest(scope=scope):
+                out = subprocess.run(
+                    ["sh", "-c", script],
+                    capture_output=True,
+                    text=True,
+                    env={"FZF_PROMPT": f"woswoar ({scope}) ", "PATH": "/usr/bin:/bin"},
+                    check=True,
+                ).stdout
+                self.assertIn(f"change-prompt(woswoar (timeline {scope}) )", out)
+                self.assertIn(f"--scope {scope} --around", out)
+
+
+class DirScopeCase(WoswoarTestCase):
+    """A sandbox with a home of its own, and a way to stand somewhere in it.
+
+    Shared because getting the fixture right is most of what testing `dir`
+    costs: `$HOME` is not in `store.ENV_KEYS`, so the base class does not
+    isolate it, and `os.chdir` does not touch `$PWD` -- it is the *shell* that
+    maintains that. A test that only chdir'd would exercise the `getcwd`
+    fallback while believing it exercised the `$PWD` path.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self.set_env("HOME", str(self.home))
+        self.addCleanup(os.chdir, os.getcwd())
+        self.ts = NOW
+
+    def set_env(self, key: str, value: str) -> None:
+        """Set one variable for the length of this test, restoring what was."""
+        patcher = mock.patch.dict(os.environ, {key: value})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def stand_in(self, path: Path | str) -> None:
+        """Move there and set `$PWD` to the same string, the way a shell does."""
+        os.chdir(path)
+        self.set_env("PWD", str(path))
+
+    def record(self, cwd: str, cmd: str, host: str = MACHINE_ID) -> None:
+        """One command, recorded as having been run in `cwd`."""
+        self.ts += 1
+        with store.private_append(store.log_file(host, "2026-07-29")) as handle:
+            handle.write(format_line(Entry(self.ts, host, "s", cwd, 0, 0, cmd)) + "\n")
+
+    @staticmethod
+    def commands(scope: search.Scope = "dir") -> list[str]:
+        return sorted(recalled(scope))
+
+
+class TestTheDirectoryScope(DirScopeCase):
+    """`dir`: this directory and everything below it, on every machine.
+
+    Every record has carried a `cwd` since the format existed -- written by the
+    hook, escaped, encrypted, synced and parsed into the cache -- and until now
+    `search` never read it. So the scope costs no new storage and no migration;
+    what it costs is getting the comparison right, and there are four ways to
+    get it wrong that all look like a working feature.
+    """
+
+    OTHER = "ffffffffffffffff"
+
+    def test_it_keeps_this_directory_and_below(self) -> None:
+        """The sibling in the fixture is the point of the fixture: with only a
+        parent and a child recorded, a filter that kept everything would give
+        the same answer as one that worked."""
+        (self.home / "src/proj").mkdir(parents=True)
+        self.record("~/src/proj", "in the project")
+        self.record("~/src/proj/sub", "in a subdirectory")
+        self.record("~/src/other", "in a sibling")
+
+        self.stand_in(self.home / "src/proj")
+        self.assertEqual(self.commands(), ["in a subdirectory", "in the project"])
+
+    def test_a_sibling_that_starts_the_same_is_not_a_child(self) -> None:
+        """`~/src/foobar` starts with `~/src/foo` and is not underneath it. The
+        same trap `entry.home_relative` is anchored against, one directory
+        further down, and a bare `startswith` walks into both."""
+        (self.home / "src/foo").mkdir(parents=True)
+        self.record("~/src/foo", "in foo")
+        self.record("~/src/foobar", "in foobar")
+
+        self.stand_in(self.home / "src/foo")
+        self.assertEqual(self.commands(), ["in foo"])
+
+    def test_a_symlinked_directory_matches_what_the_hook_recorded(self) -> None:
+        """The hook records `$PWD`, which after a `cd` through a symlink is the
+        path you typed and not the one it resolves to. Looking the other one up
+        makes every command run in a symlinked directory invisible here.
+
+        The resolved path is a different key, and stays one: that is what was
+        recorded for commands actually typed there, and guessing that the two
+        are the same directory is a resolution this does not do.
+        """
+        real = self.home / "elsewhere/project"
+        real.mkdir(parents=True)
+        (self.home / "proj").symlink_to(real)
+        self.record("~/proj", "typed through the link")
+        self.record("~/elsewhere/project", "typed at the real path")
+
+        self.stand_in(self.home / "proj")
+        self.assertEqual(self.commands(), ["typed through the link"])
+
+    def test_a_pwd_that_is_not_this_directory_is_not_believed(self) -> None:
+        """`$PWD` is inherited, so it is whatever the parent process left there.
+        Believed only when `stat` agrees it is the directory we are in."""
+        (self.home / "here").mkdir()
+        (self.home / "there").mkdir()
+        self.record("~/here", "recorded where we stand")
+        self.record("~/there", "recorded somewhere else")
+        os.chdir(self.home / "here")
+
+        for stale in (str(self.home / "there"), "."):
+            with self.subTest(pwd=stale):
+                self.set_env("PWD", stale)
+                self.assertEqual(self.commands(), ["recorded where we stand"])
+
+    def test_it_spans_machines(self) -> None:
+        """`~/src/proj` on either of your boxes is the same project, and asking
+        that across machines is the question woswoar exists for. The scopes do
+        not compose, so a `dir` that also meant `host` would remove it."""
+        (self.home / "src/proj").mkdir(parents=True)
+        self.record("~/src/proj", "mine")
+        self.record("~/src/proj", "theirs", host=self.OTHER)
+
+        self.stand_in(self.home / "src/proj")
+        self.assertEqual(self.commands(), ["mine", "theirs"])
+
+    def test_a_peer_path_stored_absolute_is_matched_too(self) -> None:
+        """`importer` rewrites a path to `~` only for this machine's own rows --
+        another machine's home is a guess -- so an atuin import of two hosts
+        stores the same directory both ways. One key silently misses half of it,
+        in exactly the multi-machine case this scope is for."""
+        (self.home / "src/proj").mkdir(parents=True)
+        self.record("~/src/proj", "mine, stored with a tilde")
+        self.record(str(self.home / "src/proj"), "theirs, stored absolute", host=self.OTHER)
+
+        self.stand_in(self.home / "src/proj")
+        self.assertEqual(self.commands(), ["mine, stored with a tilde", "theirs, stored absolute"])
+
+    def test_the_root_directory_matches_everything(self) -> None:
+        """Every recorded directory is under `/`, including the `~` ones -- which
+        do not start with `/` at all, so the anchored prefix test matches none of
+        them and would build `//` besides."""
+        self.record("~/src", "under home")
+        self.record("/etc", "outside home")
+
+        self.stand_in("/")
+        self.assertEqual(self.commands(), ["outside home", "under home"])
+
+    def test_a_control_byte_in_the_directory_name_still_matches(self) -> None:
+        """The cache holds the `cwd` that `parse_line(..., inert=True)` produced,
+        so the byte is already gone from what is stored. A key still carrying it
+        matches nothing, and the directory quietly has no history."""
+        odd = self.home / "we\x01ird"
+        odd.mkdir()
+        self.record("~/we\x01ird", "in the odd directory")
+
+        self.stand_in(odd)
+        self.assertEqual(self.commands(), ["in the odd directory"])
+
+    def test_nothing_recorded_here_is_empty_rather_than_everything(self) -> None:
+        """The failure that looks most like success: a scope that matches
+        nothing has to return nothing, not fall back to the whole history."""
+        (self.home / "empty").mkdir()
+        self.record("~/src", "somewhere else entirely")
+
+        self.stand_in(self.home / "empty")
+        self.assertEqual(self.commands(), [])
+
+    def test_a_directory_deleted_under_us_still_answers(self) -> None:
+        """`rm -rf` of the directory you are standing in, then Ctrl-R. There is
+        no `.` left to check `$PWD` against and nothing for `os.getcwd` to
+        resolve, so `$PWD` is all that is left of where you are -- and a
+        traceback here would be a worse answer than the history it still knows."""
+        doomed = self.home / "doomed"
+        doomed.mkdir()
+        self.record("~/doomed", "run before it went")
+
+        self.stand_in(doomed)
+        doomed.rmdir()
+        self.assertEqual(self.commands(), ["run before it went"])
+
+    def test_a_directory_that_cannot_be_named_at_all_is_not_a_crash(self) -> None:
+        """The same deletion with no `$PWD` to fall back on -- which is a shell
+        that never exported one, or `env -i`. Nothing can be matched, and the
+        note that would otherwise name the directory has nothing to name."""
+        doomed = self.home / "doomed"
+        doomed.mkdir()
+        self.record("~/doomed", "run before it went")
+
+        os.chdir(doomed)
+        self.set_env("PWD", "")
+        doomed.rmdir()
+        self.assertEqual(self.commands(), [])
+        self.assertEqual(
+            search.empty_note("dir"),
+            "woswoar: no commands recorded in this directory or below",
+        )
+
+
+class TestAnEmptyDirScopeSaysWhereItLooked(DirScopeCase):
+    """An empty `global` explains itself; an empty `dir` looks like a bug.
+
+    And the one fact that tells those apart is *which* directory was searched --
+    which is exactly what the `$PWD` rule in `search._here` can get wrong. So it
+    is named, once, to a person.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.stand_in(self.home)
+
+    def test_a_terminal_is_told_which_directory_was_searched(self) -> None:
+        ran = run_cli("list", "--scope", "dir", tty=True)
+        self.assertEqual(ran.out, "")
+        self.assertIn("no commands recorded in ~ or below", ran.err)
+
+    def test_a_pipe_stays_clean(self) -> None:
+        """`woswoar list --scope dir | wc -l` has to keep counting lines."""
+        ran = run_cli("list", "--scope", "dir")
+        self.assertEqual((ran.out, ran.err), ("", ""))
+
+    def test_the_pickers_reload_is_not_written_into(self) -> None:
+        """fzf reads the reload's stdout through a pipe while leaving its stderr
+        on the terminal, so a note gated on *stderr* being a tty would land in
+        the middle of the picker. The gate is on stdout, and only these two
+        streams disagreeing can tell the difference."""
+        out, err = Captured(tty=False), Captured(tty=True)
+        with redirect_stdout(out), redirect_stderr(err):
+            main(["list", "--scope", "dir"])
+        self.assertEqual(err.getvalue(), "", "the picker's screen was written into")
+
+    def test_a_scope_that_found_something_says_nothing(self) -> None:
+        with store.private_append(store.log_file(MACHINE_ID, "2026-07-29")) as handle:
+            handle.write(format_line(Entry(NOW, MACHINE_ID, "s", "~", 0, 0, "here")) + "\n")
+        ran = run_cli("list", "--scope", "dir", tty=True)
+        self.assertIn("here", ran.out)
+        self.assertEqual(ran.err, "")
+
+    def test_the_other_scopes_stay_quiet_when_empty(self) -> None:
+        """An empty `global` is a machine that has recorded nothing, which needs
+        no explaining -- and `list` is a pipe target before it is a report."""
+        for scope in ("global", "host", "session"):
+            with self.subTest(scope=scope):
+                self.assertEqual(run_cli("list", "--scope", scope, tty=True).err, "")

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -146,6 +146,14 @@ def cmd_list(args: argparse.Namespace) -> int:
     )
     if lines:
         sys.stdout.write("\n".join(lines) + "\n")
+    elif sys.stdout.isatty() and (note := search.empty_note(args.scope)):
+        # Gated on **stdout** being a terminal, not stderr, which is the half of
+        # this decision that belongs here. `woswoar list | wc -l` must stay
+        # clean, and the picker's reload runs this with stdout on a pipe but
+        # stderr still on the terminal -- a note printed there would land in the
+        # middle of fzf's screen. Which scopes have anything to say is
+        # `search`'s business, not the CLI's.
+        print(note, file=sys.stderr)
     return 0
 
 
@@ -1512,8 +1520,12 @@ def build_parser() -> argparse.ArgumentParser:
         What Ctrl-R runs. The chosen command is placed on your prompt for
         editing, never executed.
 
-        Ctrl-G, Ctrl-H and Ctrl-S switch between every machine, this machine,
-        and this shell session, without leaving the picker.
+        Ctrl-G, Ctrl-H, Ctrl-S and Ctrl-O switch between every machine, this
+        machine, this shell session, and this directory and below, without
+        leaving the picker.
+
+        The directory scope spans machines on purpose: ~/src/woswoar on either
+        of your boxes is the same project.
         """,
     )
     add_scope(p_search)
@@ -1525,8 +1537,9 @@ def build_parser() -> argparse.ArgumentParser:
         "print matching lines as plain text",
         """
         Mostly internal: this is what the picker re-runs when you switch scope
-        with Ctrl-G, Ctrl-H or Ctrl-S. It is also how to read your history
-        without fzf installed, and it pipes -- `woswoar list | grep docker`.
+        with Ctrl-G, Ctrl-H, Ctrl-S or Ctrl-O. It is also how to read your
+        history without fzf installed, and it pipes --
+        `woswoar list | grep docker`.
         """,
     )
     add_scope(p_list)

--- a/woswoar/cache.py
+++ b/woswoar/cache.py
@@ -222,6 +222,18 @@ class Cache:
         """The session column, in the same order as `stamps_and_commands`."""
         return [value for flat in self.files.values() for value in flat[1::6]]
 
+    def cwds(self) -> list[str]:
+        """The working-directory column, in the same order as `stamps_and_commands`.
+
+        Its own accessor rather than a fifth column on `display_columns`, which
+        every scope would then pay for to serve one of them -- 0.4 ms measured
+        over 54,600 rows -- and `cwd` is not a display column. It is comparable
+        exactly as it comes out, which is the other half of why this is cheap:
+        the cache stores what `parse_line(..., inert=True)` produced, so it is
+        already unescaped and already inert.
+        """
+        return [value for flat in self.files.values() for value in flat[2::6]]
+
 
 def _fingerprint(path: Path) -> bytes:
     try:

--- a/woswoar/entry.py
+++ b/woswoar/entry.py
@@ -65,6 +65,32 @@ class Entry(NamedTuple):
     cmd: str
 
 
+def home_relative(path: str, home: str) -> str:
+    """``path`` written the way a record stores it: ``~/src/woswoar`` under ``home``.
+
+    Anchored, and that is the whole subtlety. ``${PWD/#$HOME/~}`` rewrites
+    ``/home/martinuscopy`` into ``~copy`` when ``$HOME`` is ``/home/martinus``,
+    which is why the hook spells the same rule out in shell rather than using it.
+
+    Three callers have to agree on this string: the hook writes it, the importer
+    applies it to this machine's own rows, and `search`'s ``dir`` scope rebuilds
+    it to compare against. It lives here because this module is what the format
+    means -- and because `search` must not import `importer`, where it used to
+    be: `credentials` documents pulling that module onto the scope-switch path
+    as a measured cost.
+
+    An empty ``home`` leaves the path alone. That is not a guess -- it is a
+    machine whose ``$HOME`` is unset, where every path is honestly absolute.
+    """
+    if not path or not home:
+        return path
+    if path == home:
+        return "~"
+    if path.startswith(f"{home}/"):
+        return "~" + path[len(home) :]
+    return path
+
+
 def escape(value: str) -> str:
     """Make ``value`` safe to store in a tab-separated field.
 

--- a/woswoar/importer.py
+++ b/woswoar/importer.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Literal, NamedTuple
 
 from . import credentials, store
-from .entry import Entry, truncate
+from .entry import Entry, home_relative, truncate
 
 Kind = Literal["bash", "zsh", "atuin"]
 KINDS: tuple[Kind, ...] = ("bash", "zsh", "atuin")
@@ -310,17 +310,6 @@ def resolve_hosts(hostnames: Iterable[str]) -> dict[str, tuple[str, str]]:
     return resolved
 
 
-def _home_relative(cwd: str, home: str) -> str:
-    """Match the hook's storage convention for this machine's own paths."""
-    if not cwd or not home:
-        return cwd
-    if cwd == home:
-        return "~"
-    if cwd.startswith(f"{home}/"):
-        return "~" + cwd[len(home) :]
-    return cwd
-
-
 def _dedup_key(ts: int, cmd: str) -> tuple[int, str]:
     """The identity an entry will have *once written*.
 
@@ -418,7 +407,7 @@ def run_atuin(
                     # Only rewrite paths for this machine: another host's home
                     # directory is a guess, and a wrong ~ is worse than a long
                     # but honest absolute path.
-                    cwd=_home_relative(row.cwd, home) if host_id == own_id else row.cwd,
+                    cwd=home_relative(row.cwd, home) if host_id == own_id else row.cwd,
                     exit_code=row.exit_code,
                     duration_ms=row.duration_ms,
                     cmd=row.cmd,

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -18,10 +18,25 @@ if TYPE_CHECKING:
     from typing import IO
 
 from . import cache, store
-from .entry import escape, make_inert, unescape
+from .entry import escape, home_relative, make_inert, unescape
 
-Scope = Literal["global", "host", "session"]
-SCOPES: tuple[Scope, ...] = ("global", "host", "session")
+Scope = Literal["global", "host", "session", "dir"]
+#: The order Ctrl-R visits them in, and the order the header names them. `dir`
+#: is appended rather than slotted in "by narrowing": inserting it would change
+#: what an existing user's second press does, and muscle memory is a format in
+#: the sense CLAUDE.md rule 8 means.
+SCOPES: tuple[Scope, ...] = ("global", "host", "session", "dir")
+
+#: The key that jumps straight to each scope, without the `ctrl-` prefix. One
+#: table, because the picker's `--bind` and the header that advertises it are
+#: otherwise two hand-written copies of the same fact -- and the way that fails
+#: is a header naming a key nothing binds, which nothing but a reader notices.
+#:
+#: `g`, `h` and `s` are the initials of their scopes; `o` is not, and is chosen
+#: because fzf binds nothing to `ctrl-o`. `ctrl-d` is its `delete-char/eof` and
+#: *aborts the picker* on an empty query; `alt-d` is `kill-word` and is two keys,
+#: which breaks the shape of the other three.
+KEYS: dict[Scope, str] = {"global": "g", "host": "h", "session": "s", "dir": "o"}
 
 #: Every display line is ``"<7-char relative time><2 spaces><escaped command>"``.
 #: The prefix is a fixed width so recovering the command from what fzf prints
@@ -175,6 +190,105 @@ def command_from_line(line: str, host_width: int = 0) -> str:
     return make_inert(unescape(line[_PREFIX + (host_width + 2 if host_width else 0) :]))
 
 
+def _same_directory(path: str) -> bool:
+    """Whether ``path`` names the directory this process is actually in."""
+    try:
+        return os.path.samefile(path, ".")
+    except OSError:
+        return False
+
+
+def _here() -> tuple[str, ...]:
+    """The current directory, in every form a recorded ``cwd`` might take.
+
+    Both forms, always. The tilde form is what the hook writes and what the
+    importer stores for this machine's own rows; the absolute form is what the
+    importer deliberately leaves alone for a *peer's* rows, because another
+    machine's home directory is a guess. So a history imported from two atuin
+    hosts holds ``~/src/x`` for one and ``/home/you/src/x`` for the other, and a
+    single key would silently miss half of it -- in exactly the multi-machine
+    case woswoar exists for.
+
+    `$PWD` before `os.getcwd()`, because they are different answers after a `cd`
+    through a symlink: `$PWD` is the logical path you typed, `getcwd` resolves
+    it. The hook records `$PWD`, so anything else here makes every command run
+    in a symlinked directory invisible to this scope. But `$PWD` is inherited
+    and so is whatever the parent process left there: it is believed only when
+    it is absolute *and* `stat` says it is the same directory as `.`.
+
+    Made inert because the cached `cwd` was: a directory whose name carries a
+    control byte is stored with that byte removed, and a key still carrying it
+    would never match anything.
+    """
+    try:
+        physical = os.getcwd()
+    except OSError:
+        # The directory was removed out from under this process, so there is no
+        # `.` left to check `$PWD` against and no resolved path to fall back to.
+        # `rm -rf` of the directory you are standing in, then Ctrl-R, is not
+        # exotic; a traceback there would be.
+        physical = ""
+
+    logical = os.environ.get("PWD", "")
+    trusted = os.path.isabs(logical) and (not physical or _same_directory(logical))
+    path = logical if trusted else physical
+    if not path:
+        return ()
+
+    home = os.environ.get("HOME", "")
+    tilde = make_inert(home_relative(path, home))
+    absolute = make_inert(path)
+    # Standing anywhere outside home makes the two spellings the same string,
+    # and one key is then all there is to look for. Tilde first either way:
+    # that is the one `_here_label` shows a person.
+    return (tilde,) if tilde == absolute else (tilde, absolute)
+
+
+def _here_label() -> str:
+    """How to name the current directory to a person -- as a record would spell it."""
+    keys = _here()
+    return keys[0] if keys else "this directory"
+
+
+def empty_note(scope: Scope) -> str | None:
+    """What to tell someone whose scope matched nothing, if anything.
+
+    `dir` alone. An empty `global` is a machine that has recorded nothing and
+    explains itself; an empty `dir` is indistinguishable from a broken feature,
+    and the one fact that separates them is *which* directory was searched --
+    which is exactly what the `$PWD` rule in `_here` can get wrong.
+
+    Here rather than in `__main__` because which scope owes an explanation is a
+    property of the scopes, and this module already owns the prose on this path:
+    `interactive` prints the missing-fzf report and what to run instead. What
+    stays with the caller is the part that is genuinely its own -- whether
+    anyone is looking at a terminal.
+    """
+    if scope != "dir":
+        return None
+    return f"woswoar: no commands recorded in {_here_label()} or below"
+
+
+def _under(cwds: list[str], keys: tuple[str, ...]) -> list[int]:
+    """Which rows were recorded in one of ``keys`` or below it.
+
+    Equal to a key, or below it *across a separator* -- never a bare prefix
+    test. That is the `/home/martinuscopy` trap `entry.home_relative` already
+    solves, one directory further down: without the `/`, standing in
+    `~/src/foo` also matches everything in `~/src/foobar`.
+    """
+    if "/" in keys:
+        # The root is every recorded directory, including the `~` ones -- which
+        # do not start with `/` at all, so the anchored test below would match
+        # none of them, and the prefix it built would be `//`.
+        return list(range(len(cwds)))
+    # A tuple of prefixes rather than `any(... for key in keys)`, because the
+    # generator is re-entered per row: 10.9 ms against 2.6 ms over 54,600 rows.
+    # `str.startswith` takes the tuple and does the loop in C.
+    below = tuple(f"{key}/" for key in keys)
+    return [index for index, value in enumerate(cwds) if value in keys or value.startswith(below)]
+
+
 #: The four parallel columns a display line is built from.
 Columns = tuple[list[str], list[str], list[str], list[str]]
 
@@ -194,17 +308,31 @@ def _columns_for(scope: Scope) -> tuple[cache.Cache, Columns | None]:
         if not session:
             # Not an error: this is what a shell without the hook loaded looks like.
             return loaded, None
-        stamps, commands, codes, hosts = loaded.display_columns()
-        # The one column that is per entry rather than per file, so it is the
-        # one scope that cannot be answered by dropping whole files.
+        # `session` and `dir` are the two columns that are per entry rather than
+        # per file, so they are the scopes that cannot be answered by dropping
+        # whole files the way `host` is.
         wanted = [i for i, value in enumerate(loaded.sessions()) if value == session]
-        return loaded, (
-            [stamps[i] for i in wanted],
-            [commands[i] for i in wanted],
-            [codes[i] for i in wanted],
-            [hosts[i] for i in wanted],
-        )
+        return loaded, _gather(loaded.display_columns(), wanted)
+    if scope == "dir":
+        # Deliberately every machine, not this one. `~/src/woswoar` on either
+        # box is the same project, and asking that across machines is what
+        # woswoar is for; the scopes do not compose, so a `dir` that implied
+        # `host` would remove the only way to ask it. Its failure mode is an
+        # extra row with the machine column naming where it came from, against a
+        # missing row that looks like a broken feature.
+        return loaded, _gather(loaded.display_columns(), _under(loaded.cwds(), _here()))
     return loaded, loaded.display_columns()
+
+
+def _gather(columns: Columns, wanted: list[int]) -> Columns:
+    """The four display columns, narrowed to the rows at ``wanted``."""
+    stamps, commands, codes, hosts = columns
+    return (
+        [stamps[i] for i in wanted],
+        [commands[i] for i in wanted],
+        [codes[i] for i in wanted],
+        [hosts[i] for i in wanted],
+    )
 
 
 def _rows_for(columns: Columns, dedup: bool, around: int | None) -> tuple[list[Row], int]:
@@ -244,9 +372,10 @@ def lines_for(
     displayed, and building namedtuples to hold them was most of what Ctrl-R
     waited for.
 
-    `session` is the exception -- it is per entry, not per file -- so that scope
-    fetches one more column. `host` needs none: it is a property of the file,
-    so the cache filters whole files out before a single row is looked at.
+    `session` and `dir` are the exceptions -- both filter on a column that is
+    per entry rather than per file -- so each fetches one more column of its
+    own. `host` needs none: it is a property of the file, so the cache filters
+    whole files out before a single row is looked at.
     """
     loaded, columns = _columns_for(scope)
     if columns is None:
@@ -468,21 +597,49 @@ def fzf_supports_transform() -> bool:
     return parsed is not None and parsed >= TRANSFORM_SINCE
 
 
+def _scope_case(var: str, answer: dict[Scope, Scope]) -> str:
+    """An ``sh`` ``case`` that reads the current scope out of fzf's prompt.
+
+    fzf holds no variables, so both keys that need to know the scope read it
+    back out of the prompt fzf is already showing -- which is why
+    `change-prompt` is not cosmetic. One emitter for both, because the arms are
+    exactly `SCOPES` and enumerating them by hand is how one goes missing: the
+    cycle's `session` arm was absent and *correct anyway*, falling through the
+    catch-all to `global`, right up until `dir` was appended after it. Nothing
+    would have said so -- an arm that is missing looks exactly like an arm whose
+    answer happens to be the default.
+
+    The catch-all stays `SCOPES[0]`, which is what an unset or unrecognised
+    prompt should degrade to.
+
+    **The prompt these read must stay exactly `woswoar (<scope>) `.** The
+    patterns are substring matches over the whole of it, so a prompt naming the
+    directory -- `woswoar (dir ~/src/session-manager)` -- matches `*session*`
+    first and silently answers with the wrong scope. It costs nothing to put a
+    path in a prompt and there is no error when it goes wrong, which is why it
+    is written down here and pinned by a test.
+    """
+    arms = "".join(f"*{scope}*) {var}={answer[scope]} ;; " for scope in SCOPES)
+    return f'case "$FZF_PROMPT" in {arms}*) {var}={SCOPES[0]} ;; esac; '
+
+
+#: Where each scope goes when Ctrl-R is pressed: on to the next, and round.
+#: Appending to `SCOPES` therefore extends the cycle and changes no existing
+#: step of it.
+_NEXT: dict[Scope, Scope] = {
+    scope: SCOPES[(index + 1) % len(SCOPES)] for index, scope in enumerate(SCOPES)
+}
+
+
 def _cycle_binding(self_cmd: str, dedup_flag: str, width: str) -> str:
     """Ctrl-R inside the picker moves to the next scope.
 
-    fzf holds no variables, so the current scope is read back out of the prompt
-    it is already showing -- which is why `change-prompt` is not cosmetic. The
-    order matches the header: global, host, session, round again.
+    The order is `SCOPES`, which is the order the header names them in.
     """
     reload = f"{self_cmd} list --colour{width} --scope"
     script = (
-        'case "$FZF_PROMPT" in '
-        "*global*) n=host ;; "
-        "*host*) n=session ;; "
-        "*) n=global ;; "
-        "esac; "
-        f'printf "reload({reload} $n{dedup_flag})+change-prompt(woswoar ($n) )"'
+        _scope_case("n", _NEXT)
+        + f'printf "reload({reload} $n{dedup_flag})+change-prompt(woswoar ($n) )"'
     )
     return f"--bind=ctrl-r:transform:{script}"
 
@@ -509,17 +666,29 @@ def _header(host_width: int) -> str:
     """
     if fzf_supports_transform():
         # Naming the scopes in the order Ctrl-R visits them is what lets the
-        # three direct keys collapse into one segment: `g`, `h` and `s` are the
-        # initials of the words right beside them, so spelling each out again
-        # was three quarters of the line saying the same thing twice.
+        # first three direct keys collapse into one segment: `g`, `h` and `s`
+        # are the initials of the words right beside them, so spelling each out
+        # again was three quarters of the line saying the same thing twice.
+        #
+        # `ctrl-o` is the odd one out and so is spelled: `o` is not the initial
+        # of `dir`, and a reader who has to work out which key belongs to which
+        # word has lost more than the four characters this costs. Written by
+        # hand for that reason -- the compaction is editorial, and a fifth scope
+        # may well want a differently shaped sentence rather than another comma.
         #
         # `ctrl-` in full rather than the usual `^r`, because `^` already means
         # something else on this line: `^name` is fzf's anchor, not a key.
-        hints = ["ctrl-r global \u2192 host \u2192 session, or ctrl-g/h/s", "ctrl-t timeline"]
+        hints = [
+            "ctrl-r global \u2192 host \u2192 session \u2192 dir, or ctrl-g/h/s, ctrl-o dir",
+            "ctrl-t timeline",
+        ]
     else:
         # Neither key exists here, and with no cycle to name the scopes the
-        # three that do have to introduce themselves.
-        hints = ["ctrl-g global", "ctrl-h host", "ctrl-s session"]
+        # four that do have to introduce themselves. Derived from `KEYS`, unlike
+        # the sentence above: this one is a plain rendering of the bindings, and
+        # writing it out again is how a header comes to advertise a key that
+        # nothing binds.
+        hints = [f"ctrl-{KEYS[scope]} {scope}" for scope in SCOPES]
     if host_width:
         hints.append("^name one machine")
     return " | ".join(hints)
@@ -532,24 +701,19 @@ def _timeline_binding(self_cmd: str, dedup_flag: str, width: str) -> str:
     `woswoar list` just produced -- so the anchor needs nothing added to the
     line and the display format is untouched.
 
-    The scope is read back out of the prompt, exactly as `_cycle_binding` does
-    and for the same reason: fzf holds no variables. It is carried into the
-    timeline's own prompt (`woswoar (timeline host)`) so that pressing this
-    again recentres without silently changing scope, and so that ctrl-g/h/s/r
-    still read a scope out of it on the way back out.
+    The scope is read back out of the prompt by the same emitter the cycle uses,
+    which here answers with the scope it found rather than the next one. It is
+    carried into the timeline's own prompt (`woswoar (timeline host)`) so that
+    pressing this again recentres without silently changing scope, and so that
+    ctrl-g/h/s/o/r still read a scope out of it on the way back out.
     """
     reload = f"{self_cmd} list --colour{width} --scope"
     script = (
-        'case "$FZF_PROMPT" in '
-        "*global*) s=global ;; "
-        "*host*) s=host ;; "
-        "*session*) s=session ;; "
-        "*) s=global ;; "
-        "esac; "
+        _scope_case("s", {scope: scope for scope in SCOPES})
         # One extra invocation, on a keypress rather than on the prompt path:
         # `pos` has to be composed into the same action string as the `reload`
         # it applies to, so it cannot be read out of the reload's own output.
-        f"p=$({reload} $s{dedup_flag} --around {{n}} --print-anchor); "
+        + f"p=$({reload} $s{dedup_flag} --around {{n}} --print-anchor); "
         # `reload-sync`, not `reload`: a plain reload is asynchronous, so `pos`
         # ran against the list that was still on screen and the cursor was
         # wherever the new one happened to leave it. Reported as "it seems to
@@ -560,7 +724,7 @@ def _timeline_binding(self_cmd: str, dedup_flag: str, width: str) -> str:
         # down to the same match you started from, which is an empty gesture.
         # Asked for directly: "it should clear the filter, that way it's
         # filtering the timeline".
-        f'printf "clear-query+reload-sync({reload} $s{dedup_flag} --around {{n}})'
+        + f'printf "clear-query+reload-sync({reload} $s{dedup_flag} --around {{n}})'
         '+pos($p)+change-prompt(woswoar (timeline $s) )"'
     )
     return f"--bind=ctrl-t:transform:{script}"
@@ -607,9 +771,10 @@ def _fzf_argv(scope: Scope, query: str, dedup: bool, host_width: int) -> list[st
     if fzf_supports_transform():
         argv.append(_cycle_binding(self_cmd, dedup_flag, width))
         argv.append(_timeline_binding(self_cmd, dedup_flag, width))
-    for key, target in (("ctrl-g", "global"), ("ctrl-h", "host"), ("ctrl-s", "session")):
+    for target in SCOPES:
         argv.append(
-            f"--bind={key}:reload({self_cmd} list --colour{width} --scope {target}{dedup_flag})"
+            f"--bind=ctrl-{KEYS[target]}:reload("
+            f"{self_cmd} list --colour{width} --scope {target}{dedup_flag})"
             f"+change-prompt(woswoar ({target}) )"
         )
     return argv


### PR DESCRIPTION
Closes #151.

`cwd` has been on every record since the format existed — written by the hook,
escaped, encrypted, synced, and parsed into the cache — and `search.py` never
read it. This adds the scope that reads it.

**`dir`** is the current directory and everything below it, on every machine.
<kbd>Ctrl</kbd>+<kbd>O</kbd> goes straight there and <kbd>Ctrl</kbd>+<kbd>R</kbd>
now cycles `global → host → session → dir`.

## The four ways to get the comparison wrong

Each looks like a working feature from the outside, and each has a mutation
below that a test catches.

**Anchored on a separator.** `value == key or value.startswith(key + "/")`,
never a bare prefix — otherwise standing in `~/src/foo` also lists everything in
`~/src/foobar`. Same trap `home_relative` solves one directory further up.

**`$PWD`, not `os.getcwd()`.** They differ after a `cd` through a symlink:
`$PWD` is the path you typed, `getcwd` resolves it. The hook records `$PWD`, so
looking up the resolved one makes every command run in a symlinked directory
invisible. `$PWD` is also inherited and therefore whatever the parent left
there, so it is believed only when it is absolute **and** `os.path.samestat`
agrees it is the same directory as `.`.

**Both the tilde form and the absolute form.** `importer.py:410` rewrites a path
to `~` only for this machine's own rows — another machine's home is a guess — so
an atuin import of two hosts stores the same directory both ways. One key
silently misses half the history in exactly the multi-machine case this scope is
for.

**The key is made inert**, because the cached `cwd` already was: a directory
name carrying a control byte is stored with it removed, and a key still carrying
it matches nothing.

Plus `/`, which matches everything: every recorded directory is under it,
including the `~` ones, which do not start with `/` at all — and the anchored
prefix would otherwise be `//`.

## `dir` spans machines, deliberately

`~/src/woswoar` on either box is the same project, and that cross-machine
question is the one woswoar exists to answer. The scopes do not compose, so a
`dir` that implied `host` would remove the only way to ask it. Its failure mode
is an extra row with the machine column naming where it came from; the
alternative's is a missing row that looks like a broken feature. Documented in
`docs/shell-integration.md`, since it is otherwise met as a surprise.

## Cost

Measured on a generated 54,600-row history, median of seven, this laptop:

| | |
|---|---|
| `lines_for("dir")` | **29.5 ms** (7,288 lines) |
| `lines_for("global")` | 38.9 ms on this branch, 41.4 ms on `main` (18,208 lines) |
| what `dir` adds | `cwds()` slice 0.44 ms + filter 2.0 ms + gather 0.85 ms ≈ **3.3 ms** |
| what it adds to every other scope | **0** — nothing on their path changed |

`dir` comes out *faster* than `global` overall, because ranking and rendering a
subset costs less than the filter does. Against the ~105 ms keypress
`docs/shell-integration.md` publishes, this is under the noise floor, and no
`tests/test_perf.py` target moves (run with `WOSWOAR_BENCH=1`: warm load 43.4 ms
of 50, list 39.5 ms of 100, end to end 87.3 ms of 200).

One measured decision inside the filter: the obvious
`any(... for key in keys)` re-enters the generator per row and cost **10.9 ms**;
a `frozenset` plus `str.startswith` over a tuple of prefixes does the loop in C
for **2.0 ms**. Same rule, same anchoring.

## Migration: none

No record-format change, no cache change (`CACHE_VERSION` stays 2), no
`state.json` field, no repo-layout change. `dir` reads a column that has been in
the cache since the format existed. Two lines for the release notes:

- `WOSWOAR_SCOPE=dir` in a shared dotfiles repo is rejected by an older woswoar
  with a visible argparse error — visible, not silent.
- The <kbd>Ctrl</kbd>+<kbd>R</kbd> cycle grows a fourth stop without changing any
  existing sequence: `dir` is appended, not slotted in "by narrowing".

## Two decisions worth flagging

**The empty-`dir` note is gated on `stdout` being a terminal, not stderr.** The
issue said "on a tty"; both readings keep `woswoar list --scope dir | wc -l`
clean, but fzf runs the picker's reload with stdout on a pipe and **stderr still
on the terminal**, so a note gated on stderr would land in the middle of the
picker. `test_the_pickers_reload_is_not_written_into` is the only test where the
two streams disagree, and it is what pins this.

**The prompt must stay exactly `woswoar (dir) `.** The cycle's `case` arms are
substring matches over the whole prompt, so `woswoar (dir ~/src/session-manager)`
would read as `session` and jump scope, silently. There is a comment at
`_cycle_binding` and two tests: one that every prompt fzf is given is bare, and
one that pins what the substring matcher does with a path in it, so a future
change that makes the match exact has a place that says the constraint is lifted.

## Not done, and why

A symlinked directory and its real path stay two different keys. That is what
was recorded — a command typed at the real path is a different record — and
resolving the two together is a decision this scope does not make. Asserted
explicitly rather than left to chance in
`test_a_symlinked_directory_matches_what_the_hook_recorded`.

`home_relative` moves from `importer.py` to `entry.py` (public), where the
format's `~` rule is already documented, and gains its own tests including the
`/home/martinuscopy` case that had none. `search` must not import `importer`:
`credentials.py:105` records that module's weight on the scope-switch path as a
measured cost.

## `/simplify` pass

Run before the PR opened; four agents, findings deduped and applied.

**Production code:**

- One `KEYS` table beside `SCOPES`. The picker's `--bind` loop and the header
  that advertises those keys were two hand-written copies of the same fact, and
  the way that fails is a header naming a key nothing binds — visible only to a
  reader. Both now derive from the table. The transform-branch sentence stays
  hand-written: the compaction of three initials plus one spelled-out oddity is
  editorial.
- One `_scope_case` emitter behind both generated `sh` `case` blocks. The arms
  *are* `SCOPES` — the cycle's are the rotation, the timeline's the identity —
  and enumerating them by hand is exactly how the `session` arm came to be
  missing and correct anyway. The emitted text is arm-for-arm what was there,
  plus the one arm the cycle used to reach by fall-through, and both are still
  driven through a real `sh` by tests. The counterweight is real: this repo
  values reading the snippet it ships, and two literals are now one generator.
- `search.empty_note(scope)` replaces `here_label()`. Which scope owes an
  explanation is a property of the scopes; whether anyone is looking at a
  terminal is the CLI's. `here_label` became private.
- `os.path.samefile(path, ".")` for the hand-rolled `samestat(stat, stat)`.
- `_here` returns its two forms explicitly rather than through `dict.fromkeys`;
  `_under` drops a `frozenset` that measured 0.2 ms of 105.

**Tests:** one `recalled()` helper and one `SCOPE_KEYS` table where there were
two of each; a `DirScopeCase` base shared by the two new classes; fixture
`mkdir`s removed that nothing reads (`_under` compares strings — in the root
test that `mkdir` actively misled); and `test_the_other_scopes_are_unchanged`
deleted as a duplicate of `TestScope` that no mutation could fail alone.

**Two findings I declined**, both noted rather than argued with:
`test_a_pipe_stays_clean` is subsumed by the stricter stderr test but names the
`| wc -l` contract, and `test_a_directory_in_the_prompt_would_misroute` pins
input the code never produces — deliberately, as the concrete form of the
constraint above.

**One thing the review surfaced that is worth stating rather than fixing:**
under Ctrl-R, an empty `dir` is a blank picker with no explanation — the note is
only reachable from `woswoar list --scope dir` typed at a terminal. `--header`
is where it would belong, and fzf cannot rewrite a header on reload without
`transform-header`.

## Verification

`python -m tools.mutate`, per rule 3, re-run against the post-`/simplify` tree.
Twenty-five mutations, all caught:

```
  caught    the filter keeps every row
  caught    the directory itself is not a match, only what is below it
  caught    the prefix is not anchored on a separator
  caught    the resolved path is used instead of the one the hook records
  caught    an inherited $PWD is believed without checking it
  caught    a relative $PWD is believed
  caught    a deleted directory is a traceback instead of an answer
  caught    $PWD is dropped once getcwd fails
  caught    dir also narrows to this machine
  caught    only the tilde form is looked for, so a peer's absolute path is missed
  caught    only the absolute form is looked for
  caught    the root directory loses its special case
  caught    the key is not made inert
  caught    cwds() reads the session column
  caught    no scope ever explains an empty result
  caught    every scope explains an empty result
  caught    the note is gated on stderr, so it lands in the picker
  caught    the emitted case loses its last arm
  caught    the cycle stays where it is instead of advancing
  caught    an unknown prompt no longer degrades to the first scope
  caught    the dir key is one fzf has already taken
  caught    a scope gets no direct key
  caught    the header without transform stops naming a scope
  caught    the header stops naming dir in the cycle
  caught    home_relative is not anchored
```

The fixtures are built to tell the two answers apart: the "keeps this directory
and below" test records in a *sibling*, and the anchoring test records both
`~/src/foo` and `~/src/foobar`.

Three tests that used to hardcode `("global", "host", "session")` now iterate
`search.SCOPES` — including the cycle test, which had three hand-written
assertions and where `session → global` had been correct only by *accident*: it
was falling through the catch-all rather than being decided, which is why the arm
it needed as soon as something followed it was never missed.

Full suite: 698 tests, green. Preflight (`ruff`, `mypy`, `shellcheck`,
`tools.run_tests`) clean.

## Review

Rule 1 row 2 — changes behaviour on a path a user reaches. Taken as the row's
second option: a careful read of the diff against this issue's own "constraint
that makes the obvious fix wrong", rather than an agent. What that produced, all
already in the branch: `lines_for`'s docstring still claimed `session` was the
only per-entry scope; `_under`'s quoted the `any(...)` form after the loop had
been rewritten; and the `cwds()` docstring carried the issue's estimated 0.14 ms
instead of a number measured here.

One thing it found and I did **not** change: a `$PWD` carrying a trailing slash
would build the key `~/src/` and match nothing. Bash normalises `$PWD`, so this
needs a non-shell parent to set it, `samestat` still has to accept it, and the
failure is an empty list with the directory named back to you. Not worth a line
of code or an issue — recording it here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
