### PR TITLE
search: a preview pane for the three recorded fields nobody can see

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,18 +45,44 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
-      - name: install age and fzf
-        # Sync tests skip themselves without age, the ranking tests without
-        # fzf, and a silently skipped suite looks exactly like a passing one.
-        # One apt-get for both: the round trip is what costs, not the packages.
+      - name: install age
+        # Sync tests skip themselves without age, and a silently skipped suite
+        # looks exactly like a passing one.
         #
         # `update` only when the direct install misses: refreshing the lists
         # costs ~10s and the runner image usually already has what age needs,
         # which on the critical path is most of the job. The fallback keeps it
         # correct on an image where that stops being true.
         run: |
-          sudo apt-get install -y -qq age fzf \
-            || { sudo apt-get update -qq && sudo apt-get install -y -qq age fzf; }
+          sudo apt-get install -y -qq age \
+            || { sudo apt-get update -qq && sudo apt-get install -y -qq age; }
+      - name: install fzf
+        # **Not apt.** ubuntu-latest ships fzf 0.44.1, which is one release
+        # below `search.TRANSFORM_SINCE` -- so on the runner woswoar correctly
+        # withholds ctrl-r cycling, the ctrl-t timeline and the ctrl-/ pane, and
+        # every test whose subject is one of those has nothing to drive. They
+        # cannot skip themselves out of it either: the `--no-skips` step below
+        # makes a skipped `test_search` fatal, deliberately.
+        #
+        # Pinned rather than "latest", so a release upstream cannot turn a green
+        # branch red overnight. Bumping it is a normal change; the floor that
+        # must hold is `search.TRANSFORM_SINCE`, asserted here so a wrong or
+        # silently-downgraded install fails loudly instead of skipping.
+        env:
+          FZF_VERSION: 0.74.2
+        run: |
+          curl -fsSL -o /tmp/fzf.tar.gz \
+            "https://github.com/junegunn/fzf/releases/download/v${FZF_VERSION}/fzf-${FZF_VERSION}-linux_amd64.tar.gz"
+          sudo tar -xzf /tmp/fzf.tar.gz -C /usr/local/bin fzf
+          fzf --version
+          python -c "
+          import sys
+          sys.path.insert(0, '.')
+          from woswoar import search
+          got = search.fzf_version()[1]
+          floor = search.TRANSFORM_SINCE
+          assert got is not None and got >= floor, f'fzf {got} is below {floor}'
+          "
       - name: ssh-keygen is present
         # Signing needs it. Present on ubuntu-latest, asserted rather than
         # assumed for the same reason as bash below: a silently skipped suite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,19 @@ jobs:
         # tool is missing. CI installs both, this installed only age, and the
         # two therefore ran different code. That difference is what failed a
         # release after every check on the pull request was green.
+        #
+        # fzf comes from upstream rather than apt, for the reason `ci.yml`
+        # spells out: ubuntu-latest ships 0.44.1, one release below
+        # `search.TRANSFORM_SINCE`, and the tests that drive a real picker have
+        # nothing to drive on it. Keep the pin here in step with that one.
+        env:
+          FZF_VERSION: 0.74.2
         run: |
-          sudo apt-get update -qq && sudo apt-get install -y -qq age fzf
+          sudo apt-get update -qq && sudo apt-get install -y -qq age
           age --version
+          curl -fsSL -o /tmp/fzf.tar.gz \
+            "https://github.com/junegunn/fzf/releases/download/v${FZF_VERSION}/fzf-${FZF_VERSION}-linux_amd64.tar.gz"
+          sudo tar -xzf /tmp/fzf.tar.gz -C /usr/local/bin fzf
           fzf --version
 
       - name: tests

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ is cleared, so typing now filters *the timeline* rather than repeating the searc
 that got you here. Repeats are kept — running `cargo test` twice is the shape of
 what happened, and the deduplicated search list hides it.
 
+### See the rest of what was recorded
+
+Six fields go into every record and a list line has room for two. Press
+<kbd>Ctrl</kbd>+<kbd>/</kbd> for the other four on whichever row you are on:
+
+```
+2026-08-10 14:32:07  (3h12m ago)
+thinkpad · session 6a79f245-36ea53
+~/src/woswoar
+exit 0 · 1.2 s
+
+docker compose up -d --build
+```
+
+Which directory, which shell, how long it took, and the command in full rather
+than clipped at the window edge. The pane starts hidden and costs nothing until
+you ask for it — see [the numbers](docs/shell-integration.md#the-details-pane).
+
 ## Quick start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -65,17 +65,24 @@ Six fields go into every record and a list line has room for two. Press
 <kbd>Ctrl</kbd>+<kbd>/</kbd> for the other four on whichever row you are on:
 
 ```
-2026-08-10 14:32:07  (3h12m ago)
-thinkpad · session 6a79f245-36ea53
-~/src/woswoar
-exit 0 · 1.2 s
+when     2026-08-10 14:32:07  (3h12m ago)
+dir      ~/src/woswoar
+host     thinkpad
+session  6a79f245-36ea53
+exit     0
+took     1.2 s
 
 docker compose up -d --build
 ```
 
-Which directory, which shell, how long it took, and the command in full rather
-than clipped at the window edge. The pane starts hidden and costs nothing until
-you ask for it — see [the numbers](docs/shell-integration.md#the-details-pane).
+Which directory, which machine, which shell, how long it took, and the command
+in full rather than clipped at the window edge. `dir`, `host` and `session` are
+also three of the four scopes, so the pane says which key would narrow the list
+to whatever it is pointing at. A field nobody recorded says so rather than going
+missing — most of a freshly imported history.
+
+The pane starts hidden and costs nothing until you ask for it — see
+[the numbers](docs/shell-integration.md#the-details-pane).
 
 ## Quick start
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -428,7 +428,7 @@ every other check you can run without believing anyone.
 |---|---|
 | The cache cannot execute | a pickle that would run code on load is written to the cache path; it is refused and a witness file never appears |
 | A recalled command is one command | control characters never survive from the picker into the shell buffer |
-| Nothing woswoar prints can drive your terminal | no C0 byte reaches the terminal raw from `list`, `search`, `stats` or `import` -- a peer's command is made inert as it leaves the cache, a peer's machine name where it is read |
+| Nothing woswoar prints can drive your terminal | no C0 byte reaches the terminal raw from `list`, `search`, `stats`, `import` or the picker's preview pane -- a peer's command, directory and session are made inert on the way into the cache, a peer's machine name where it is read |
 | Shell and Python escaping agree | a command containing a literal tab and newline must round-trip byte-for-byte |
 
 **It stays yours, and stays fast**

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -77,15 +77,28 @@ Six fields are recorded per command and the list has room for two. Press
 <kbd>Ctrl</kbd>+<kbd>/</kbd> for the rest of the highlighted one:
 
 ```
-2026-08-10 14:32:07  (3h12m ago)
-thinkpad · session 6a79f245-36ea53
-~/src/woswoar
-exit 0 · 1.2 s
+when     2026-08-10 14:32:07  (3h12m ago)
+dir      ~/src/woswoar
+host     thinkpad
+session  6a79f245-36ea53
+exit     0
+took     1.2 s
 
 docker compose up -d --build
 ```
 
-It also shows a long command whole, where the list clips it at the window edge.
+Every field is named, and one that was never recorded says `not recorded`
+instead of vanishing — an imported history has no directory, no exit code, no
+duration and no session, so a table with holes in it would be most of a fresh
+install. The labels are `dir`, `host` and `session` because those are also three
+of the four scopes: the pane names the key that would narrow the list to what it
+is describing.
+
+The exit code is green when it is zero and red when it is not; a code nobody
+recorded is neither, for the same reason the list does not paint an imported
+history red. The command comes last and outside the table — it is the one field
+with no bound on its length, and the pane has a fixed number of rows. It is also
+shown whole here, where the list clips it at the window edge.
 
 **It starts hidden, and that is on purpose.** Rendering it forks a fresh
 interpreter and reads the whole cache — **79 ms** on a 54,000-command history,

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -71,6 +71,32 @@ symlink the hook stores the path you typed, and so does the lookup.
 `WOSWOAR_NO_BIND=1` skips the <kbd>Ctrl</kbd>+<kbd>R</kbd> binding entirely if
 you would rather keep another tool's.
 
+### The details pane
+
+Six fields are recorded per command and the list has room for two. Press
+<kbd>Ctrl</kbd>+<kbd>/</kbd> for the rest of the highlighted one:
+
+```
+2026-08-10 14:32:07  (3h12m ago)
+thinkpad · session 6a79f245-36ea53
+~/src/woswoar
+exit 0 · 1.2 s
+
+docker compose up -d --build
+```
+
+It also shows a long command whole, where the list clips it at the window edge.
+
+**It starts hidden, and that is on purpose.** Rendering it forks a fresh
+interpreter and reads the whole cache — **79 ms** on a 54,000-command history,
+against 85 ms for the entire list — and that is paid again for every row the
+cursor passes over. Visible by default it is felt as lag under a held arrow key;
+hidden, it costs nothing at all until you ask.
+
+It needs fzf 0.45+, like <kbd>Ctrl</kbd>+<kbd>R</kbd> cycling and
+<kbd>Ctrl</kbd>+<kbd>T</kbd>. On anything older the key is neither bound nor
+advertised.
+
 ## Commands that are never recorded
 
 Anything bash itself keeps out of history is invisible to woswoar, so
@@ -190,6 +216,7 @@ Measured on a real **54,943-entry** history across ~750 daily files:
 | decide whether a sync is due | **~5 µs**, 0 forks |
 | start a background sync | once per `WOSWOAR_SYNC_INTERVAL`, 2 forks, no wait |
 | <kbd>Ctrl</kbd>+<kbd>R</kbd>, whole process | **~105 ms** |
+| one <kbd>Ctrl</kbd>+<kbd>/</kbd> details pane, per row | **~79 ms**, and only while it is open |
 
 No index, no SQLite — a parse cache that only re-reads what changed is enough,
 and CI re-measures it on every push.

--- a/tests/support.py
+++ b/tests/support.py
@@ -192,8 +192,22 @@ def _read_until(fd: int, marker: str, timeout: float, index: int, before: list[s
             chunk = b""
         if not chunk:
             raise stalled("the program exited")
+        if _CURSOR_QUERY in chunk:
+            # A real terminal answers this, and a program that asks waits. fzf
+            # asks as soon as it starts, because `--height` draws an inline
+            # window and it has to know which row it is on -- so without a reply
+            # it never paints, and the failure looks like a picker that produced
+            # nothing rather than one that is still waiting for us.
+            os.write(fd, _CURSOR_REPORT)
         buffer += chunk
     return buffer.decode("utf-8", "replace")
+
+
+#: "Where is the cursor?", and an answer. Row 1 column 1 is a lie in general and
+#: exactly right here: nothing has been printed above the program under test, so
+#: it has the whole window.
+_CURSOR_QUERY = b"\x1b[6n"
+_CURSOR_REPORT = b"\x1b[1;1R"
 
 
 def loose_paths() -> list[str]:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -270,10 +270,18 @@ class TestDoctorReportsWhatFzfCanDo(WoswoarTestCase):
         self.assertNotIn("need", line, "a capable fzf was told what it is missing")
 
     def test_an_old_fzf_is_told_exactly_what_it_is_missing(self) -> None:
+        """Every key the gate withholds, spelled here by hand rather than read
+        out of `search.GATED_KEYS` -- a test that built the sentence the way the
+        code does would agree with it about a missing key. The count is asserted
+        against that tuple instead, so a fourth gated key fails here until
+        someone decides whether this line should name it."""
+        from woswoar import search
+
         line = self.fzf_line("0.44.1 (debian)", (0, 44))
         self.assertIn("0.44.1", line)
-        for named in ("ctrl-r", "ctrl-t", "0.45+"):
+        for named in ("ctrl-r", "ctrl-t", "ctrl-/", "0.45+"):
             self.assertIn(named, line, f"{named} is not mentioned")
+        self.assertEqual(len(search.GATED_KEYS), 3, "a gated key with nothing saying so")
 
     def test_an_old_fzf_is_not_reported_as_a_failure(self) -> None:
         """Search works perfectly there. A red cross would say the machine is

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1252,6 +1252,19 @@ class TestThePreviewBlock(WoswoarTestCase):
     def shown(self, index: int, *argv: str) -> str:
         return run_cli("list", "--show", str(index), *argv).out
 
+    def fields(self, block: str) -> dict[str, str]:
+        """The pane's labelled table as a mapping, command excluded.
+
+        By name rather than by line number, which is what these tests used to do
+        -- and a line number says nothing about which field it meant, so adding
+        a row silently moved four assertions onto their neighbours.
+        """
+        table, _, _ = unstyled(block).partition("\n\n")
+        return {
+            label: rest.strip()
+            for label, _, rest in (line.partition("  ") for line in table.splitlines())
+        }
+
     def test_show_reports_the_row_the_list_shows(self) -> None:
         """Every index, and every field of it.
 
@@ -1272,11 +1285,13 @@ class TestThePreviewBlock(WoswoarTestCase):
             with self.subTest(index=index):
                 cmd = search.command_from_line(line)
                 i = commands.index(cmd)
-                block = self.shown(index, "--scope", "global").splitlines()
-                self.assertEqual(block[-1], cmd)
-                self.assertIn(f"session sess{i}", block[1])
-                self.assertEqual(block[2], f"~/d{i}")
-                self.assertEqual(block[3], f"exit {i} · {i + 1} ms")
+                block = self.shown(index, "--scope", "global")
+                shows = self.fields(block)
+                self.assertEqual(block.splitlines()[-1], cmd)
+                self.assertEqual(shows["session"], f"sess{i}")
+                self.assertEqual(shows["dir"], f"~/d{i}")
+                self.assertEqual(shows["exit"], str(i))
+                self.assertEqual(shows["took"], f"{i + 1} ms")
 
     def test_show_under_a_timeline_uses_the_window(self) -> None:
         """After Ctrl-T the list fzf holds is the timeline *window*, so `{n}`
@@ -1300,7 +1315,7 @@ class TestThePreviewBlock(WoswoarTestCase):
         # differently at the index the loop above checked.
         with_window = self.shown(3, "--scope", "global", "--around", str(anchor))
         self.assertNotEqual(with_window, self.shown(3, "--scope", "global"))
-        self.assertEqual(with_window.splitlines()[2], "~/d1")
+        self.assertEqual(self.fields(with_window)["dir"], "~/d1")
 
     def test_a_cursor_past_the_end_gets_a_blank_pane_not_a_traceback(self) -> None:
         """The index comes from fzf and a background sync can merge commands
@@ -1350,9 +1365,60 @@ class TestThePreviewBlock(WoswoarTestCase):
         and that is most of a fresh install. `exit -1` would invent a failure --
         the same misreading that once painted every imported command red."""
         self.record("ls -la", cwd="", code=-1, ms=-1, session="import")
-        block = self.shown(0, "--scope", "global").splitlines()
-        self.assertEqual(block[2], "directory not recorded")
-        self.assertEqual(block[3], "exit not recorded")
+        shows = self.fields(self.shown(0, "--scope", "global"))
+        self.assertEqual(shows["dir"], "not recorded")
+        self.assertEqual(shows["exit"], "not recorded")
+        self.assertEqual(shows["took"], "not recorded")
+
+    def test_every_field_is_named_and_none_is_ever_missing(self) -> None:
+        """Reported as "hard to read, and there is no information what each line
+        means": five values run together on four lines need a reader who already
+        knows the record format, and the whole point of the pane is that nobody
+        does -- three of these fields have never been on a screen.
+
+        Named *and* always present. An imported row has no directory, no exit
+        code, no duration and no session, and the first version of this simply
+        left those lines out; a table with holes in it reads as a broken pane
+        rather than as a fact about the row, and there is nothing left to line
+        the remaining values up against.
+        """
+        self.record("ls -la", cwd="", code=-1, ms=-1, session="")
+        block = self.shown(0, "--scope", "global")
+        self.assertEqual(
+            list(self.fields(block)),
+            ["when", "dir", "host", "session", "exit", "took"],
+        )
+        self.assertEqual(self.fields(block)["session"], "not recorded")
+        # Last, and outside the table: it is the one field with no bound on its
+        # length, and the pane has a fixed number of rows.
+        self.assertEqual(block.splitlines()[-1], "ls -la")
+
+    def test_colour_is_asked_for_and_never_reaches_a_pipe(self) -> None:
+        """`--show` is a command line like any other, so `woswoar list --show 0`
+        has no more business emitting escapes unasked than `woswoar list` does.
+        The pane passes `--colour` and that is the only reason they are there."""
+        self.record("true")
+        plain = self.shown(0, "--scope", "global")
+        painted = self.shown(0, "--scope", "global", "--colour")
+        self.assertNotIn("\x1b", plain)
+        self.assertEqual(unstyled(painted), plain, "colour changed more than the colour")
+        # The label column is what the eye skips: it is the same six words on
+        # every row, where the value is the answer.
+        self.assertIn(f"{search._DIM}when", painted)
+        self.assertIn(f"{search._BOLD}true{search._RESET}", painted)
+
+    def test_the_exit_code_is_painted_green_red_or_not_at_all(self) -> None:
+        """Three answers, which is why `is_failure` cannot serve here: it has
+        two, and its unknown-is-not-failure rule is exactly what stops an
+        imported history reading as a screenful of failures. The pane still has
+        to distinguish "exited cleanly" from "nobody ever knew"."""
+        for cmd, code in (("boom", 127), ("fine", 0), ("imported", -1)):
+            self.record(cmd, code=code)
+        boom, fine, imported = (self.shown(i, "--scope", "global", "--colour") for i in (2, 1, 0))
+        self.assertIn(f"{search._FAILED}127{search._RESET}", boom)
+        self.assertIn(f"{search._OK}0{search._RESET}", fine)
+        self.assertIn(f"{search._DIM}not recorded{search._RESET}", imported)
+        self.assertNotIn(search._FAILED, imported, "an unrecorded exit code was painted a failure")
 
     def test_a_duration_is_readable_at_every_scale(self) -> None:
         for ms, expected in [
@@ -1404,7 +1470,7 @@ class TestThePreviewBinding(unittest.TestCase):
         for scope in search.SCOPES:
             with self.subTest(scope=scope):
                 out = self.preview(f"woswoar ({scope}) ")
-                self.assertEqual(out.strip(), f"RAN list --show {{n}} --scope {scope}")
+                self.assertEqual(out.strip(), f"RAN list --colour --show {{n}} --scope {scope}")
 
     def argv(self) -> list[str]:
         with mock.patch.object(search, "fzf_supports_transform", return_value=True):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import sqlite3
 import subprocess
+import sys
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -18,7 +19,15 @@ from woswoar import search, store
 from woswoar.__main__ import main
 from woswoar.entry import Entry, format_line
 
-from .support import MACHINE_ID, Captured, WoswoarTestCase, requires_fzf, run_cli
+from .support import (
+    MACHINE_ID,
+    Captured,
+    Typed,
+    WoswoarTestCase,
+    requires_fzf,
+    run_cli,
+    run_in_pty,
+)
 
 NOW = 1_800_000_000
 
@@ -84,7 +93,7 @@ class TestRelativeTime(unittest.TestCase):
 
 class TestRankRows(unittest.TestCase):
     @staticmethod
-    def rows(*pairs: tuple[int, str]) -> tuple[list[str], list[str], list[str], list[str]]:
+    def rows(*pairs: tuple[int, str]) -> tuple[list[str], ...]:
         """Stamps and exit codes come out of the cache as strings, so that is
         what goes in. These cases are about order, so everything succeeded."""
         return (
@@ -95,20 +104,26 @@ class TestRankRows(unittest.TestCase):
         )
 
     def test_newest_first(self) -> None:
-        stamps, commands, codes, hosts = self.rows((1, "old"), (3, "new"), (2, "mid"))
-        ranked = search.rank_rows(stamps, commands, codes, hosts)
+        ranked = search.rank_rows(self.rows((1, "old"), (3, "new"), (2, "mid")))
         self.assertEqual([cmd for _, cmd, _, _ in ranked], ["new", "mid", "old"])
 
     def test_dedup_keeps_the_most_recent_occurrence(self) -> None:
-        stamps, commands, codes, hosts = self.rows((1, "git status"), (5, "git status"), (3, "ls"))
         self.assertEqual(
-            search.rank_rows(stamps, commands, codes, hosts),
+            search.rank_rows(self.rows((1, "git status"), (5, "git status"), (3, "ls"))),
             [(5, "git status", "0", MACHINE_ID), (3, "ls", "0", MACHINE_ID)],
         )
 
     def test_dedup_can_be_disabled(self) -> None:
-        stamps, commands, codes, hosts = self.rows((1, "ls"), (2, "ls"))
-        self.assertEqual(len(search.rank_rows(stamps, commands, codes, hosts, dedup=False)), 2)
+        self.assertEqual(len(search.rank_rows(self.rows((1, "ls"), (2, "ls")), dedup=False)), 2)
+
+    def test_the_extra_columns_are_ranked_by_the_same_function(self) -> None:
+        """The preview's three ride along rather than being ordered separately,
+        which is what lets `--show n` and line `n` of the list mean one row."""
+        stamps, commands, codes, hosts = self.rows((1, "old"), (3, "new"))
+        ranked = search.rank_rows((stamps, commands, codes, hosts, ["~/first", "~/second"]))
+        self.assertEqual(
+            [(row[1], row[4]) for row in ranked], [("new", "~/second"), ("old", "~/first")]
+        )
 
 
 class TestRenderRoundTrip(unittest.TestCase):
@@ -147,6 +162,32 @@ def recalled(scope: search.Scope) -> list[str]:
     return [
         search.command_from_line(line, width) for line in search.lines_for(scope, host_width=width)
     ]
+
+
+def run_binding(binding: str, marker: str, prompt: str | None = None) -> str:
+    """Run the `sh` out of one fzf binding, with the prompt fzf would export.
+
+    Four test classes drive a binding this way -- the cycle, the timeline, the
+    preview, and the prompt-repaint check -- and what they share is not the
+    binding but the *environment*: an `$FZF_PROMPT` and nothing else, because
+    what is under test is a decision this snippet makes from that one variable.
+    One function rather than a copy per class, for the reason `recalled` above
+    is one function: the day fzf exports something else, there is one place to
+    say so.
+
+    ``prompt`` of `None` leaves `$FZF_PROMPT` unset, which is a different case
+    from empty and is the one the preview has to fail closed on.
+    """
+    env = {"PATH": "/usr/bin:/bin"}
+    if prompt is not None:
+        env["FZF_PROMPT"] = prompt
+    return subprocess.run(
+        ["sh", "-c", binding.split(marker, 1)[1]],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    ).stdout
 
 
 #: Every scope's direct key, spelled as fzf takes it. Hand-written rather than
@@ -731,15 +772,9 @@ class TestCtrlRCyclesTheScope(unittest.TestCase):
     """
 
     def next_scope(self, prompt: str) -> str:
-        binding = search._cycle_binding("woswoar", "", " --host-width 0")
-        script = binding.split("transform:", 1)[1]
-        out = subprocess.run(
-            ["sh", "-c", script],
-            capture_output=True,
-            text=True,
-            env={"FZF_PROMPT": prompt, "PATH": "/usr/bin:/bin"},
-            check=True,
-        ).stdout
+        out = run_binding(
+            search._cycle_binding("woswoar", "", " --host-width 0"), "transform:", prompt
+        )
         return out.split("--scope ", 1)[1].split(")", 1)[0].strip()
 
     def test_it_goes_round(self) -> None:
@@ -784,15 +819,11 @@ class TestCtrlRCyclesTheScope(unittest.TestCase):
 
     def test_it_repaints_the_prompt_it_reads_back(self) -> None:
         """`change-prompt` is not decoration: the next press reads it."""
-        binding = search._cycle_binding("woswoar", "", " --host-width 0")
-        script = binding.split("transform:", 1)[1]
-        out = subprocess.run(
-            ["sh", "-c", script],
-            capture_output=True,
-            text=True,
-            env={"FZF_PROMPT": "woswoar (global) ", "PATH": "/usr/bin:/bin"},
-            check=True,
-        ).stdout
+        out = run_binding(
+            search._cycle_binding("woswoar", "", " --host-width 0"),
+            "transform:",
+            "woswoar (global) ",
+        )
         self.assertIn("change-prompt(woswoar (host) )", out)
 
     def test_the_reload_keeps_the_colour_and_the_width(self) -> None:
@@ -1176,18 +1207,363 @@ class TestTheTimelineAroundACommand(WoswoarTestCase):
         Driven as the real `sh`, because what is under test is that snippet's
         decision. `--print-anchor` is stubbed out of the way: this is about the
         scope it chooses, and the anchor needs a history to look at."""
-        script = search._timeline_binding("true", "", " --host-width 0").split("transform:", 1)[1]
+        binding = search._timeline_binding("true", "", " --host-width 0")
         for scope in search.SCOPES:
             with self.subTest(scope=scope):
-                out = subprocess.run(
-                    ["sh", "-c", script],
-                    capture_output=True,
-                    text=True,
-                    env={"FZF_PROMPT": f"woswoar ({scope}) ", "PATH": "/usr/bin:/bin"},
-                    check=True,
-                ).stdout
+                out = run_binding(binding, "transform:", f"woswoar ({scope}) ")
                 self.assertIn(f"change-prompt(woswoar (timeline {scope}) )", out)
                 self.assertIn(f"--scope {scope} --around", out)
+
+
+class TestThePreviewBlock(WoswoarTestCase):
+    """`list --show N`: the three recorded fields nobody could read back.
+
+    `cwd`, `duration_ms` and `session` are recorded, encrypted, synced and
+    cached, and there is no width on the display line for any of them -- it is a
+    fixed-width prefix that `command_from_line` slices rather than parses. The
+    pane costs no width because it describes one row.
+    """
+
+    #: Sorts *before* `MACHINE_ID`, which is what makes the alignment test below
+    #: able to fail: the columns are built by walking the log files, so a peer
+    #: whose id sorts second would occupy the same indices either way.
+    PEER = "0000000000000001"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.ts = NOW
+
+    def record(
+        self,
+        cmd: str,
+        cwd: str = "~/src/woswoar",
+        code: int = 0,
+        ms: int = 1234,
+        session: str = "6a79f245-36ea53",
+        host: str = MACHINE_ID,
+    ) -> None:
+        self.ts += 1
+        with store.private_append(store.log_file(host, "2026-07-29")) as handle:
+            handle.write(format_line(Entry(self.ts, host, session, cwd, code, ms, cmd)) + "\n")
+
+    def listed(self, *argv: str) -> list[str]:
+        return run_cli("list", *argv).out.splitlines()
+
+    def shown(self, index: int, *argv: str) -> str:
+        return run_cli("list", "--show", str(index), *argv).out
+
+    def test_show_reports_the_row_the_list_shows(self) -> None:
+        """Every index, and every field of it.
+
+        The two sides rank from the same columns, so this holds by construction
+        -- right up until a column is reordered for the preview's sake, which
+        moves nothing on a display line and is therefore invisible from the
+        picker. Each row's directory, session, status and duration are derived
+        from its position here, so a pair of columns swapped in either direction
+        shows up as the wrong value rather than as a shorter list.
+        """
+        commands = ["one", "two", "three", "four", "five"]
+        for i, cmd in enumerate(commands):
+            self.record(cmd, cwd=f"~/d{i}", code=i, ms=i + 1, session=f"sess{i}")
+
+        lines = self.listed("--scope", "global")
+        self.assertEqual(len(lines), len(commands))
+        for index, line in enumerate(lines):
+            with self.subTest(index=index):
+                cmd = search.command_from_line(line)
+                i = commands.index(cmd)
+                block = self.shown(index, "--scope", "global").splitlines()
+                self.assertEqual(block[-1], cmd)
+                self.assertIn(f"session sess{i}", block[1])
+                self.assertEqual(block[2], f"~/d{i}")
+                self.assertEqual(block[3], f"exit {i} · {i + 1} ms")
+
+    def test_show_under_a_timeline_uses_the_window(self) -> None:
+        """After Ctrl-T the list fzf holds is the timeline *window*, so `{n}`
+        indexes that -- and the same number resolved against the ranked list is
+        a different command, silently. Repeats are what makes the two disagree:
+        the ranked list collapses them and the timeline must not."""
+        for i, cmd in enumerate(["first", "dup", "second", "dup", "third"]):
+            self.record(cmd, cwd=f"~/d{i}")
+        anchor = next(
+            i for i, line in enumerate(self.listed("--scope", "global")) if "second" in line
+        )
+
+        window = self.listed("--scope", "global", "--around", str(anchor))
+        for index, line in enumerate(window):
+            with self.subTest(index=index):
+                block = self.shown(index, "--scope", "global", "--around", str(anchor))
+                self.assertEqual(block.splitlines()[-1], search.command_from_line(line))
+
+        # Without this the fixture would pass just as happily with `--around`
+        # dropped from `--show`: it says the two lists really do answer
+        # differently at the index the loop above checked.
+        with_window = self.shown(3, "--scope", "global", "--around", str(anchor))
+        self.assertNotEqual(with_window, self.shown(3, "--scope", "global"))
+        self.assertEqual(with_window.splitlines()[2], "~/d1")
+
+    def test_a_cursor_past_the_end_gets_a_blank_pane_not_a_traceback(self) -> None:
+        """The index comes from fzf and a background sync can merge commands
+        between the picker opening and the cursor moving."""
+        self.record("only one")
+        self.assertEqual(self.shown(9999, "--scope", "global"), "")
+        self.assertEqual(self.shown(0, "--scope", "session"), "", "no hook, no session")
+
+    def test_the_extra_fields_belong_to_the_row_they_are_shown_with(self) -> None:
+        """The `host` scope drops whole files before a row is looked at, so the
+        four display columns can be shorter than the history. Fetching the other
+        three separately -- `Cache.cwds()` walks every file -- lines them up only
+        by luck, and the pane would then put a peer's directory under this
+        machine's command with nothing on screen to say so.
+
+        `zip(strict=True)` turns that particular slip into an exception rather
+        than a wrong answer, which is the point of it being there; this asserts
+        the answer that exception is protecting.
+        """
+        self.record("theirs", cwd="~/their-dir", host=self.PEER)
+        self.record("mine", cwd="~/my-dir")
+        block = self.shown(0, "--scope", "host")
+        self.assertEqual(block.splitlines()[-1], "mine")
+        self.assertIn("~/my-dir", block)
+        self.assertNotIn("their-dir", block)
+
+    def test_a_peers_record_cannot_drive_the_terminal(self) -> None:
+        """Every field in the block came off another machine, and the pane is a
+        new place for each of them to reach a terminal. `cwd` and `session` had
+        never been printed anywhere before this; `session` was not made inert at
+        the cache door until it was.
+        """
+        store.write_atomic(store.name_file(self.PEER), b"peer\x1b[1A\x1b[2K\n")
+        self.record(
+            "echo hi\x07",
+            cwd="~/\x1b[2K\x1b[1Aspoofed",
+            session="s1\x1b[2Kfaked",
+            host=self.PEER,
+        )
+        block = self.shown(0, "--scope", "global")
+        self.assertIn("spoofed", block, "the directory must still be shown")
+        self.assertIn("faked", block, "the session must still be shown")
+        self.assertEqual([c for c in block if c < " " and c != "\n"], [])
+
+    def test_what_was_never_recorded_says_so_rather_than_reading_as_zero(self) -> None:
+        """An imported history has no directory, no exit code and no duration,
+        and that is most of a fresh install. `exit -1` would invent a failure --
+        the same misreading that once painted every imported command red."""
+        self.record("ls -la", cwd="", code=-1, ms=-1, session="import")
+        block = self.shown(0, "--scope", "global").splitlines()
+        self.assertEqual(block[2], "directory not recorded")
+        self.assertEqual(block[3], "exit not recorded")
+
+    def test_a_duration_is_readable_at_every_scale(self) -> None:
+        for ms, expected in [
+            ("0", "0 ms"),
+            ("87", "87 ms"),
+            ("999", "999 ms"),
+            ("1000", "1.0 s"),
+            ("1234", "1.2 s"),
+            ("59999", "60.0 s"),
+            ("60000", "1m 0s"),
+            ("3599000", "59m 59s"),
+            ("3725000", "1h 2m"),
+        ]:
+            with self.subTest(ms=ms):
+                self.assertEqual(search._duration_label(ms), expected)
+
+    def test_a_duration_that_was_never_measured_is_left_out(self) -> None:
+        """None, not "0 ms": a whole column of zeroes is a claim, and an absent
+        line is the truth. `nonsense` stands for a damaged field, which should
+        cost this line and not the block."""
+        self.assertIsNone(search._duration_label("-1"))
+        self.assertIsNone(search._duration_label("nonsense"))
+
+
+class TestThePreviewBinding(unittest.TestCase):
+    """The `sh` the preview runs, and the actions that repoint it.
+
+    Driven as the real shell for the same reason `TestCtrlRCyclesTheScope` is:
+    the decision this snippet makes is the part that can be wrong, and it needs
+    no terminal to make it.
+    """
+
+    def preview(self, prompt: str | None, self_cmd: str = "echo RAN") -> str:
+        return run_binding(search._preview_binding(self_cmd, ""), "--preview=", prompt)
+
+    def test_the_preview_fails_closed_without_a_prompt(self) -> None:
+        """Guessing `global` is fine for a key that *reloads* -- you get a list
+        whose prompt says what it is. Here the same guess is unfalsifiable: a
+        block describing the wrong row looks exactly like one describing the
+        right row. `FZF_PROMPT` is read on the assumption fzf exports it, and no
+        version is known to have introduced it."""
+        for prompt in (None, "", "$ "):
+            with self.subTest(prompt=prompt):
+                out = self.preview(prompt)
+                self.assertEqual(out.strip(), search.PREVIEW_UNKNOWN)
+                self.assertNotIn("RAN", out, "it fell through and described some other list")
+
+    def test_it_asks_about_the_list_that_is_on_screen(self) -> None:
+        for scope in search.SCOPES:
+            with self.subTest(scope=scope):
+                out = self.preview(f"woswoar ({scope}) ")
+                self.assertEqual(out.strip(), f"RAN list --show {{n}} --scope {scope}")
+
+    def argv(self) -> list[str]:
+        with mock.patch.object(search, "fzf_supports_transform", return_value=True):
+            return search._fzf_argv("global", "", dedup=True, host_width=0)
+
+    def test_the_preview_is_hidden_until_toggled(self) -> None:
+        """It forks an interpreter and reads the whole cache per cursor move.
+        Visible by default, that is felt as lag under a held arrow key; hidden,
+        a user who never presses the key pays nothing at all."""
+        argv = self.argv()
+        window = next(a for a in argv if a.startswith("--preview-window="))
+        self.assertIn("hidden", window)
+        self.assertIn(f"--bind={search.PREVIEW_KEY}:toggle-preview", argv)
+        self.assertIn(
+            f"{search.PREVIEW_KEY} details",
+            next(a for a in argv if a.startswith("--header=")),
+        )
+
+    def test_nothing_is_offered_to_an_fzf_that_may_not_have_the_pieces(self) -> None:
+        """An unknown key name in a `--bind` makes fzf refuse to start, so the
+        cost of guessing wrong about `ctrl-/` is the picker, not the key."""
+        with mock.patch.object(search, "fzf_supports_transform", return_value=False):
+            argv = search._fzf_argv("global", "", dedup=True, host_width=0)
+        self.assertNotIn("--preview", " ".join(argv))
+        self.assertNotIn(search.PREVIEW_KEY, " ".join(argv))
+
+    def test_every_key_that_changes_the_list_repoints_the_pane(self) -> None:
+        """A preview left pointing at the list it was set up for is the whole
+        hazard of this feature. Ctrl-T pins it to one `--around` window, and
+        every key that can be pressed *next* has to take it back off again --
+        including the two that reach it through a `transform`, where the `{n}`
+        meant for the pane has to survive fzf expanding the transform's own
+        command line."""
+        binds = [a for a in self.argv() if a.startswith("--bind=")]
+        for key in [f"ctrl-{search.KEYS[scope]}" for scope in search.SCOPES] + ["ctrl-r", "ctrl-t"]:
+            with self.subTest(key=key):
+                bind = next(a for a in binds if a.startswith(f"--bind={key}:"))
+                self.assertIn("change-preview(", bind)
+                self.assertIn("--show", bind)
+        timeline = next(a for a in binds if a.startswith("--bind=ctrl-t:"))
+        self.assertIn("--show \\{n} --scope $s --around {n}", timeline)
+        cycle = next(a for a in binds if a.startswith("--bind=ctrl-r:"))
+        self.assertIn("--show \\{n} --scope $n", cycle)
+        self.assertNotIn("--around", cycle, "the way out of a timeline must not stay in it")
+
+
+@requires_fzf
+class TestThePreviewUnderARealFzf(WoswoarTestCase):
+    """The pane, driven through a real fzf under a real terminal.
+
+    Every other test here asserts the strings woswoar hands fzf. This one
+    asserts what fzf does with them, and there is one step of the design nothing
+    else can reach: the `{n}` a `transform` prints for the preview has to
+    survive fzf expanding the transform's own command line first. `man fzf`
+    documents that a backslash escapes a placeholder; what becomes of that
+    escape inside a transform's *output* is written down nowhere, and the whole
+    timeline interaction rests on it.
+
+    The markers are directories, which appear only in the pane -- never on a
+    display line, and never in anything the harness types.
+    """
+
+    #: Chronological. The repeat is what makes the ranked list and the timeline
+    #: window disagree about which command index 3 is, which is the only way a
+    #: preview that ignored `--around` could be caught.
+    HISTORY: ClassVar[list[str]] = ["first", "dup", "second", "dup", "third"]
+
+    def setUp(self) -> None:
+        super().setUp()
+        with store.private_append(store.log_file(MACHINE_ID, "2026-07-29")) as handle:
+            for i, cmd in enumerate(self.HISTORY):
+                entry = Entry(NOW + i * 60, MACHINE_ID, "s1", f"~/d{i}", 0, 1234, cmd)
+                handle.write(format_line(entry) + "\n")
+
+    def picker_env(self) -> dict[str, str]:
+        """A sandbox whose `woswoar` on PATH is *this* tree.
+
+        Not optional: `_self_command` prefers whatever `woswoar` it finds, and
+        on a machine with woswoar installed that is a released copy which may
+        predate `--show` entirely. The test would then pass or fail on which
+        version happens to be on the developer's PATH.
+        """
+        bin_dir = self.root / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        shim = bin_dir / "woswoar"
+        shim.write_text(
+            f'#!/bin/sh\nexec {sys.executable} -m woswoar "$@"\n',
+            encoding="utf-8",
+        )
+        shim.chmod(0o755)
+        return {
+            "PATH": f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+            "TERM": "xterm",
+            "HOME": str(self.root),
+            "SHELL": "/bin/sh",
+            "PYTHONPATH": str(Path(__file__).resolve().parent.parent),
+            "WOSWOAR_DIR": os.environ["WOSWOAR_DIR"],
+            "XDG_CONFIG_HOME": os.environ["XDG_CONFIG_HOME"],
+            "XDG_CACHE_HOME": os.environ["XDG_CACHE_HOME"],
+        }
+
+    def drive(self, steps: list[Typed]) -> list[str]:
+        return run_in_pty([sys.executable, "-m", "woswoar", "search"], steps, env=self.picker_env())
+
+    #: Ctrl-/ and Ctrl-N as a terminal sends them. Ctrl-N is fzf's own `down`,
+    #: which under `--layout=reverse` is the next item in the list.
+    TOGGLE = "\x1f"
+    NEXT = "\x0e"
+
+    #: **The `until` markers are the assertions here.** `_read_until` loops
+    #: until its needle appears and returns the buffer it found it in, so
+    #: `assertIn(marker, that_step)` is true by construction and tests nothing --
+    #: the same shape as CLAUDE.md's "a marker asserted in a shell's stdout also
+    #: appears in the harness's echo of the line that was typed". A step that
+    #: does not see its marker stalls and raises, carrying every screen with it.
+    #: What is left for an `assert` is only what a *stall* cannot say: that
+    #: something is absent.
+    def test_the_pane_is_dark_until_the_key_and_then_follows_the_cursor(self) -> None:
+        """Reaching the last step proves the pane appeared on the key and then
+        renumbered itself, which is what says `change-preview` was handed a live
+        template rather than one row's answer frozen into it. The `assert` adds
+        the one thing the steps cannot: that it was not already there."""
+        before, _revealed, _moved = self.drive(
+            [
+                # A command on screen means fzf has drawn the list and is
+                # reading keys; asserting the *absence* of the pane before that
+                # would assert nothing at all.
+                Typed("", "third"),
+                Typed(self.TOGGLE, "~/d4"),
+                Typed(self.NEXT, "~/d3"),
+            ]
+        )
+        self.assertNotIn("~/d4", before, "the pane rendered before anyone asked for it")
+
+    def test_a_timeline_repoints_the_pane_at_its_own_window(self) -> None:
+        """Ctrl-T replaces the list with a window that keeps the repeats, so the
+        fourth row of it is `dup` at `~/d1`, where the fourth row of the ranked
+        list is `first` at `~/d0`.
+
+        Both directions are needed and neither alone is enough. Waiting for
+        `~/d1` fails on a pane that ignored `--around`, because it would be
+        showing `~/d0`; but it would also be satisfied by a pane that rendered
+        *both* at some point, so the absence of `~/d0` is asserted as well. That
+        is the answer the ranked list would have given, and seeing it here is
+        exactly the plausible-looking wrong block this feature can produce.
+        """
+        *_, moved = self.drive(
+            [
+                Typed("", "third"),
+                Typed(self.TOGGLE, "~/d4"),
+                # Down twice to `second`, which has history either side of it,
+                # then Ctrl-T to unfold it.
+                Typed(self.NEXT, "~/d3"),
+                Typed(self.NEXT, "~/d2"),
+                Typed("\x14", "~/d2"),
+                Typed(self.NEXT, "~/d1"),
+            ]
+        )
+        self.assertNotIn("~/d0", moved, "the pane answered from the ranked list, not the window")
 
 
 class DirScopeCase(WoswoarTestCase):

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -129,6 +129,15 @@ def cmd_install(args: argparse.Namespace) -> int:
 
 
 def cmd_list(args: argparse.Namespace) -> int:
+    if args.show is not None:
+        # The preview pane, one row at a time. Ahead of everything else because
+        # it shares none of it: no display line, no width, no colour, and an
+        # empty answer is a cursor sitting past the end of a list that moved
+        # under it -- a blank pane, not a message.
+        block = search.detail(args.show, args.scope, dedup=not args.no_dedup, around=args.around)
+        if block is not None:
+            print(block)
+        return 0
     if args.print_anchor:
         # Where fzf should park the cursor once it has unfolded the timeline.
         # A separate invocation because `transform` composes `reload(...)` and
@@ -344,21 +353,26 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         check("fzf", False, f"not found - {deps.advice([deps.FZF])}")
     else:
         # Which keys this fzf can actually offer, not just that it is there.
-        # An fzf below 0.45 gets a working picker with no Ctrl-R cycling and no
-        # Ctrl-T timeline -- correct, silent, and impossible to tell from a bug
-        # unless something says so. Reported from a fleet running 0.73 on one
-        # machine and Debian's 0.44.1 on another.
+        # An fzf below 0.45 gets a working picker with several keys missing --
+        # correct, silent, and impossible to tell from a bug unless something
+        # says so. Reported from a fleet running 0.73 on one machine and
+        # Debian's 0.44.1 on another.
+        #
+        # The list comes from `search.GATED_KEYS` rather than being written out
+        # here: this sentence and the bindings it describes are the same fact in
+        # two modules, and it was already wrong once -- it still named two keys
+        # after the preview pane became the third.
         said, _ = search.fzf_version()
         shown = said or "version unknown"
         if search.fzf_supports_transform():
             check("fzf", True, f"{fzf}  ({shown})")
         else:
             floor = ".".join(str(part) for part in search.TRANSFORM_SINCE)
+            missing = ", ".join(search.GATED_KEYS[:-1]) + f" and {search.GATED_KEYS[-1]}"
             check(
                 "fzf",
                 True,
-                f"{fzf}  ({shown} - searching works; ctrl-r cycling and the"
-                f" ctrl-t timeline need {floor}+)",
+                f"{fzf}  ({shown} - searching works; {missing} need {floor}+)",
             )
 
     machine_file = store.machine_file()
@@ -1526,6 +1540,9 @@ def build_parser() -> argparse.ArgumentParser:
 
         The directory scope spans machines on purpose: ~/src/woswoar on either
         of your boxes is the same project.
+
+        Ctrl-/ shows the rest of what was recorded for the highlighted command
+        -- its directory, session, exit code and duration.
         """,
     )
     add_scope(p_search)
@@ -1537,9 +1554,9 @@ def build_parser() -> argparse.ArgumentParser:
         "print matching lines as plain text",
         """
         Mostly internal: this is what the picker re-runs when you switch scope
-        with Ctrl-G, Ctrl-H, Ctrl-S or Ctrl-O. It is also how to read your
-        history without fzf installed, and it pipes --
-        `woswoar list | grep docker`.
+        with Ctrl-G, Ctrl-H, Ctrl-S or Ctrl-O, and what fills the Ctrl-/ pane.
+        It is also how to read your history without fzf installed, and it pipes
+        -- `woswoar list | grep docker`.
         """,
     )
     add_scope(p_list)
@@ -1557,6 +1574,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     # Both passed by the picker's ctrl-t binding rather than typed.
     p_list.add_argument("--print-anchor", action="store_true", help=argparse.SUPPRESS)
+    # The preview pane's own entry point: one row of the list this would print,
+    # as a block. fzf's interface, not a person's, so it is suppressed like the
+    # two above rather than documented.
+    p_list.add_argument("--show", type=int, default=None, help=argparse.SUPPRESS)
     p_list.add_argument(
         "--colour",
         "--color",

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -131,10 +131,17 @@ def cmd_install(args: argparse.Namespace) -> int:
 def cmd_list(args: argparse.Namespace) -> int:
     if args.show is not None:
         # The preview pane, one row at a time. Ahead of everything else because
-        # it shares none of it: no display line, no width, no colour, and an
-        # empty answer is a cursor sitting past the end of a list that moved
-        # under it -- a blank pane, not a message.
-        block = search.detail(args.show, args.scope, dedup=not args.no_dedup, around=args.around)
+        # it shares none of it: no display line, no width, and an empty answer
+        # is a cursor sitting past the end of a list that moved under it -- a
+        # blank pane, not a message. `--colour` it does share, and means the
+        # same thing by it.
+        block = search.detail(
+            args.show,
+            args.scope,
+            dedup=not args.no_dedup,
+            around=args.around,
+            colour=args.colour,
+        )
         if block is not None:
             print(block)
         return 0

--- a/woswoar/cache.py
+++ b/woswoar/cache.py
@@ -54,7 +54,12 @@ from .entry import Entry, parse_line
 #: branches on it -- there is no migration code and no need for any -- so the
 #: whole first field is simply compared, and a pickle, an empty file or last
 #: year's shape all fail it alike.
-CACHE_VERSION = 2
+#: 3: `parse_line` began neutralising `session` as well as `cwd` and the
+#: command, and a cache written before that holds a peer's raw bytes for a day
+#: file that may never be appended to again. The shape did not change; what a
+#: field is allowed to contain did, and there is no cheaper way to be sure no
+#: stale copy is still carrying the old answer. One cold rebuild, ~75 ms, once.
+CACHE_VERSION = 3
 _MAGIC = f"woswoar-cache-{CACHE_VERSION}"
 
 #: Field, record and file separators. See the module docstring for why these
@@ -188,8 +193,8 @@ class Cache:
         return stamps, commands
 
     def display_columns(
-        self, hosts: set[str] | None = None
-    ) -> tuple[list[str], list[str], list[str], list[str]]:
+        self, hosts: set[str] | None = None, extra: bool = False
+    ) -> tuple[list[str], ...]:
         """Timestamps, commands, exit codes and host ids, aligned, as strings.
 
         One pass and one place. Each caller used to slice what it happened to
@@ -199,11 +204,26 @@ class Cache:
 
         ``hosts`` narrows to those machines, which costs one dict lookup per
         *file*: the host belongs to the file, not the row.
+
+        ``extra`` appends the three fields that are recorded but have no screen
+        width -- cwd, duration and session -- for the preview pane, which shows
+        one row rather than all of them. Appended rather than slotted in, so
+        every index the picker already uses keeps its meaning; and produced in
+        this same pass rather than by `cwds` and `sessions`, because those walk
+        *every* file and the four above may have been narrowed to one machine.
+        Two columns that disagree about which rows they hold would put another
+        machine's directory under this machine's command, silently.
+
+        Off by default and therefore free: Ctrl-R never asks for it, and the
+        preview is a separate process that has already paid for a cache load.
         """
         stamps: list[str] = []
         commands: list[str] = []
         codes: list[str] = []
         owners: list[str] = []
+        cwds: list[str] = []
+        durations: list[str] = []
+        sessions: list[str] = []
         for relpath, flat in self.files.items():
             host = self.meta[relpath].host
             if hosts is not None and host not in hosts:
@@ -212,11 +232,13 @@ class Cache:
             commands += flat[5::6]
             codes += flat[3::6]
             owners += [host] * (len(flat) // _FIELDS_PER_ENTRY)
+            if extra:
+                cwds += flat[2::6]
+                durations += flat[4::6]
+                sessions += flat[1::6]
+        if extra:
+            return stamps, commands, codes, owners, cwds, durations, sessions
         return stamps, commands, codes, owners
-
-    def exit_codes(self) -> list[str]:
-        """The exit status column, in the same order as `stamps_and_commands`."""
-        return [value for flat in self.files.values() for value in flat[3::6]]
 
     def sessions(self) -> list[str]:
         """The session column, in the same order as `stamps_and_commands`."""
@@ -225,12 +247,19 @@ class Cache:
     def cwds(self) -> list[str]:
         """The working-directory column, in the same order as `stamps_and_commands`.
 
-        Its own accessor rather than a fifth column on `display_columns`, which
-        every scope would then pay for to serve one of them -- 0.4 ms measured
-        over 54,600 rows -- and `cwd` is not a display column. It is comparable
-        exactly as it comes out, which is the other half of why this is cheap:
-        the cache stores what `parse_line(..., inert=True)` produced, so it is
-        already unescaped and already inert.
+        Its own accessor rather than a column `display_columns` always returns,
+        which every scope would then pay for to serve one of them -- 0.4 ms
+        measured over 54,600 rows.
+
+        It answers a different question from that method's ``extra`` copy, and
+        both are needed. This one is the *filter* input, so it must hold every
+        row in file order, from before any scope has narrowed anything; the copy
+        is what the pane displays, and has been narrowed exactly as the row it
+        is shown beside was.
+
+        Comparable exactly as it comes out, which is the other half of why this
+        is cheap: the cache stores what `parse_line(..., inert=True)` produced,
+        so it is already unescaped and already inert.
         """
         return [value for flat in self.files.values() for value in flat[2::6]]
 

--- a/woswoar/entry.py
+++ b/woswoar/entry.py
@@ -226,14 +226,23 @@ def parse_line(line: str, host: str, inert: bool = False) -> Entry | None:
     final line (a shell killed mid-append) or a line from a future format
     version should cost us that one entry, never the whole file.
 
-    ``inert`` applies :func:`make_inert` to the two free-text fields as they are
-    built. A flag rather than a second pass because the caller that wants it --
+    ``inert`` applies :func:`make_inert` to the three fields whose contents this
+    machine did not choose -- session, cwd and command. A flag rather than a
+    second pass because the caller that wants it --
     :mod:`woswoar.cache`, on behalf of everything that displays history -- reads
     the whole log, and rebuilding each entry afterwards measured 82ms against
     59ms for 52,000 lines. The caller that does *not* want it is
     `store.existing_keys`, which compares against commands as the importer read
     them: sanitising there would stop an already-imported entry matching itself
     and re-import the whole file.
+
+    `session` joined the other two when the preview pane started showing it. It
+    is a `<hex>-<hex>` token as *this* machine writes it, and free text as far
+    as the format is concerned -- a peer's chunk can put anything in that field,
+    and until it had a display site nothing would have noticed. Sanitising it
+    here rather than at that site is the rule `cache` states: this is the one
+    door a peer's history comes through, and a rule about remembering to clean
+    at each display had already been forgotten once before it moved here.
     """
     line = line.rstrip("\n")
     if not line:
@@ -255,7 +264,7 @@ def parse_line(line: str, host: str, inert: bool = False) -> Entry | None:
     return Entry(
         ts=ts,
         host=host,
-        session=session,
+        session=clean(session),
         cwd=clean(unescape(cwd)),
         exit_code=exit_code,
         duration_ms=duration_ms,

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -12,7 +12,7 @@ import os
 import sys
 import time
 from operator import itemgetter
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from typing import IO
@@ -38,6 +38,11 @@ SCOPES: tuple[Scope, ...] = ("global", "host", "session", "dir")
 #: which breaks the shape of the other three.
 KEYS: dict[Scope, str] = {"global": "g", "host": "h", "session": "s", "dir": "o"}
 
+#: The key that shows the preview. fzf's own convention -- `man fzf` binds
+#: `ctrl-/` in its `change-preview-window` example -- and what it displaces is
+#: `toggle-wrap-word`, which is the thing here worth losing.
+PREVIEW_KEY = "ctrl-/"
+
 #: Every display line is ``"<7-char relative time><2 spaces><escaped command>"``.
 #: The prefix is a fixed width so recovering the command from what fzf prints
 #: back is an exact slice rather than a parse. Seven fits the widest age
@@ -50,8 +55,22 @@ _PREFIX = _TIME_WIDTH + 2
 #: Sort key for a row. In C, rather than a lambda.
 _STAMP = itemgetter(0)
 
-#: One display row: when, what, how it ended, and which machine ran it.
-Row = tuple[int, str, str, str]
+#: One row: when, what, how it ended, and which machine ran it -- and, when the
+#: preview pane asked for them, the three recorded fields there is no screen
+#: width for, appended after those four.
+#:
+#: Loosely typed because the length varies with the caller, and there is no way
+#: to say better on this floor: the shape is
+#: ``tuple[int, str, str, str, Unpack[tuple[str, ...]]]``, and `typing.Unpack` is
+#: 3.11, where `pyproject` says 3.10 and the dependency list is empty on purpose.
+#:
+#: So the invariant is prose and a test rather than a type: the first four never
+#: move, because the sort reads ``[0]``, the dedup reads ``[1]`` and
+#: `render_rows` unpacks all four. `test_show_reports_the_row_the_list_shows`
+#: pins it by asking both sides about every index of a list built from all seven,
+#: with a distinct value per field, so a swapped pair shows up as a wrong answer
+#: rather than a short list.
+Row = tuple[Any, ...]
 
 #: Plain red rather than the dim red this started as. Dim was the right choice
 #: while the whole line carried it -- a screen of dim red is legible where a
@@ -289,20 +308,29 @@ def _under(cwds: list[str], keys: tuple[str, ...]) -> list[int]:
     return [index for index, value in enumerate(cwds) if value in keys or value.startswith(below)]
 
 
-#: The four parallel columns a display line is built from.
-Columns = tuple[list[str], list[str], list[str], list[str]]
+#: The parallel columns a display line is built from -- stamps, commands, exit
+#: codes and hosts, plus whatever `Cache.display_columns` was asked to append
+#: after them. Variadic for the same reason `Row` is: the extras ride along
+#: through the sort and the dedup, and only the first four are ever displayed.
+Columns = tuple[list[str], ...]
 
 
-def _columns_for(scope: Scope) -> tuple[cache.Cache, Columns | None]:
+def _columns_for(scope: Scope, extra: bool = False) -> tuple[cache.Cache, Columns | None]:
     """The rows a scope is about, straight out of the cache's columns.
 
     Split out of `lines_for` so a timeline can start from exactly the same set
     -- asking the same question twice and getting different answers is how the
-    anchor `{n}` names would stop meaning what fzf thinks it means.
+    anchor `{n}` names would stop meaning what fzf thinks it means. `detail`
+    takes the same route for the same reason, one step further: it is handed an
+    index into a list another process rendered.
+
+    ``extra`` is passed straight through to the cache, so the preview's three
+    additional columns are narrowed by exactly the same scope logic as the four
+    below them -- rather than being fetched separately and lined up by hope.
     """
     loaded = cache.load_columns()
     if scope == "host":
-        return loaded, loaded.display_columns({store.machine().id})
+        return loaded, loaded.display_columns({store.machine().id}, extra=extra)
     if scope == "session":
         session = os.environ.get("WOSWOAR_SESSION", "")
         if not session:
@@ -312,7 +340,7 @@ def _columns_for(scope: Scope) -> tuple[cache.Cache, Columns | None]:
         # per file, so they are the scopes that cannot be answered by dropping
         # whole files the way `host` is.
         wanted = [i for i, value in enumerate(loaded.sessions()) if value == session]
-        return loaded, _gather(loaded.display_columns(), wanted)
+        return loaded, _gather(loaded.display_columns(extra=extra), wanted)
     if scope == "dir":
         # Deliberately every machine, not this one. `~/src/woswoar` on either
         # box is the same project, and asking that across machines is what
@@ -320,19 +348,24 @@ def _columns_for(scope: Scope) -> tuple[cache.Cache, Columns | None]:
         # `host` would remove the only way to ask it. Its failure mode is an
         # extra row with the machine column naming where it came from, against a
         # missing row that looks like a broken feature.
-        return loaded, _gather(loaded.display_columns(), _under(loaded.cwds(), _here()))
-    return loaded, loaded.display_columns()
+        wanted = _under(loaded.cwds(), _here())
+        return loaded, _gather(loaded.display_columns(extra=extra), wanted)
+    return loaded, loaded.display_columns(extra=extra)
 
 
 def _gather(columns: Columns, wanted: list[int]) -> Columns:
-    """The four display columns, narrowed to the rows at ``wanted``."""
-    stamps, commands, codes, hosts = columns
-    return (
-        [stamps[i] for i in wanted],
-        [commands[i] for i in wanted],
-        [codes[i] for i in wanted],
-        [hosts[i] for i in wanted],
-    )
+    """Every column, narrowed to the rows at ``wanted``."""
+    return tuple([column[i] for i in wanted] for column in columns)
+
+
+def _zipped(columns: Columns) -> list[Row]:
+    """The columns as rows, with the timestamp converted once.
+
+    One `int` per row, here, where the sort needs it -- rather than on every
+    entry of a history at parse time.
+    """
+    stamps, *rest = columns
+    return list(zip(map(int, stamps), *rest, strict=True))
 
 
 def _rows_for(columns: Columns, dedup: bool, around: int | None) -> tuple[list[Row], int]:
@@ -342,8 +375,7 @@ def _rows_for(columns: Columns, dedup: bool, around: int | None) -> tuple[list[R
     anchor to sit on -- which is every ordinary list, and also a timeline whose
     anchor has gone.
     """
-    stamps, commands, codes, hosts = columns
-    ranked = rank_rows(stamps, commands, codes, hosts, dedup=dedup)
+    ranked = rank_rows(columns, dedup=dedup)
     if around is None:
         return ranked, 0
     anchor = ranked[around] if 0 <= around < len(ranked) else None
@@ -388,6 +420,134 @@ def lines_for(
     return render_rows(rows, colour=colour, host_width=host_width)
 
 
+def _exit_label(code: str) -> str:
+    """``exit 0``, or what to say when the history never knew.
+
+    A negative code is `importer`'s "never knew": `~/.bash_history` records no
+    exit codes whatsoever, so a literal ``exit -1`` would invent a failure that
+    never happened -- the same misreading that painted a freshly imported
+    history entirely red, one screen further in.
+
+    Parsed rather than compared against the string ``"-1"``, for the reason
+    `is_failure` gives two screens up: the same bug comes back for any other
+    sentinel, and ``-01`` is the same number written differently. An
+    unparseable code is shown as it was stored, because at that point the honest
+    thing is to hand over what the file says.
+    """
+    try:
+        recorded = int(code) >= 0
+    except ValueError:
+        recorded = True
+    return f"exit {code}" if recorded else "exit not recorded"
+
+
+def _duration_label(raw: str) -> str | None:
+    """How long the command took, or ``None`` when nothing was recorded.
+
+    ``None`` rather than "0 ms": an imported history has no durations at all,
+    and a whole column of zeroes is a claim, where an absent line is the truth.
+    Unparseable is treated the same way -- a damaged field should cost this one
+    line, never the block.
+
+    At most two units, and no more precision than anyone reads off a pane they
+    opened to see where a command ran: ``87 ms``, ``1.2 s``, ``2m 3s``, ``1h 2m``.
+    """
+    try:
+        ms = int(raw)
+    except ValueError:
+        return None
+    if ms < 0:
+        return None
+    if ms < 1000:
+        return f"{ms} ms"
+    if ms < 60_000:
+        return f"{ms / 1000:.1f} s"
+    minutes, seconds = divmod(ms // 1000, 60)
+    if minutes < 60:
+        return f"{minutes}m {seconds}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes}m"
+
+
+def _block(row: Row, now: int | None = None) -> str:
+    """The three unseen fields, plus the two the line already shows, as a block.
+
+    Nothing here neutralises anything, and that is deliberate rather than an
+    omission: every field comes out of the cache, which is the one door a peer's
+    history enters through and which applies `make_inert` on the way in --
+    `session` included, since this is what gave it a display site. `host` is the
+    exception, because it is not stored with the row at all: the name is a file
+    a peer wrote, so it goes through `host_label`.
+
+    `host_label` and not `host_labels`, which is what the display line uses.
+    The pane names one machine and has no column to fit, so it shows the whole
+    `user@host` where the line shows the abbreviation that keeps two machines
+    apart -- more, not different, and there is no host *set* here to compute the
+    abbreviation from anyway.
+
+    The command is printed as it was recorded rather than `escape`d, because
+    this is the one place with room to show it whole: the picker's line is
+    clipped at the window edge, and `--preview-window=wrap` is not.
+    """
+    ts, cmd, code, host, cwd, duration, session = row
+    when = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(ts))
+    age = relative_time(ts, now)
+    # "now" is what `relative_time` says for a stamp in the future, which is
+    # another machine's clock running ahead. "(now ago)" would be nonsense.
+    head = f"{when}  ({age})" if age == "now" else f"{when}  ({age} ago)"
+
+    where = [host_label(host)]
+    if session:
+        where.append(f"session {session}")
+    status = [_exit_label(code)]
+    took = _duration_label(duration)
+    if took:
+        status.append(took)
+
+    return "\n".join(
+        [
+            head,
+            " · ".join(where),
+            # An imported line has no directory at all, so the line says so
+            # rather than vanishing: a block that is four lines here and three
+            # there reads as a bug in the preview, not as a fact about the row.
+            cwd or "directory not recorded",
+            " · ".join(status),
+            "",
+            cmd,
+        ]
+    )
+
+
+def detail(
+    index: int,
+    scope: Scope,
+    dedup: bool = True,
+    around: int | None = None,
+) -> str | None:
+    """The preview block for one row of what `lines_for` would print, or ``None``.
+
+    ``index`` is fzf's `{n}`, so this has to reproduce the very list the picker
+    is showing -- which is why it takes the same `scope`, `dedup` and `around`
+    the reload that filled it was given. Get `around` wrong and the preview
+    describes a different command from the highlighted one, confidently and with
+    nothing on screen to contradict it; that is the whole hazard of this feature
+    and it is why the timeline's binding repoints the preview as well as the
+    list.
+
+    ``None`` for an index that is not there, which is the same race
+    `_window_around` guards: a background sync can merge new commands between
+    the picker opening and the cursor moving.
+    """
+    _, columns = _columns_for(scope, extra=True)
+    if columns is None:
+        return None
+    rows, _ = _rows_for(columns, dedup=dedup, around=around)
+    if not 0 <= index < len(rows):
+        return None
+    return _block(rows[index])
+
+
 #: How many commands a timeline shows either side of the one it is centred on.
 #: A screenful each way: enough that the thing you were looking for is usually
 #: already on it, few enough that the picker still opens instantly.
@@ -415,11 +575,7 @@ def _window_around(anchor: Row | None, columns: Columns) -> tuple[list[Row], int
     """
     if anchor is None:
         return [], 0
-    stamps, commands, codes, hosts = columns
-    chronological = sorted(
-        zip((int(s) for s in stamps), commands, codes, hosts, strict=True),
-        key=_STAMP,
-    )
+    chronological = sorted(_zipped(columns), key=_STAMP)
     try:
         # By identity of the whole row, not by timestamp: two machines can
         # record in the same second, and `sorted` is stable but not meaningful
@@ -450,26 +606,20 @@ def anchor_position(index: int, scope: Scope, dedup: bool = True) -> int:
     return _rows_for(columns, dedup=dedup, around=index)[1]
 
 
-def rank_rows(
-    stamps: list[str],
-    commands: list[str],
-    codes: list[str],
-    hosts: list[str],
-    dedup: bool = True,
-) -> list[Row]:
+def rank_rows(columns: Columns, dedup: bool = True) -> list[Row]:
     """Newest first, optionally collapsing repeats.
 
-    The exit status and the host ride along so the display can colour by one and
-    label by the other. Deduplication
+    Takes the whole `Columns` tuple rather than four named lists, so the
+    preview's extras are ranked by the *same* function and cannot be ordered
+    differently from what the picker shows -- and so that this reads like its
+    neighbours `_gather`, `_zipped` and `_window_around`, which all take one.
+    The exit status and the host ride along so the
+    display can colour by one and label by the other. Deduplication
     keeps the *most recent* run, so a command that failed last time is shown as
     failed even if it has succeeded a hundred times before -- which is the way
     round that helps.
     """
-    # One `int` per row, here, where the sort needs it -- rather than on every
-    # entry of a history at parse time.
-    ordered = sorted(
-        zip(map(int, stamps), commands, codes, hosts, strict=True), key=_STAMP, reverse=True
-    )
+    ordered = sorted(_zipped(columns), key=_STAMP, reverse=True)
     if not dedup:
         return ordered
 
@@ -510,6 +660,11 @@ def render_rows(
     labels = host_labels({row[3] for row in rows}) if host_width else {}
 
     out = []
+    # Unpacked, not sliced, even though a `Row` can be seven fields wide: the
+    # wide ones are built by `detail` and go to `_block`, and nothing routes
+    # them here -- `lines_for` is the only caller and it asks `_columns_for` for
+    # four. A `[:4]` that tolerated them would be a guard against a call that
+    # does not exist, and would read as if one did.
     for ts, cmd, code, host in rows:
         when = f"{relative_time(ts, now):>{_TIME_WIDTH}}"
         if colour and is_failure(code):
@@ -585,6 +740,19 @@ def fzf_version() -> tuple[str, tuple[int, int] | None]:
         return out, None
 
 
+#: What an fzf below `TRANSFORM_SINCE` silently does not get. One list, because
+#: `_fzf_argv` withholds them and `doctor` has to name them, and the way those
+#: two part company is a machine being told it is missing two keys while three
+#: are gone -- which is exactly what happened when the preview joined the gate.
+#: Written as phrases rather than key names because `doctor` reads them out in a
+#: sentence and that is the only place they are rendered.
+GATED_KEYS: tuple[str, ...] = (
+    "ctrl-r cycling",
+    "the ctrl-t timeline",
+    f"the {PREVIEW_KEY} details pane",
+)
+
+
 def fzf_supports_transform() -> bool:
     """Whether this fzf has the `transform` action, added in 0.45.
 
@@ -597,7 +765,7 @@ def fzf_supports_transform() -> bool:
     return parsed is not None and parsed >= TRANSFORM_SINCE
 
 
-def _scope_case(var: str, answer: dict[Scope, Scope]) -> str:
+def _scope_case(var: str, answer: dict[Scope, Scope], fallback: str = SCOPES[0]) -> str:
     """An ``sh`` ``case`` that reads the current scope out of fzf's prompt.
 
     fzf holds no variables, so both keys that need to know the scope read it
@@ -609,8 +777,13 @@ def _scope_case(var: str, answer: dict[Scope, Scope]) -> str:
     would have said so -- an arm that is missing looks exactly like an arm whose
     answer happens to be the default.
 
-    The catch-all stays `SCOPES[0]`, which is what an unset or unrecognised
-    prompt should degrade to.
+    The catch-all is `SCOPES[0]` for the two keys that *reload*: an unset or
+    unrecognised prompt then shows the global list, which is a list you can see
+    and whose prompt says what it is. The preview passes ``fallback=""`` instead,
+    because there the same guess is unfalsifiable -- a block describing the wrong
+    row looks exactly like a block describing the right one. `FZF_PROMPT` is
+    read here on the assumption that fzf exports it, and no version is known to
+    hang that on, so the failure has to be the visible kind.
 
     **The prompt these read must stay exactly `woswoar (<scope>) `.** The
     patterns are substring matches over the whole of it, so a prompt naming the
@@ -620,7 +793,7 @@ def _scope_case(var: str, answer: dict[Scope, Scope]) -> str:
     is written down here and pinned by a test.
     """
     arms = "".join(f"*{scope}*) {var}={answer[scope]} ;; " for scope in SCOPES)
-    return f'case "$FZF_PROMPT" in {arms}*) {var}={SCOPES[0]} ;; esac; '
+    return f'case "$FZF_PROMPT" in {arms}*) {var}={fallback} ;; esac; '
 
 
 #: Where each scope goes when Ctrl-R is pressed: on to the next, and round.
@@ -631,15 +804,148 @@ _NEXT: dict[Scope, Scope] = {
 }
 
 
+#: Hidden until asked for, and that is not a default worth revisiting: the
+#: preview forks an interpreter and reads the whole cache on every cursor move.
+#: Measured on the 52,000-command history in `tests/test_perf.py`, one render is
+#: **79 ms** against 85 ms for the whole of `woswoar list` -- it skips the render
+#: of 23,000 lines and pays for everything else, and neither term is
+#: optimisable here: one is process startup and the other is reading a 5 MB
+#: cache. That is paid *per row the cursor passes over*. fzf coalesces to the
+#: latest request, so an always-on pane degrades to visible lag under a held
+#: arrow key rather than to a queue -- but a user who never presses
+#: `PREVIEW_KEY` should pay nothing at all, and hidden is how they do.
+#:
+#: `wrap` because this is the one place with room to show a long command whole;
+#: the picker's own line is clipped at the window edge.
+PREVIEW_WINDOW = "--preview-window=hidden,down,45%,border-top,wrap"
+
+#: What the preview says when it could not tell which list it is looking at.
+#: See `_scope_case`: the alternative is a confidently wrong record.
+PREVIEW_UNKNOWN = "preview needs a newer fzf"
+
+#: fzf substitutes every `{...}` in the command it is about to run, and a
+#: `transform` *is* such a command -- so a `{n}` that is meant for the preview
+#: the transform prints has to survive that pass. `man fzf`: "you can escape a
+#: placeholder pattern by prepending a backslash". The backslash is consumed
+#: there, a bare `{n}` reaches `change-preview`, and it stays a live template
+#: that fzf re-expands on every cursor move.
+#:
+#: Measured against fzf 0.73.1 rather than taken from the manual, which
+#: documents the escape but not what becomes of it inside a transform's output:
+#: `TestThePreviewUnderARealFzf` drives a real picker through a pty and watches
+#: the pane renumber itself as the cursor moves.
+_ESCAPED_N = r"\{n}"
+
+#: Read the scope back and answer with itself. `_NEXT`'s counterpart, named for
+#: the same reason: the two callers that want "whatever is on screen, unchanged"
+#: were spelling the dict inline.
+_SAME: dict[Scope, Scope] = {scope: scope for scope in SCOPES}
+
+
+def _preview_command(
+    self_cmd: str, scope: str, dedup_flag: str, row: str = "{n}", around: str = ""
+) -> str:
+    """The command that renders one row's block into the preview pane.
+
+    ``scope`` is a literal for the four per-scope key binds, which know it up
+    front, and a shell variable `_scope_case` set for the three that cannot --
+    the `--preview` the picker opens with, and the two `transform` keys, all of
+    which have to keep meaning the right thing after a switch they did not make.
+    It arrives quoted (``"$s"``) for the first of those, because that one is a
+    bare command line where the shell would word-split an empty value; inside
+    the two `printf`s it is already inside quotes.
+
+    ``row`` is fzf's index of the highlighted item and is left as a template on
+    purpose; see `_ESCAPED_N` for the callers that have to spell it differently.
+
+    ``around`` is what makes the preview agree with a timeline. It is the same
+    flag `lines_for` takes, and for the same reason: under a timeline the list
+    fzf holds is a *window*, so `row` indexes that window and resolving it
+    against the ranked list would describe some entirely unrelated command.
+    """
+    return f"{self_cmd} list --show {row} --scope {scope}{dedup_flag}{around}"
+
+
+def _preview_binding(self_cmd: str, dedup_flag: str) -> str:
+    """The pane showing what the display line has no width for.
+
+    `cwd`, `duration_ms` and `session` are recorded, encrypted, synced and
+    cached, and until this there was no way for anyone to read them back. They
+    do not fit on the line -- it is a fixed-width prefix that `command_from_line`
+    slices rather than parses -- and a pane costs no width at all, because it
+    only ever describes the one row under the cursor.
+    """
+    show = _preview_command(self_cmd, '"$s"', dedup_flag)
+    script = (
+        _scope_case("s", _SAME, fallback="")
+        + f'if [ -n "$s" ]; then {show}; else printf "%s\\n" "{PREVIEW_UNKNOWN}"; fi'
+    )
+    return f"--preview={script}"
+
+
+def _list_command(self_cmd: str, scope: str, dedup_flag: str, width: str, around: str = "") -> str:
+    """The `woswoar list` the picker reloads itself from.
+
+    One spelling, because both sides of the picker have to lay a line out
+    identically: `command_from_line` slices at a fixed width decided when it
+    opened, so a binding that reloaded without `--colour` or with a different
+    `--host-width` would cut somebody's recalled command in the wrong place.
+    Three bindings and one key loop write this, and `--host-width` was already
+    once a flag that had to be added to each of them by hand.
+    """
+    return f"{self_cmd} list --colour{width} --scope {scope}{dedup_flag}{around}"
+
+
+def _switch_to(
+    self_cmd: str,
+    scope: str,
+    dedup_flag: str,
+    width: str,
+    row: str = "{n}",
+    preview: bool = True,
+) -> str:
+    """Every action a key needs to move the picker to one scope, in one string.
+
+    The list, the prompt and the preview are three statements of a single fact,
+    and the prompt is not decoration: `_scope_case` reads the scope back *out*
+    of it, so a key that repainted only two of the three would leave the next
+    keypress reading a scope the screen no longer shows. Emitting them together
+    is what stops them disagreeing.
+
+    The preview is included because these keys are also the way *out* of a
+    timeline, whose pane is pinned to one `--around` window; left alone it would
+    keep describing rows of a list that is no longer there -- and describing
+    them plausibly, which is the whole hazard of this feature.
+
+    ``row`` is `_ESCAPED_N` for a caller whose output fzf expands first.
+
+    ``preview`` is False on an fzf that was never offered a pane. Not only
+    because there would be nothing to repoint: `change-preview` arrived in fzf
+    0.31 and `transform` in 0.45, so a version below the gate may not know the
+    *action name* either -- and an unknown action in a `--bind` makes fzf refuse
+    to start, which costs the picker rather than the key.
+    """
+    actions = (
+        f"reload({_list_command(self_cmd, scope, dedup_flag, width)})"
+        f"+change-prompt(woswoar ({scope}) )"
+    )
+    if preview:
+        actions += f"+change-preview({_preview_command(self_cmd, scope, dedup_flag, row=row)})"
+    return actions
+
+
 def _cycle_binding(self_cmd: str, dedup_flag: str, width: str) -> str:
     """Ctrl-R inside the picker moves to the next scope.
 
     The order is `SCOPES`, which is the order the header names them in.
+
+    `$n` rather than a literal, and `_ESCAPED_N` rather than `{n}`: this is the
+    same switch the four direct keys make, but composed by a shell fzf runs
+    first, so the scope is a variable and the preview's placeholder has to
+    survive that pass.
     """
-    reload = f"{self_cmd} list --colour{width} --scope"
-    script = (
-        _scope_case("n", _NEXT)
-        + f'printf "reload({reload} $n{dedup_flag})+change-prompt(woswoar ($n) )"'
+    script = _scope_case("n", _NEXT) + (
+        f'printf "{_switch_to(self_cmd, "$n", dedup_flag, width, row=_ESCAPED_N)}"'
     )
     return f"--bind=ctrl-r:transform:{script}"
 
@@ -657,12 +963,13 @@ def _header(host_width: int) -> str:
     Only with a column to filter on. On a single-machine install there is no
     machine name in the line and the hint would describe nothing.
 
-    Ctrl-R and Ctrl-T are listed only where they work: both need `transform`,
-    which is fzf 0.45+, and advertising a key that does nothing is worse than
-    staying quiet about it.
+    Ctrl-R, Ctrl-T and the preview key are listed only where they work: all
+    three ride on `transform`, which is fzf 0.45+, and advertising a key that
+    does nothing is worse than staying quiet about it.
 
     Ordered by how far each takes you from an ordinary search: change what is
-    listed, then change the *kind* of list, then narrow the one you have.
+    listed, then change the *kind* of list, then narrow the one you have, then
+    look harder at the one row you are on.
     """
     if fzf_supports_transform():
         # Naming the scopes in the order Ctrl-R visits them is what lets the
@@ -681,6 +988,10 @@ def _header(host_width: int) -> str:
         hints = [
             "ctrl-r global \u2192 host \u2192 session \u2192 dir, or ctrl-g/h/s, ctrl-o dir",
             "ctrl-t timeline",
+            # Last, because it is the only one that changes nothing about the
+            # list -- and because a key nobody presses costs nothing, which is
+            # the whole reason the pane starts hidden.
+            f"{PREVIEW_KEY} details",
         ]
     else:
         # Neither key exists here, and with no cycle to name the scopes the
@@ -706,14 +1017,24 @@ def _timeline_binding(self_cmd: str, dedup_flag: str, width: str) -> str:
     carried into the timeline's own prompt (`woswoar (timeline host)`) so that
     pressing this again recentres without silently changing scope, and so that
     ctrl-g/h/s/o/r still read a scope out of it on the way back out.
+
+    The preview is repointed at the same window in the same breath, and it is
+    the one part of this that is silently wrong if forgotten: fzf would go on
+    running a preview command that resolves `{n}` against the *ranked* list
+    while the screen shows a timeline, so the pane would describe a command
+    forty rows from the highlighted one and look entirely plausible doing it.
     """
-    reload = f"{self_cmd} list --colour{width} --scope"
+    # Not `_switch_to`: every one of its three actions is different here --
+    # `reload-sync` rather than `reload`, a prompt that says `timeline`, and a
+    # preview pinned to this window. What they have in common is only the shape.
+    window = _list_command(self_cmd, "$s", dedup_flag, width, around=" --around {n}")
+    preview = _preview_command(self_cmd, "$s", dedup_flag, row=_ESCAPED_N, around=" --around {n}")
     script = (
-        _scope_case("s", {scope: scope for scope in SCOPES})
+        _scope_case("s", _SAME)
         # One extra invocation, on a keypress rather than on the prompt path:
         # `pos` has to be composed into the same action string as the `reload`
         # it applies to, so it cannot be read out of the reload's own output.
-        + f"p=$({reload} $s{dedup_flag} --around {{n}} --print-anchor); "
+        + f"p=$({window} --print-anchor); "
         # `reload-sync`, not `reload`: a plain reload is asynchronous, so `pos`
         # ran against the list that was still on screen and the cursor was
         # wherever the new one happened to leave it. Reported as "it seems to
@@ -724,8 +1045,9 @@ def _timeline_binding(self_cmd: str, dedup_flag: str, width: str) -> str:
         # down to the same match you started from, which is an empty gesture.
         # Asked for directly: "it should clear the filter, that way it's
         # filtering the timeline".
-        + f'printf "clear-query+reload-sync({reload} $s{dedup_flag} --around {{n}})'
-        '+pos($p)+change-prompt(woswoar (timeline $s) )"'
+        + f'printf "clear-query+reload-sync({window})'
+        f"+pos($p)+change-prompt(woswoar (timeline $s) )"
+        f'+change-preview({preview})"'
     )
     return f"--bind=ctrl-t:transform:{script}"
 
@@ -768,15 +1090,29 @@ def _fzf_argv(scope: Scope, query: str, dedup: bool, host_width: int) -> list[st
         f"--prompt=woswoar ({scope}) ",
         f"--header={_header(host_width)}",
     ]
-    if fzf_supports_transform():
+    # Asked once and reused, because it forks `fzf --version`.
+    transform = fzf_supports_transform()
+    if transform:
         argv.append(_cycle_binding(self_cmd, dedup_flag, width))
         argv.append(_timeline_binding(self_cmd, dedup_flag, width))
+        # The preview rides on the same gate, though nothing in it needs
+        # `transform` as such. Two reasons, and the second is the one that
+        # decides it: it reads `$FZF_PROMPT`, which no version is known to have
+        # introduced, so an fzf old enough to lack it would get the fail-closed
+        # message on every row rather than a preview -- and an unknown key name
+        # in a `--bind` makes fzf refuse to start, so offering `ctrl-/` to a
+        # version that predates it costs the picker entirely, not the key.
+        argv.append(_preview_binding(self_cmd, dedup_flag))
+        argv.append(PREVIEW_WINDOW)
+        argv.append(f"--bind={PREVIEW_KEY}:toggle-preview")
     for target in SCOPES:
-        argv.append(
-            f"--bind=ctrl-{KEYS[target]}:reload("
-            f"{self_cmd} list --colour{width} --scope {target}{dedup_flag})"
-            f"+change-prompt(woswoar ({target}) )"
-        )
+        # The same switch the cycle makes, with the scope known up front rather
+        # than read out of the prompt -- and `{n}` unescaped, because this is a
+        # plain action and not a `transform` whose command line fzf expands
+        # first. Without `transform` there is no pane to repoint, so the
+        # `change-preview` is dropped rather than pointed at nothing.
+        actions = _switch_to(self_cmd, target, dedup_flag, width, preview=transform)
+        argv.append(f"--bind=ctrl-{KEYS[target]}:{actions}")
     return argv
 
 

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -79,6 +79,14 @@ Row = tuple[Any, ...]
 _FAILED = "\x1b[31m"
 _RESET = "\x1b[0m"
 
+#: The rest of the palette, used only by the preview pane. Green, red and dim,
+#: which is what `doctor` already paints with -- a fourth colour would be a new
+#: thing for a reader to learn, and these three already mean "fine", "not fine"
+#: and "structure, not content" everywhere else in the program.
+_OK = "\x1b[32m"
+_DIM = "\x1b[2m"
+_BOLD = "\x1b[1m"
+
 
 def is_failure(code: str) -> bool:
     """Whether a recorded exit code is a *known* failure.
@@ -420,34 +428,42 @@ def lines_for(
     return render_rows(rows, colour=colour, host_width=host_width)
 
 
-def _exit_label(code: str) -> str:
-    """``exit 0``, or what to say when the history never knew.
+def _exit_field(code: str) -> tuple[str | None, str]:
+    """What the ``exit`` row shows, and what colour it is.
 
-    A negative code is `importer`'s "never knew": `~/.bash_history` records no
-    exit codes whatsoever, so a literal ``exit -1`` would invent a failure that
-    never happened -- the same misreading that painted a freshly imported
-    history entirely red, one screen further in.
+    ``None`` is `importer`'s "never knew": `~/.bash_history` records no exit
+    codes whatsoever, so it stores -1, and a literal ``exit -1`` would invent a
+    failure that never happened -- the same misreading that painted a freshly
+    imported history entirely red, one screen further in.
 
     Parsed rather than compared against the string ``"-1"``, for the reason
     `is_failure` gives two screens up: the same bug comes back for any other
     sentinel, and ``-01`` is the same number written differently. An
-    unparseable code is shown as it was stored, because at that point the honest
-    thing is to hand over what the file says.
+    unparseable code is handed over exactly as it was stored and painted
+    nothing, because at that point the honest thing is to show what the file
+    says and claim nothing about what it means.
+
+    Three answers, so `is_failure` -- which has two, and deliberately treats
+    unknown as "not a failure" -- cannot serve: the pane distinguishes a clean
+    exit from an unknowable one, where a display line only ever asks whether to
+    paint the age red.
     """
     try:
-        recorded = int(code) >= 0
+        parsed = int(code)
     except ValueError:
-        recorded = True
-    return f"exit {code}" if recorded else "exit not recorded"
+        return code, ""
+    if parsed < 0:
+        return None, ""
+    return code, _OK if parsed == 0 else _FAILED
 
 
 def _duration_label(raw: str) -> str | None:
     """How long the command took, or ``None`` when nothing was recorded.
 
     ``None`` rather than "0 ms": an imported history has no durations at all,
-    and a whole column of zeroes is a claim, where an absent line is the truth.
-    Unparseable is treated the same way -- a damaged field should cost this one
-    line, never the block.
+    and a whole column of zeroes is a claim, where `_field`'s "not recorded" is
+    the truth. Unparseable is treated the same way -- a damaged field should
+    cost this one line, never the block.
 
     At most two units, and no more precision than anyone reads off a pane they
     opened to see where a command ran: ``87 ms``, ``1.2 s``, ``2m 3s``, ``1h 2m``.
@@ -469,7 +485,34 @@ def _duration_label(raw: str) -> str | None:
     return f"{hours}h {minutes}m"
 
 
-def _block(row: Row, now: int | None = None) -> str:
+#: Wide enough for ``session``, which is the longest label. The names are the
+#: picker's own -- `host`, `session` and `dir` are three of its four scopes -- so
+#: the pane says which key would narrow the list to the thing it is pointing at.
+_LABEL_WIDTH = 7
+
+
+def _field(label: str, value: str | None, colour: bool, tint: str = "") -> str:
+    """One ``label  value`` row of the pane's table.
+
+    Every label is always present, including the ones with nothing to say. The
+    first version left those lines out and read as a bug in the preview rather
+    than as a fact about the row -- a block that is six lines here and three
+    there gives a reader nothing to scan against, and "not recorded" is an
+    answer where a missing line is a question. An imported history has no
+    directory, no exit code, no duration and no session, so on a fresh import
+    that is four of the six.
+
+    The label is dim rather than the value bright: it is the same six words on
+    every row, so it should be the part the eye skips.
+    """
+    if value is None:
+        value, tint = "not recorded", _DIM
+    if not colour:
+        return f"{label:<{_LABEL_WIDTH}}  {value}"
+    return f"{_DIM}{label:<{_LABEL_WIDTH}}{_RESET}  {tint}{value}{_RESET if tint else ''}"
+
+
+def _block(row: Row, now: int | None = None, colour: bool = False) -> str:
     """The three unseen fields, plus the two the line already shows, as a block.
 
     Nothing here neutralises anything, and that is deliberate rather than an
@@ -487,34 +530,39 @@ def _block(row: Row, now: int | None = None) -> str:
 
     The command is printed as it was recorded rather than `escape`d, because
     this is the one place with room to show it whole: the picker's line is
-    clipped at the window edge, and `--preview-window=wrap` is not.
+    clipped at the window edge, and `--preview-window=wrap` is not. It goes
+    *last*, and below the table rather than in it: last because it is the one
+    field with no bound on its length, and a pane is a fixed number of rows --
+    put it first and a `find` invocation with forty arguments pushes everything
+    the pane exists to show off the bottom. Below the table because a value that
+    wraps cannot sit in a label column; fzf continues a wrapped line at column
+    zero.
+
+    With `colour`, the labels are dim, the exit code is green or red, and the
+    command is bold. Safe for the same reason `render_rows` is: `make_inert` has
+    already taken every C0 byte, ESC among them, off everything that came out of
+    the cache, so nothing a peer published can add escapes of its own. `host` is
+    the exception and `host_label` is why it is not one.
     """
     ts, cmd, code, host, cwd, duration, session = row
     when = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(ts))
     age = relative_time(ts, now)
     # "now" is what `relative_time` says for a stamp in the future, which is
     # another machine's clock running ahead. "(now ago)" would be nonsense.
-    head = f"{when}  ({age})" if age == "now" else f"{when}  ({age} ago)"
-
-    where = [host_label(host)]
-    if session:
-        where.append(f"session {session}")
-    status = [_exit_label(code)]
-    took = _duration_label(duration)
-    if took:
-        status.append(took)
+    ago = f"({age})" if age == "now" else f"({age} ago)"
+    stamp = f"{when}  {_DIM}{ago}{_RESET}" if colour else f"{when}  {ago}"
+    shown, tint = _exit_field(code)
 
     return "\n".join(
         [
-            head,
-            " · ".join(where),
-            # An imported line has no directory at all, so the line says so
-            # rather than vanishing: a block that is four lines here and three
-            # there reads as a bug in the preview, not as a fact about the row.
-            cwd or "directory not recorded",
-            " · ".join(status),
+            _field("when", stamp, colour),
+            _field("dir", cwd or None, colour),
+            _field("host", host_label(host), colour),
+            _field("session", session or None, colour),
+            _field("exit", shown, colour, tint),
+            _field("took", _duration_label(duration), colour),
             "",
-            cmd,
+            f"{_BOLD}{cmd}{_RESET}" if colour else cmd,
         ]
     )
 
@@ -524,6 +572,7 @@ def detail(
     scope: Scope,
     dedup: bool = True,
     around: int | None = None,
+    colour: bool = False,
 ) -> str | None:
     """The preview block for one row of what `lines_for` would print, or ``None``.
 
@@ -545,7 +594,7 @@ def detail(
     rows, _ = _rows_for(columns, dedup=dedup, around=around)
     if not 0 <= index < len(rows):
         return None
-    return _block(rows[index])
+    return _block(rows[index], colour=colour)
 
 
 #: How many commands a timeline shows either side of the one it is centred on.
@@ -862,8 +911,13 @@ def _preview_command(
     flag `lines_for` takes, and for the same reason: under a timeline the list
     fzf holds is a *window*, so `row` indexes that window and resolving it
     against the ranked list would describe some entirely unrelated command.
+
+    ``--colour`` is the same flag the display line is rendered with, meaning the
+    same thing: a terminal is watching. It is passed rather than assumed because
+    `--show` is a command line like any other, and `woswoar list --show 0 | cat`
+    should no more contain escapes than `woswoar list` does.
     """
-    return f"{self_cmd} list --show {row} --scope {scope}{dedup_flag}{around}"
+    return f"{self_cmd} list --colour --show {row} --scope {scope}{dedup_flag}{around}"
 
 
 def _preview_binding(self_cmd: str, dedup_flag: str) -> str:
@@ -1063,8 +1117,12 @@ def _fzf_argv(scope: Scope, query: str, dedup: bool, host_width: int) -> list[st
 
     argv = [
         "fzf",
-        # Safe here and only here: `render_rows` writes the escapes and
-        # `make_inert` guarantees no command can contain any of its own.
+        # Safe here and only here: `render_rows` and `_block` write the escapes
+        # and `make_inert` guarantees no command can contain any of its own.
+        # It covers the pane as well as the list -- verified against a real fzf
+        # rather than assumed, since the manual describes this flag in terms of
+        # the input stream: dim and bold both arrive at the terminal, re-emitted
+        # by fzf as its own SGR.
         "--ansi",
         "--height=60%",
         "--layout=reverse",


### PR DESCRIPTION
Closes #152.

Six fields go into every record and a display line has room for two. `cwd`,
`duration_ms` and `session` are recorded, encrypted, synced and cached, and
until now nobody could read one back. <kbd>Ctrl</kbd>+<kbd>/</kbd> shows them:

```
when     2026-08-10 14:32:07  (3h12m ago)
dir      ~/src/woswoar
host     thinkpad
session  6a79f245-36ea53
exit     0
took     1.2 s

docker compose up -d --build
```

A field nobody recorded says `not recorded` rather than inventing a `-1` — the
same misreading that once painted a fresh import red.

## The pane, restructured (review feedback)

Reported on the first version: "it is hard to read, and there is no information
what each line means." Five values ran together across four lines, separated by
`·`, and reading it needed a reader who already knew the record format — which
for three of these fields is nobody, since they have never been on a screen.

Before / after:

```
2026-08-10 14:32:07  (3h12m ago)        when     2026-08-10 14:32:07  (3h12m ago)
thinkpad · session 6a79f245-36ea53      dir      ~/src/woswoar
~/src/woswoar                           host     thinkpad
exit 0 · 1.2 s                          session  6a79f245-36ea53
                                        exit     0
docker compose up -d --build            took     1.2 s

                                        docker compose up -d --build
```

- **Every field is named, and none is ever missing.** The first version dropped
  the duration line when nothing was measured and folded "not recorded" into the
  value; a table with holes reads as a broken pane rather than as a fact about
  the row, and an imported history is missing four of the six.
- **The labels are the picker's own scope names.** `dir`, `host` and `session`
  are three of the four scopes, so the pane also says which key would narrow the
  list to what it is pointing at.
- **Colour, from the palette `doctor` already uses** — green, red, dim, and
  nothing new to learn. Labels dim, because they are the same six words on every
  row and are the part the eye should skip; the exit code green at zero and red
  above it; the command bold. `_exit_field` replaces `_exit_label` because the
  pane needs three answers where `is_failure` has two: it must tell a clean exit
  from one nobody ever recorded, and painting the second red is the misreading
  that once turned a freshly imported history into a screen of failures.
- **The command stays last, and outside the table.** It is the one field with no
  bound on its length and the pane has a fixed number of rows, so first would
  push everything the pane exists to show off the bottom; and fzf continues a
  wrapped line at column zero, where a label column cannot follow it.
- **`--colour` is passed, not assumed.** `--show` is a command line like any
  other: `woswoar list --show 0 | cat` has no more business emitting escapes
  than `woswoar list` does. Same flag, same meaning, and the preview binding
  now sends it.

## The measured numbers

The issue estimated ~85 ms per render and asked for a real one. On the
52,000-command history in `tests/test_perf.py`:

| | |
|---|---|
| one preview render (`list --show 0`) | **79 ms** |
| the whole of `woswoar list` | 85 ms |

So the pane starts **hidden**. A user who never presses the key pays nothing.

Ctrl-R itself is unchanged — `lines_for` measured **34.9–38.8 ms on `main`**
against **35.2–36.4 ms on this branch** (medians of 9, both from committed
trees, per CLAUDE.md). `display_columns()` without `extra` is unmeasurably
different (±0.004 ms on a 0.88 ms call), and `clean(session)` costs +0.06 ms on
a 95 ms cold build.

## The design decisions worth reading

**`{n}` is a position, not a row**, so `--show N` has to reproduce the very list
fzf is holding. That is the whole hazard: get it wrong and the pane describes
some other command, plausibly, with nothing on screen to contradict it. Three
things follow.

*The extras are produced in the cache's own pass*, not fetched from `cwds()` /
`sessions()`. Those walk every file, while the four display columns may have
been narrowed to one machine — so fetching separately lines them up by luck.
`zip(strict=True)` turns that slip into an exception rather than a wrong answer.

*Every key that changes the list repoints the pane.* Ctrl-T pins it to one
`--around` window; ctrl-g/h/s/o and ctrl-r are the way back out. One
`_switch_to` emitter now produces the reload, the prompt and the preview
together, because the prompt is not decoration — `_scope_case` reads the scope
back out of it, so a key that repainted two of the three would leave the *next*
keypress reading a scope the screen no longer shows.

*The `\{n}` escape is measured, not assumed.* fzf expands every `{...}` in a
`transform`'s own command line before running it, so the `{n}` meant for the
pane it prints has to survive that pass. `man fzf` documents the escape and says
nothing about what becomes of it in a transform's *output*.
`TestThePreviewUnderARealFzf` drives a real fzf 0.73.1 through the pty harness
from #166 and watches the pane renumber itself.

**The pane fails closed.** An unrecognised `$FZF_PROMPT` prints
`preview needs a newer fzf` rather than guessing `global`. Guessing is fine for
a key that *reloads* — you get a list whose prompt says what it is — and
unfalsifiable here.

## This turned out to be a rule-1 top-row change

The issue said row 2, one agent. Showing `session` meant auditing it, and
`entry.parse_line` was making `cwd` and the command inert but **not** `session`
— a peer's chunk can put an escape sequence in that field, and it had no display
site until now. Fixed at the cache door, where `cache.py` argues sanitising
belongs ("a rule about remembering to clean at each display had already been
forgotten once"). `docs/security.md`'s claim now names all three fields, and
`CACHE_VERSION` goes 2 → 3 so no already-written cache keeps serving raw bytes
for a day file that may never be appended to again. One automatic rebuild,
measured at 95 ms, once — rule 8's cheap kind of upgrade path.

So this got the full `/simplify`, four angles.

## Mutation testing

Every edit these tests are supposed to notice, applied one at a time with
`python -m tools.mutate` (baseline green, tree restored):

```
  caught    the preview's extra columns are fetched separately from the four
  caught    the cwd and the session columns are swapped
  caught    the duration and the exit code are read out of each other's field
  caught    the block is built from the row after the one asked for
  caught    `--show` ignores `--around`, so it resolves against the ranked list
  caught    a cursor past the end of the list is a traceback
  caught    the table loses its labels and is five values again
  caught    a field with nothing to say is left out instead of saying so
  caught    the command goes above the table, where a long one pushes it off
  caught    an exit code that was never recorded is printed as -1
  caught    a directory that was never recorded is an empty line
  caught    a duration that was never measured is printed as -1 ms
  caught    a damaged duration field takes the whole block down
  caught    seconds and minutes swap places above a minute
  caught    the pane paints itself whether or not anyone asked
  caught    the label column is painted like the value it labels
  caught    the command is not marked out from the fields above it
  caught    every exit code is a failure, including the clean ones
  caught    `session` is not neutralised on the way into the cache
  caught    a peer's machine name reaches the block raw
  caught    an unrecognised prompt falls through to `global` instead of failing closed
  caught    the preview asks about `global` whatever the prompt says
  caught    the pane is rendered plain, as if it were going down a pipe
  caught    the pane is visible from the moment the picker opens
  caught    the header advertises a key nothing binds
  caught    an fzf too old for the pieces is offered them anyway
  caught    the timeline leaves the pane pointed at the ranked list
  caught    the timeline repoints the pane but forgets its window
  caught    the `{n}` printed for the pane is expanded by the transform instead
  caught    no key that switches scope repoints the pane
  caught    the direct scope keys leave the pane where it was
  caught    an old fzf is told about two missing keys when three are gone
  caught    the harness never answers fzf's cursor-position query
```

**33 mutations, 33 caught.**

## What `/simplify` changed

- **`render_rows` no longer slices `row[:4]`.** Three agents independently found
  it: `detail` never reaches `render_rows`, so it guarded a call that does not
  exist while reading as though one did. 0.4–0.5 ms of Ctrl-R, and a comment
  that was false.
- **One `_switch_to` and one `_list_command`.** The reload command line was
  written out three times and the prompt/preview pairing four; `--host-width`
  was already once a flag that had to be added to each by hand.
- **`_SAME` beside `_NEXT`**, replacing two inline identity dicts.
- **`_exit_field` parses the sentinel** instead of comparing to `"-1"` — the
  reason `is_failure` gives, two screens up: the bug returns for any other
  sentinel, and `-01` is the same number written differently. (It was
  `_exit_label` until the restructure above gave it a colour to return too.)
- **`rank_rows(columns)`** rather than variadic, so it reads like `_gather`,
  `_zipped` and `_window_around`, all of which take one `Columns`.
- **`doctor` was telling an old fzf it was missing two keys while three were
  gone.** Now rendered from a `GATED_KEYS` tuple that `_fzf_argv` and `doctor`
  share; the test spells the keys by hand and asserts the count, so a fourth
  fails until someone decides whether the sentence should name it.
- **Three assertions in my own pty tests could not fail.** `_read_until` returns
  the buffer it found its needle in, so `assertIn(marker, that_step)` is true by
  construction — CLAUDE.md rule 3's trap in a new dress. The `until` markers
  *are* the assertions; what is left for an `assert` is what a stall cannot say,
  so the timeline test now asserts the *absence* of `~/d0`, which is the answer
  the ranked list would have given.
- One `run_binding` helper replacing four copies of "run this binding's `sh`
  with a fake `$FZF_PROMPT`"; `self.argv()` called once instead of three times.
- Comment fixes: `_ESCAPED_N` named a test that does not exist,
  `_preview_command`'s docstring described its `scope` parameter backwards and
  miscounted the call sites, and `_block`'s claimed to use the same host
  labelling as the display line when it deliberately does not.

**Declined, with reasons:**

- **`Row` as `tuple[int, str, str, str, Unpack[tuple[str, ...]]]`** would put the
  "first four never move" invariant back in the type system. `typing.Unpack` is
  3.11; `pyproject` says 3.10 and the dependency list is empty on purpose. I ran
  mypy against it to be sure — `Module "typing" has no attribute "Unpack"`. The
  invariant stays prose plus `test_show_reports_the_row_the_list_shows`, which
  gives every field a distinct value per row so a swapped pair shows as a wrong
  answer rather than a short list.
- **Renaming `fzf_supports_transform`**, since it now gates something that has
  nothing to do with `transform`. The name is accurate about what it *tests*;
  the preview riding on it is a deliberate decision documented at the call site,
  and inventing a `PREVIEW_SINCE` constant equal to `TRANSFORM_SINCE` would be
  pretend-precision about a version nobody has established.
- **Lifting `shell_env` out of `test_shell_hook.py`** so both pty tests share a
  sandbox-env builder. Real duplication, but the two genuinely differ (`TERM`
  `dumb` vs `xterm`, `PS1`, a runtime dir) and it restructures a class hierarchy
  outside this diff.
- **Promoting the fifth copy of the `private_append`/`format_line` fixture
  helper** into `tests/support.py`. Pre-existing across four other classes; the
  reviewer that raised it also said not to do it in this diff.
- **The second `fzf --version` fork per picker open** — `_header` asks
  independently of `_fzf_argv`. 2.0 ms of 105 (1.9%), pre-existing, and the
  one-line fix changes `_header`'s signature at eight test call sites. Below the
  convergence threshold; recording it rather than filing it.
- **Carrying a row index instead of three 54k columns through the sort.** 5.3 ms
  of the 79, of which the alternative recovers 3, and it trades away the
  align-in-one-pass property. Stopping per the convergence rule.

## Filed rather than fixed

**#169** — put the preview's fields on the line and hide them with
`--with-nth`, which would make the pane cost *nothing* and delete `--show`,
`detail`, `_block`, `extra=`, the variadic types and all six `change-preview`
actions. I verified the load-bearing claim myself:

```
$ printf 'aaa\tsecret\n' | fzf -d$'\t' --with-nth=1 --filter=aaa
aaa	secret
```

fzf hands back the *original* line, so hidden fields survive selection. #152
rejected this design because `--nth=2..` and the documented `^name` anchor both
need whitespace splitting and fzf has one delimiter — the issue records the way
round that (`--with-nth=1..3 --nth=2..3`) and flags it as unverified, which is
the first task on it. It is a display-format redesign, not a change to this PR.

## Also in here

- `Cache.exit_codes()` deleted — dead on `main`, no callers, and this diff was
  already in that class.
- `run_in_pty` answers fzf's `ESC[6n` cursor-position query. `--height` makes
  fzf ask before it paints anything, so without a reply the picker never draws
  and the failure reads as "produced nothing" rather than "still waiting".

## CI now installs fzf from upstream, not apt

The first push went red on all three `test` jobs, identically. ubuntu-latest
ships **fzf 0.44.1** — one release below `search.TRANSFORM_SINCE` — so on the
runner woswoar correctly withholds ctrl-r cycling, the ctrl-t timeline *and* the
new pane, and the two tests that drive a real picker had nothing to drive.

They cannot skip their way out of it, and that is deliberate: `ci.yml` runs
`--only tests.test_search --no-skips`, so a skipped search test is already a
build failure ("a green run that ranked nothing at all is exactly the failure
worth catching"). Which is the right call — a skip here would mean the
`\{n}`-through-a-`transform` behaviour is verified on my machine and nowhere
else.

So both workflows now fetch a pinned fzf (0.74.2) instead of apt's, and assert
it clears `TRANSFORM_SINCE` so a silent downgrade fails loudly rather than
skipping. `release.yml` needed the same change — it runs the whole suite.

Worth knowing: this also means `TestRealFzfRanking`, whose subject *is* fzf's
behaviour, has been asserting against a two-year-old fzf while users run modern
ones. I ran the full suite locally against 0.74.2 before pushing — 714 pass, and
`tests.test_search --no-skips` is 112 tests with zero skips.

## Not fixed, and outside this diff

fzf runs `--preview` and `transform` commands with `$SHELL`, so a fish user
running `woswoar search` gets `case`/`if` snippets fish cannot parse. That is
true of the existing ctrl-r and ctrl-t bindings too, and woswoar only supports
bash today (zsh is #158) — recording it rather than filing it.
