### PR TITLE
release: publish to PyPI over Trusted Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,24 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - run: pip install .
+      - name: build the artefacts a release would publish, and install one
+        # `pip install .` was already a wheel install -- pip builds one and
+        # installs that -- so this is not about the install path. It is about
+        # the two files themselves, now that a release uploads them somewhere a
+        # version can be yanked but never reused.
+        #
+        # `python -m build` is the guard that earns its place: it rejects a
+        # classifier PyPI does not recognise, and a `[project.urls]` table
+        # written above `dependencies` rather than below it -- both of which
+        # this diff got wrong on the way in, and neither of which any other job
+        # here would have noticed. `twine check` is the cheaper half, the same
+        # look twine takes immediately before an upload.
+        run: |
+          python -m pip install --quiet build twine
+          python -m build
+          python -m twine check dist/*
+          pip install dist/*.whl
+
       - name: first-run flow
         run: |
           set -euxo pipefail

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,0 +1,42 @@
+name: Publish to TestPyPI
+
+# A rehearsal for `release.yml`'s publish step, and the reason it exists is that
+# the real one cannot be rehearsed: a PyPI version can be yanked but never
+# reused, so the first upload is also the first test of the whole path --
+# metadata, the trusted-publisher configuration, the shape of `dist/`.
+#
+# Run by hand from the Actions tab rather than on a tag. A tag is a release, and
+# a release is not the place to find out that PyPI dislikes a classifier.
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write # prove to TestPyPI which workflow is publishing
+
+jobs:
+  testpypi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: build
+        # Deliberately *not* the fixed-name copy `release.yml` also makes: a
+        # filename with no version in it is not a distribution name any index
+        # accepts, and this rehearsal exists to find that kind of thing.
+        run: |
+          python -m pip install --quiet build
+          python -m build
+          ls -l dist/
+
+      - name: publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          # The version in the tree has usually been uploaded by an earlier
+          # rehearsal, and re-running to check a metadata change should not fail
+          # on that. TestPyPI is a scratch index; nothing here is a claim.
+          skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,13 @@ jobs:
           # A wheel or sdist filename has to encode the version, so the normal
           # artefacts cannot serve that; a PEP 508 direct reference supplies the
           # project name instead, which is what makes the arbitrary name legal.
-          cp dist/woswoar-*.tar.gz dist/woswoar.tar.gz
+          #
+          # Beside `dist/` rather than in it, and that is load-bearing now: the
+          # PyPI upload takes a whole directory, and a filename without a
+          # version in it is not a distribution name PyPI will accept. One
+          # stray file would fail the publish of an otherwise good release.
+          mkdir -p alias
+          cp dist/woswoar-*.tar.gz alias/woswoar.tar.gz
 
       - name: attest what was built
         # Binds each artefact to this repository, this workflow file and this
@@ -103,7 +109,31 @@ jobs:
         # Before `publish`, so nothing unattested is ever offered for download.
         uses: actions/attest-build-provenance@v4
         with:
-          subject-path: dist/*
+          subject-path: |
+            dist/*
+            alias/*
+
+      - name: publish to PyPI
+        # Trusted Publishing (OIDC), not an API token, and not a preference:
+        # `docs/security.md` claims a supply chain with no long-lived secret in
+        # it, and a token in repository secrets is a credential that can be
+        # stolen and used to publish a release nobody tagged. The run proves who
+        # it is with the same short-lived identity that signs the attestation
+        # above -- which is why `id-token: write` is already at the top of this
+        # file. PyPI is told which repository and which *workflow file* to
+        # trust, so a publish from anywhere else is refused rather than believed.
+        #
+        # Here rather than after the GitHub release, because this is the only
+        # irreversible step in the file: a version number can be yanked but
+        # never reused. Everything downstream of it can be re-run.
+        #
+        # `skip-existing` is what makes that re-run work. If `gh release create`
+        # or the `stable` push fails, the fix is to re-run the job -- and
+        # without this it would die on "file already exists" at the one step
+        # that had actually succeeded.
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
       - name: publish the release
         env:
@@ -112,7 +142,7 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
             --generate-notes \
-            dist/*
+            dist/* alias/woswoar.tar.gz
 
       - name: move stable to this release
         # The install line in the README is `@stable`, so this is what makes it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,22 @@ license = "Apache-2.0"
 authors = [{ name = "Martin Leitner-Ankerl", email = "martin.ankerl@gmail.com" }]
 keywords = ["shell", "history", "fzf", "git", "bash"]
 
+# What a PyPI project page shows beside the README, and the only place a
+# stranger can find the repository from an index listing.
+#
+# No `License ::` classifier: `license = "Apache-2.0"` above is the SPDX
+# expression PEP 639 replaced it with, and declaring both is how a build starts
+# failing on a future packaging release.
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: System :: Shells",
+    "Topic :: Utilities",
+]
+
 # Deliberately empty, and intended to stay that way: woswoar is standard library
 # only. fzf is required at runtime as the UI, age only for `woswoar sync`.
 dependencies = []
@@ -28,6 +44,17 @@ dev = ["ruff>=0.16", "mypy>=2.3", "shellcheck-py>=0.11"]
 
 [project.scripts]
 woswoar = "woswoar.__main__:main"
+
+# Below every plain key of `[project]`, not beside `classifiers` where it reads
+# better: a TOML sub-table ends its parent, so `[project.urls]` up there quietly
+# swallows `dependencies` and the rest into itself. The build fails with "URL
+# `dependencies` must be a string", which does not sound like a misplaced
+# heading.
+[project.urls]
+Homepage = "https://github.com/martinus/woswoar"
+Source = "https://github.com/martinus/woswoar"
+Issues = "https://github.com/martinus/woswoar/issues"
+Changelog = "https://github.com/martinus/woswoar/releases"
 
 [tool.hatch.version]
 path = "woswoar/__init__.py"


### PR DESCRIPTION
Part of #154 — **the pipeline half only**. The README still documents the git
URL, and that is deliberate: see the sequencing note at the bottom.

## The publish step

`release.yml` gains one action, between the attestation and the GitHub release:

```yaml
- name: publish to PyPI
  uses: pypa/gh-action-pypi-publish@release/v1
  with:
    skip-existing: true
```

**Trusted Publishing (OIDC), not an API token.** Not a preference —
`docs/security.md` claims a supply chain with no long-lived secret in it, and a
token in repository secrets is a credential that can be stolen and used to
publish a release nobody tagged. The run proves who it is with the same
short-lived identity that already signs the attestation, which is why
`id-token: write` was at the top of this file before today. PyPI is told which
repository *and which workflow file* to trust, so a publish from anywhere else
is refused rather than believed.

**Placed before `gh release create`, not after.** It is the only irreversible
step in the file — a version can be yanked but never reused — so it goes where a
failure costs the least: nothing else has happened yet. `skip-existing` is what
makes the converse safe. If the GitHub release or the `stable` push fails, the
fix is to re-run the job, and without it the re-run would die at the one step
that had actually succeeded.

## `dist/` now holds only what an index accepts

The fixed-name `woswoar.tar.gz` — the copy that makes
`releases/latest/download/woswoar.tar.gz` a stable pasteable URL — moves out of
`dist/` and into `alias/`.

The publish action takes a whole directory, and a filename with no version in it
is not a distribution name PyPI will accept. Left where it was, one stray file
would have failed the publish of an otherwise good release, at the irreversible
step, on the first tag. Both files are still attested (`subject-path` takes both
globs) and both still reach the GitHub release.

## The rehearsal

`publish-testpypi.yml`, run by hand from the Actions tab — `workflow_dispatch`,
no tag. The real path cannot be rehearsed, so without this a tag would be the
first test of the trusted-publisher configuration, of the metadata, and of the
shape of `dist/`. A release is not the place to find out that PyPI dislikes a
classifier.

## Metadata, and the guard that caught it

`pyproject.toml` gains the classifiers and `[project.urls]` a PyPI project page
shows — the only way someone landing on an index listing finds the repository.
No `License ::` classifier: `license = "Apache-2.0"` is the SPDX expression PEP
639 replaced it with, and declaring both is how a build starts failing on a
future packaging release.

`ci.yml`'s `install` job now runs `python -m build` and `twine check` before
installing the wheel. `pip install .` was *already* a wheel install — pip builds
one and installs that — so this is not about the install path; it is about the
two files themselves, now that a release uploads them somewhere permanent.

`python -m build` is the part that earns its place, and I know because this diff
tripped it twice while I wrote it:

- `[project.urls]` written above `dependencies` — a TOML sub-table ends its
  parent, so it silently swallowed the rest of `[project]`. The build fails with
  ``URL `dependencies` of field `project.urls` must be a string``, which does not
  sound like a misplaced heading.
- An unrecognised classifier (`Environment :: Consoul`) is rejected by hatchling
  at build time, before `twine check` ever sees it. Verified by doing it.

Neither would have been caught by any other job here, and both would have landed
at the upload.

## Verification

- `python -m build` + `twine check`: both artefacts **PASSED** locally.
- Wheel metadata inspected: name, version, all four project URLs, the SPDX
  licence expression, the classifiers, `Requires-Python: >=3.10`, and an empty
  install-requires — the dependency list stays deliberately empty.
- All three workflow files parse.
- Full suite green; lint, format, mypy, shellcheck clean.
- **Not yet verified, and only you can:** an actual upload. That is what
  `publish-testpypi.yml` is for, and it needs the pending publisher on
  test.pypi.org first.

## Sequencing — why the README is untouched

`pipx install woswoar` 404s until the first tagged release publishes. Rewriting
the quick start in this PR would put an instruction in the README that fails for
every reader between merging and tagging — which is precisely the defect #155
was, freshly committed.

So:

1. Add the pending publishers on **pypi.org** (workflow `release.yml`) and
   **test.pypi.org** (workflow `publish-testpypi.yml`).
2. Merge this.
3. Run **Publish to TestPyPI** from the Actions tab. Green means the OIDC
   handshake, the metadata and the directory shape all work.
4. Bump the version and tag → the first real publish.
5. *Then* the README rewrite: `pipx install woswoar`, delete the ten-line
   `--force` / `UV_VENV_CLEAR` block, demote the git URL into a `<details>`,
   correct "git is sync only", and make `pipx upgrade woswoar` the upgrade line.
   #154 stays open until that lands.

## Migration

Nothing on disk changes — history lives in `~/.local/share/woswoar`, never in
the venv. The release note for step 4 should say that an existing git-URL
install may need one `pipx uninstall woswoar` first, since pipx can refuse to
overlay a differently-sourced package of the same name. Worth testing at step 4
rather than asserting now.
