### PR TITLE
docs: install with 'pipx install woswoar'

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ venv.
 
 To track the tip instead of releases, the git URL is still there —
 `pipx install "git+https://github.com/martinus/woswoar.git@main"`, or `@stable`
-for the most recent tag, or `@v0.8.2` to pin exactly. That form needs `git` on
+for the most recent tag, or `@v0.9.0` to pin exactly. That form needs `git` on
 the machine; `pipx install woswoar` does not.
 </details>
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The pane starts hidden and costs nothing until you ask for it — see
 ## Quick start
 
 ```bash
-pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
+pipx install woswoar
 woswoar
 ```
 
@@ -118,29 +118,42 @@ Open a new shell, press <kbd>Ctrl</kbd>+<kbd>R</kbd>. That is the whole thing on
 one machine.
 
 > [!TIP]
-> **The same line upgrades an existing install** — run it again whenever you want
-> the latest release. The shell hook is a copy rather than the packaged file, but
-> it brings itself up to date on the next background sync, so there is nothing
-> else to run; open a new shell to pick it up. `stable` tracks the most recent
-> tag, so the command never changes and you never edit a version number on five
-> machines. Swap `@stable` for `@main` to track the tip, or `@v0.7.2` to pin
-> exactly.
+> **`pipx upgrade woswoar` for the next release.** The shell hook is a copy
+> rather than the packaged file, but it brings itself up to date on the next
+> background sync, so there is nothing else to run; open a new shell to pick it
+> up.
 >
 > **Coming from 0.6.x or earlier, run `woswoar install` once.** Those versions
 > had no background sync, so there is nothing running that could notice.
 > `woswoar` and `woswoar doctor` both say so if it is skipped.
->
-> If `--force` fails with **"A virtual environment already exists"**, your pipx
-> is using `uv` as its backend and cannot reuse the old venv. Either
-> `UV_VENV_CLEAR=1 pipx install --force …`, or the version that always works:
->
-> ```bash
-> pipx uninstall woswoar
-> pipx install "git+https://github.com/martinus/woswoar.git@stable"
-> ```
->
-> Neither touches your history: it lives in `~/.local/share/woswoar`, not in the
-> venv.
+
+<details>
+<summary>Installed from the git URL before woswoar was on PyPI?</summary>
+
+`pipx upgrade` keeps whatever a package was installed *from*, so an install made
+with `git+https://…` goes on cloning the repository rather than moving to PyPI.
+Switch it over once:
+
+```bash
+pipx install --force woswoar
+```
+
+If that fails with **"A virtual environment already exists"**, your pipx is using
+`uv` as its backend and cannot reuse the old venv. Then:
+
+```bash
+pipx uninstall woswoar
+pipx install woswoar
+```
+
+Neither touches your history: it lives in `~/.local/share/woswoar`, not in the
+venv.
+
+To track the tip instead of releases, the git URL is still there —
+`pipx install "git+https://github.com/martinus/woswoar.git@main"`, or `@stable`
+for the most recent tag, or `@v0.8.2` to pin exactly. That form needs `git` on
+the machine; `pipx install woswoar` does not.
+</details>
 
 **Needs:** bash 5.0+ (Linux) · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) ·
@@ -164,7 +177,7 @@ on a NAS, a folder on a USB stick). You do that once, ever.
 Then on **every** machine, first or fifth, the same two lines:
 
 ```bash
-pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
+pipx install woswoar
 woswoar                          # paste the repository URL when it asks
 ```
 
@@ -534,10 +547,17 @@ git tag v0.2.0 && git push origin v0.2.0
 
 Everything after that is automatic. `.github/workflows/release.yml` refuses the
 tag unless it matches `__version__` and sits on `main`, re-runs the whole suite
-at that exact commit, builds the sdist and wheel, publishes a GitHub release
-with generated notes, and fast-forwards `stable` — which is what the install
-command tracks. The `stable` push is not forced, so tagging an older commit
-fails loudly rather than moving everyone backwards.
+at that exact commit, builds the sdist and wheel, attests both, uploads them to
+PyPI over Trusted Publishing — no token, an identity minted for that one run —
+publishes a GitHub release with generated notes, and fast-forwards `stable`,
+which is what the `git+https://…@stable` form tracks. The `stable` push is not
+forced, so tagging an older commit fails loudly rather than moving everyone
+backwards.
+
+PyPI is the one step that cannot be undone: a version can be yanked but never
+reused. It runs before the GitHub release for that reason, and
+`.github/workflows/publish-testpypi.yml` is the rehearsal, run by hand against
+TestPyPI whenever the packaging changes.
 
 </details>
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -174,11 +174,13 @@ cleanly. It rules out the quieter failures — an asset replaced after
 publication, or a tarball built on somebody's compromised laptop rather than
 in the audited workflow.
 
-The install line in the README tracks `stable`, a branch the release workflow
-fast-forwards — convenient, and it means whoever controls the GitHub
+The install line in the README is `pipx install woswoar`, which takes the
+latest release from PyPI — uploaded by that same workflow over Trusted
+Publishing, so no long-lived token exists that could publish a release
+nobody tagged. Convenient, and it still means whoever controls the GitHub
 repository controls what your next upgrade installs. If that is a trade you
 do not want, pin the exact commit you audited; a full commit hash is a handle
-nobody can quietly move:
+nobody can quietly move, where a version number is one somebody else chooses:
 
 ```sh
 pipx install --force "git+https://github.com/martinus/woswoar.git@<full 40-character sha>"


### PR DESCRIPTION
Closes #154 — **but must not merge until a release has actually published to
PyPI.** Opened as a draft for that reason: `pipx install woswoar` 404s until the
first tag runs, and merging this early would put a failing instruction in the
first screen of the README, which is exactly what #155 was.

## The quick start

```diff
-pipx install --force "git+https://github.com/martinus/woswoar.git@stable"
+pipx install woswoar
 woswoar
```

The ten-line `--force` / `UV_VENV_CLEAR` TIP block goes with it — it existed only
because `--force` was needed to reinstall from a git URL, and it disappears with
the URL. The two-lines-per-machine block under "Adding another machine" gets the
same treatment.

**`git` is genuinely sync-only now.** The "Needs:" line already claimed that and
was wrong about it until today, since installing needed a clone.

## The migration note is measured, not guessed

I installed from the git URL into a scratch `PIPX_HOME` and tried each path
against the TestPyPI copy:

| | |
|---|---|
| `pipx install woswoar` over a git install | **refuses** — "already seems to be installed", points at `--force` or `pipx upgrade` |
| `pipx upgrade woswoar` on a git install | **re-clones the git URL**. pipx remembers what a package was installed *from*, so this never moves anyone to PyPI |
| `pipx install --force woswoar` | **works**, and rewrites the recorded spec to `woswoar`. No uninstall needed on pipx's own venv backend |
| `pipx upgrade woswoar` afterwards | works, reports "already at latest version" |

That second row is the one worth writing down: an existing user who keeps typing
`pipx upgrade` will go on tracking git forever without ever being told. So the
`<details>` says to run `pipx install --force woswoar` once, keeps
`pipx uninstall` first as the form that always works (the uv-backend caveat
survives for that single step — I have no uv here to test it), and keeps the git
URL documented as the way to track the tip.

## `docs/verify.md`

It said *"the install line in the README tracks `stable`"*. It tracks PyPI now.
Same trade by a different route — whoever controls the repository controls your
next upgrade — so the pin-a-commit advice stands and only the sentence around it
changes. It also now says why Trusted Publishing matters for that claim: no
long-lived token exists that could publish a release nobody tagged.

The release section at the bottom of the README gains the PyPI step, why it runs
before the GitHub release (it is the only irreversible one), and a pointer to the
TestPyPI rehearsal workflow.

## Verification

- `tests/test_docs.py` still green — the systemd block is untouched but the file
  around it moved.
- Full suite, ruff, format: clean.
- No test here: this is prose, and the one instruction in the README that *is*
  executable is already driven by `test_docs.py`. The claims added are about
  pipx's behaviour on someone else's machine, and the table above is how they
  were established.

## Order

1. Bump `__version__`, merge that PR, tag it. The release publishes to PyPI.
2. Confirm `pipx install woswoar` works from the real index.
3. Mark this ready and merge.
