### PR TITLE
release: 0.9.0

### DIFF
--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.8.2"
+__version__ = "0.9.0"


### PR DESCRIPTION
Bumps `__version__` to 0.9.0. One line, as every release PR here is.

A minor rather than a patch, because since 0.8.2 the picker gained two things a
user presses keys for and the project gained a way to be installed:

- **`dir` scope** — commands from this directory and below, on every machine
  (#151, #168). <kbd>Ctrl</kbd>+<kbd>O</kbd>, or the fourth stop of
  <kbd>Ctrl</kbd>+<kbd>R</kbd>.
- **The details pane** (#152, #170) — <kbd>Ctrl</kbd>+<kbd>/</kbd> shows `cwd`,
  `duration_ms` and `session`, three fields that were recorded, encrypted, synced
  and cached and that nobody could read back. Hidden by default; 78 ms a render,
  paid only while it is open.
- **PyPI publishing** (#154, #172) — this is the tag that creates the project.
  Trusted Publishing, rehearsed against TestPyPI on
  [run 31463953842](https://github.com/martinus/woswoar/actions/runs/31463953842).

Also in it: the systemd instructions that could not work for anyone who
installed the documented way (#155), a stale doc claiming the repository has no
code (#156), and the `TestPromptTriggeredSync` cleanup race that went red on an
unrelated PR (#167).

## What happens on the tag

`release.yml` re-runs the whole suite at the tagged commit, builds and attests
both artefacts, **uploads to PyPI**, publishes the GitHub release, and
fast-forwards `stable`. The PyPI step is new and is the only irreversible one —
it runs before the GitHub release for that reason.

## After it lands

Draft PR #174 rewrites the quick start to `pipx install woswoar` and closes #154.
It is deliberately held until this publishes: the instruction 404s until then,
and a README that tells strangers to run a command that fails is precisely the
defect #155 was.