### PR TITLE
docs: CONTRIBUTING, SECURITY, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Something woswoar does that it should not, or does not do that it should
+# No `labels:`. Every issue here carries exactly one of P0-P3, and which one is
+# a triage judgement about impact and reachability that a reporter cannot make
+# and a template must not guess.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If this is a security problem, **stop** and use
+        [the private channel](https://github.com/martinus/woswoar/security/advisories/new)
+        instead — a public issue is a disclosure. See
+        [SECURITY.md](https://github.com/martinus/woswoar/blob/main/SECURITY.md).
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you did, what you expected, and what you got instead.
+      placeholder: |
+        Pressed Ctrl-R after `woswoar sync` and the picker was empty, but
+        `woswoar stats` says 54,804 commands.
+    validations:
+      required: true
+
+  - type: textarea
+    id: doctor
+    attributes:
+      label: "`woswoar doctor` output"
+      description: |
+        Paste the whole thing. It runs a dozen or more checks and answers most
+        of what would otherwise be a round trip of questions — where your
+        history lives, which tools are present and at what versions, whether the
+        hook is installed and current, whether permissions are right, whether
+        every machine publishing here is one you accepted.
+
+        It prints **no recorded commands and no machine names**, only paths,
+        versions and counts. The paths do contain your username, so redact them
+        if you would rather not have it here.
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: "`woswoar --version`"
+      placeholder: woswoar 0.9.0
+    validations:
+      required: true
+
+  - type: input
+    id: shell
+    attributes:
+      label: Shell and version
+      description: "`echo $BASH_VERSION`, or the equivalent for your shell."
+      placeholder: bash 5.2.26
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS and distribution
+      placeholder: Fedora 44, or Ubuntu 24.04, or macOS 15
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: |
+        A reproduction, however rough. How many machines sync into this history,
+        if that might matter. Whether it started after an upgrade, and from
+        which version.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# A vulnerability must not arrive as a public issue, so the blank-issue escape
+# hatch is closed and the private channel is offered beside the two templates.
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/martinus/woswoar/security/advisories/new
+    about: Privately, where only the maintainer can read it. Never a public issue.
+  - name: How the repository works
+    url: https://github.com/martinus/woswoar/blob/main/CONTRIBUTING.md
+    about: The preflight one-liner, and what a patch needs before it lands.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Something you wanted woswoar to do and could not
+labels: []
+body:
+  - type: textarea
+    id: trying
+    attributes:
+      label: What were you trying to do?
+      description: |
+        The task, not the feature. What you were actually after is the thing
+        worth designing against — there is often a shorter way to it than the
+        one that comes to mind first, and it is the part nobody else can supply.
+      placeholder: |
+        I wanted the command I ran in this directory last month, but I only
+        remember roughly when, not what it was called.
+    validations:
+      required: true
+
+  - type: textarea
+    id: instead
+    attributes:
+      label: What did you do instead?
+      description: What you fell back on, and why it was not good enough.
+    validations:
+      required: false
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: What you had in mind, if you have something in mind
+      description: |
+        Optional, and genuinely so. A clear problem with no proposed solution is
+        a better issue than a solution with no problem behind it.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing
+
+Bug reports and patches are welcome. This file is the short version of how the
+repository works; [`CLAUDE.md`](CLAUDE.md) is **the same rules written for
+agents**, kept as the single source so the two cannot drift into disagreeing.
+Where this file is shorter, that one is the detail.
+
+## Before you push
+
+One line, and it is exactly what CI runs:
+
+```sh
+ruff check . && ruff format --check . && mypy woswoar tests tools \
+  && shellcheck --shell=bash woswoar/shell/woswoar.bash \
+  && python -m tools.run_tests
+```
+
+`python -m tools.run_tests` is the parallel runner. `python -m unittest discover
+-s . -t . -p 'test_*.py'` runs the same tests serially and takes about three
+times as long.
+
+There is nothing to install for woswoar itself — it is standard library only,
+and the dependency list is empty on purpose. The tools above are the `dev`
+extra: `pip install -e '.[dev]'`. The suite also drives real `age`, real `git`,
+a real `bash` and a real `fzf`, and it will tell you which one is missing.
+
+## Every fix needs a test that fails when the fix is reverted
+
+Not "a test exists". The bar is that the test **fails** with the fix taken out,
+and the only way to know is to try it:
+
+1. Revert the fix in the working tree.
+2. Run the suite and confirm the new test fails.
+3. Restore the fix and confirm it passes.
+
+[`tools/mutate.py`](tools/mutate.py) is that loop, written down. Give it a table
+of edits, run `python -m tools.mutate <spec>.py`, and paste its output into the
+pull request. Use it rather than writing the loop by hand: it clears every
+`__pycache__` between mutations, because a `.pyc` is validated against
+`(mtime, size)` and two edits of the same size inside one second will run each
+other's cached bytecode — which reported a *correct* test as decoration here and
+nearly got it deleted.
+
+### When a mutation survives, suspect the fixture first
+
+A test that passes either way is decoration, and reading it will not tell you
+which kind you have written. Every one of these was written in this repository,
+passed review, and guarded nothing:
+
+- two day directories cannot distinguish a sorted walk from a reversed one;
+- a directory holding only `.age` files cannot test a suffix filter;
+- a day written moments ago is skipped by the racy-timestamp rule regardless, so
+  a test about *why else* it might be skipped asserts nothing;
+- a marker asserted in a shell's stdout also appears in the harness's echo of the
+  line that was typed.
+
+Prefer driving the real thing over asserting on a mock. The suite already runs a
+real `bash` for the shell hook and real `age` and `git` for sync; follow that.
+
+## Comments explain *why*
+
+The comment density here is deliberate and is most of the value of the codebase.
+The useful comment is the one that says **why an obvious alternative was
+rejected** — not what the line does. A patch that strips those as noise will be
+asked to put them back; a patch that adds one where a reader would otherwise
+reach for the wrong fix is doing the main thing.
+
+## Pull requests
+
+- Branch before the first commit. `main` is protected.
+- Say what you measured, if the change is about performance. "Faster" is not a
+  number, and a benchmark run by checking out another revision on top of
+  uncommitted changes measures the same tree twice — commit first.
+- If you found something wrong that does not belong in your change, say so in the
+  PR description rather than fixing it quietly or filing an issue nobody will
+  do. The bar for filing is in [`CLAUDE.md`](CLAUDE.md) rule 4.
+- Every issue carries exactly one priority label, `P0`–`P3`, and they sort
+  lexically so the open list reads as an implementation order.
+
+Nothing is merged without the maintainer saying so, including by the maintainer's
+own agents.
+
+## Security
+
+Do not report a vulnerability in a public issue. [`SECURITY.md`](SECURITY.md) has
+the private channel and what is in scope.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,73 @@
+# Security policy
+
+woswoar encrypts, signs and publishes your shell history to a git remote you
+choose. If you have found a way to break one of those, please tell me privately
+first.
+
+## Reporting a vulnerability
+
+**[Open a private advisory](https://github.com/martinus/woswoar/security/advisories/new)**
+— GitHub's private vulnerability reporting is enabled on this repository, so
+that form is a channel only the maintainer can read. Do not open a public issue
+for something exploitable; a public issue is a disclosure.
+
+If the form is not available to you for any reason, email
+<martin.ankerl@gmail.com> instead.
+
+Useful in a report, in rough order of usefulness:
+
+- what an attacker gets, and what they need in order to get it — push access to
+  the repository, an account on the machine, a network position;
+- the output of `woswoar doctor`, and `woswoar --version`;
+- anything that reproduces it, however rough.
+
+**Expected response: best effort, usually within a week.** This is one person's
+project. That is a real number rather than a comfortable one — if a report is
+urgent enough that a week is too slow, say so in the first line and I will treat
+it that way.
+
+Nothing here is paid. There is no bounty programme, and I would rather say so
+than have you find out afterwards.
+
+## What is in scope
+
+Anything that breaks a claim in **[the security model](docs/security.md)** — most
+usefully the ones in
+[Guarantees pinned by tests](docs/security.md#-guarantees-pinned-by-tests-not-by-prose), which
+is the list of things this project asserts and backs with a test.
+
+The clearest shapes of a real finding:
+
+- **plaintext or identifying metadata reaching the remote** — a command, a
+  directory, a username, a hostname, in any git object;
+- **history from a machine you never trusted appearing in your Ctrl-R**, or a
+  signature check that can be made to pass without the signing key;
+- **a revoked machine still able to read or publish**;
+- **a secret woswoar was supposed to skip being recorded anyway**, where the
+  shape is one `WOSWOAR_IGNORE` claims to cover;
+- **anything in the picker that lets another machine's recorded text drive your
+  terminal** — the display line and the details pane both render peer-supplied
+  strings, and `make_inert` is what stands between them and your ANSI parser.
+
+## What is not in scope
+
+`docs/security.md` has a section titled
+[**What is *not* protected**](docs/security.md#%EF%B8%8F-what-is-not-protected),
+and it is the authoritative list — deliberately one copy, so it cannot drift from
+this file. Read it before reporting; everything in it is documented behaviour,
+argued for, and not a finding. In particular, the one people notice first:
+
+> **Local history is plaintext.** `~/.local/share/woswoar/logs/` holds your
+> commands unencrypted, `0700`/`0600`, the same as `~/.bash_history`. Encryption
+> protects the *synced* copy, not your disk. Use full-disk encryption for that.
+
+Also out of scope: findings in `age`, `git`, `ssh-keygen` or `fzf` themselves.
+woswoar composes those four and implements no cryptography of its own, so those
+belong upstream — though if woswoar *uses* one of them wrongly, that is very much
+in scope and is exactly the kind of report worth having.
+
+## Supported versions
+
+The most recent release, which is what `pipx install woswoar` gives you and what
+`stable` points at. There are no maintained branches behind it: a fix ships as a
+new release.

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -128,7 +128,7 @@ reaching the address you gave `woswoar init`, and nothing else.
 
 ## 🧪 Run the guarantee suite where you can watch
 
-The tables in [security.md](security.md#-guarantees-pinned-by-tests) —
+The tables in [security.md](security.md#-guarantees-pinned-by-tests-not-by-prose) —
 forged history is refused, tampering is refused, a revoked machine stays
 revoked — are each backed by a test, and the suite runs anywhere:
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,4 +1,4 @@
-"""Instructions in the README that a reader is expected to paste and run.
+"""The parts of the documentation that can be wrong in a checkable way.
 
 Prose can be reviewed by reading it. A command block cannot: the systemd one
 told people to `cp contrib/systemd/woswoar-sync.*`, which is a path that exists
@@ -10,6 +10,9 @@ scratch `$HOME`, and a stub `systemctl` standing in for the one piece that needs
 a running system. Following the repository's habit of driving the real thing --
 the shell hook is tested against a real `bash`, sync against real `age` and
 `git`.
+
+A link is the same kind of claim and fails the same way: silently, and only for
+the reader. Two were broken when this file grew its second class.
 """
 
 from __future__ import annotations
@@ -18,8 +21,10 @@ import os
 import re
 import subprocess
 import tempfile
+import unicodedata
 import unittest
 from pathlib import Path
+from urllib.parse import unquote
 
 REPO = Path(__file__).resolve().parent.parent
 README = REPO / "README.md"
@@ -115,6 +120,102 @@ class TestTheSystemdInstructionsWork(unittest.TestCase):
         block = systemd_block()
         self.assertNotIn("contrib/", block)
         self.assertNotIn("git clone", block)
+
+
+#: Markdown inline links, `[text](target)`. Reference-style links are not used
+#: anywhere in these files, and adding the second syntax to this pattern for a
+#: form nobody writes would only make it harder to read.
+_LINK = re.compile(r"\]\(([^)\s]+)\)")
+
+#: A heading, and the text GitHub turns into its anchor.
+_HEADING = re.compile(r"^#{1,6}\s+(.*?)\s*$", re.M)
+
+
+def slug(heading: str) -> str:
+    """The anchor GitHub gives a heading.
+
+    Lowercase, spaces to hyphens, and everything that is neither alphanumeric
+    nor a hyphen or underscore dropped -- *except* combining marks and format
+    characters, which survive. That last clause is not pedantry: `## ⚠️ What is
+    not protected` anchors at `%EF%B8%8F-what-is-not-protected`, because U+26A0
+    is a symbol and goes, while the U+FE0F variation selector welded to it is a
+    nonspacing mark and stays. A link that drops it lands nowhere, silently.
+
+    Derived from the rendered page rather than from a specification -- GitHub
+    publishes no algorithm -- and checked against every heading in `docs/`, the
+    ticks and boxes and warning signs included.
+    """
+    out = []
+    for char in heading.lower():
+        if char.isalnum() or char in "-_":
+            out.append(char)
+        elif char == " ":
+            out.append("-")
+        elif unicodedata.category(char) in ("Mn", "Cf"):
+            out.append(char)
+    return "".join(out)
+
+
+def markdown_files() -> list[Path]:
+    # Dot-directories are other tools' working space, `.github` excepted --
+    # `.pytest_cache/README.md` was being read and checked here, and a failure
+    # in somebody else's generated file is one nobody in this repository can act
+    # on. Whether the cache exists at all depends on how the suite was last run,
+    # which is not a thing a test should vary with.
+    return sorted(
+        p
+        for p in REPO.glob("**/*.md")
+        if not any(part.startswith(".") and part != ".github" for part in p.parts)
+    )
+
+
+class TestEveryDocumentLinkLandsSomewhere(unittest.TestCase):
+    """A relative link in the docs points at a file, and at a heading in it.
+
+    Both halves have been wrong here. `docs/verify.md` pointed at
+    `#-guarantees-pinned-by-tests` for a heading that ends `, not by prose`, so
+    the reader sent to "the list of things this project asserts" arrived at the
+    top of the page instead. Nothing said so: a browser given an anchor it
+    cannot find does not complain, it just does not move.
+
+    Only relative links. An external URL needs the network to check, and a test
+    that fails when GitHub is slow is worse than no test.
+    """
+
+    def links(self) -> list[tuple[Path, str]]:
+        found = []
+        for path in markdown_files():
+            for target in _LINK.findall(path.read_text(encoding="utf-8")):
+                if target.startswith(("http://", "https://", "mailto:")):
+                    continue
+                found.append((path, target))
+        return found
+
+    def test_there_are_links_to_check(self) -> None:
+        """Without this the two tests below are vacuous if the pattern rots."""
+        self.assertGreater(len(self.links()), 25)
+
+    def test_each_one_names_a_file_that_exists(self) -> None:
+        missing = []
+        for source, target in self.links():
+            path, _, _ = target.partition("#")
+            if path and not (source.parent / path).exists():
+                missing.append(f"{source.relative_to(REPO)} -> {target}")
+        self.assertEqual(missing, [])
+
+    def test_each_anchor_names_a_heading_that_exists(self) -> None:
+        broken = []
+        for source, target in self.links():
+            path, _, anchor = target.partition("#")
+            if not anchor:
+                continue
+            doc = (source.parent / path) if path else source
+            headings = {slug(h) for h in _HEADING.findall(doc.read_text(encoding="utf-8"))}
+            # Percent-encoded, because that is how a `⚠️` anchor has to be
+            # written in a link and how the two in this repository are written.
+            if anchor not in headings and unquote(anchor) not in headings:
+                broken.append(f"{source.relative_to(REPO)} -> {target}")
+        self.assertEqual(broken, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #161.

woswoar has been installable by strangers for about an hour. What a stranger
finds is a repository whose only process document opens *"Rules for AI agents
working in this repository"*, and a 495-line threat model with no way to report
against it privately.

## `SECURITY.md`

The gap with something real behind it. Someone who finds a flaw in a tool that
encrypts, signs and publishes to a git remote currently has nowhere to send it
but a public issue, which *is* the disclosure.

- **I enabled GitHub private vulnerability reporting on the repository.** It was
  off, and a `SECURITY.md` pointing at a disabled feature is the #155 defect
  again. One `gh api --method DELETE` turns it back off if you disagree.
- **Scope links `docs/security.md` rather than restating it** — specifically
  [Guarantees pinned by tests](docs/security.md#-guarantees-pinned-by-tests-not-by-prose)
  and [What is *not* protected](docs/security.md#%EF%B8%8F-what-is-not-protected).
  One copy, so the two cannot drift.
- **Response time is "best effort, usually within a week"**, which is true, not
  the number that sounds better. It also says there is no bounty, rather than
  letting someone find that out afterwards.
- Out of scope explicitly includes findings in `age`, `git`, `ssh-keygen` and
  `fzf` themselves — *but* says that woswoar using one of them wrongly is very
  much in scope, which is the report worth having.

## `CONTRIBUTING.md`

`CLAUDE.md` addressed to a person, linked as "the same rules written for agents"
so the two cannot drift. It carries the three things the issue names as
unguessable: the preflight one-liner, that a test must **fail** when the fix is
reverted with `tools/mutate.py` as that loop, and that the comment density is
deliberate. The fixtures-too-weak list is reproduced, because it is the most
useful paragraph in the repository and nobody arrives at it alone.

## Issue templates

`bug.yml` asks for `doctor` output. Before writing that field I ran it and read
the output, because the template tells people to paste it in public:

- **12 checks** on a single-machine install, more once a repo is configured — so
  the text says "a dozen or more", not the "about fifteen" I first wrote.
- It prints **no recorded commands and no machine names**. I checked
  `trust_status` in particular, which reports counts (`2 of 3 other machine(s)
  accepted`) rather than names.
- It **does** print paths, which contain your username. The field says so and
  says to redact them.

`feature.yml` asks what the person was trying to do rather than what they want
built. `config.yml` sets `blank_issues_enabled: false` and offers the private
security channel beside the two templates, so the path of least resistance for a
vulnerability is not a public issue.

No `labels:` on either. Every issue here carries exactly one of P0–P3, and which
one is a triage judgement about impact and reachability that a reporter cannot
make and a template must not guess.

## Two broken links, one for months

While checking my own links I found `docs/verify.md` pointing at
`#-guarantees-pinned-by-tests` for a heading that ends `, not by prose` — so the
reader sent to "the list of things this project asserts" arrived at the top of
the page. A browser given an anchor it cannot find does not complain; it just
does not move. I had written the same wrong anchor into `SECURITY.md`.

So `tests/test_docs.py` grew a second class: every relative link in every
markdown file names a file that exists, and an anchor that exists.

The anchor rule is derived from the rendered page rather than a specification,
since GitHub publishes no algorithm. The subtle part is worth knowing:
`## ⚠️ What is not protected` anchors at `%EF%B8%8F-what-is-not-protected`,
because U+26A0 is a symbol and is dropped while the U+FE0F variation selector
welded to it is a nonspacing mark and survives.

It also skips dot-directories — `.pytest_cache/README.md` was being read and
checked, and a failure in another tool's generated file is one nobody here can
act on.

### Mutation testing

```
  caught    the anchor that was broken for months comes back
  caught    an emoji heading's variation selector is dropped from the link
  caught    a link points at a file that is not there
  caught    the link pattern stops matching, and both checks go quiet
```

**4 mutations, 4 caught.** The last is the vacuity guard: 29 relative links are
checked today, and a pattern that stops matching would otherwise leave two green
tests asserting nothing.

## The roadmap section: deliberately not done

The issue's last item asks for a visible roadmap and then answers itself — *do
not invent good-first-issues*. Six issues closed today, which is the thing that
actually makes a project read as moving; the open ones are real work with real
priorities and are the entry points. Nothing invented here.

## Verification

- Both templates validated against GitHub's issue-forms schema: required
  top-level keys, valid element types, every non-`markdown` element with an `id`
  and a `label`.
- `gh api repos/martinus/woswoar/private-vulnerability-reporting` → `{"enabled":
  true}`.
- Every relative link in every markdown file resolves — that is now a test.
- Full suite, ruff, format, mypy, shellcheck: clean.
- Not done, and only you can: filing a real private advisory to confirm it
  reaches you. The form is live; whether the notification lands where you read it
  is worth one look.

## One judgement call to overrule if you like

The issue labels this **P3**. I would make it **P2** now: it was polish while
nobody could install woswoar, and the release an hour ago is what changes that.
Happy to leave the label alone.
