### PR TITLE
docs: say what each Ctrl-R step costs, not just the running total

### DIFF
--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -237,14 +237,14 @@ and CI re-measures it on every push.
 <details>
 <summary>Where those 105 ms go</summary>
 
-| | cumulative |
-|---|---|
-| Python interpreter start | 8.8 ms |
-| importing woswoar | 29 ms |
-| building the argparse parser | 36 ms |
-| loading the cache (deserialising 55k entries) | 67 ms |
-| filter, sort, dedup, render | 87 ms |
-| writing 1.5 MB to fzf | 105 ms |
+| | this step | cumulative |
+|---|---|---|
+| Python interpreter start | 8.8 ms | 8.8 ms |
+| importing woswoar | 20.2 ms | 29 ms |
+| building the argparse parser | 7 ms | 36 ms |
+| loading the cache (deserialising 55k entries) | 31 ms | 67 ms |
+| filter, sort, dedup, render | 20 ms | 87 ms |
+| writing 1.5 MB to fzf | 18 ms | 105 ms |
 
 Roughly half is fixed Python startup and half is proportional to history size.
 Micro-optimising it was measured and did not help: the costs are structural, and


### PR DESCRIPTION
The "Where those 105 ms go" table in `docs/shell-integration.md` had a single
**cumulative** column, so reading the cost of any one step meant subtracting the
row above it — and the two steps that dominate were the least visible.

A **this step** column now sits in front of it:

| | this step | cumulative |
|---|---|---|
| Python interpreter start | 8.8 ms | 8.8 ms |
| importing woswoar | 20.2 ms | 29 ms |
| building the argparse parser | 7 ms | 36 ms |
| loading the cache (deserialising 55k entries) | 31 ms | 67 ms |
| filter, sort, dedup, render | 20 ms | 87 ms |
| writing 1.5 MB to fzf | 18 ms | 105 ms |

The cumulative column stays: "how far in is the prompt still blocked" is the
other question a reader of this table has, and it is also what the paragraph
below it about half-startup / half-history-size refers to.

No new measurement and no new claim — the per-step figures are the differences
of the cumulative ones, and they sum to 105 ms exactly.

`python -m tools.run_tests` is green.