### PR TITLE
sync: record which layout the history repo is

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -456,7 +456,11 @@ Being straight about the limits is part of the security story:
 >   not your disk. Use full-disk encryption for that.
 > - **Metadata leaks.** Anyone with the repo can see how many machines you have,
 >   when they synced, and roughly how many commands you ran per day. Not *which*
->   machines: no username or hostname is committed.
+>   machines: no username or hostname is committed. Two files in the repo are
+>   plaintext on purpose and neither adds to that: `recipients.txt` holds
+>   *public* keys, and `FORMAT` holds the layout version — which the directory
+>   listing already shows, and which a machine has to read before it knows where
+>   the keys are.
 > - **Trust on first use.** Cloning pins whatever machines the repository shows
 >   at that moment. A machine planted *before* you clone is accepted; one that
 >   appears afterwards is refused until you say otherwise. `woswoar init` prints

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -602,9 +602,27 @@ Each sync encrypts only the lines added since the last sync into a brand-new,
 never-modified file:
 
 ```
+history/FORMAT                                        woswoar-repo-1, plaintext
 history/hosts/<id>/2026-07-29/<synctime>-<rand>.age   one plain age file
 history/hosts/<id>/keys/2026-07-29.age                that day's identity, sealed to all recipients
 ```
+
+**`FORMAT` names the layout, and it is there before there is anything to
+upgrade.** The cache carries `woswoar-cache-2` and a manifest carries
+`woswoar-manifest-v1` inside its signed bytes; the repository was the one format
+woswoar owns that said nothing about itself. That is only fixable early: a
+machine still on the old version does not write the marker, so a layout change
+that needed one would find the repositories it has to migrate silent about which
+shape they are. Written by `init` and by the first `sync` that finds it absent,
+so an existing installation acquires it with nothing to run.
+
+It is read but barely enforced. A version *newer* than the running woswoar
+refuses the whole sync -- nothing exported, nothing merged, because publishing
+into a shape this version does not understand would be permanent in an
+append-only repo. An older version, an absent file, or content that does not
+parse all read as "this shape" and proceed: the file sits in a repository anyone
+with push access can write, and refusing on garbage would hand any of them a way
+to stop every machine syncing with four bytes.
 
 A chunk covers exactly one plaintext day file, so a machine offline for five
 days emits five chunks. One directory per day keeps a directory to a day's
@@ -830,6 +848,9 @@ Encrypted contents and opaque machine ids still leave the number of machines,
 commit timestamps, and approximate command volume per day visible. Accepted.
 The one shared mutable file is `recipients.txt` (plaintext SSH *public* keys,
 changed only at onboarding); `merge=union` in `.gitattributes` resolves it.
+`FORMAT` is plaintext too and adds nothing: it says which layout the directory
+listing is already showing. It needs no merge rule — it is written once, only
+when absent, so two machines racing to create it write the same bytes.
 
 ---
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5651,3 +5651,268 @@ class TestTheStatusLineOnAMachineThatCannotReadYet(SyncTestCase):
 
         out = self.run_cli(newcomer).out
         self.assertNotIn("sealed", out, "a readable name was read as unreadable")
+
+
+class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
+    """`history/FORMAT`, and the migration it exists to make possible.
+
+    The marker is worth nothing on the day it lands and everything on the day a
+    layout changes -- and by then it cannot be added, because the machines that
+    would have to be migrated are running versions that never wrote it. So what
+    is pinned here is the part that has to be right *now*: every repo acquires
+    it without anyone running anything, an unmarked repo keeps working, and a
+    repo from the future is refused rather than half-written.
+    """
+
+    def marker(self, fake: Fake) -> str:
+        with fake.active():
+            path = store.format_file()
+            return path.read_text(encoding="utf-8") if path.is_file() else ""
+
+    def publish_marker(self, fake: Fake, content: str | None) -> None:
+        """Put ``content`` in the repo's marker -- or remove it, for ``None`` --
+        and push, so every machine's next fetch sees it.
+
+        `sync.run` first, because every `self.machine(...)` pushes as it enrols:
+        a hand-made commit on top of a stale tree is rejected by the remote
+        rather than tested. Pushed rather than left local because each of the
+        checks under test reads what the *fetch* brought, so a marker only this
+        machine can see would prove nothing about the others.
+        """
+        with fake.active():
+            sync.run()
+            if content is None:
+                store.format_file().unlink()
+                sync.git("rm", "--quiet", "--cached", store.FORMAT)
+            else:
+                store.write_atomic(store.format_file(), content.encode("utf-8"))
+                sync.git("add", store.FORMAT)
+            sync.git("commit", "--quiet", "-m", "the marker, as another version left it")
+            sync.git("push", "--quiet", "origin", "HEAD")
+        self.assertEqual(self.marker(fake), content or "", "the fixture did not take")
+
+    def strip_marker(self, fake: Fake) -> None:
+        """The repository as it was before the marker existed."""
+        self.publish_marker(fake, None)
+
+    def mark_future(self, fake: Fake) -> None:
+        """A layout this woswoar does not know, as a newer one would write it."""
+        self.publish_marker(fake, store.format_content(store.REPO_FORMAT + 1))
+
+    def test_a_new_repo_records_its_format(self) -> None:
+        alpha = self.machine("alpha")
+        self.assertEqual(self.marker(alpha), store.FORMAT_CONTENT)
+
+    def test_an_existing_repo_acquires_the_marker_on_sync(self) -> None:
+        """The migration itself: a repository written before the marker existed
+        gains it on the next ordinary sync, and the file is *committed* and
+        pushed rather than left in the working tree for a later export to sweep
+        up -- which on a machine that records nothing would be never.
+        """
+        alpha = self.machine("alpha")
+        self.strip_marker(alpha)
+
+        with alpha.active():
+            # Nothing recorded since, so there is nothing to export: the marker
+            # has to be enough on its own to make this run commit and push.
+            sync.run()
+
+        self.assertEqual(self.marker(alpha), store.FORMAT_CONTENT)
+        self.assertIn(
+            store.FORMAT, self.git_in_repo(alpha, "ls-tree", "--name-only", "HEAD").split()
+        )
+        self.assertIn(
+            store.FORMAT,
+            self.git_in_repo(alpha, "ls-tree", "--name-only", "origin/HEAD").split(),
+            "the marker never reached the remote, so no other machine sees it",
+        )
+
+    def test_an_absent_marker_is_not_a_failure(self) -> None:
+        """An older repository is this shape, so it goes on working: a full
+        two-machine exchange against a repo whose marker has been removed, and
+        whose removal is on the remote before either machine syncs again."""
+        # `history_across_days` is alpha with history, beta enrolled after it,
+        # and the `grant` in between that re-seals the day keys to whoever is in
+        # recipients.txt by then.
+        alpha, beta = self.history_across_days(days=1, per_day=1)
+        self.accept_everyone(beta)
+        self.strip_marker(alpha)
+
+        with beta.active():
+            report = sync.run()
+            # Inside `active()`: `commands()` reads the *ambient* environment,
+            # so asking outside it answers with the developer's own history --
+            # a test that passes or fails on what someone typed today.
+            merged = beta.commands()
+
+        self.assertEqual(merged, {"day 0 command 0"})
+        self.assertEqual(report.lines_imported, 1)
+
+    def test_a_sync_refuses_a_newer_repo_format(self) -> None:
+        """A repo written by a woswoar this one does not understand stops the
+        run before it exports or merges anything. Not only the merge: this
+        machine publishing into a layout it cannot read would be permanent,
+        because nothing in the repo is ever rewritten."""
+        alpha, beta = self.history_across_days(days=1, per_day=1)
+        self.accept_everyone(beta)
+        self.mark_future(alpha)
+
+        with beta.active():
+            beta.record("2023-11-15", 1_700_100_001, "beta was here")
+            with self.assertRaises(sync.SyncError) as caught:
+                sync.run()
+            # Nothing merged, and nothing published either.
+            self.assertEqual(beta.commands(), {"beta was here"}, "alpha's history was merged")
+            self.assertEqual(
+                list(store.iter_chunks(beta.id)), [], "it published into a repo it cannot read"
+            )
+
+        message = str(caught.exception)
+        self.assertIn(str(store.REPO_FORMAT + 1), message, message)
+        self.assertIn(str(store.REPO_FORMAT), message, message)
+
+    def test_content_that_does_not_parse_is_not_a_wedge(self) -> None:
+        """Anyone who can push can write this file, so garbage in it must not be
+        able to stop every machine syncing. It reads as "no marker", which is
+        the same answer as an old repo -- unlike a legible higher number, which
+        a newer woswoar wrote on purpose.
+
+        The superscript is not decoration. `"\u00b2".isdigit()` is True and
+        `int("\u00b2")` raises, so a version check written with `isdigit`
+        crashes every sync on four bytes anyone with push access can write --
+        which is this test's whole subject, and `b"gibberish"` alone never
+        reaches it.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            for junk in (
+                b"gibberish\n",
+                b"woswoar-repo-\n",
+                b"woswoar-repo-two\n",
+                "woswoar-repo-\u00b2\n".encode(),
+            ):
+                store.write_atomic(store.format_file(), junk)
+                self.assertIsNone(store.repo_format(), junk.decode(errors="replace"))
+                # Not just the parse: the whole sync path has to survive it.
+                sync.run()
+
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            report = sync.run()
+
+        self.assertEqual(report.chunks_written, 1)
+
+    def test_two_machines_writing_the_marker_do_not_conflict(self) -> None:
+        """Both sides create the file from a state where neither has it, and a
+        real rebase over a real bare remote has to absorb that.
+
+        This is why the file is written only when absent and never rewritten to
+        match: two machines on different versions taking turns overwriting one
+        line would conflict on every sync, forever.
+        """
+        alpha = self.machine("alpha")
+        beta = self.machine("beta")
+        self.strip_marker(alpha)
+        with beta.active():
+            # Beta's own tree back to the same state, without syncing -- a fetch
+            # here would be one machine learning about the other, which is the
+            # thing this test needs not to have happened yet.
+            sync.git("fetch", "--quiet", "origin")
+            sync.git("reset", "--hard", "--quiet", "origin/HEAD")
+            self.assertFalse(store.format_file().is_file(), "the fixture still has the marker")
+
+            # Committed locally and deliberately not pushed, so alpha's marker
+            # lands on the remote first and beta's arrives on top of it.
+            beta.record("2023-11-14", 1_700_000_002, "beta was here")
+            sync.run(push=False)
+
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "alpha was here")
+            sync.run()
+        with beta.active():
+            sync.run()
+
+        for machine in (alpha, beta):
+            self.assertEqual(self.marker(machine), store.FORMAT_CONTENT)
+            self.assertNotIn(
+                "<<<<<<<",
+                self.marker(machine),
+                "git three-way merged a file that should never have needed one",
+            )
+
+    def test_joining_a_newer_repo_is_refused_before_anything_is_enrolled(self) -> None:
+        """`init` is the one that matters most: a machine that enrols publishes
+        a key, a signer and a sealed name into a layout it cannot read, and
+        nothing in this repository is ever rewritten."""
+        alpha = self.machine("alpha")
+        self.mark_future(alpha)
+        with alpha.active():
+            before = store.recipients_file().read_text(encoding="utf-8")
+
+        with self.assertRaises(sync.SyncError):
+            self.machine("beta")
+
+        with alpha.active():
+            sync.git("fetch", "--quiet", "origin")
+            sync.git("reset", "--hard", "--quiet", "origin/HEAD")
+            self.assertEqual(
+                store.recipients_file().read_text(encoding="utf-8"),
+                before,
+                "the newcomer enrolled into a repo it had already been told to refuse",
+            )
+
+    def test_grant_refuses_a_newer_repo_format(self) -> None:
+        """`grant` rewrites every sealed key file, which is a larger write than
+        a sync makes -- so it is gated on the same question."""
+        alpha, beta = self.history_across_days(days=1, per_day=1)
+        self.accept_everyone(beta)
+        self.mark_future(alpha)
+
+        with alpha.active():
+            sealed = store.day_key(alpha.id, "2023-11-14").read_bytes()
+            with self.assertRaises(sync.SyncError):
+                sync.grant()
+            self.assertEqual(
+                store.day_key(alpha.id, "2023-11-14").read_bytes(),
+                sealed,
+                "the day key was re-sealed into a repo this version cannot read",
+            )
+
+    def test_compact_refuses_a_newer_repo_format(self) -> None:
+        """The only routine operation that deletes files, so the last place this
+        can be allowed to run blind. It never fetches, so the check reads the
+        local checkout -- which is what a fetch left there."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            for i in range(3):
+                alpha.record("2023-11-14", 1_700_000_001 + i, f"command {i}")
+                sync.run()
+            chunks = len(list(store.iter_chunks(alpha.id)))
+        self.assertGreater(chunks, 1, "nothing to compact, so the fixture proves nothing")
+        self.mark_future(alpha)
+
+        with alpha.active():
+            with self.assertRaises(sync.SyncError):
+                sync.compact(before="2023-11-15")
+            self.assertEqual(
+                len(list(store.iter_chunks(alpha.id))), chunks, "chunks were deleted anyway"
+            )
+
+    def test_doctor_reports_the_format_the_repo_is(self) -> None:
+        """The marker is a file nobody would think to `cat`, and a working sync
+        never mentions it. `doctor` is where it becomes visible."""
+        alpha = self.machine("alpha")
+        self.assertRegex(
+            self.run_cli(alpha, "doctor").out, rf"\[ok\] repo format\s+{store.REPO_FORMAT}\b"
+        )
+
+    def test_doctor_says_what_a_refused_repo_needs(self) -> None:
+        """The same judgement `sync` refuses on, rendered rather than re-derived
+        -- a doctor that reported the old rule after the rule changed would be
+        worse than one that said nothing."""
+        alpha = self.machine("alpha")
+        self.mark_future(alpha)
+
+        out = self.run_cli(alpha, "doctor").out
+        self.assertRegex(out, r"\[FAIL\] repo format")
+        self.assertIn(str(store.REPO_FORMAT + 1), out)
+        self.assertIn("upgrade woswoar", out)

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -456,6 +456,14 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
     if sync.is_repo():
         info("remote", sync.remote_summary())
+
+        # The one fact about the repository that decides whether this machine
+        # may write to it at all, and the only place a person can see it: the
+        # marker is a file nobody would think to `cat`, and `sync` mentions it
+        # only by refusing. The verdict comes from `sync` rather than being
+        # re-derived here, like every other line in this block.
+        repo_format = sync.repo_format_status()
+        check("repo format", repo_format.ok, repo_format.detail)
         status = sync.signing_status(store.machine())
         check("signing", status.ok, status.detail)
 

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -32,6 +32,36 @@ _NAME_FILE = ".name"
 RECIPIENTS = "recipients.txt"
 GITATTRIBUTES = ".gitattributes"
 README = "README.md"
+FORMAT = "FORMAT"
+
+#: The layout of the *repository* -- `recipients.txt`, `hosts/<id>/keys/`,
+#: `manifests/`, `<day>/<ts>-<rand>.age`. Every other format woswoar owns already
+#: says which one it is: the cache carries `woswoar-cache-2`, a manifest carries
+#: `woswoar-manifest-v1` inside the bytes it signs. The repo was the exception,
+#: and it is the one an upgrade cannot be retrofitted onto later -- a machine
+#: still running the old version would not write the marker, so by the time a
+#: layout change needs one it is too late by definition.
+#:
+#: Deliberately not `woswoar.__version__`. The program version moved sixteen
+#: times in a fortnight and this has moved zero times; coupling them means a
+#: meaningless bump on every release and no signal on the one release where it
+#: matters.
+REPO_FORMAT = 1
+_FORMAT_PREFIX = "woswoar-repo-"
+
+
+def format_content(version: int = REPO_FORMAT) -> str:
+    """What the marker says for ``version``. The one place the prefix is spelt.
+
+    Takes a version because the tests need to write one this build does not
+    understand, and hand-typing `woswoar-repo-2` there would put a second copy
+    of the prefix outside this module -- where it would go on parsing after a
+    rename, as `None`, and quietly stop testing the refusal.
+    """
+    return f"{_FORMAT_PREFIX}{version}\n"
+
+
+FORMAT_CONTENT = format_content()
 
 #: What a stranger finding the repository sees first, and what its owner sees in
 #: three years having forgotten what it was. Deliberately says nothing about
@@ -488,6 +518,52 @@ def history_dir() -> Path:
 
 def recipients_file() -> Path:
     return history_dir() / RECIPIENTS
+
+
+def format_file() -> Path:
+    """Which shape this repository is, in plaintext at its root.
+
+    Plaintext, and it has to be: a machine reads this *before* it knows how to
+    find the day keys, so a version of it sealed to a key is a fact you can only
+    learn by already understanding the layout it describes.
+
+    It says nothing an observer could not get from the directory listing anyway
+    -- `docs/security.md` has always put the shape and size of the repository
+    outside what encryption hides.
+    """
+    return history_dir() / FORMAT
+
+
+def repo_format() -> int | None:
+    """The version the repository claims, or ``None`` when nothing legible does.
+
+    ``None`` is "the shape that predates the marker", which is this shape -- so
+    an absent file reads as compatible and every existing installation goes on
+    working untouched. That is the whole migration.
+
+    Unreadable *content* answers ``None`` too, rather than refusing. The file
+    sits in a repository anyone with push access can write, so treating garbage
+    as a fatal disagreement would hand any of them a way to stop every machine
+    syncing by writing four bytes -- while a legible number is a statement made
+    deliberately by a newer woswoar, and is worth stopping for. `State.load`
+    degrades the same way, for the same reason.
+    """
+    try:
+        text = format_file().read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not text.startswith(_FORMAT_PREFIX):
+        return None
+    try:
+        return int(text[len(_FORMAT_PREFIX) :])
+    except ValueError:
+        # `int` in a `try`, and not `str.isdigit` before it: those are different
+        # questions, and the gap between them is this function's whole promise.
+        # `"²".isdigit()` is True and `int("²")` raises, so a marker holding
+        # `woswoar-repo-²` crashed every sync with an unhandled ValueError --
+        # four bytes, writable by anyone with push access, exactly the wedge the
+        # docstring above says cannot happen.
+        return None
 
 
 def state_file() -> Path:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1978,6 +1978,15 @@ def run(push: bool = True, now: int | None = None) -> Report:
         # append-only.
         in_sync = _fetch_and_rebase(repo) if remote else False
 
+        # Straight after the fetch, so what is checked is what the remote says
+        # rather than what this machine last wrote, and before anything is
+        # exported, committed or merged.
+        require_known_repo_format()
+        # An existing repository acquires its marker here rather than through
+        # `init`, which nobody runs twice. This is the migration, and it costs
+        # one `is_file` on every idle sync.
+        marked = write_repo_format()
+
         # Before anything is trusted, and only ever subtracting -- see
         # `apply_withdrawals`.
         apply_withdrawals(state, report)
@@ -2015,7 +2024,18 @@ def run(push: bool = True, now: int | None = None) -> Report:
         # old chunks it signed -- and `grant`, `revoke` and `init` still sweep
         # the tree unconditionally, which is also what catches a
         # `recipients.txt` edited by hand.
-        committed = _commit() if published or exported else False
+        # `marked` joins the other two for the same reason they are here: the
+        # marker is a write into the working tree, so the run that makes it is
+        # the run that has to stage it. Left out, it would sit unstaged until
+        # some unrelated export swept it up -- which on a machine that records
+        # nothing is never.
+        #
+        # A run that dies between writing it and committing leaves it unstaged
+        # and the next run says `marked` is False, because the file is there.
+        # Benign in the same way `publish_signer`'s equivalent is: the marker
+        # waits for the next export, `grant`, `revoke` or `init`, all of which
+        # sweep the tree unconditionally -- and every peer writes it too.
+        committed = _commit() if published or exported or marked else False
 
         if remote:
             # `push` contacts the remote even with nothing to send, which is the
@@ -2319,6 +2339,12 @@ def initialise(
     if publishing:
         _fetch_and_rebase(repo)
 
+    # Before enrolling, not after: joining a repository whose layout this
+    # version cannot read would publish a key and a name into it, and nothing
+    # in the repo is ever rewritten. The message says to upgrade, which is the
+    # whole of the fix.
+    require_known_repo_format()
+
     if _write_repo_metadata(known, chosen):
         _commit()
 
@@ -2347,6 +2373,62 @@ def initialise(
     return known, chosen, pinned
 
 
+def write_repo_format() -> bool:
+    """Write the layout marker if the repo has none. Says whether it wrote.
+
+    Only when absent, and never rewritten to match: a repo that says something
+    *older* is still this shape, and a repo that says something newer has
+    already been refused by `require_known_repo_format` before anything reaches
+    here. Rewriting it would also give two machines on different versions a file
+    to take turns overwriting, which is the failure `store.README_CONTENT`
+    describes for prose and which matters more for a version.
+    """
+    if store.format_file().is_file():
+        return False
+    store.write_atomic(store.format_file(), store.FORMAT_CONTENT.encode("utf-8"))
+    return True
+
+
+def repo_format_status() -> IdentityStatus:
+    """Whether this machine may write to the repository as it stands.
+
+    Beside `signing_status` and `trust_status` for the reason their docstrings
+    give: the judgement is stated once and is testable, rather than derived
+    inline in the CLI. `doctor` renders it and `require_known_repo_format`
+    refuses on it, so the rule and its wording cannot drift apart -- which they
+    would the first time this version understands two formats rather than one.
+
+    The detail names both numbers, because the fix is "upgrade this machine" and
+    neither is visible anywhere else.
+    """
+    found = store.repo_format()
+    if found is None:
+        return IdentityStatus(True, f"{store.REPO_FORMAT} - unmarked, the next sync records it")
+    if found > store.REPO_FORMAT:
+        return IdentityStatus(
+            False,
+            f"repo is format {found}, this woswoar understands {store.REPO_FORMAT}"
+            " - upgrade woswoar here ('pipx upgrade woswoar'); until then nothing"
+            " is published or merged",
+        )
+    return IdentityStatus(True, str(found))
+
+
+def require_known_repo_format() -> None:
+    """Refuse a repository written by a woswoar newer than this one.
+
+    Read after the fetch and before anything is exported or merged, so the
+    answer is the *remote's* view and a refusal leaves the local history exactly
+    as it was. Refusing the whole operation rather than only the merge is
+    deliberate: publishing into a layout this version does not understand is how
+    one machine writes what the new shape cannot account for, and the
+    append-only repo makes that permanent.
+    """
+    status = repo_format_status()
+    if not status.ok:
+        raise SyncError(f"refusing to write to this history repo: {status.detail}")
+
+
 def _write_repo_metadata(known: Machine, identity: Path) -> bool:
     """Ensure this machine is enrolled. Returns whether anything changed."""
     changed = False
@@ -2362,6 +2444,9 @@ def _write_repo_metadata(known: Machine, identity: Path) -> bool:
     readme = store.history_dir() / store.README
     if not readme.is_file():
         store.write_atomic(readme, store.README_CONTENT.encode("utf-8"))
+        changed = True
+
+    if write_repo_format():
         changed = True
 
     recipient = crypto.recipient_for(identity).strip()
@@ -2710,6 +2795,10 @@ def _access_change() -> Iterator[_AccessChange]:
     with lock():
         if remote:
             _fetch_and_rebase(repo)
+        # `grant` and `revoke` rewrite every sealed key file in the repo, which
+        # is a bigger write than `sync` makes -- so the version gate belongs
+        # here too, and after the fetch for the same reason.
+        require_known_repo_format()
         yield _AccessChange(identity, known, remote)
         _commit()
         if remote:
@@ -2973,6 +3062,12 @@ def compact(before: str | None = None) -> tuple[int, int, int]:
     known = store.machine()
 
     with lock():
+        # The only routine operation that *deletes* files, so it is the last
+        # place to run against a layout this version does not understand. No
+        # fetch to be after: `compact` touches this host's own chunks and never
+        # goes to the remote, so the local checkout is the only view there is.
+        require_known_repo_format()
+
         verify_key = signing_public()
         by_day: dict[str, list[store.Chunk]] = {}
         for chunk in store.iter_chunks(known.id):


### PR DESCRIPTION
Closes #165.

`history/FORMAT`, one plaintext line, `woswoar-repo-1`.

Every other format woswoar owns already says which one it is — the parse cache
carries `woswoar-cache-2`, a manifest carries `woswoar-manifest-v1` inside the
bytes it signs. The synced repository was the exception, and it is the one that
cannot be fixed later: a layout change needs the *old* machines to have been
writing a marker before the change, and they were not, so the options at that
point are sniffing the directory shape, requiring every machine to upgrade at
once, or never changing the layout. CLAUDE.md rule 8 names this as work to do
"before the first such change, not during one".

## What it does

- **Written by `init`, and by the first `sync` that finds it absent.** That is
  the migration: an existing installation acquires it on its next background
  sync, with nothing to run and nothing to read. The write joins `published`
  and `exported` in the commit condition, so the run that creates it is the run
  that stages and pushes it — otherwise it would wait for an unrelated export,
  which on a machine that records nothing is never.
- **Only when absent, never rewritten to match.** Two machines on different
  versions taking turns overwriting one line is a conflict on every sync
  forever; two machines *creating* it write the same bytes and rebase cleanly.
- **Read, and barely enforced.** A version newer than this build refuses — in
  all four places that write to the repo, not just `sync`. An older version, an
  absent file, or content that does not parse all read as "this shape" and
  proceed.

## Two decisions worth arguing with

**The gate covers `init`, `grant`/`revoke` and `compact`, not just `sync`.** The
issue only asked for `sync`. But the argument for refusing — publishing into a
layout this version does not understand is permanent in an append-only repo —
applies at least as strongly to `init` (which enrols a key, a signer and a
sealed name), to `grant`/`revoke` (which rewrite *every* sealed key file), and
to `compact` (the only routine operation that deletes chunks). Four one-line
calls; each has a test and each was mutation-verified.

**Garbage in the file is not a refusal.** Anyone with push access can write it,
so treating unparseable content as a fatal disagreement hands any of them a way
to stop every machine syncing with four bytes. A legible higher number is a
statement a newer woswoar made on purpose and is worth stopping for;
`State.load` degrades the same way for the same reason.

## Verified against v0.8.2, not argued

The issue asks specifically that a machine on an older woswoar be unaffected. I
extracted `v0.8.2` and ran it against a repo written by this branch:

```
--- v0.8.2 publishes into the marked repo
exported 1 line(s) in 1 chunk(s); merged 0 line(s) ...
root after: FORMAT .git .gitattributes hosts README.md recipients.txt
FORMAT still says: woswoar-repo-1
[ok] manifests    all present
[ok] day keys     all sealed
[ok] chunks       all accounted for
```

It syncs, it publishes, it leaves the marker alone, and its checks stay green.
Statically: v0.8.2 enumerates only `logs/hosts/`, `history/hosts/` and `keys/` —
nothing walks the repo root objecting to an unknown entry, and `is_chunk_path`
matches a four-part shape that a root-level file cannot satisfy.

## Review (CLAUDE.md rule 1, row 1)

Full `/simplify`, four angles. It found a **real defect in this branch**, which
is the reason that rule exists:

> `store.repo_format()` parsed with `str.isdigit()` before `int()`. Those are
> different questions: `"²".isdigit()` is `True` and `int("²")` raises, so a
> marker holding `woswoar-repo-²` crashed **every sync** with an unhandled
> `ValueError` — four bytes, writable by anyone with push access, and precisely
> the wedge the function's own docstring promises to absorb.

Now `startswith` + `try/int`, with the superscript case in the test that claims
to cover garbage — `b"gibberish"` alone never reached it.

Also applied: `sync.repo_format_status()` beside `signing_status` and
`trust_status`, so `doctor` renders the verdict instead of re-deriving the
comparison and re-wording the remedy (flagged independently by three of the four
agents; the CLI branch had no test, and now has two); `store.format_content()`
so the `woswoar-repo-` prefix is spelt in one place; and on the test side, one
`publish_marker` helper instead of two near-identical ones, with three tests
switched to the existing `history_across_days` fixture.

Skipped, with reasons: dropping `test_an_absent_marker_is_not_a_failure` as
redundant — it is the test that catches the "check demands a marker" mutation,
re-confirmed in the final run; and a `repo_write()` context manager to hold the
gate at one choke point — `initialise` never locks, `lock()` is taken *before*
the fetch (so the check would read a stale checkout), and `compact` never
fetches, so the abstraction would cover three of four sites and still need a
hand-placed call. The efficiency pass returned nothing: ~12 µs and no new forks
on a 10.3 ms idle sync.

## Mutation testing

`python -m tools.mutate`, baseline green, run again after the review changes:

```
  caught    init stops writing the marker into a new repo
  caught    sync stops writing the marker an existing repo lacks
  caught    the marker is written but never staged, so it never reaches the remote
  caught    the format check accepts anything
  caught    the format check demands a marker, so every existing repo is refused
  caught    the parse trusts str.isdigit, which int does not agree with
  caught    the marker's content varies per machine instead of being a constant
  caught    init joins a repo it cannot read
  caught    grant and revoke re-seal into a repo they cannot read
  caught    compact deletes chunks in a repo it cannot read
  caught    doctor reports every repo format as fine
```

## Docs

`docs/woswoar_design_summary.md` gains the file in the repo-layout block and the
paragraph on why it is enforced in one direction only; `docs/security.md`'s
"what is not protected" now says which two files in the repo are plaintext on
purpose and why neither adds to the metadata already leaked.

## Verification

`ruff check . && ruff format --check . && mypy woswoar tests tools && shellcheck
--shell=bash woswoar/shell/woswoar.bash && python -m tools.run_tests` — clean,
749 tests, 4 benchmark skips.