### PR TITLE
shell: a zsh hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,13 @@ jobs:
       - run: ruff format --check .
       - run: mypy woswoar tests tools
       - run: shellcheck --shell=bash woswoar/shell/woswoar.bash
+      # shellcheck has no zsh mode -- it refuses the dialect outright rather
+      # than checking what it can -- so the zsh hook gets the only static check
+      # zsh itself offers. Said here rather than left as a silent gap: `zsh -n`
+      # is a parse, not a lint, and nothing below this line is checking the zsh
+      # hook for the class of thing shellcheck finds in the bash one.
+      - run: sudo apt-get install -y -qq zsh || { sudo apt-get update -qq && sudo apt-get install -y -qq zsh; }
+      - run: zsh -n woswoar/shell/woswoar.zsh
 
   test:
     runs-on: ubuntu-latest
@@ -117,18 +124,27 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - name: install strace and locales
+      - name: install strace, zsh and locales
+        # zsh is not on ubuntu-latest by default, and the zsh suite skips itself
+        # without it -- which under `--no-skips` below is fatal rather than a
+        # green run that measured nothing. That is the property this job exists
+        # for, so it stays that way.
         run: |
-          sudo apt-get install -y -qq strace locales \
-            || { sudo apt-get update -qq && sudo apt-get install -y -qq strace locales; }
+          sudo apt-get install -y -qq strace zsh locales \
+            || { sudo apt-get update -qq && sudo apt-get install -y -qq strace zsh locales; }
           # The comma-decimal test needs a locale where $EPOCHREALTIME uses ","
           sudo locale-gen de_AT.UTF-8
+          zsh --version
       # --jobs 1 on purpose: this job counts forks under strace, and the whole
       # point of it is a measurement that concurrent load has no say in. The
       # runner is used anyway for --no-skips -- strace and bash 5 are installed
       # here, so a skip means one of them stopped working, not that the test is
       # inapplicable.
       - run: python -m tools.run_tests --only tests.test_shell_hook --jobs 1 --no-skips
+      # A second invocation rather than one over both: `--only` selects by
+      # module or class prefix, and `tests.test_shell_hook` does not prefix
+      # `tests.test_shell_hook_zsh` -- the dot is what separates them.
+      - run: python -m tools.run_tests --only tests.test_shell_hook_zsh --jobs 1 --no-skips
 
   sync:
     # Two machines exchanging encrypted history through a bare repo, plus the

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,6 +16,9 @@ it again.
 `woswoar install` checks for these and prints the install command for your
 distribution. `woswoar doctor` diagnoses anything else that looks wrong.
 
+There is a **zsh 5.0+** hook too, but `install` does not wire it up — see
+[Living in your shell](shell-integration.md#zsh) for the one line it takes.
+
 > [!WARNING]
 > **Do not install `age` as a snap.** It works, and it starts a sandbox on every
 > call — about 250 ms against 2 ms for a distribution binary. woswoar runs `age`

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -3,6 +3,11 @@
 woswoar is never the only thing hooked into a real `.bashrc`, and it runs on
 every prompt. Both of those constrain it more than anything else in the design.
 
+There are two hooks: `woswoar.bash`, which `woswoar install` wires up, and
+`woswoar.zsh`, which for now you [source by hand](#zsh). Everything below is
+about the bash one unless it says otherwise; the zsh section covers what is
+genuinely different, and it is almost all about *not* recording.
+
 ## Your normal bash is untouched
 
 **Up-arrow and `~/.bash_history` still work exactly as before.** woswoar never
@@ -110,11 +115,102 @@ It needs fzf 0.45+, like <kbd>Ctrl</kbd>+<kbd>R</kbd> cycling and
 <kbd>Ctrl</kbd>+<kbd>T</kbd>. On anything older the key is neither bound nor
 advertised.
 
+## zsh
+
+Add the hook **last** in `~/.zshrc`:
+
+```zsh
+source ~/.local/share/woswoar/woswoar.zsh
+```
+
+`woswoar install` does not write that line yet — it installs the bash hook and
+edits `.bashrc` — so for now this one line is yours to add. Everything else is
+shared: the same machine id, the same `logs/hosts/<id>/<day>.tsv`, the same
+sync. A machine that runs both shells records into one history and every
+<kbd>Ctrl</kbd>+<kbd>R</kbd> in either sees the other's commands, with nothing
+to exchange in between.
+
+**Last, because whoever binds <kbd>Ctrl</kbd>+<kbd>R</kbd> last wins.** Oh My
+Zsh, Prezto and atuin all bind it when they load. `WOSWOAR_NO_BIND=1` keeps
+theirs instead.
+
+Needs **zsh 5.0+**. The hook says so and switches itself off on anything older
+rather than half-working.
+
+### What zsh records that bash does not
+
+A multi-line command keeps its **newlines**. bash reads the line back out of
+`history`, which joins it with semicolons; zsh hands the hook the buffer you
+typed. Both are faithful to their shell. In the picker such a command shows a
+visible `\n`, which is deliberate — see the note in `entry.make_inert`.
+
+### The history rules are reimplemented, not inherited
+
+This is the one place the zsh hook is *less* elegant than the bash one, and it
+is worth knowing about rather than glossing.
+
+The bash hook never decides what to skip: it checks whether bash's history
+number moved, so `HISTCONTROL`, `ignoredups` and `HISTIGNORE` apply for free and
+there is only ever one set of rules. zsh offers no equivalent signal. `preexec`
+fires for every line, including the ones zsh has already thrown away; `$HISTCMD`
+moves *backwards* over one of those, so watching it would drop the next real
+command as well; and `$history` still holds a space-prefixed command at the
+moment the hook runs, so reading that would publish exactly what you hid.
+
+So the hook applies the rules itself. Mirrored:
+
+| setting | what the hook does |
+|---|---|
+| `HIST_IGNORE_SPACE` | skips a line that starts with whitespace |
+| `HIST_IGNORE_DUPS`, `HIST_IGNORE_ALL_DUPS` | skips a line identical to the one before it |
+| `HISTORY_IGNORE` | skips a line matching the pattern, in your `EXTENDED_GLOB` dialect |
+
+**Not** mirrored, in the same spirit as the list of what `$WOSWOAR_IGNORE` does
+not catch: `HIST_NO_STORE`, `HIST_SAVE_NO_DUPS`, `HIST_EXPIRE_DUPS_FIRST` and
+`HIST_REDUCE_BLANKS`. A command those would keep out of `~/.zsh_history` is
+still recorded by woswoar. The first three are about pruning a fixed-size
+history file, which a log that only appends does not have; the fourth
+reformats rather than drops. If you rely on one of them to keep something out
+of a synced file, use `WOSWOAR_IGNORE_EXTRA` instead, which both shells and
+`woswoar import` honour.
+
+`HIST_IGNORE_SPACE` is the one that matters most, and it is the one with the
+most tests: a leading space is how people keep a secret out of history, and a
+miss here is not merely recorded but encrypted, pushed and pulled onto every
+other machine.
+
+### Coexistence
+
+`precmd` and `preexec` are lists in zsh, so nothing has to be chained or
+restored: the hook registers with `add-zsh-hook` and every other participant
+keeps working. zsh hands each `precmd` entry your real `$?`, so an
+exit-code-colouring prompt downstream is unaffected — none of the
+`PROMPT_COMMAND` apparatus the bash hook needs exists here.
+
+Two known rough edges, neither of them verified against an install of the thing
+in question:
+
+- **zsh-autosuggestions** wraps the widgets it knows about, and one defined
+  after it loads is not among them, so the ghost suggestion may linger after
+  <kbd>Ctrl</kbd>+<kbd>R</kbd>. The remedy is
+  `ZSH_AUTOSUGGEST_CLEAR_WIDGETS+=(__woswoar_widget)`.
+- **Powerlevel10k's instant prompt** captures output written before the first
+  prompt and warns about it. The hook prints at load time in exactly one case —
+  the machine has no identity yet, so run `woswoar install`.
+
+### macOS
+
+Still unsupported, and zsh does not change that on its own. The hook's central
+claim is that it does not fork on the per-command path, and CI proves that with
+`strace`, which macOS does not have. That is a separate piece of work.
+
 ## Commands that are never recorded
 
 Anything bash itself keeps out of history is invisible to woswoar, so
 `HISTCONTROL=ignorespace` (a leading space) and `HISTIGNORE` work exactly as they
-already do — a command bash declines to store is never seen here.
+already do — a command bash declines to store is never seen here. Under zsh the
+same three rules apply but are [reimplemented rather than
+inherited](#the-history-rules-are-reimplemented-not-inherited).
 
 On top of that, `$WOSWOAR_IGNORE` is an extended regex matched against every
 command, and anything it matches is dropped before it reaches a file that gets

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -117,18 +117,30 @@ advertised.
 
 ## zsh
 
-Add the hook **last** in `~/.zshrc`:
+**`woswoar install` does not know about zsh yet.** It writes `woswoar.bash` into
+`~/.local/share/woswoar/` and edits `.bashrc`; the zsh hook ships inside the
+package and stays there. So both the copy and the `.zshrc` line are yours to
+make, and the hook is the one file `woswoar` does not keep up to date for you —
+after `pip install -U woswoar`, repeat the copy.
+
+Add it **last** in `~/.zshrc`:
 
 ```zsh
-source ~/.local/share/woswoar/woswoar.zsh
+source "$(python3 -c 'import pathlib, woswoar
+print(pathlib.Path(woswoar.__file__).parent / "shell" / "woswoar.zsh")')"
 ```
 
-`woswoar install` does not write that line yet — it installs the bash hook and
-edits `.bashrc` — so for now this one line is yours to add. Everything else is
-shared: the same machine id, the same `logs/hosts/<id>/<day>.tsv`, the same
-sync. A machine that runs both shells records into one history and every
-<kbd>Ctrl</kbd>+<kbd>R</kbd> in either sees the other's commands, with nothing
-to exchange in between.
+That sources it straight out of the package, so an upgrade is picked up by the
+next shell and there is nothing to keep in step — at the cost of a Python start
+in your `.zshrc`. If that matters, copy the file to
+`~/.local/share/woswoar/woswoar.zsh` and source the copy instead, and remember
+that `woswoar doctor` does not check that copy for staleness the way it checks
+the bash one.
+
+Everything else is shared: the same machine id, the same
+`logs/hosts/<id>/<day>.tsv`, the same sync. A machine that runs both shells
+records into one history and every <kbd>Ctrl</kbd>+<kbd>R</kbd> in either sees
+the other's commands, with nothing to exchange in between.
 
 **Last, because whoever binds <kbd>Ctrl</kbd>+<kbd>R</kbd> last wins.** Oh My
 Zsh, Prezto and atuin all bind it when they load. `WOSWOAR_NO_BIND=1` keeps

--- a/tests/support.py
+++ b/tests/support.py
@@ -150,11 +150,20 @@ def run_in_pty(
     # that prompt would then wait for something it had already been handed, until
     # the timeout. It is a load-dependent flake: rare on an idle machine, and
     # reproducible under the parallel runner.
+    #
+    # Offered only to a step that sends *nothing*, which is the only shape that
+    # flake takes. A step that types something must wait for output produced
+    # after its keypress, or its marker stops witnessing that the keypress was
+    # processed at all -- and two consecutive steps sharing a marker (`~/d2` at
+    # `tests/test_search.py`, where Ctrl-T waits for the row it was pressed on)
+    # would then let the second one return before fzf had seen the key. What is
+    # dropped is only ever a tail the previous step already read.
     carry = b""
     try:
         for index, step in enumerate(steps):
             if step.send:
                 os.write(master, step.send.encode())
+                carry = b""
             seen, carry = _read_until(master, step.until, timeout, index, transcript, carry)
             transcript.append(seen)
         return transcript

--- a/tests/support.py
+++ b/tests/support.py
@@ -144,11 +144,19 @@ def run_in_pty(
         os._exit(127)
 
     transcript: list[str] = []
+    # Whatever arrived *after* the previous step's marker. A single `os.read`
+    # takes up to 64 KiB, so a shell that prints its output and redraws its
+    # prompt quickly enough delivers both in one chunk -- and a step waiting for
+    # that prompt would then wait for something it had already been handed, until
+    # the timeout. It is a load-dependent flake: rare on an idle machine, and
+    # reproducible under the parallel runner.
+    carry = b""
     try:
         for index, step in enumerate(steps):
             if step.send:
                 os.write(master, step.send.encode())
-            transcript.append(_read_until(master, step.until, timeout, index, transcript))
+            seen, carry = _read_until(master, step.until, timeout, index, transcript, carry)
+            transcript.append(seen)
         return transcript
     finally:
         os.close(master)
@@ -159,8 +167,14 @@ def run_in_pty(
         os.waitpid(pid, 0)
 
 
-def _read_until(fd: int, marker: str, timeout: float, index: int, before: list[str]) -> str:
+def _read_until(
+    fd: int, marker: str, timeout: float, index: int, before: list[str], carry: bytes = b""
+) -> tuple[str, bytes]:
     """Read from ``fd`` until ``marker`` appears, or fail with what did appear.
+
+    Returns what was read up to and including the marker, and whatever came
+    after it -- which the caller hands back as ``carry`` on the next step, so
+    that output the marker shared a read with is not thrown away.
 
     An `AssertionError` rather than a `TimeoutError`, and carrying every step's
     output rather than this one's: a terminal test that goes wrong says nothing
@@ -169,7 +183,7 @@ def _read_until(fd: int, marker: str, timeout: float, index: int, before: list[s
     line before.
     """
     deadline = time.monotonic() + timeout
-    buffer = b""
+    buffer = carry
     needle = marker.encode()
 
     def stalled(reason: str) -> AssertionError:
@@ -200,7 +214,8 @@ def _read_until(fd: int, marker: str, timeout: float, index: int, before: list[s
             # nothing rather than one that is still waiting for us.
             os.write(fd, _CURSOR_REPORT)
         buffer += chunk
-    return buffer.decode("utf-8", "replace")
+    cut = buffer.index(needle) + len(needle)
+    return buffer[:cut].decode("utf-8", "replace"), buffer[cut:]
 
 
 #: "Where is the cursor?", and an answer. Row 1 column 1 is a lie in general and

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -196,7 +196,10 @@ class TestTheUsersOwnPattern(unittest.TestCase):
             credentials.user_pattern()
 
 
-HOOK = Path(__file__).resolve().parent.parent / "woswoar" / "shell" / "woswoar.bash"
+#: Every hook that carries a copy of the rules. There are two shells now, and
+#: a rule added to one of them is a rule the other silently does not apply --
+#: which for a *credential* filter is a secret published to a git repository.
+HOOKS = sorted((Path(__file__).resolve().parent.parent / "woswoar" / "shell").glob("woswoar.*"))
 
 
 def as_posix_ere(pattern: str) -> str:
@@ -224,27 +227,35 @@ class TestParityWithTheHook(unittest.TestCase):
     duplicated logic.
     """
 
-    def hook_pattern(self) -> str:
-        source = HOOK.read_text(encoding="utf-8")
+    def hook_pattern(self, hook: Path) -> str:
+        source = hook.read_text(encoding="utf-8")
         match = re.search(r'^: "\$\{WOSWOAR_IGNORE=(.*)\}"$', source, re.MULTILINE)
-        assert match is not None, "the hook's default WOSWOAR_IGNORE was not found"
-        # `\$` is the bash escaping of the regex anchor, not part of the pattern.
+        assert match is not None, f"{hook.name} ships no default WOSWOAR_IGNORE"
+        # `\$` is the shell escaping of the regex anchor, not part of the pattern.
         return match.group(1).replace("\\$", "$")
 
-    def test_the_hook_ships_exactly_the_shared_rules(self) -> None:
-        self.assertEqual(
-            self.hook_pattern(),
-            "|".join(as_posix_ere(rule) for rule in credentials._SHARED),
-            "woswoar/shell/woswoar.bash and credentials._SHARED have diverged; "
-            "a rule added to one must be added to the other",
-        )
+    def test_there_are_hooks_to_check(self) -> None:
+        """Otherwise a rename under `woswoar/shell/` empties the glob and the two
+        tests below pass having compared nothing."""
+        self.assertEqual([hook.name for hook in HOOKS], ["woswoar.bash", "woswoar.zsh"], str(HOOKS))
+
+    def test_every_hook_ships_exactly_the_shared_rules(self) -> None:
+        expected = "|".join(as_posix_ere(rule) for rule in credentials._SHARED)
+        for hook in HOOKS:
+            with self.subTest(hook=hook.name):
+                self.assertEqual(
+                    self.hook_pattern(hook),
+                    expected,
+                    f"woswoar/shell/{hook.name} and credentials._SHARED have diverged; "
+                    "a rule added to one must be added to all of them",
+                )
 
     def test_the_import_only_rules_are_deliberately_not_in_the_hook(self) -> None:
         """They are the ones the prompt path cannot afford; that is the design."""
-        hook = self.hook_pattern()
-        for rule in credentials._IMPORT_ONLY + credentials._TOKENS:
-            with self.subTest(rule=rule):
-                self.assertNotIn(as_posix_ere(rule), hook)
+        for hook in HOOKS:
+            for rule in credentials._IMPORT_ONLY + credentials._TOKENS:
+                with self.subTest(hook=hook.name, rule=rule):
+                    self.assertNotIn(as_posix_ere(rule), self.hook_pattern(hook))
 
 
 class TestTheRulesAreReadable(unittest.TestCase):

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -5,6 +5,13 @@ that recording never forks. That duplication is deliberate but fragile, so these
 tests drive the *real* hook in a *real* bash and parse the result with the
 *real* Python parser. If the two implementations ever disagree, this is where it
 shows up.
+
+There is a second hook now, ``woswoar.zsh``, and a third copy of the same
+claims would be a third thing to drift. So the parts that are about *woswoar*
+rather than about bash -- the escape corpus, the two mirrored constants, the
+default ignore pattern, the fork-scaling measurement -- live here as mixins
+parameterised by ``(INTERPRETER, HOOK)``, and ``tests/test_shell_hook_zsh.py``
+subclasses them for zsh. One corpus, one set of assertions, two shells.
 """
 
 from __future__ import annotations
@@ -20,7 +27,7 @@ import textwrap
 import time
 import unittest
 from pathlib import Path
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from woswoar import cache, search, store
 from woswoar.entry import MAX_CMD_CHARS, TRUNCATION_MARKER, Entry, escape, unescape
@@ -28,7 +35,9 @@ from woswoar.entry import MAX_CMD_CHARS, TRUNCATION_MARKER, Entry, escape, unesc
 from .credential_shapes import DOCUMENTED_GAPS, INNOCENT_SHAPES, SECRET_SHAPES
 from .support import MACHINE_ID, Typed, WoswoarTestCase, requires_bash, run_in_pty
 
-HOOK = Path(__file__).resolve().parent.parent / "woswoar" / "shell" / "woswoar.bash"
+SHELL_DIR = Path(__file__).resolve().parent.parent / "woswoar" / "shell"
+BASH_HOOK = SHELL_DIR / "woswoar.bash"
+ZSH_HOOK = SHELL_DIR / "woswoar.zsh"
 
 #: Inputs the two escape implementations must agree on. Command arguments cannot
 #: carry a NUL byte, so that one case is out of reach here and is covered by the
@@ -68,6 +77,17 @@ requires_bash5 = unittest.skipUnless(bash_major() >= 5, "bash 5.0+ required")
 
 
 class ShellHookTestCase(WoswoarTestCase):
+    #: How to start an interactive shell that reads its commands from stdin, and
+    #: which hook that shell sources. Overridden wholesale by the zsh suite --
+    #: everything below is written in terms of these two.
+    INTERPRETER: ClassVar[list[str]] = ["bash", "--norc", "-i"]
+    HOOK: ClassVar[Path] = BASH_HOOK
+
+    #: Typed ahead of everything else, including ``before``. Empty for bash,
+    #: which draws no prompt at all when its stdin is a pipe; zsh does, and needs
+    #: a line to turn it off before any output a test reads. See the zsh suite.
+    PREAMBLE: ClassVar[str] = ""
+
     def runtime_dir(self) -> Path:
         """Where XDG_RUNTIME_DIR points for these runs."""
         return self.root / "run"
@@ -94,7 +114,7 @@ class ShellHookTestCase(WoswoarTestCase):
         env_extra: dict[str, str] | None = None,
         before: str = "",
     ) -> str:
-        """Run ``script`` line by line in an interactive bash with the hook loaded.
+        """Run ``script`` line by line in an interactive shell with the hook loaded.
 
         ``before`` runs *ahead of* the hook, which is how a real ~/.bashrc looks:
         the interesting bugs are all about what else already owns PROMPT_COMMAND
@@ -102,8 +122,9 @@ class ShellHookTestCase(WoswoarTestCase):
         so a test can assert the other tool still ran.
         """
         result = subprocess.run(
-            ["bash", "--norc", "-i"],
-            input=f"{textwrap.dedent(before)}\nsource {HOOK}\n{textwrap.dedent(script)}",
+            self.INTERPRETER,
+            input=f"{self.PREAMBLE}{textwrap.dedent(before)}\nsource {self.HOOK}\n"
+            f"{textwrap.dedent(script)}",
             text=True,
             env=self.shell_env(env_extra),
             stdout=subprocess.PIPE,
@@ -138,6 +159,21 @@ class ShellHookTestCase(WoswoarTestCase):
     def by_cmd(self) -> dict[str, Entry]:
         """Recorded entries indexed by command, for asserting on metadata."""
         return {e.cmd: e for e in self.recorded()}
+
+
+#: Bases for the classes shared with the zsh suite. `object` at runtime, so that
+#: unittest's loader -- which collects every TestCase subclass in a module,
+#: whatever it is called -- does not also run each mixin as an extra,
+#: unparameterised copy of the bash suite. The real base is restored for mypy,
+#: which otherwise cannot see `assertEqual` or `run_shell` on `self`. Making the
+#: mixin skip itself instead is not available: CI runs the hook job with
+#: `--no-skips`, deliberately.
+if TYPE_CHECKING:
+    SharedTestBase = unittest.TestCase
+    SharedShellTestBase = ShellHookTestCase
+else:
+    SharedTestBase = object
+    SharedShellTestBase = object
 
 
 @requires_bash5
@@ -472,8 +508,7 @@ class TestCoexistence(ShellHookTestCase):
         self.assertEqual(self.commands(), ["echo only-this"])
 
 
-@requires_bash5
-class TestEscapeParity(unittest.TestCase):
+class EscapeParityMixin(SharedTestBase):
     """The drift guard.
 
     Calls the hook's ``__woswoar_escape`` directly rather than going through an
@@ -482,7 +517,16 @@ class TestEscapeParity(unittest.TestCase):
     tab before the command even runs (a real terminal, where readline handles
     bracketed paste, does not). Testing the function directly exercises the
     thing that can actually drift.
+
+    Parameterised over ``(NONINTERACTIVE, HOOK)`` so that both hooks are checked
+    against **one** corpus and one set of assertions. A second copy of
+    ``ESCAPE_CORPUS`` for zsh would be exactly the thing this class's own
+    argument says not to have.
     """
+
+    #: How to run a scrap of shell with ``$1`` set: ``[*argv, script, "$0", value]``.
+    NONINTERACTIVE: ClassVar[list[str]] = ["bash", "--norc", "-c"]
+    HOOK: ClassVar[Path] = BASH_HOOK
 
     _extracted: Path
     _tmpdir: tempfile.TemporaryDirectory[str]
@@ -492,23 +536,23 @@ class TestEscapeParity(unittest.TestCase):
         # Lift the function out of the real hook rather than copying it here --
         # a copy would be one more thing that can drift. The hook itself cannot
         # be sourced non-interactively; it returns early by design.
-        source = HOOK.read_text(encoding="utf-8")
+        source = cls.HOOK.read_text(encoding="utf-8")
         match = re.search(r"^__woswoar_escape\(\) \{\n.*?^\}$", source, re.MULTILINE | re.DOTALL)
-        assert match is not None, "__woswoar_escape not found in the hook"
+        assert match is not None, f"__woswoar_escape not found in {cls.HOOK.name}"
         cls._tmpdir = tempfile.TemporaryDirectory(prefix="woswoar-escape-")
-        cls._extracted = Path(cls._tmpdir.name) / "escape.bash"
+        cls._extracted = Path(cls._tmpdir.name) / "escape.sh"
         cls._extracted.write_text(match.group(0) + "\n", encoding="utf-8")
 
     @classmethod
     def tearDownClass(cls) -> None:
         cls._tmpdir.cleanup()
 
-    def escape_in_bash(self, value: str) -> str:
+    def escape_in_shell(self, value: str) -> str:
         script = (
             f'source "{self._extracted}"; __woswoar_escape "$1"; printf %s "$__woswoar_escaped"'
         )
         out = subprocess.run(
-            ["bash", "--norc", "-c", script, "bash", value],
+            [*self.NONINTERACTIVE, script, "shell", value],
             capture_output=True,
             text=True,
             check=True,
@@ -518,20 +562,25 @@ class TestEscapeParity(unittest.TestCase):
     def test_matches_python_escape(self) -> None:
         for value in ESCAPE_CORPUS:
             with self.subTest(value=value):
-                self.assertEqual(self.escape_in_bash(value), escape(value))
+                self.assertEqual(self.escape_in_shell(value), escape(value))
 
-    def test_python_can_unescape_what_bash_produced(self) -> None:
+    def test_python_can_unescape_what_the_shell_produced(self) -> None:
         for value in ESCAPE_CORPUS:
             with self.subTest(value=value):
-                self.assertEqual(unescape(self.escape_in_bash(value)), value)
+                self.assertEqual(unescape(self.escape_in_shell(value)), value)
 
-    def test_bash_output_is_always_single_line(self) -> None:
+    def test_shell_output_is_always_single_line(self) -> None:
         for value in ESCAPE_CORPUS:
             with self.subTest(value=value):
-                encoded = self.escape_in_bash(value)
+                encoded = self.escape_in_shell(value)
                 self.assertNotIn("\n", encoded)
                 self.assertNotIn("\t", encoded)
                 self.assertNotIn("\r", encoded)
+
+
+@requires_bash5
+class TestBashEscapeParity(EscapeParityMixin, unittest.TestCase):
+    pass
 
 
 @requires_bash5
@@ -626,25 +675,35 @@ class TestFiltering(ShellHookTestCase):
         self.assertLess(micros, 1_000_000, "the ignore pattern went superlinear again")
 
 
-@requires_bash5
-class TestTheDefaultIgnorePattern(ShellHookTestCase):
+class DefaultIgnorePatternMixin(SharedShellTestBase):
     """What the shipped pattern does and does not catch.
 
-    Evaluated by the same bash that will run it, against the value the hook
+    Evaluated by the same shell that will run it, against the value the hook
     actually sets -- not against a copy in this file, which could drift from the
     hook and keep passing. One shell tests the whole corpus, because starting a
-    bash per command would cost more than the rest of the suite.
+    shell per command would cost more than the rest of the suite.
+
+    Run against **both** hooks, for exactly the reason above: the pattern is a
+    string in two files, `[[ =~ ]]` is a different implementation in each shell,
+    and a rule that catches `PGPASSWORD=` in bash and not in zsh is a secret
+    published to a git repository. `TestTheIgnorePatternIsSharedByBothShells`
+    pins the two strings together; this pins what each shell does with it.
     """
 
     def classify(self, commands: list[str]) -> dict[str, bool]:
-        """Ask a real bash which of `commands` the default pattern matches."""
+        """Ask a real shell which of `commands` the default pattern matches."""
+        # Through `set --` rather than a named array: bash indexes from 0 and
+        # zsh from 1, `${!a[@]}` is bash-only, and one loop that means the same
+        # thing in both shells is worth more here than the array was.
         array = " ".join(shlex.quote(command) for command in commands)
         out = self.run_shell(
-            f"__corpus=({array})\n"
+            f"set -- {array}\n"
             'printf "PATTERN %s\\n" "${#WOSWOAR_IGNORE}"\n'
-            'for i in "${!__corpus[@]}"; do\n'
-            '  [[ ${__corpus[i]} =~ $WOSWOAR_IGNORE ]] && printf "MATCH %s\\n" "$i" '
-            '|| printf "KEEP %s\\n" "$i"\n'
+            "__i=0\n"
+            'for __c in "$@"; do\n'
+            '  [[ $__c =~ $WOSWOAR_IGNORE ]] && printf "MATCH %s\\n" "$__i" '
+            '|| printf "KEEP %s\\n" "$__i"\n'
+            "  __i=$((__i + 1))\n"
             "done\n"
         )
 
@@ -685,39 +744,81 @@ class TestTheDefaultIgnorePattern(ShellHookTestCase):
 
 
 @requires_bash5
-class TestConstantParity(unittest.TestCase):
+class TestTheBashDefaultIgnorePattern(DefaultIgnorePatternMixin, ShellHookTestCase):
+    pass
+
+
+class ConstantParityMixin(SharedTestBase):
     """The hook hardcodes values that live in Python; pin them together.
 
     ``escape`` has its own parity test. These two constants were mirrored into
     the hook with only a comment to keep them honest, so changing
-    ``MAX_CMD_CHARS`` in Python would silently leave bash truncating at the old
-    length with the old marker, and CI would stay green.
+    ``MAX_CMD_CHARS`` in Python would silently leave the shell truncating at the
+    old length with the old marker, and CI would stay green. There are two hooks
+    now, so each carries its own copy and each needs pinning.
     """
+
+    HOOK: ClassVar[Path] = BASH_HOOK
 
     source: str
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.source = HOOK.read_text(encoding="utf-8")
+        cls.source = cls.HOOK.read_text(encoding="utf-8")
 
     def test_truncation_length_matches(self) -> None:
         match = re.search(r"^__woswoar_max=(\d+)$", self.source, re.MULTILINE)
-        assert match is not None, "__woswoar_max not found in the hook"
+        assert match is not None, f"__woswoar_max not found in {self.HOOK.name}"
         self.assertEqual(int(match.group(1)), MAX_CMD_CHARS)
 
     def test_truncation_marker_matches(self) -> None:
         self.assertIn(f"'{TRUNCATION_MARKER}'", self.source)
 
+
+@requires_bash5
+class TestConstantParity(ConstantParityMixin, unittest.TestCase):
     def test_hook_requires_the_documented_bash_version(self) -> None:
         # doctor reports "5.0+ required" independently; make sure the gate the
         # hook actually enforces is the same one.
         self.assertIn("BASH_VERSINFO[0] < 5", self.source)
 
 
-@requires_bash5
-@unittest.skipUnless(shutil.which("strace"), "strace required")
-class TestForkFree(ShellHookTestCase):
-    """Recording runs on every prompt, so its cost must not scale with usage."""
+class TestTheIgnorePatternIsSharedByBothShells(unittest.TestCase):
+    """One credential filter, spelled out in two files.
+
+    `DefaultIgnorePatternMixin` asks each shell what the pattern it holds does,
+    so a rule missing from one of them is caught there -- but only as 87 corpus
+    entries suddenly classified differently, in whichever suite happens to run.
+    This says the simpler thing directly: the two strings are the same string.
+    It is the cheap half, and it is the half that fails with a useful message
+    when someone extends the pattern in the hook they happened to be editing.
+    """
+
+    #: `: "${WOSWOAR_IGNORE=...}"`, whose closing brace is the last one on the
+    #: line -- the pattern itself contains braces, so a non-greedy match would
+    #: stop inside it.
+    ASSIGNMENT = re.compile(r'^: "\$\{WOSWOAR_IGNORE=(?P<pattern>.*)\}"$', re.MULTILINE)
+
+    def pattern(self, hook: Path) -> str:
+        match = self.ASSIGNMENT.search(hook.read_text(encoding="utf-8"))
+        assert match is not None, f"no WOSWOAR_IGNORE default in {hook.name}"
+        return match.group("pattern")
+
+    def test_both_hooks_ship_the_same_default(self) -> None:
+        bash = self.pattern(BASH_HOOK)
+        # Long enough to be the real thing: an empty capture would make the two
+        # trivially equal and assert nothing.
+        self.assertGreater(len(bash), 100)
+        self.assertEqual(bash, self.pattern(ZSH_HOOK))
+
+
+class CloneScalingMixin(SharedShellTestBase):
+    """Recording runs on every prompt, so its cost must not scale with usage.
+
+    The measurement, and the one assertion that is the same claim for either
+    shell. Everything bash-specific about forking -- the boot string, the shapes
+    of PROMPT_COMMAND that can leave it behind -- stays in `TestForkFree`.
+    """
 
     def clone_count(
         self,
@@ -727,8 +828,8 @@ class TestForkFree(ShellHookTestCase):
     ) -> int:
         script = "".join(f"echo cmd{i}\n" for i in range(command_count))
         proc = subprocess.run(
-            ["strace", "-f", "-c", "-e", "trace=clone,clone3,vfork,fork", "bash", "--norc", "-i"],
-            input=f"{textwrap.dedent(before)}\nsource {HOOK}\n{script}",
+            ["strace", "-f", "-c", "-e", "trace=clone,clone3,vfork,fork", *self.INTERPRETER],
+            input=f"{self.PREAMBLE}{textwrap.dedent(before)}\nsource {self.HOOK}\n{script}",
             text=True,
             env=self.shell_env(env_extra),
             stdout=subprocess.DEVNULL,
@@ -754,6 +855,24 @@ class TestForkFree(ShellHookTestCase):
     #: pins them with a stamp file rather than with a clock.
     NO_SYNC: ClassVar[dict[str, str]] = {"WOSWOAR_SYNC_INTERVAL": "0"}
 
+    def test_clone_count_does_not_scale_with_commands(self) -> None:
+        # Not "zero forks": startup legitimately runs mkdir, and bash two
+        # `trap -p` subshells besides. What matters is that the per-command path
+        # adds nothing, so the count must be identical for 3 and for 30 commands.
+        few = self.clone_count(3, self.NO_SYNC)
+        many = self.clone_count(30, self.NO_SYNC)
+        self.assertEqual(
+            few,
+            many,
+            f"record path forks: {few} clones for 3 commands, {many} for 30",
+        )
+
+
+@requires_bash5
+@unittest.skipUnless(shutil.which("strace"), "strace required")
+class TestForkFree(CloneScalingMixin, ShellHookTestCase):
+    """The bash-specific half: which PROMPT_COMMAND shapes can leave a fork behind."""
+
     def stamp_opens(self, command_count: int) -> int:
         """How many times the shell opened the sync stamp across the run.
 
@@ -766,7 +885,7 @@ class TestForkFree(ShellHookTestCase):
         script = "".join(f"echo cmd{i}\n" for i in range(command_count))
         proc = subprocess.run(
             ["strace", "-f", "-e", "trace=openat", "bash", "--norc", "-i"],
-            input=f"source {HOOK}\n{script}",
+            input=f"source {BASH_HOOK}\n{script}",
             text=True,
             env=self.shell_env(),
             stdout=subprocess.DEVNULL,
@@ -791,16 +910,14 @@ class TestForkFree(ShellHookTestCase):
         self.assertGreater(few, 0, "the stamp was never consulted at all")
         self.assertEqual(few, many, f"{few} stamp reads for 3 commands, {many} for 30")
 
-    def test_clone_count_does_not_scale_with_commands(self) -> None:
-        # Not "zero forks": startup legitimately runs mkdir and two `trap -p`
-        # subshells -- one to see whether the EXIT trap is free, one at the first
-        # prompt to read any prior DEBUG trap. What matters is that the
-        # per-command path adds nothing, so the count must be identical for 3 and
-        # for 30 commands. That also pins the boot string removing itself: were
-        # it left in PROMPT_COMMAND, its substitution would fork every time.
+    def test_neither_scratch_file_branch_forks_per_command(self) -> None:
+        # `CloneScalingMixin` already makes the bare claim for both shells; this
+        # is the half only bash has. The scratch file's directory is chosen at
+        # startup, and a fork added to either branch would be paid on every
+        # command of that shell.
         #
-        # Both scratch-file branches, because they are chosen at startup and a
-        # fork added to either would be paid on every command of that shell.
+        # It also pins the boot string removing itself: were it left in
+        # PROMPT_COMMAND, its substitution would fork at every prompt.
         for label, extra in (("runtime dir", {}), ("fallback", {"XDG_RUNTIME_DIR": ""})):
             with self.subTest(scratch=label):
                 env = {**self.NO_SYNC, **extra}
@@ -1180,7 +1297,7 @@ class TestRecordingIsPrivate(ShellHookTestCase):
         being left behind, which is the direction that silently reopens the
         hole this class exists for.
         """
-        source = HOOK.read_text(encoding="utf-8")
+        source = BASH_HOOK.read_text(encoding="utf-8")
         self.assertIn("umask 077", source)
         self.assertEqual(store.DIR_MODE, 0o700)
         self.assertEqual(store.FILE_MODE, 0o600)
@@ -1477,7 +1594,7 @@ class TestCtrlRLandsOnThePrompt(ShellHookTestCase):
     def test_the_selection_arrives_for_editing_and_does_not_run(self) -> None:
         steps = [
             Typed("", self.PROMPT),
-            Typed(f"source {HOOK}; echo LOAD''ED\n", "LOADED"),
+            Typed(f"source {BASH_HOOK}; echo LOAD''ED\n", "LOADED"),
             # `LOADED` is printed while bash is still running the line; the
             # prompt after it is what says readline has the terminal back.
             Typed("", self.PROMPT),

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -108,6 +108,20 @@ class ShellHookTestCase(WoswoarTestCase):
         env.update(extra or {})
         return env
 
+    def shell_input(self, script: str, before: str = "") -> str:
+        """What gets typed at the shell: preamble, ``before``, the hook, ``script``.
+
+        One place, because two callers already assemble it -- `run_shell` and
+        `CloneScalingMixin.clone_count` -- and a third spelling of "how a
+        ~/.bashrc is shaped" is a way for the fork count to be measured against
+        a shell the behaviour tests never run.
+        """
+        return (
+            f"{self.PREAMBLE}{textwrap.dedent(before)}\n"
+            f"source {self.HOOK}\n"
+            f"{textwrap.dedent(script)}"
+        )
+
     def run_shell(
         self,
         script: str,
@@ -123,8 +137,7 @@ class ShellHookTestCase(WoswoarTestCase):
         """
         result = subprocess.run(
             self.INTERPRETER,
-            input=f"{self.PREAMBLE}{textwrap.dedent(before)}\nsource {self.HOOK}\n"
-            f"{textwrap.dedent(script)}",
+            input=self.shell_input(script, before),
             text=True,
             env=self.shell_env(env_extra),
             stdout=subprocess.PIPE,
@@ -160,6 +173,28 @@ class ShellHookTestCase(WoswoarTestCase):
         """Recorded entries indexed by command, for asserting on metadata."""
         return {e.cmd: e for e in self.recorded()}
 
+    def raw_logs(self) -> str:
+        """Every byte the hook wrote, unparsed.
+
+        The assertion of choice for anything about a command that must *not* be
+        recorded. `commands()` goes through the parser and the cache, either of
+        which could drop a line for its own reasons -- so "the secret is not in
+        `commands()`" is a weaker claim than the one that matters, which is that
+        it is nowhere on disk.
+        """
+        return "".join(
+            path.read_text(encoding="utf-8") for path in sorted(store.logs_dir().rglob("*.tsv"))
+        )
+
+    def logdir(self) -> Path:
+        """Where this machine's days are written.
+
+        `store`'s idea of the path, not a second copy of it: the layout under
+        `logs/` is rule 8 territory, and a test that spells it out by hand is one
+        more place to remember.
+        """
+        return store.host_dir(MACHINE_ID)
+
 
 #: Bases for the classes shared with the zsh suite. `object` at runtime, so that
 #: unittest's loader -- which collects every TestCase subclass in a module,
@@ -176,25 +211,31 @@ else:
     SharedShellTestBase = object
 
 
-@requires_bash5
-class TestCapture(ShellHookTestCase):
+class CaptureMixin(SharedShellTestBase):
+    """What either hook must record, and what it must record *about* a command.
+
+    Every claim here was written twice before it was written once: these bodies
+    were byte-identical in the two suites, which is the shape that lets a new
+    metadata column or a changed cwd rule be covered for one shell and silently
+    not for the other. What stays behind in each suite is what the two shells
+    genuinely disagree about -- how a multi-line command reads, where the exit
+    status comes from, whether `$2` exists to be got wrong.
+    """
+
     def test_records_a_plain_command(self) -> None:
         self.run_shell("echo hello\n")
         self.assertEqual(self.commands(), ["echo hello"])
 
     def test_records_the_whole_compound_line(self) -> None:
-        # $BASH_COMMAND would report only "true a" here. Capturing the full line
-        # is the entire reason the hook reads from `history` instead.
+        # $BASH_COMMAND would report only "true a" here, which is the entire
+        # reason the bash hook reads from `history` instead; zsh's preexec is
+        # handed the line outright. Two mechanisms, one claim.
         self.run_shell("true a && true b\n")
         self.assertEqual(self.commands(), ["true a && true b"])
 
     def test_records_a_pipeline_in_full(self) -> None:
         self.run_shell("echo x | cat\n")
         self.assertEqual(self.commands(), ["echo x | cat"])
-
-    def test_records_a_multiline_loop_as_one_entry(self) -> None:
-        self.run_shell("for i in 1 2; do\ntrue $i\ndone\n")
-        self.assertEqual(self.commands(), ["for i in 1 2; do true $i; done"])
 
     def test_blank_lines_record_nothing(self) -> None:
         self.run_shell("\n\n\necho only-this\n\n")
@@ -210,7 +251,8 @@ class TestCapture(ShellHookTestCase):
 
     def test_session_id_is_compact_and_hex(self) -> None:
         # Repeated on every line, so its size is not cosmetic. <second>-<pid>,
-        # both hex.
+        # both hex -- and lower case, which zsh's `[##16]` does not give for
+        # free.
         self.run_shell("echo hello\n")
         session = self.recorded()[0].session
         self.assertRegex(session, r"^[0-9a-f]+-[0-9a-f]+$")
@@ -258,12 +300,24 @@ class TestCapture(ShellHookTestCase):
         self.assertLess(entry.duration_ms, 30_000)
 
     def test_duration_survives_a_comma_decimal_locale(self) -> None:
-        # $EPOCHREALTIME honours LC_NUMERIC, so it reads "1785321992,048777"
-        # under a de_AT locale. Splitting on "." alone silently yields garbage.
+        # bash's $EPOCHREALTIME honours LC_NUMERIC, so it reads
+        # "1785321992,048777" under a de_AT locale and splitting on "." alone
+        # silently yields garbage. zsh's does not -- but both hooks tolerate the
+        # comma, and a bound on the duration is what says so.
         self.run_shell("sleep 0.3\n", env_extra={"LC_NUMERIC": "de_AT.UTF-8"})
         entry = self.recorded()[0]
         self.assertGreaterEqual(entry.duration_ms, 250)
         self.assertLess(entry.duration_ms, 30_000)
+
+
+@requires_bash5
+class TestCapture(CaptureMixin, ShellHookTestCase):
+    def test_records_a_multiline_loop_as_one_entry(self) -> None:
+        """Per-shell on purpose: bash reads the line back out of `history`, which
+        joins it with semicolons, where zsh is handed the buffer as typed. Both
+        are faithful, so the zsh suite states its own expectation."""
+        self.run_shell("for i in 1 2; do\ntrue $i\ndone\n")
+        self.assertEqual(self.commands(), ["for i in 1 2; do true $i; done"])
 
 
 @requires_bash5
@@ -783,35 +837,6 @@ class TestConstantParity(ConstantParityMixin, unittest.TestCase):
         self.assertIn("BASH_VERSINFO[0] < 5", self.source)
 
 
-class TestTheIgnorePatternIsSharedByBothShells(unittest.TestCase):
-    """One credential filter, spelled out in two files.
-
-    `DefaultIgnorePatternMixin` asks each shell what the pattern it holds does,
-    so a rule missing from one of them is caught there -- but only as 87 corpus
-    entries suddenly classified differently, in whichever suite happens to run.
-    This says the simpler thing directly: the two strings are the same string.
-    It is the cheap half, and it is the half that fails with a useful message
-    when someone extends the pattern in the hook they happened to be editing.
-    """
-
-    #: `: "${WOSWOAR_IGNORE=...}"`, whose closing brace is the last one on the
-    #: line -- the pattern itself contains braces, so a non-greedy match would
-    #: stop inside it.
-    ASSIGNMENT = re.compile(r'^: "\$\{WOSWOAR_IGNORE=(?P<pattern>.*)\}"$', re.MULTILINE)
-
-    def pattern(self, hook: Path) -> str:
-        match = self.ASSIGNMENT.search(hook.read_text(encoding="utf-8"))
-        assert match is not None, f"no WOSWOAR_IGNORE default in {hook.name}"
-        return match.group("pattern")
-
-    def test_both_hooks_ship_the_same_default(self) -> None:
-        bash = self.pattern(BASH_HOOK)
-        # Long enough to be the real thing: an empty capture would make the two
-        # trivially equal and assert nothing.
-        self.assertGreater(len(bash), 100)
-        self.assertEqual(bash, self.pattern(ZSH_HOOK))
-
-
 class CloneScalingMixin(SharedShellTestBase):
     """Recording runs on every prompt, so its cost must not scale with usage.
 
@@ -829,7 +854,7 @@ class CloneScalingMixin(SharedShellTestBase):
         script = "".join(f"echo cmd{i}\n" for i in range(command_count))
         proc = subprocess.run(
             ["strace", "-f", "-c", "-e", "trace=clone,clone3,vfork,fork", *self.INTERPRETER],
-            input=f"{self.PREAMBLE}{textwrap.dedent(before)}\nsource {self.HOOK}\n{script}",
+            input=self.shell_input(script, before),
             text=True,
             env=self.shell_env(env_extra),
             stdout=subprocess.DEVNULL,
@@ -855,28 +880,11 @@ class CloneScalingMixin(SharedShellTestBase):
     #: pins them with a stamp file rather than with a clock.
     NO_SYNC: ClassVar[dict[str, str]] = {"WOSWOAR_SYNC_INTERVAL": "0"}
 
-    def test_clone_count_does_not_scale_with_commands(self) -> None:
-        # Not "zero forks": startup legitimately runs mkdir, and bash two
-        # `trap -p` subshells besides. What matters is that the per-command path
-        # adds nothing, so the count must be identical for 3 and for 30 commands.
-        few = self.clone_count(3, self.NO_SYNC)
-        many = self.clone_count(30, self.NO_SYNC)
-        self.assertEqual(
-            few,
-            many,
-            f"record path forks: {few} clones for 3 commands, {many} for 30",
-        )
-
-
-@requires_bash5
-@unittest.skipUnless(shutil.which("strace"), "strace required")
-class TestForkFree(CloneScalingMixin, ShellHookTestCase):
-    """The bash-specific half: which PROMPT_COMMAND shapes can leave a fork behind."""
-
     def stamp_opens(self, command_count: int) -> int:
         """How many times the shell opened the sync stamp across the run.
 
-        The fork count cannot see this: skipping the `__woswoar_next_sync` memo
+        Both hooks carry the `__woswoar_next_sync` memo, so both are measured
+        here. The fork count cannot see it: skipping the memo
         adds a file open per prompt, not a fork, so the clone-count assertions
         stay green while every command grows a syscall. Counted the same way and
         for the same reason -- a per-command cost has to be pinned by something
@@ -884,8 +892,8 @@ class TestForkFree(CloneScalingMixin, ShellHookTestCase):
         """
         script = "".join(f"echo cmd{i}\n" for i in range(command_count))
         proc = subprocess.run(
-            ["strace", "-f", "-e", "trace=openat", "bash", "--norc", "-i"],
-            input=f"source {BASH_HOOK}\n{script}",
+            ["strace", "-f", "-e", "trace=openat", *self.INTERPRETER],
+            input=self.shell_input(script),
             text=True,
             env=self.shell_env(),
             stdout=subprocess.DEVNULL,
@@ -909,6 +917,24 @@ class TestForkFree(CloneScalingMixin, ShellHookTestCase):
         few, many = counts
         self.assertGreater(few, 0, "the stamp was never consulted at all")
         self.assertEqual(few, many, f"{few} stamp reads for 3 commands, {many} for 30")
+
+    def test_clone_count_does_not_scale_with_commands(self) -> None:
+        # Not "zero forks": startup legitimately runs mkdir, and bash two
+        # `trap -p` subshells besides. What matters is that the per-command path
+        # adds nothing, so the count must be identical for 3 and for 30 commands.
+        few = self.clone_count(3, self.NO_SYNC)
+        many = self.clone_count(30, self.NO_SYNC)
+        self.assertEqual(
+            few,
+            many,
+            f"record path forks: {few} clones for 3 commands, {many} for 30",
+        )
+
+
+@requires_bash5
+@unittest.skipUnless(shutil.which("strace"), "strace required")
+class TestForkFree(CloneScalingMixin, ShellHookTestCase):
+    """The bash-specific half: which PROMPT_COMMAND shapes can leave a fork behind."""
 
     def test_neither_scratch_file_branch_forks_per_command(self) -> None:
         # `CloneScalingMixin` already makes the bare claim for both shells; this
@@ -975,17 +1001,21 @@ class TestForkFree(CloneScalingMixin, ShellHookTestCase):
                 self.assertEqual(few, many, f"{label}: {few} clones for 3 commands, {many} for 30")
 
 
-@requires_bash5
-class TestPromptTriggeredSync(ShellHookTestCase):
+class PromptSyncMixin(SharedShellTestBase):
     """Syncing from the prompt instead of a systemd timer (#134).
 
-    Driven with a real bash and a stand-in `woswoar` on PATH that records that
+    Driven with a real shell and a stand-in `woswoar` on PATH that records that
     it was called, because what is under test is the shell's decision -- when to
     fire, when to stay quiet, and that the prompt never waits for the answer.
 
     Time is never slept on. Every "the interval has passed" case is set up by
     writing the stamp file, so nothing here can become slow or flaky on a loaded
     runner.
+
+    The fixture and the three claims that are about the *decision* rather than
+    about a shell's syntax are shared, so the reasoning below -- why the stub
+    sleeps three seconds, why it lives outside the sandbox -- is written once and
+    cannot be dropped from a copy.
     """
 
     def setUp(self) -> None:
@@ -1083,6 +1113,41 @@ class TestPromptTriggeredSync(ShellHookTestCase):
             time.sleep(0.05)
         return seen
 
+    def test_it_syncs_once_per_interval_not_once_per_command(self) -> None:
+        """The whole cost argument in #134 rests on this number."""
+        self.run_shell("".join(f"echo cmd{i}\n" for i in range(30)))
+        self.assertEqual(self.syncs(), 1)
+
+    def test_the_stamp_is_owner_only(self) -> None:
+        """It is written by the shell, so `>` alone would create it 0644 and
+        `doctor` would report an exposure in woswoar's own data directory."""
+        self.run_shell("")
+        self.syncs()
+        self.assertTrue(self.stamp.exists(), "no stamp was written")
+        self.assertEqual(self.stamp.stat().st_mode & 0o077, 0)
+
+    def test_the_sync_never_enters_the_shells_job_table(self) -> None:
+        """A plain `&` would print `[1] 1234` and later `[1]+ Done` at the
+        prompt, once a minute for the life of the shell.
+
+        Asserted through `jobs` rather than by looking for `[1]` in the output,
+        because bash only prints those notifications when job control is on and
+        a shell reading a pipe has it off -- so the notification itself is
+        invisible to this harness and a test looking for it passes against a
+        bare `&`. Job *table* membership is the same fact and is observable
+        here. The stand-in sleeps, so the job is still running when `jobs` asks.
+        """
+        out = self.run_shell("echo marker\njobs\n")
+        self.assertIn("marker", out, "precondition: the shell ran at all")
+        self.assertNotIn("woswoar sync", out, "the sync is a job of this shell")
+
+
+@requires_bash5
+class TestPromptTriggeredSync(PromptSyncMixin, ShellHookTestCase):
+    """The cases whose answer is spelled in bash: what `((...))` does with a
+    value that is not a number, and what it prints when it refuses.
+    """
+
     def test_the_detached_sync_writes_nowhere_the_sandbox_is_being_deleted(self) -> None:
         """#167, stated as the invariant rather than as the race.
 
@@ -1109,11 +1174,6 @@ class TestPromptTriggeredSync(ShellHookTestCase):
     def test_a_shell_that_types_nothing_still_syncs_at_startup(self) -> None:
         """Sitting down and pressing Ctrl-R has to show current history."""
         self.run_shell("")
-        self.assertEqual(self.syncs(), 1)
-
-    def test_it_syncs_once_per_interval_not_once_per_command(self) -> None:
-        """The whole cost argument in #134 rests on this number."""
-        self.run_shell("".join(f"echo cmd{i}\n" for i in range(30)))
         self.assertEqual(self.syncs(), 1)
 
     def test_a_fresh_stamp_from_another_shell_suppresses_the_sync(self) -> None:
@@ -1232,29 +1292,6 @@ class TestPromptTriggeredSync(ShellHookTestCase):
                     "an unreadable stamp was believed rather than replaced",
                 )
 
-    def test_the_stamp_is_owner_only(self) -> None:
-        """It is written by the shell, so `>` alone would create it 0644 and
-        `doctor` would report an exposure in woswoar's own data directory."""
-        self.run_shell("")
-        self.syncs()
-        self.assertTrue(self.stamp.exists(), "no stamp was written")
-        self.assertEqual(self.stamp.stat().st_mode & 0o077, 0)
-
-    def test_the_sync_never_enters_the_shells_job_table(self) -> None:
-        """A plain `&` would print `[1] 1234` and later `[1]+ Done` at the
-        prompt, once a minute for the life of the shell.
-
-        Asserted through `jobs` rather than by looking for `[1]` in the output,
-        because bash only prints those notifications when job control is on and
-        a shell reading a pipe has it off -- so the notification itself is
-        invisible to this harness and a test looking for it passes against a
-        bare `&`. Job *table* membership is the same fact and is observable
-        here. The stand-in sleeps, so the job is still running when `jobs` asks.
-        """
-        out = self.run_shell("echo marker\njobs\n")
-        self.assertIn("marker", out, "precondition: the shell ran at all")
-        self.assertNotIn("woswoar sync", out, "the sync is a job of this shell")
-
     def test_junk_in_the_stamp_does_not_reach_shell_arithmetic(self) -> None:
         """Bash evaluates array subscripts inside `((...))`, so a value read
         from a file and handed straight to arithmetic executes what is in it.
@@ -1275,17 +1312,18 @@ class TestPromptTriggeredSync(ShellHookTestCase):
         self.assertFalse(canary.exists(), "the stamp's contents were executed")
 
 
-@requires_bash5
-class TestRecordingIsPrivate(ShellHookTestCase):
+class RecordingIsPrivateMixin(SharedShellTestBase):
     """The hook creates the log file, so the hook is where its mode is decided.
 
     Python never touches that file on the recording path, so a fix in `store`
-    alone would not have covered the case this exists for.
+    alone would not have covered the case this exists for -- and a hook the
+    parity test below does not read is a hook that can be left behind when
+    `store.DIR_MODE` changes. It reads `self.HOOK`, so every hook is covered.
     """
 
     def test_the_day_file_is_owner_only_under_a_stock_umask(self) -> None:
         self.run_shell("echo hello\n")
-        files = list((Path(os.environ["WOSWOAR_DIR"]) / "logs" / "hosts").rglob("*.tsv"))
+        files = sorted(self.logdir().parent.rglob("*.tsv"))
         self.assertTrue(files, "nothing was recorded")
         for path in files:
             self.assertEqual(path.stat().st_mode & 0o077, 0, f"{path} is world-readable")
@@ -1297,16 +1335,20 @@ class TestRecordingIsPrivate(ShellHookTestCase):
         being left behind, which is the direction that silently reopens the
         hole this class exists for.
         """
-        source = BASH_HOOK.read_text(encoding="utf-8")
+        source = self.HOOK.read_text(encoding="utf-8")
         self.assertIn("umask 077", source)
         self.assertEqual(store.DIR_MODE, 0o700)
         self.assertEqual(store.FILE_MODE, 0o600)
 
+
+@requires_bash5
+class TestRecordingIsPrivate(RecordingIsPrivateMixin, ShellHookTestCase):
     def test_the_hook_leaves_the_shell_umask_alone(self) -> None:
         """It drops to 077 to create the file; it must put it back.
 
         Otherwise every file the user creates afterwards would silently become
-        0600 -- a surprising thing for a history tool to do to a shell.
+        0600 -- a surprising thing for a history tool to do to a shell. Not
+        shared: bash's `umask` prints `0022` and zsh's prints `022`.
         """
         out = self.run_shell("echo start\numask\n")
         self.assertIn("0022", out)
@@ -1525,21 +1567,24 @@ class TestThePtyHarness(unittest.TestCase):
         self.assertIn("41 123", chunks[1])
 
 
-@requires_bash5
-class TestCtrlRLandsOnThePrompt(ShellHookTestCase):
+class CtrlROnThePromptMixin(SharedShellTestBase):
     """The one property that keeps a recalled command from running by itself.
 
     Every other test of the widget checks a piece of it from the outside: what
     the picker would print, what the cycle binding decides. None of them press
-    the key, because the key does nothing without a terminal -- `bind -x` is
-    readline, and readline does no line editing on a pipe. So the claim the
-    whole feature rests on, that a selection arrives *on the prompt for editing*
-    and is never executed, was guarded by nothing at all.
+    the key, because the key does nothing without a terminal -- readline does no
+    line editing on a pipe, and neither does zle. So the claim the whole feature
+    rests on, that a selection arrives *on the prompt for editing* and is never
+    executed, was guarded by nothing at all.
 
-    Here it is driven: a real bash, a real readline, a real pty, the real hook.
-    What is stubbed is the picker itself -- the widget's contract with it is one
-    line on stdout, and fzf choosing that line needs its own test rather than a
-    share of this one.
+    Here it is driven: a real shell, a real line editor, a real pty, the real
+    hook. What is stubbed is the picker itself -- the widget's contract with it
+    is one line on stdout, and fzf choosing that line needs its own test rather
+    than a share of this one.
+
+    Shared between the two suites because none of it is shell-specific once the
+    interpreter and the hook are class attributes: `bind -x` and `zle -N` differ,
+    but what they must *do* does not.
     """
 
     #: What the picker hands back, and what running it would print. Two strings
@@ -1553,7 +1598,7 @@ class TestCtrlRLandsOnThePrompt(ShellHookTestCase):
     SELECTION = "echo RAN''MARK"
     IF_EXECUTED = "RANMARK"
 
-    #: Handed to bash in the environment, so the harness waits for a string it
+    #: Handed to the shell in the environment, so the harness waits for a string it
     #: has never typed. It doubles as the "readline is listening" signal:
     #: readline puts the terminal into raw mode *before* it draws the prompt, so
     #: a prompt on screen means the next keypress reaches the widget rather than
@@ -1583,9 +1628,9 @@ class TestCtrlRLandsOnThePrompt(ShellHookTestCase):
                 # Not `dumb`, which the rest of this file uses: this is the one
                 # test that wants readline to behave as it does for a person.
                 "TERM": "xterm",
-                # Bash only defaults PS1 when it is unset, so handing it in is
-                # enough -- and it means the harness never *types* the string it
-                # waits for to know the shell is up.
+                # Both shells default PS1 only when it is unset, so handing it
+                # in is enough -- and it means the harness never *types* the
+                # string it waits for to know the shell is up.
                 "PS1": self.PROMPT,
                 "WOSWOAR_TEST_SELECTION": self.SELECTION,
             }
@@ -1594,9 +1639,9 @@ class TestCtrlRLandsOnThePrompt(ShellHookTestCase):
     def test_the_selection_arrives_for_editing_and_does_not_run(self) -> None:
         steps = [
             Typed("", self.PROMPT),
-            Typed(f"source {BASH_HOOK}; echo LOAD''ED\n", "LOADED"),
-            # `LOADED` is printed while bash is still running the line; the
-            # prompt after it is what says readline has the terminal back.
+            Typed(f"source {self.HOOK}; echo LOAD''ED\n", "LOADED"),
+            # `LOADED` is printed while the shell is still running the line; the
+            # prompt after it is what says the line editor has the terminal back.
             Typed("", self.PROMPT),
             # Ctrl-R, and then wait for the recalled text. That text is a marker
             # the harness has not typed, so its only possible source is readline
@@ -1604,16 +1649,15 @@ class TestCtrlRLandsOnThePrompt(ShellHookTestCase):
             Typed("\x12", self.SELECTION),
             # Typed where the widget left the cursor, so it lands *after* the
             # recalled command rather than in front of it, and then Enter. A
-            # READLINE_POINT of 0 would run `EXTRAecho ...` instead, and this
-            # step would time out with the transcript.
+            # cursor position of 0 -- READLINE_POINT under bash, CURSOR under
+            # zsh -- would run `EXTRAecho ...` instead, and this step would time
+            # out with the transcript.
             Typed(" EXTRA\r", f"{self.IF_EXECUTED} EXTRA"),
         ]
         # Named rather than indexed: the two that matter are the last two, and a
         # step inserted above must not silently move an assertion onto the wrong
         # screen.
-        *_, after_keypress, after_enter = run_in_pty(
-            ["bash", "--norc", "-i"], steps, env=self.picker_env()
-        )
+        *_, after_keypress, after_enter = run_in_pty(self.INTERPRETER, steps, env=self.picker_env())
 
         self.assertNotIn(
             self.IF_EXECUTED,
@@ -1621,3 +1665,8 @@ class TestCtrlRLandsOnThePrompt(ShellHookTestCase):
             "the keypress executed the selection instead of offering it for editing",
         )
         self.assertIn(f"{self.IF_EXECUTED} EXTRA", after_enter, "the edited line is what ran")
+
+
+@requires_bash5
+class TestCtrlRLandsOnThePrompt(CtrlROnThePromptMixin, ShellHookTestCase):
+    pass

--- a/tests/test_shell_hook_zsh.py
+++ b/tests/test_shell_hook_zsh.py
@@ -19,26 +19,26 @@ to a git repository.
 
 from __future__ import annotations
 
-import os
-import shlex
 import shutil
 import subprocess
-import tempfile
-import time
 import unittest
 from pathlib import Path
 from typing import ClassVar
 
-from woswoar import search, store
+from woswoar import search
 
-from .support import MACHINE_ID, Typed, run_in_pty
+from .support import MACHINE_ID
 from .test_shell_hook import (
     BASH_HOOK,
     ZSH_HOOK,
+    CaptureMixin,
     CloneScalingMixin,
     ConstantParityMixin,
+    CtrlROnThePromptMixin,
     DefaultIgnorePatternMixin,
     EscapeParityMixin,
+    PromptSyncMixin,
+    RecordingIsPrivateMixin,
     ShellHookTestCase,
 )
 
@@ -79,18 +79,6 @@ class ZshHookTestCase(ShellHookTestCase):
     #: alone. It runs before the hook is sourced, so it is never recorded.
     PREAMBLE: ClassVar[str] = "PS1=; PS2=; unsetopt promptcr promptsp; print\n"
 
-    def raw_logs(self) -> str:
-        """Every byte the hook wrote, unparsed.
-
-        The assertion of choice for anything about a command that must *not* be
-        recorded. `commands()` goes through the parser and the cache, either of
-        which could drop a line for its own reasons -- so "the secret is not in
-        `commands()`" is a weaker claim than the one that matters, which is that
-        it is nowhere on disk.
-        """
-        logs = (Path(os.environ["WOSWOAR_DIR"]) / "logs").rglob("*.tsv")
-        return "".join(path.read_text(encoding="utf-8") for path in logs)
-
     def assertRecorded(self, expected: list[str]) -> None:
         """Which commands were recorded, and how many times each -- not in which order.
 
@@ -108,18 +96,10 @@ class ZshHookTestCase(ShellHookTestCase):
 
 
 @requires_zsh5
-class TestCapture(ZshHookTestCase):
-    def test_records_a_plain_command(self) -> None:
-        self.run_shell("echo hello\n")
-        self.assertEqual(self.commands(), ["echo hello"])
-
-    def test_records_the_whole_compound_line(self) -> None:
-        self.run_shell("true a && true b\n")
-        self.assertEqual(self.commands(), ["true a && true b"])
-
-    def test_records_a_pipeline_in_full(self) -> None:
-        self.run_shell("echo x | cat\n")
-        self.assertEqual(self.commands(), ["echo x | cat"])
+class TestCapture(CaptureMixin, ZshHookTestCase):
+    """`CaptureMixin` carries every claim the two shells share. What is left here
+    is where zsh differs: it is handed the command line rather than reading it
+    back, and its `$?` has to be caught before `emulate` clobbers it."""
 
     def test_a_multiline_loop_is_one_record(self) -> None:
         """The one place the two shells legitimately record different text.
@@ -151,87 +131,6 @@ class TestCapture(ZshHookTestCase):
         """
         self.run_shell("_marker() { echo inside-the-body }\n")
         self.assertEqual(self.commands(), ["_marker() { echo inside-the-body }"])
-
-    def test_blank_lines_record_nothing(self) -> None:
-        self.run_shell("\n\n\necho only-this\n\n")
-        self.assertEqual(self.commands(), ["echo only-this"])
-
-    def test_the_prompt_at_which_the_hook_loads_records_nothing(self) -> None:
-        # `preexec` had not been registered when the `source` line ran, so
-        # nothing was captured for it -- but `precmd` fires at the prompt that
-        # follows, with the state a fresh shell left behind.
-        self.run_shell("echo only-this\n")
-        self.assertEqual(self.commands(), ["echo only-this"])
-
-    def test_metadata_is_captured(self) -> None:
-        self.run_shell("cd /tmp\nfalse\n")
-        by_cmd = self.by_cmd()
-        self.assertEqual(by_cmd["false"].exit_code, 1)
-        self.assertEqual(by_cmd["false"].cwd, "/tmp")
-        self.assertEqual(by_cmd["false"].host, MACHINE_ID)
-        self.assertTrue(by_cmd["false"].session)
-
-    def test_session_id_is_compact_and_hex(self) -> None:
-        # Built with `[##16]`, which yields *upper* case; the `(L)` that fixes
-        # that is the whole reason this assertion is repeated for zsh.
-        self.run_shell("echo hello\n")
-        session = self.recorded()[0].session
-        self.assertRegex(session, r"^[0-9a-f]+-[0-9a-f]+$")
-        self.assertLessEqual(len(session), 16)
-
-    def test_two_shells_get_different_sessions(self) -> None:
-        self.run_shell("echo one\n")
-        self.run_shell("echo two\n")
-        sessions = {e.session for e in self.recorded()}
-        self.assertEqual(len(sessions), 2, "session id must be unique per shell")
-
-    def test_home_is_stored_as_tilde(self) -> None:
-        self.run_shell("cd ~\ntrue marker\n")
-        self.assertEqual(self.by_cmd()["true marker"].cwd, "~")
-
-    def test_path_under_home_is_stored_relative(self) -> None:
-        (self.root / "src").mkdir(exist_ok=True)
-        self.run_shell("cd ~/src\ntrue marker\n")
-        self.assertEqual(self.by_cmd()["true marker"].cwd, "~/src")
-
-    def test_path_outside_home_stays_absolute(self) -> None:
-        self.run_shell("cd /tmp\ntrue marker\n")
-        self.assertEqual(self.by_cmd()["true marker"].cwd, "/tmp")
-
-    def test_sibling_of_home_is_not_mangled(self) -> None:
-        # The trap in ${PWD/#$HOME/~}: with $HOME=/home/martinus it rewrites
-        # /home/martinuscopy to ~copy. Anchored matching must leave it alone.
-        sibling = self.root.parent / f"{self.root.name}-sibling"
-        sibling.mkdir(exist_ok=True)
-        self.addCleanup(sibling.rmdir)
-        self.run_shell(f"cd {sibling}\ntrue marker\n")
-        self.assertEqual(self.by_cmd()["true marker"].cwd, str(sibling))
-
-    def test_duration_is_measured(self) -> None:
-        """Bounded from both sides, and that is the point of it.
-
-        zsh's $EPOCHREALTIME carries *ten* fractional digits where bash's carries
-        six, so woswoar.bash's "strip three characters" conversion is wrong here
-        by a factor of 10,000 -- and a lower bound alone passes with flying
-        colours when the answer is ten thousand times too large.
-        """
-        self.run_shell("sleep 0.3\n")
-        entry = self.recorded()[0]
-        self.assertEqual(entry.cmd, "sleep 0.3")
-        self.assertGreaterEqual(entry.duration_ms, 250)
-        self.assertLess(entry.duration_ms, 30_000)
-
-    def test_duration_survives_a_comma_decimal_locale(self) -> None:
-        """zsh 5.9 formats $EPOCHREALTIME with a period whatever LC_NUMERIC says,
-        where bash does not -- so this passes today with the comma substitution
-        removed. It is kept because the failure it guards is silent and awful: a
-        comma reaching `$((...))` is the comma *operator*, which evaluates to the
-        fractional part and calls it a timestamp.
-        """
-        self.run_shell("sleep 0.3\n", env_extra={"LC_NUMERIC": "de_AT.UTF-8"})
-        entry = self.recorded()[0]
-        self.assertGreaterEqual(entry.duration_ms, 250)
-        self.assertLess(entry.duration_ms, 30_000)
 
     def test_exit_codes_are_recorded(self) -> None:
         """`emulate -L zsh` clobbers $?, so the capture has to come first.
@@ -461,14 +360,7 @@ class TestOptionsThatWouldSilenceRecording(ZshHookTestCase):
 
 
 @requires_zsh5
-class TestRecordingIsPrivate(ZshHookTestCase):
-    def test_the_day_file_is_owner_only_under_a_stock_umask(self) -> None:
-        self.run_shell("echo hello\n")
-        files = list((Path(os.environ["WOSWOAR_DIR"]) / "logs" / "hosts").rglob("*.tsv"))
-        self.assertTrue(files, "nothing was recorded")
-        for path in files:
-            self.assertEqual(path.stat().st_mode & 0o077, 0, f"{path} is world-readable")
-
+class TestRecordingIsPrivate(RecordingIsPrivateMixin, ZshHookTestCase):
     def test_every_line_written_is_parseable(self) -> None:
         self.run_shell("echo 'a\tb'\necho 'c\\d'\nfor i in 1; do\ntrue\ndone\necho done\n")
         raw = self.raw_logs()
@@ -488,9 +380,6 @@ class TestALostLogDirectory(ZshHookTestCase):
     catches it, and without one the user gets a path printed at the prompt after
     every command, which is exactly the bug 0.4.1 shipped.
     """
-
-    def logdir(self) -> Path:
-        return Path(os.environ["WOSWOAR_DIR"]) / "logs" / "hosts" / MACHINE_ID
 
     def test_losing_it_mid_session_is_silent(self) -> None:
         out = self.run_shell(
@@ -528,8 +417,13 @@ class TestAZshAndABashShellShareOneHistory(ZshHookTestCase):
     file, and every Ctrl-R re-reads it.
     """
 
-    def test_each_shell_sees_the_others_commands(self) -> None:
-        self.run_shell("echo from_the_zsh_shell\n")
+    def run_a_bash_shell(self) -> None:
+        """One command through the *other* hook, into the same sandbox.
+
+        Not `run_shell`: that one is this suite's zsh. The point of the class is
+        that the two programs land in one file, so one of them has to be spelled
+        out.
+        """
         subprocess.run(
             ["bash", "--norc", "-i"],
             input=f"source {BASH_HOOK}\necho from_the_bash_shell\n",
@@ -540,6 +434,10 @@ class TestAZshAndABashShellShareOneHistory(ZshHookTestCase):
             check=False,
             timeout=60,
         )
+
+    def test_each_shell_sees_the_others_commands(self) -> None:
+        self.run_shell("echo from_the_zsh_shell\n")
+        self.run_a_bash_shell()
         shown = [search.command_from_line(line) for line in search.lines_for("global")]
         self.assertIn("echo from_the_zsh_shell", shown)
         self.assertIn("echo from_the_bash_shell", shown)
@@ -553,88 +451,16 @@ class TestAZshAndABashShellShareOneHistory(ZshHookTestCase):
         reachable from two different programs at once, so it is worth saying
         that they really do share the file."""
         self.run_shell("echo from_the_zsh_shell\n")
-        subprocess.run(
-            ["bash", "--norc", "-i"],
-            input=f"source {BASH_HOOK}\necho from_the_bash_shell\n",
-            text=True,
-            env=self.shell_env(),
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-            timeout=60,
-        )
-        files = sorted((Path(os.environ["WOSWOAR_DIR"]) / "logs" / "hosts").rglob("*.tsv"))
+        self.run_a_bash_shell()
+        files = sorted(self.logdir().parent.rglob("*.tsv"))
         self.assertEqual(len(files), 1, f"two shells wrote {len(files)} files: {files}")
 
 
 @requires_zsh5
-class TestPromptTriggeredSync(ZshHookTestCase):
-    """The zsh half of #134, which is a straight port -- so this covers what
-    porting it could have got wrong rather than the feature again.
-
-    Time is never slept on: every "the interval has passed" case is set up by
-    writing the stamp file.
-    """
-
-    def setUp(self) -> None:
-        super().setUp()
-        # Outside the sandbox, for the reason `tests/test_shell_hook.py` spells
-        # out at length: the stand-in is run by a process nobody waits for, and
-        # a file it creates mid-`rmtree` fails an unrelated test.
-        stub_root = Path(tempfile.mkdtemp(prefix="woswoar-zsyncstub-"))
-        self.addCleanup(shutil.rmtree, stub_root, ignore_errors=True)
-        self.calls = stub_root / "sync-calls"
-
-        bindir = self.root / "bin"
-        bindir.mkdir(exist_ok=True)
-        fake = bindir / "woswoar"
-        fake.write_text(
-            f'#!/bin/sh\necho "$*" >> {shlex.quote(str(self.calls))}\nsleep 3\n',
-            encoding="utf-8",
-        )
-        fake.chmod(0o755)
-        self.bindir = bindir
-        self.repo = store.history_dir()
-        (self.repo / ".git").mkdir(parents=True, exist_ok=True)
-        self.stamp = store.sync_stamp_file()
-
-    def shell_env(self, extra: dict[str, str] | None = None) -> dict[str, str]:
-        return super().shell_env(
-            {"PATH": f"{self.bindir}:{os.environ.get('PATH', '')}", **(extra or {})}
-        )
-
-    def syncs(self, timeout: float = 20.0) -> int:
-        deadline = time.monotonic() + timeout
-        seen = 0
-        while time.monotonic() < deadline:
-            if self.calls.exists():
-                lines = self.calls.read_text(encoding="utf-8").splitlines()
-                if lines and len(lines) == seen:
-                    return seen
-                seen = len(lines)
-            time.sleep(0.05)
-        return seen
-
-    def test_it_syncs_once_per_interval_not_once_per_command(self) -> None:
-        self.run_shell("".join(f"echo cmd{i}\n" for i in range(30)))
-        self.assertEqual(self.syncs(), 1)
-
-    def test_the_sync_never_enters_the_shells_job_table(self) -> None:
-        """A plain `&` would report the job at the prompt once a minute forever.
-
-        Asserted through `jobs` rather than by looking for `[1]` in the output:
-        a shell reading a pipe has job control off, so the notification itself is
-        invisible here and a test looking for it passes against a bare `&`.
-        """
-        out = self.run_shell("echo marker\njobs\n")
-        self.assertIn("marker", out, "precondition: the shell ran at all")
-        self.assertNotIn("woswoar sync", out, "the sync is a job of this shell")
-
-    def test_the_stamp_is_owner_only(self) -> None:
-        self.run_shell("")
-        self.syncs()
-        self.assertTrue(self.stamp.exists(), "no stamp was written")
-        self.assertEqual(self.stamp.stat().st_mode & 0o077, 0)
+class TestPromptTriggeredSync(PromptSyncMixin, ZshHookTestCase):
+    """`PromptSyncMixin` owns the stand-in, the polling and the claims about
+    *when* a sync fires. What is left is what zsh does with a value that is not a
+    number, which is not what bash does with one."""
 
     def test_a_hostile_interval_from_the_environment_never_reaches_arithmetic(self) -> None:
         """`WOSWOAR_SYNC_INTERVAL` is inherited: whatever started your shell sets it.
@@ -735,71 +561,10 @@ class TestForkFree(CloneScalingMixin, ZshHookTestCase):
 
 
 @requires_zsh5
-class TestCtrlRLandsOnThePrompt(ZshHookTestCase):
-    """The one property that keeps a recalled command from running by itself.
-
-    `zle` does nothing without a terminal, so this needs a real pty, a real zsh
-    and the real hook. What is stubbed is the picker: the widget's contract with
-    it is one line on stdout.
-    """
-
-    #: What the picker hands back, and what running it would print. Two strings
-    #: on purpose: a terminal echoes what you type at it, so if the recalled text
-    #: and the executed output were spelled the same, "it did not run" would be
-    #: satisfied by the harness's own echo of the line -- `CLAUDE.md` rule 3,
-    #: fourth bullet. The empty `''` is removed by the shell that runs the line
-    #: and by nothing else.
-    SELECTION = "echo RAN''MARK"
-    IF_EXECUTED = "RANMARK"
-
-    PROMPT = "ps> "
-
-    def picker_env(self) -> dict[str, str]:
-        bin_dir = self.root / "bin"
-        bin_dir.mkdir(exist_ok=True)
-        fake = bin_dir / "woswoar"
-        fake.write_text(
-            "#!/bin/sh\n"
-            # Anything but `search` exits quietly: the hook reaches for
-            # `woswoar sync` too, and a complaint would land on the terminal
-            # this test reads.
-            '[ "$1" = search ] || exit 0\n'
-            "printf '%s\\n' \"$WOSWOAR_TEST_SELECTION\"\n",
-            encoding="utf-8",
-        )
-        fake.chmod(0o755)
-        return self.shell_env(
-            {
-                "PATH": f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
-                "TERM": "xterm",
-                "PS1": self.PROMPT,
-                "WOSWOAR_TEST_SELECTION": self.SELECTION,
-            }
-        )
-
-    def test_the_selection_arrives_for_editing_and_does_not_run(self) -> None:
-        steps = [
-            Typed("", self.PROMPT),
-            Typed(f"source {ZSH_HOOK}; echo LOAD''ED\n", "LOADED"),
-            Typed("", self.PROMPT),
-            # Ctrl-R, then wait for text the harness has not typed: its only
-            # possible source is zle redrawing the buffer the widget filled in.
-            Typed("\x12", self.SELECTION),
-            # Typed where the widget left the cursor, so it lands *after* the
-            # recalled command. A CURSOR of 0 would run `EXTRAecho ...` instead
-            # and this step would time out with the transcript.
-            Typed(" EXTRA\r", f"{self.IF_EXECUTED} EXTRA"),
-        ]
-        *_, after_keypress, after_enter = run_in_pty(
-            ["zsh", "-f", "-i"], steps, env=self.picker_env()
-        )
-
-        self.assertNotIn(
-            self.IF_EXECUTED,
-            after_keypress,
-            "the keypress executed the selection instead of offering it for editing",
-        )
-        self.assertIn(f"{self.IF_EXECUTED} EXTRA", after_enter, "the edited line is what ran")
+class TestCtrlRLandsOnThePrompt(CtrlROnThePromptMixin, ZshHookTestCase):
+    """The pty test itself is the mixin's -- `self.INTERPRETER` and `self.HOOK`
+    are the only things in it that were ever shell-specific. What is left is the
+    binding, which is `bindkey` here and `bind -x` there."""
 
     def test_the_binding_is_skipped_when_asked(self) -> None:
         """`WOSWOAR_NO_BIND=1` is what a user keeping atuin's Ctrl-R sets, and

--- a/tests/test_shell_hook_zsh.py
+++ b/tests/test_shell_hook_zsh.py
@@ -1,0 +1,812 @@
+"""Contract tests for the zsh hook.
+
+A sibling of ``tests/test_shell_hook.py``, not a rewrite of it. What the two
+hooks must agree on -- the escape function, the two constants mirrored from
+Python, the credential filter, the fork count -- is asserted by mixins that live
+in that file and are subclassed here, so there is one corpus and one set of
+assertions for both shells.
+
+What is left is the part where zsh is genuinely a different shell, and it is
+almost all about *not recording*. bash hands the hook a signal for "I declined
+to store that line" -- the history number did not move -- and woswoar.bash
+defers to it, which buys HISTCONTROL, `ignoredups` and HISTIGNORE for nothing.
+zsh offers no such signal: $HISTCMD moves backwards over an ignored line and
+$history still holds a space-hidden command while `preexec` runs. So the hook
+reimplements those rules, and every one of them is a test here -- HIST_IGNORE_SPACE
+most of all, because that is how a person hides a secret and a miss publishes it
+to a git repository.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from typing import ClassVar
+
+from woswoar import search, store
+
+from .support import MACHINE_ID, Typed, run_in_pty
+from .test_shell_hook import (
+    BASH_HOOK,
+    ZSH_HOOK,
+    CloneScalingMixin,
+    ConstantParityMixin,
+    DefaultIgnorePatternMixin,
+    EscapeParityMixin,
+    ShellHookTestCase,
+)
+
+
+def zsh_major() -> int:
+    zsh = shutil.which("zsh")
+    if not zsh:
+        return 0
+    out = subprocess.run(
+        [zsh, "-f", "-c", "echo ${ZSH_VERSION%%.*}"], capture_output=True, text=True, check=False
+    )
+    return int(out.stdout.strip() or 0)
+
+
+requires_zsh5 = unittest.skipUnless(zsh_major() >= 5, "zsh 5.0+ required")
+
+
+class ZshHookTestCase(ShellHookTestCase):
+    """The bash harness, pointed at zsh.
+
+    ``-f`` rather than bash's ``--norc``: same idea, no startup files, so the
+    only thing in this shell is what the test put there.
+    """
+
+    INTERPRETER: ClassVar[list[str]] = ["zsh", "-f", "-i"]
+    HOOK: ClassVar[Path] = ZSH_HOOK
+
+    #: bash draws no prompt when its stdin is a pipe. zsh does, and decorates
+    #: it: `PROMPT_SP` prints an inverse `%` for a partial line and `PROMPT_CR` a
+    #: carriage return, so the first thing a test's own `printf` shares a line
+    #: with is a `\r` and a `%`. That is not cosmetic -- assertions here match
+    #: whole lines, and `for> for> KEEP 0` is not the line the test is looking
+    #: for. PS2 is cleared for the same reason: it is what puts those `for>`s in
+    #: front of the first line a multi-line command prints.
+    #:
+    #: The trailing `print` flushes the prompts drawn *before* this line took
+    #: effect onto a line of their own, so every line after it is the shell's
+    #: alone. It runs before the hook is sourced, so it is never recorded.
+    PREAMBLE: ClassVar[str] = "PS1=; PS2=; unsetopt promptcr promptsp; print\n"
+
+    def raw_logs(self) -> str:
+        """Every byte the hook wrote, unparsed.
+
+        The assertion of choice for anything about a command that must *not* be
+        recorded. `commands()` goes through the parser and the cache, either of
+        which could drop a line for its own reasons -- so "the secret is not in
+        `commands()`" is a weaker claim than the one that matters, which is that
+        it is nowhere on disk.
+        """
+        logs = (Path(os.environ["WOSWOAR_DIR"]) / "logs").rglob("*.tsv")
+        return "".join(path.read_text(encoding="utf-8") for path in logs)
+
+    def assertRecorded(self, expected: list[str]) -> None:
+        """Which commands were recorded, and how many times each -- not in which order.
+
+        `recorded()` sorts by `(ts, duration_ms)`, and three `echo`s inside one
+        second share a timestamp and differ only in a duration of 0 or 1
+        milliseconds. So the order it returns is decided by which of them
+        happened to take the extra millisecond, and asserting on it is a flake
+        that reproduces about once in ten runs -- observed, not predicted.
+
+        Sorting both sides costs nothing here: every claim in this file is about
+        the set of commands that survived a history rule, never about their
+        order.
+        """
+        self.assertEqual(sorted(self.commands()), sorted(expected))
+
+
+@requires_zsh5
+class TestCapture(ZshHookTestCase):
+    def test_records_a_plain_command(self) -> None:
+        self.run_shell("echo hello\n")
+        self.assertEqual(self.commands(), ["echo hello"])
+
+    def test_records_the_whole_compound_line(self) -> None:
+        self.run_shell("true a && true b\n")
+        self.assertEqual(self.commands(), ["true a && true b"])
+
+    def test_records_a_pipeline_in_full(self) -> None:
+        self.run_shell("echo x | cat\n")
+        self.assertEqual(self.commands(), ["echo x | cat"])
+
+    def test_a_multiline_loop_is_one_record(self) -> None:
+        """The one place the two shells legitimately record different text.
+
+        bash reads the line back out of `history`, which joins it with
+        semicolons; zsh is handed the buffer the user typed, newlines and all.
+        Both are faithful to their shell, so this is a per-shell expectation
+        rather than a shared one.
+
+        It is also the only test in either suite where a real newline reaches
+        `__woswoar_escape` through a shell. Drop the `\\n` substitution and this
+        record becomes three lines, none of which parses.
+        """
+        self.run_shell("for i in 1 2; do\ntrue $i\ndone\n")
+        raw = self.raw_logs()
+        self.assertEqual(raw.count("\n"), 1, f"the record did not stay on one line: {raw!r}")
+        self.assertTrue(raw.rstrip("\n").endswith(r"for i in 1 2; do\ntrue $i\ndone"), raw)
+        # And what comes back out carries a *visible* `\n`, which is
+        # `entry.make_inert` and not a failure to unescape: a recalled multi-line
+        # command must not arrive in the edit buffer as several commands.
+        self.assertEqual(self.commands(), [r"for i in 1 2; do\ntrue $i\ndone"])
+
+    def test_a_function_definition_is_recorded_whole(self) -> None:
+        """`preexec` is handed the command line twice, and $2 is lossy.
+
+        $2 is the "expanded" form, and it renders a function body as
+        `f () { ... }` -- the three dots literally. Reading it instead of $1
+        would record a definition nobody can get back.
+        """
+        self.run_shell("_marker() { echo inside-the-body }\n")
+        self.assertEqual(self.commands(), ["_marker() { echo inside-the-body }"])
+
+    def test_blank_lines_record_nothing(self) -> None:
+        self.run_shell("\n\n\necho only-this\n\n")
+        self.assertEqual(self.commands(), ["echo only-this"])
+
+    def test_the_prompt_at_which_the_hook_loads_records_nothing(self) -> None:
+        # `preexec` had not been registered when the `source` line ran, so
+        # nothing was captured for it -- but `precmd` fires at the prompt that
+        # follows, with the state a fresh shell left behind.
+        self.run_shell("echo only-this\n")
+        self.assertEqual(self.commands(), ["echo only-this"])
+
+    def test_metadata_is_captured(self) -> None:
+        self.run_shell("cd /tmp\nfalse\n")
+        by_cmd = self.by_cmd()
+        self.assertEqual(by_cmd["false"].exit_code, 1)
+        self.assertEqual(by_cmd["false"].cwd, "/tmp")
+        self.assertEqual(by_cmd["false"].host, MACHINE_ID)
+        self.assertTrue(by_cmd["false"].session)
+
+    def test_session_id_is_compact_and_hex(self) -> None:
+        # Built with `[##16]`, which yields *upper* case; the `(L)` that fixes
+        # that is the whole reason this assertion is repeated for zsh.
+        self.run_shell("echo hello\n")
+        session = self.recorded()[0].session
+        self.assertRegex(session, r"^[0-9a-f]+-[0-9a-f]+$")
+        self.assertLessEqual(len(session), 16)
+
+    def test_two_shells_get_different_sessions(self) -> None:
+        self.run_shell("echo one\n")
+        self.run_shell("echo two\n")
+        sessions = {e.session for e in self.recorded()}
+        self.assertEqual(len(sessions), 2, "session id must be unique per shell")
+
+    def test_home_is_stored_as_tilde(self) -> None:
+        self.run_shell("cd ~\ntrue marker\n")
+        self.assertEqual(self.by_cmd()["true marker"].cwd, "~")
+
+    def test_path_under_home_is_stored_relative(self) -> None:
+        (self.root / "src").mkdir(exist_ok=True)
+        self.run_shell("cd ~/src\ntrue marker\n")
+        self.assertEqual(self.by_cmd()["true marker"].cwd, "~/src")
+
+    def test_path_outside_home_stays_absolute(self) -> None:
+        self.run_shell("cd /tmp\ntrue marker\n")
+        self.assertEqual(self.by_cmd()["true marker"].cwd, "/tmp")
+
+    def test_sibling_of_home_is_not_mangled(self) -> None:
+        # The trap in ${PWD/#$HOME/~}: with $HOME=/home/martinus it rewrites
+        # /home/martinuscopy to ~copy. Anchored matching must leave it alone.
+        sibling = self.root.parent / f"{self.root.name}-sibling"
+        sibling.mkdir(exist_ok=True)
+        self.addCleanup(sibling.rmdir)
+        self.run_shell(f"cd {sibling}\ntrue marker\n")
+        self.assertEqual(self.by_cmd()["true marker"].cwd, str(sibling))
+
+    def test_duration_is_measured(self) -> None:
+        """Bounded from both sides, and that is the point of it.
+
+        zsh's $EPOCHREALTIME carries *ten* fractional digits where bash's carries
+        six, so woswoar.bash's "strip three characters" conversion is wrong here
+        by a factor of 10,000 -- and a lower bound alone passes with flying
+        colours when the answer is ten thousand times too large.
+        """
+        self.run_shell("sleep 0.3\n")
+        entry = self.recorded()[0]
+        self.assertEqual(entry.cmd, "sleep 0.3")
+        self.assertGreaterEqual(entry.duration_ms, 250)
+        self.assertLess(entry.duration_ms, 30_000)
+
+    def test_duration_survives_a_comma_decimal_locale(self) -> None:
+        """zsh 5.9 formats $EPOCHREALTIME with a period whatever LC_NUMERIC says,
+        where bash does not -- so this passes today with the comma substitution
+        removed. It is kept because the failure it guards is silent and awful: a
+        comma reaching `$((...))` is the comma *operator*, which evaluates to the
+        fractional part and calls it a timestamp.
+        """
+        self.run_shell("sleep 0.3\n", env_extra={"LC_NUMERIC": "de_AT.UTF-8"})
+        entry = self.recorded()[0]
+        self.assertGreaterEqual(entry.duration_ms, 250)
+        self.assertLess(entry.duration_ms, 30_000)
+
+    def test_exit_codes_are_recorded(self) -> None:
+        """`emulate -L zsh` clobbers $?, so the capture has to come first.
+
+        Get the order wrong and every command in the log is a success -- the
+        same class of bug woswoar.bash carries a prepended PROMPT_COMMAND entry
+        to avoid, reached by a different route.
+        """
+        self.run_shell("false\ntrue\n(exit 42)\n")
+        by_cmd = self.by_cmd()
+        self.assertEqual(by_cmd["false"].exit_code, 1)
+        self.assertEqual(by_cmd["true"].exit_code, 0)
+        self.assertEqual(by_cmd["(exit 42)"].exit_code, 42)
+
+    def test_the_hook_returns_the_status_it_was_given(self) -> None:
+        """Called directly, because that is the only way to see the return value.
+
+        zsh hands each `precmd_functions` entry the user's own $? regardless of
+        what the entry before it returned -- observed on 5.9, and the reason the
+        sibling test below passes either way. Whether that is a promise or an
+        implementation detail is not written down anywhere, so the hook returns
+        the status explicitly; this is what says the line is doing something.
+        """
+        out = self.run_shell("false; __woswoar_precmd; printf 'RC[%s]\\n' \"$?\"\n")
+        self.assertIn("RC[1]", out)
+
+    def test_a_later_precmd_hook_still_sees_the_real_status(self) -> None:
+        """The property a user's exit-code-colouring prompt depends on."""
+        before = """
+            autoload -Uz add-zsh-hook
+            _later() { printf 'LATER[%s]\\n' "$?" }
+            add-zsh-hook precmd _later
+        """
+        out = self.run_shell("false\n", before=before)
+        self.assertIn("LATER[1]", out)
+        self.assertEqual(self.by_cmd()["false"].exit_code, 1)
+
+
+@requires_zsh5
+class TestTheHistoryRulesZshDoesNotHandOver(ZshHookTestCase):
+    """The rules bash gives woswoar for free and zsh does not.
+
+    Every one of these was verified to *need* reimplementing before it was
+    written: `preexec` fires for space-prefixed, duplicate and
+    HISTORY_IGNORE-matching lines alike, and none of the three signals zsh does
+    offer can tell them apart. $HISTCMD read at `precmd` over
+    `echo a` / ` echo spaced` / `echo a` / `echo a` / `echo b` goes 5, 6, 5, 5, 6
+    -- so "did it advance" drops the next real command after every ignored one.
+    """
+
+    def test_hist_ignore_space_is_respected(self) -> None:
+        """A leading space is how a person keeps a command out of history.
+
+        In woswoar a missed one is not merely recorded, it is encrypted, pushed
+        to a git repository and pulled onto every other machine. So this asserts
+        against the bytes on disk rather than against `commands()`, which would
+        also pass if the parser happened to drop the line for some other reason.
+        """
+        out = self.run_shell(
+            " echo hidden-marker\necho visible-marker\n", before="setopt hist_ignore_space"
+        )
+        self.assertIn("hidden-marker", out, "precondition: the command really ran")
+        self.assertNotIn("hidden-marker", self.raw_logs())
+        self.assertIn("echo visible-marker", self.commands())
+
+    def test_hist_ignore_space_off_records_the_space_prefixed_line(self) -> None:
+        """Otherwise the test above passes against a hook that drops every line
+        beginning with whitespace, which is a different and much worse rule.
+
+        The `echo first` is not decoration: `run_shell` puts the script through
+        `textwrap.dedent`, so a lone indented line has its indentation removed
+        before the shell ever sees it -- and this test would then assert nothing
+        while looking exactly as it does now.
+        """
+        self.run_shell("echo first\n echo spaced-marker\n")
+        self.assertIn(" echo spaced-marker", self.commands())
+
+    def test_hist_ignore_dups_is_respected(self) -> None:
+        self.run_shell("echo twice\necho twice\necho after\n", before="setopt hist_ignore_dups")
+        self.assertRecorded(["echo twice", "echo after"])
+
+    def test_hist_ignore_all_dups_is_respected(self) -> None:
+        self.run_shell("echo twice\necho twice\necho after\n", before="setopt hist_ignore_all_dups")
+        self.assertRecorded(["echo twice", "echo after"])
+
+    def test_a_repeat_is_recorded_when_neither_option_is_set(self) -> None:
+        """The default. Without this the two above pass against a hook that
+        drops every repeated command, which is not what either option means."""
+        self.run_shell("echo twice\necho twice\n")
+        self.assertRecorded(["echo twice", "echo twice"])
+
+    def test_an_ignored_line_does_not_hide_the_command_after_it(self) -> None:
+        """The failure mode of every "did the history move" scheme on zsh.
+
+        $HISTCMD goes *backwards* over an ignored line, so a hook that watched it
+        would drop the next real command as well -- silently losing history that
+        the user did nothing to hide.
+
+        `echo two` twice, then `echo three`: the duplicate is what the option
+        asks to be dropped, and `echo three` is what says the run recovered
+        rather than stopping at the hidden line.
+        """
+        self.run_shell(
+            "echo one\n echo hidden\necho two\necho two\necho three\n",
+            before="setopt hist_ignore_space hist_ignore_dups",
+        )
+        self.assertRecorded(["echo one", "echo two", "echo three"])
+
+    def test_history_ignore_is_respected(self) -> None:
+        self.run_shell("cd /tmp\necho kept\n", before='HISTORY_IGNORE="(ls|cd *)"')
+        self.assertEqual(self.commands(), ["echo kept"])
+
+    def test_a_history_ignore_in_extended_glob_syntax_is_honoured(self) -> None:
+        """`emulate -L zsh` turns EXTENDED_GLOB *off*, and $HISTORY_IGNORE is the
+        user's pattern written in whichever dialect their options select.
+
+        `^echo*` means "anything but an echo" with the option on and something
+        else entirely with it off, so matching it in the wrong dialect records
+        exactly the commands they told zsh to forget. The option is therefore
+        read before emulating and put back afterwards.
+        """
+        self.run_shell(
+            "true dropped-marker\necho kept\n",
+            before="setopt extended_glob\nHISTORY_IGNORE='^echo*'",
+        )
+        self.assertEqual(self.commands(), ["echo kept"])
+
+    def test_a_history_ignore_holding_a_command_substitution_runs_nothing(self) -> None:
+        """`${~VAR}` is pattern interpretation, not evaluation.
+
+        It reads like `eval` and is not, and the difference is whether a value
+        that arrives from the environment can run a command on every prompt.
+        `$HISTORY_IGNORE` is an ordinary exported variable, so whatever started
+        your shell chooses it.
+        """
+        canary = self.root / "history-ignore-ran"
+        out = self.run_shell("echo marker\n", env_extra={"HISTORY_IGNORE": f"$(touch {canary})"})
+        self.assertIn("marker", out)
+        self.assertFalse(canary.exists(), "the pattern was evaluated as a command")
+        self.assertIn("echo marker", self.commands())
+
+    def test_an_aws_secret_never_reaches_the_log(self) -> None:
+        """$WOSWOAR_IGNORE is the one filter zsh and bash share outright."""
+        self.run_shell("export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI\necho safe\n")
+        self.assertEqual(self.commands(), ["echo safe"])
+        self.assertNotIn("wJalrXUtnFEMI", self.raw_logs())
+
+    def test_the_match_parameters_do_not_leak(self) -> None:
+        """A `[[ =~ ]]` sets six parameters, in the user's shell -- unless the
+        function declares all six local first. Four of them are `MATCH`,
+        `MBEGIN`, `MEND` and `match`, which are the names zsh's own globbing
+        uses, so leaking them is not merely untidy.
+
+        The command has to be one the pattern actually *matches*. zsh sets these
+        only on a successful match, so an ordinary `echo` leaves them alone
+        whether or not they were declared -- which is how this test first
+        managed to pass with the six `local`s deleted.
+        """
+        out = self.run_shell(
+            "export GITHUB_TOKEN=ghp_secret\n"
+            'printf "LEAK[%s][%s][%s][%s]\\n" '
+            '"${MATCH-unset}" "${MBEGIN-unset}" "${MEND-unset}" "${match-unset}"\n'
+        )
+        self.assertNotIn("ghp_secret", self.raw_logs(), "precondition: the pattern matched")
+        self.assertIn("LEAK[unset][unset][unset][unset]", out)
+
+
+@requires_zsh5
+class TestOptionsThatWouldSilenceRecording(ZshHookTestCase):
+    """Options a user sets for their own reasons that the hook must survive.
+
+    All of these fail the same way -- the hook loads, `doctor` is happy, and
+    nothing is ever written -- which is the failure worth the most tests.
+    """
+
+    def test_noclobber_does_not_silence_recording(self) -> None:
+        """`setopt noclobber` makes `>>` to a file that does not exist yet *fail*.
+
+        Not a corner: it is a common setting, and the day file does not exist at
+        the first command of every day. A zsh user with it set would record
+        nothing, ever, and nothing would say so. Guarded twice -- `emulate -L zsh`
+        clears NO_CLOBBER for the function, and the append is written `>>|`.
+        """
+        self.run_shell("echo hello\n", before="setopt noclobber")
+        self.assertEqual(self.commands(), ["echo hello"])
+
+    def test_recording_survives_a_shell_full_of_hostile_options(self) -> None:
+        """`emulate -L zsh` earns its place here.
+
+        Each of these changes the meaning of something on the record path:
+        KSH_ARRAYS the string subscripting, SH_WORD_SPLIT the expansions,
+        EXTENDED_GLOB the patterns, NO_UNSET every `${x-}` that is not written
+        defensively, and REMATCH_PCRE the credential filter.
+
+        WARN_CREATE_GLOBAL is the odd one out: it breaks nothing, it just talks.
+        `__woswoar_escape` assigns a global from inside a function, so without
+        `emulate` the user gets a line about it at their prompt after every
+        command -- which is the same kind of failure as the redirection message
+        above, and is why the output is asserted on and not only the log.
+        """
+        options = (
+            "ksh_arrays sh_word_split extended_glob no_unset"
+            " re_match_pcre noclobber warn_create_global"
+        )
+        out = self.run_shell(
+            "echo hello\nexport GITHUB_TOKEN=ghp_secret\n", before=f"setopt {options}"
+        )
+        self.assertEqual(self.commands(), ["echo hello"])
+        self.assertNotIn("ghp_secret", self.raw_logs())
+        self.assertNotIn("created globally", out)
+
+    def test_recording_works_without_add_zsh_hook(self) -> None:
+        """`add-zsh-hook` is autoloaded from $fpath, and $fpath is a variable.
+
+        A shell that cannot find it would otherwise register neither hook and
+        record nothing, so the wiring falls back to appending to the two arrays
+        itself -- which is all add-zsh-hook does with the names it is given.
+        """
+        out = self.run_shell("echo hello\n", before="fpath=()")
+        self.assertNotIn("command not found", out)
+        self.assertEqual(self.commands(), ["echo hello"])
+
+    def test_the_hook_leaves_the_shell_umask_alone(self) -> None:
+        """It drops to 077 to create the day file; it must put it back."""
+        out = self.run_shell("echo start\numask\n")
+        self.assertIn("022", out)
+
+
+@requires_zsh5
+class TestRecordingIsPrivate(ZshHookTestCase):
+    def test_the_day_file_is_owner_only_under_a_stock_umask(self) -> None:
+        self.run_shell("echo hello\n")
+        files = list((Path(os.environ["WOSWOAR_DIR"]) / "logs" / "hosts").rglob("*.tsv"))
+        self.assertTrue(files, "nothing was recorded")
+        for path in files:
+            self.assertEqual(path.stat().st_mode & 0o077, 0, f"{path} is world-readable")
+
+    def test_every_line_written_is_parseable(self) -> None:
+        self.run_shell("echo 'a\tb'\necho 'c\\d'\nfor i in 1; do\ntrue\ndone\necho done\n")
+        raw = self.raw_logs()
+        self.assertTrue(raw.endswith("\n"))
+        for line in raw.splitlines():
+            with self.subTest(line=line):
+                self.assertEqual(len(line.split("\t")), 6)
+
+
+@requires_zsh5
+class TestALostLogDirectory(ZshHookTestCase):
+    """Recording may stop. It may not talk about it.
+
+    zsh reports a failed redirection on the *shell's* stderr rather than the
+    command's, so woswoar.bash's fix for this -- ordering `2>/dev/null` ahead of
+    the append -- does nothing here, in either order. Only a surrounding block
+    catches it, and without one the user gets a path printed at the prompt after
+    every command, which is exactly the bug 0.4.1 shipped.
+    """
+
+    def logdir(self) -> Path:
+        return Path(os.environ["WOSWOAR_DIR"]) / "logs" / "hosts" / MACHINE_ID
+
+    def test_losing_it_mid_session_is_silent(self) -> None:
+        out = self.run_shell(
+            f"""
+            echo first
+            rm -rf {self.logdir()}
+            echo second
+            echo third
+            """
+        )
+        self.assertNotIn("no such file or directory", out.lower())
+        self.assertIn("third", out, "precondition: the shell kept running")
+
+    def test_it_comes_back_when_the_day_turns(self) -> None:
+        target = self.logdir()
+        self.run_shell(
+            f"""
+            echo before
+            rm -rf {target}
+            __woswoar_today=not-today
+            echo after
+            """
+        )
+        self.assertTrue(target.is_dir(), "the log directory was not remade")
+        self.assertEqual(target.stat().st_mode & 0o077, 0, "and not owner-only")
+        self.assertIn("echo after", self.commands(), f"recording did not resume: {self.commands()}")
+
+
+@requires_zsh5
+class TestAZshAndABashShellShareOneHistory(ZshHookTestCase):
+    """One machine id, one host directory, one day file -- whichever shell wrote it.
+
+    This is the case a user reaches by adding zsh to a machine that already runs
+    the bash hook, and it needs nothing to be exchanged: both append to the same
+    file, and every Ctrl-R re-reads it.
+    """
+
+    def test_each_shell_sees_the_others_commands(self) -> None:
+        self.run_shell("echo from_the_zsh_shell\n")
+        subprocess.run(
+            ["bash", "--norc", "-i"],
+            input=f"source {BASH_HOOK}\necho from_the_bash_shell\n",
+            text=True,
+            env=self.shell_env(),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=60,
+        )
+        shown = [search.command_from_line(line) for line in search.lines_for("global")]
+        self.assertIn("echo from_the_zsh_shell", shown)
+        self.assertIn("echo from_the_bash_shell", shown)
+
+        hosts = {entry.host for entry in self.recorded()}
+        self.assertEqual(hosts, {MACHINE_ID}, "the two shells disagreed about the machine")
+
+    def test_one_day_file_holds_both(self) -> None:
+        """O_APPEND is what makes that safe, and it is a property of the file
+        rather than of the shell doing the writing -- but it is only now
+        reachable from two different programs at once, so it is worth saying
+        that they really do share the file."""
+        self.run_shell("echo from_the_zsh_shell\n")
+        subprocess.run(
+            ["bash", "--norc", "-i"],
+            input=f"source {BASH_HOOK}\necho from_the_bash_shell\n",
+            text=True,
+            env=self.shell_env(),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=60,
+        )
+        files = sorted((Path(os.environ["WOSWOAR_DIR"]) / "logs" / "hosts").rglob("*.tsv"))
+        self.assertEqual(len(files), 1, f"two shells wrote {len(files)} files: {files}")
+
+
+@requires_zsh5
+class TestPromptTriggeredSync(ZshHookTestCase):
+    """The zsh half of #134, which is a straight port -- so this covers what
+    porting it could have got wrong rather than the feature again.
+
+    Time is never slept on: every "the interval has passed" case is set up by
+    writing the stamp file.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Outside the sandbox, for the reason `tests/test_shell_hook.py` spells
+        # out at length: the stand-in is run by a process nobody waits for, and
+        # a file it creates mid-`rmtree` fails an unrelated test.
+        stub_root = Path(tempfile.mkdtemp(prefix="woswoar-zsyncstub-"))
+        self.addCleanup(shutil.rmtree, stub_root, ignore_errors=True)
+        self.calls = stub_root / "sync-calls"
+
+        bindir = self.root / "bin"
+        bindir.mkdir(exist_ok=True)
+        fake = bindir / "woswoar"
+        fake.write_text(
+            f'#!/bin/sh\necho "$*" >> {shlex.quote(str(self.calls))}\nsleep 3\n',
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        self.bindir = bindir
+        self.repo = store.history_dir()
+        (self.repo / ".git").mkdir(parents=True, exist_ok=True)
+        self.stamp = store.sync_stamp_file()
+
+    def shell_env(self, extra: dict[str, str] | None = None) -> dict[str, str]:
+        return super().shell_env(
+            {"PATH": f"{self.bindir}:{os.environ.get('PATH', '')}", **(extra or {})}
+        )
+
+    def syncs(self, timeout: float = 20.0) -> int:
+        deadline = time.monotonic() + timeout
+        seen = 0
+        while time.monotonic() < deadline:
+            if self.calls.exists():
+                lines = self.calls.read_text(encoding="utf-8").splitlines()
+                if lines and len(lines) == seen:
+                    return seen
+                seen = len(lines)
+            time.sleep(0.05)
+        return seen
+
+    def test_it_syncs_once_per_interval_not_once_per_command(self) -> None:
+        self.run_shell("".join(f"echo cmd{i}\n" for i in range(30)))
+        self.assertEqual(self.syncs(), 1)
+
+    def test_the_sync_never_enters_the_shells_job_table(self) -> None:
+        """A plain `&` would report the job at the prompt once a minute forever.
+
+        Asserted through `jobs` rather than by looking for `[1]` in the output:
+        a shell reading a pipe has job control off, so the notification itself is
+        invisible here and a test looking for it passes against a bare `&`.
+        """
+        out = self.run_shell("echo marker\njobs\n")
+        self.assertIn("marker", out, "precondition: the shell ran at all")
+        self.assertNotIn("woswoar sync", out, "the sync is a job of this shell")
+
+    def test_the_stamp_is_owner_only(self) -> None:
+        self.run_shell("")
+        self.syncs()
+        self.assertTrue(self.stamp.exists(), "no stamp was written")
+        self.assertEqual(self.stamp.stat().st_mode & 0o077, 0)
+
+    def test_a_hostile_interval_from_the_environment_never_reaches_arithmetic(self) -> None:
+        """`WOSWOAR_SYNC_INTERVAL` is inherited: whatever started your shell sets it.
+
+        This is **not** the bash hazard, and saying so is the point of the test.
+        bash runs a command substitution it finds in an arithmetic array
+        subscript, so `x[$(...)]` there is code execution; zsh does not, verified
+        both ways with the same two lines. What zsh does is print
+        `bad math expression` on the shell's *own* stderr -- so at the user's
+        prompt, after every command -- and abandon the assignment, which leaves
+        the shell not syncing at all. Both of those are what is asserted, because
+        both of them can fail.
+        """
+        out = self.run_shell(
+            "echo marker\n", {"WOSWOAR_SYNC_INTERVAL": f"x[$(touch {self.root / 'interval-ran'})]"}
+        )
+        self.assertIn("marker", out)
+        self.assertNotIn("bad math expression", out)
+        self.assertTrue(self.stamp.exists(), "it should fall back to the default, not switch off")
+
+    def test_a_leading_zero_in_the_interval_is_read_as_decimal(self) -> None:
+        """`08` is a perfectly reasonable way to write eight seconds.
+
+        The interval is normalised at file scope, before any `emulate` has had a
+        chance to turn OCTAL_ZEROES off -- so under a user who sets it, `08` is
+        `bad math expression` printed at every prompt and `010` quietly means
+        eight. Driven with the option on, because with it off this test passes
+        against a hook that does no normalising at all.
+        """
+        out = self.run_shell(
+            "echo marker\n", {"WOSWOAR_SYNC_INTERVAL": "08"}, before="setopt octal_zeroes"
+        )
+        self.assertIn("marker", out)
+        self.assertNotIn("bad math expression", out)
+        self.assertTrue(self.stamp.exists(), "a valid interval stopped it syncing at all")
+
+    def test_a_stamp_that_is_not_a_plain_number_is_rejected_not_salvaged(self) -> None:
+        """`>` is not atomic and every shell on this machine writes this file, so
+        a value that is not a number needs no attacker -- a torn write is enough.
+
+        Which junk is used matters, and it is not the junk the bash suite uses.
+        `x[$(...)]` is code execution under bash, which reads it as an arithmetic
+        array subscript and runs the substitution; zsh reads it as an *unset*
+        array and quietly calls it zero, so a test built on that payload alone
+        passes with the sanitising line deleted -- which is how this one was
+        first written. What zsh handles badly is the ordinary torn write, an
+        epoch with a leftover tail on it: that is `bad math expression` on the
+        shell's own stderr, at the user's prompt, after every command.
+
+        So the corpus is both shapes, and the assertion the tail can fail is the
+        one that carries the test.
+        """
+        for junk in ("9999999999oops", "1785321992abc", "not-a-number", "", "x[$(touch it)]"):
+            with self.subTest(stamp=junk):
+                self.stamp.write_text(f"{junk}\n", encoding="utf-8")
+                out = self.run_shell("echo marker\n")
+                self.assertIn("marker", out)
+                self.assertNotIn("bad math expression", out)
+                self.assertNotEqual(
+                    self.stamp.read_text(encoding="utf-8").strip(),
+                    junk,
+                    "an unreadable stamp was believed rather than replaced",
+                )
+
+    def test_a_missing_stamp_is_not_announced_at_the_prompt(self) -> None:
+        """The `{ read } 2>/dev/null` block, for the same reason as the append:
+        zsh puts a failed redirection on the shell's stderr, so the obvious
+        spelling prints the stamp's path after every command."""
+        self.stamp.unlink(missing_ok=True)
+        out = self.run_shell("echo marker\n")
+        self.assertIn("marker", out)
+        self.assertNotIn("sync-stamp", out)
+
+
+@requires_zsh5
+class TestZshEscapeParity(EscapeParityMixin, unittest.TestCase):
+    NONINTERACTIVE: ClassVar[list[str]] = ["zsh", "-f", "-c"]
+    HOOK: ClassVar[Path] = ZSH_HOOK
+
+
+@requires_zsh5
+class TestZshConstantParity(ConstantParityMixin, unittest.TestCase):
+    HOOK: ClassVar[Path] = ZSH_HOOK
+
+    def test_hook_requires_the_documented_zsh_version(self) -> None:
+        self.assertIn("${ZSH_VERSION%%.*} < 5", self.source)
+
+
+@requires_zsh5
+class TestTheZshDefaultIgnorePattern(DefaultIgnorePatternMixin, ZshHookTestCase):
+    pass
+
+
+@requires_zsh5
+@unittest.skipUnless(shutil.which("strace"), "strace required")
+class TestForkFree(CloneScalingMixin, ZshHookTestCase):
+    pass
+
+
+@requires_zsh5
+class TestCtrlRLandsOnThePrompt(ZshHookTestCase):
+    """The one property that keeps a recalled command from running by itself.
+
+    `zle` does nothing without a terminal, so this needs a real pty, a real zsh
+    and the real hook. What is stubbed is the picker: the widget's contract with
+    it is one line on stdout.
+    """
+
+    #: What the picker hands back, and what running it would print. Two strings
+    #: on purpose: a terminal echoes what you type at it, so if the recalled text
+    #: and the executed output were spelled the same, "it did not run" would be
+    #: satisfied by the harness's own echo of the line -- `CLAUDE.md` rule 3,
+    #: fourth bullet. The empty `''` is removed by the shell that runs the line
+    #: and by nothing else.
+    SELECTION = "echo RAN''MARK"
+    IF_EXECUTED = "RANMARK"
+
+    PROMPT = "ps> "
+
+    def picker_env(self) -> dict[str, str]:
+        bin_dir = self.root / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        fake = bin_dir / "woswoar"
+        fake.write_text(
+            "#!/bin/sh\n"
+            # Anything but `search` exits quietly: the hook reaches for
+            # `woswoar sync` too, and a complaint would land on the terminal
+            # this test reads.
+            '[ "$1" = search ] || exit 0\n'
+            "printf '%s\\n' \"$WOSWOAR_TEST_SELECTION\"\n",
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        return self.shell_env(
+            {
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+                "TERM": "xterm",
+                "PS1": self.PROMPT,
+                "WOSWOAR_TEST_SELECTION": self.SELECTION,
+            }
+        )
+
+    def test_the_selection_arrives_for_editing_and_does_not_run(self) -> None:
+        steps = [
+            Typed("", self.PROMPT),
+            Typed(f"source {ZSH_HOOK}; echo LOAD''ED\n", "LOADED"),
+            Typed("", self.PROMPT),
+            # Ctrl-R, then wait for text the harness has not typed: its only
+            # possible source is zle redrawing the buffer the widget filled in.
+            Typed("\x12", self.SELECTION),
+            # Typed where the widget left the cursor, so it lands *after* the
+            # recalled command. A CURSOR of 0 would run `EXTRAecho ...` instead
+            # and this step would time out with the transcript.
+            Typed(" EXTRA\r", f"{self.IF_EXECUTED} EXTRA"),
+        ]
+        *_, after_keypress, after_enter = run_in_pty(
+            ["zsh", "-f", "-i"], steps, env=self.picker_env()
+        )
+
+        self.assertNotIn(
+            self.IF_EXECUTED,
+            after_keypress,
+            "the keypress executed the selection instead of offering it for editing",
+        )
+        self.assertIn(f"{self.IF_EXECUTED} EXTRA", after_enter, "the edited line is what ran")
+
+    def test_the_binding_is_skipped_when_asked(self) -> None:
+        """`WOSWOAR_NO_BIND=1` is what a user keeping atuin's Ctrl-R sets, and
+        the documentation now points zsh users at it too."""
+        out = self.run_shell("bindkey '^R'\n", env_extra={"WOSWOAR_NO_BIND": "1", "TERM": "xterm"})
+        self.assertNotIn("__woswoar_widget", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/woswoar/credentials.py
+++ b/woswoar/credentials.py
@@ -1,10 +1,12 @@
 """Recognise credential-shaped commands, for the paths that are not the hook.
 
-The bash hook carries its own copy of these rules, as one POSIX ERE in
-``woswoar/shell/woswoar.bash``. It has to: it runs on every prompt, must not
-fork, and cannot call Python. This module is for ``woswoar import``, which reads
-history recorded long before woswoar existed -- years of it, filtered by nothing
-at all.
+Each shell hook under ``woswoar/shell/`` carries its own copy of these rules, as
+one POSIX ERE. It has to: it runs on every prompt, must not fork, and cannot
+call Python. ``tests/test_credentials.py`` holds every hook against
+``_SHARED``, so a rule can never be added to one shell alone.
+
+This module is for ``woswoar import``, which reads history recorded long before
+woswoar existed -- years of it, filtered by nothing at all.
 
 Two things are different here, both because an importer has no per-prompt
 budget to spend:

--- a/woswoar/entry.py
+++ b/woswoar/entry.py
@@ -1,9 +1,9 @@
 """The on-disk record format.
 
-This module is the single source of truth for how a history line looks. The bash
-hook in ``woswoar/shell/woswoar.bash`` reimplements :func:`escape` in pure shell
-so that recording stays fork-free; ``tests/test_shell_hook.py`` pins the two
-implementations together by driving the real hook and parsing its output here.
+This module is the single source of truth for how a history line looks. Both
+shell hooks under ``woswoar/shell/`` reimplement :func:`escape` in pure shell so
+that recording stays fork-free; ``tests/test_shell_hook.py`` pins every one of
+them to this one, by driving the real hook and parsing its output here.
 
 Format v1, six tab-separated fields, command last::
 

--- a/woswoar/shell/woswoar.zsh
+++ b/woswoar/shell/woswoar.zsh
@@ -1,0 +1,508 @@
+# woswoar - zsh integration
+#
+# Source this from ~/.zshrc:
+#     source /path/to/woswoar.zsh
+#
+# Requires zsh 5.0+ for the `zsh/datetime` module and `add-zsh-hook`.
+#
+# Design constraint: recording runs on *every* prompt, so it must not fork and
+# must not exec. Everything below the startup section uses builtins only, and CI
+# counts clones for 3 commands and for 30 to prove it.
+#
+# This file is about sixty lines shorter than woswoar.bash, and that is the
+# point. zsh hands `preexec` the command line as $1 with newlines intact, so
+# there is no `history 1` round trip, and with it go the scratch file, the
+# XDG_RUNTIME_DIR fallback, the EXIT trap that cleans it up, and the parsing of
+# a leading history number. $2 is *not* the same thing -- it renders a function
+# definition as `f () { ... }`, which is data loss -- so $1 is used throughout.
+#
+# What zsh does not hand over is bash's "did the history number advance", which
+# is how woswoar.bash defers to HISTCONTROL and HISTIGNORE for free. There is no
+# equivalent: $HISTCMD moves *backwards* over a line zsh declined to store, and
+# $history[$HISTCMD-1] still holds a space-hidden command while this runs. So
+# the rules are reimplemented in __woswoar_preexec. docs/shell-integration.md
+# lists which ones, and says plainly which are not mirrored.
+
+[[ -n ${__WOSWOAR_LOADED:-} ]] && return 0
+[[ -o interactive ]] || return 0
+
+if (( ${ZSH_VERSION%%.*} < 5 )); then
+    printf 'woswoar: zsh 5.0+ required, found %s; history recording disabled\n' \
+        "$ZSH_VERSION" >&2
+    return 0
+fi
+
+# ---------------------------------------------------------------------------
+# Startup. Forks here are fine; they happen once per shell.
+#
+# Deliberately *not* opened with `emulate -L zsh`. The -L scopes options to the
+# enclosing function, and a sourced file is not one: verified on 5.9, a `setopt`
+# inside a sourced file is still set after the source returns, so emulating here
+# would silently rewrite the user's options for the life of the shell. Every
+# function below emulates for itself instead, and this section sticks to
+# constructs that do not care which options are set.
+# ---------------------------------------------------------------------------
+
+# $EPOCHSECONDS, $EPOCHREALTIME and a builtin `strftime`, none of which fork.
+# Its own error is left visible: a zsh that cannot load a shipped module is
+# broken in a way worth hearing about, and recording cannot work without it.
+zmodload zsh/datetime || return 0
+
+__woswoar_dir=${WOSWOAR_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/woswoar}
+__woswoar_conf=${XDG_CONFIG_HOME:-$HOME/.config}/woswoar
+
+__woswoar_id=
+if [[ -r $__woswoar_conf/machine ]]; then
+    while IFS='=' read -r __woswoar_k __woswoar_v; do
+        [[ $__woswoar_k == id ]] && __woswoar_id=$__woswoar_v
+    done <"$__woswoar_conf/machine"
+    unset -v __woswoar_k __woswoar_v
+fi
+
+if [[ -z $__woswoar_id ]]; then
+    printf "woswoar: not initialised yet, run 'woswoar install'\n" >&2
+    unset -v __woswoar_dir __woswoar_conf __woswoar_id
+    return 0
+fi
+
+__woswoar_logdir=$__woswoar_dir/logs/hosts/$__woswoar_id
+
+# 077 so the whole chain is owner-only from the moment it exists. `mkdir -p`
+# would otherwise honour the ambient umask, which is 022 almost everywhere, and
+# these files hold more than ~/.zsh_history does -- which zsh creates 0600.
+#
+# Only creation happens here. Re-tightening a tree from an older woswoar is
+# `woswoar install`'s job: a recursive chmod is proportional to the number of
+# days recorded, and this runs on every interactive shell.
+(umask 077 && mkdir -p "$__woswoar_logdir") 2>/dev/null || return 0
+
+# Identifies this shell for `--scope session`. Start second plus pid, both in
+# hex, exactly as woswoar.bash builds it -- a bash started inside a zsh
+# overwrites this rather than inheriting it, so nesting yields a fresh id.
+#
+# `[##16]` is arithmetic, so this forks nothing. The (L) is not cosmetic:
+# `[##16]` yields upper case, and the session column is documented as lower-case
+# hex.
+WOSWOAR_SESSION="${(L)$(( [##16] EPOCHSECONDS ))}-${(L)$(( [##16] $$ ))}"
+export WOSWOAR_SESSION
+
+# Commands matching this extended regex are never recorded.
+#
+# Unlike bash, none of zsh's own history rules apply for free here -- see
+# __woswoar_preexec, which reimplements them -- but this pattern is a separate
+# thing regardless: it is for what you want in your local history and never in a
+# file that gets synced.
+#
+# The value is byte-identical to woswoar.bash's and must stay that way. Every
+# alternative in it was argued for and measured there, and that is where the
+# reasoning lives; `TestTheIgnorePatternIsSharedByBothShells` fails if the two
+# drift, so a fix can never be applied to only one shell.
+: "${WOSWOAR_IGNORE=(TOKEN|SECRET|PASSW|CREDENTIAL|APIKEY|_KEY|_PASS|_AUTH)[A-Za-z0-9_]*=|--([a-z]+-)*((passw|token|secret|credential)[a-z-]*|api-?key|access-?key|auth)([=[:space:]]|\$)|--from-literal=|://[^/[:space:]]+:[^/@[:space:]]+@|://(hooks\.slack\.com|discord(app)?\.com/api/webhooks)/[^[:space:]]|[Aa]uthorization:[[:space:]]*[A-Za-z]|(sshpass|htpasswd|openssl passwd)[[:space:]]|curl[^|;&]*[[:space:]]-u[[:space:]]|mysql[a-z]*[^|;&]*[[:space:]]-p[^-[:space:]]|docker login[^|;&]*[[:space:]]-p|ssh-keygen[^|;&]*[[:space:]]-N[[:space:]]}"
+
+# Appended, not merged into the default above, so that adding one rule of your
+# own does not pin you to today's default forever.
+if [[ -n ${WOSWOAR_IGNORE_EXTRA:-} ]]; then
+    WOSWOAR_IGNORE=${WOSWOAR_IGNORE:+$WOSWOAR_IGNORE|}$WOSWOAR_IGNORE_EXTRA
+fi
+
+#: Mirrors MAX_CMD_CHARS in woswoar/entry.py.
+__woswoar_max=8000
+
+#: Seconds between prompt-triggered syncs; 0 turns them off entirely. Validated
+#: rather than trusted, because the value is inherited -- whatever started your
+#: shell chooses it -- and it reaches `((...))`.
+#:
+#: The hazard is *not* the one woswoar.bash guards, and the difference is worth
+#: writing down rather than copying the comment across. bash runs a command
+#: substitution it finds in an arithmetic array subscript, so `x[$(...)]` there
+#: is code execution. zsh does not: verified, `last='x[$(touch f)]'` followed by
+#: `(( 1 - last ))` creates nothing, where the same two lines under bash create
+#: the file. What zsh does instead is print `bad math expression` -- on the
+#: shell's *own* stderr, so at the user's prompt after every command -- and
+#: abandon the assignment, which leaves this shell not syncing either. That is
+#: the shape of the bug 0.4.1 shipped, and reason enough on its own.
+#:
+#: "Nothing is left once the digits are removed" rather than woswoar.bash's
+#: `=~ ^[0-9]+$`. A match sets $MATCH, $MBEGIN and $MEND, and this line runs at
+#: file scope where there is no function to make them local -- so the regex form
+#: leaves three parameters behind in the user's shell. Same answer, no residue,
+#: and character classes need no options to be set a particular way.
+#:
+#: Then normalised through `10#`, because this line runs at file scope, under
+#: whatever the user set -- and with `setopt octal_zeroes` a perfectly
+#: reasonable `WOSWOAR_SYNC_INTERVAL=08` is `bad math expression: operator
+#: expected` at every prompt, while `010` quietly means eight. That is the shape
+#: of the bug 0.4.1 shipped. The same prefix inside a function would be dead
+#: code: `emulate -L zsh` turns the option off there.
+[[ -n ${WOSWOAR_SYNC_INTERVAL:-} && -z ${WOSWOAR_SYNC_INTERVAL//[0-9]/} ]] \
+    || WOSWOAR_SYNC_INTERVAL=60
+WOSWOAR_SYNC_INTERVAL=$((10#$WOSWOAR_SYNC_INTERVAL))
+
+#: Shared between every shell on this machine, deliberately: ten open terminals
+#: with ten private clocks would sync ten times an hour between them rather than
+#: once. See store.sync_stamp_file.
+__woswoar_syncstamp=$__woswoar_dir/sync-stamp
+
+#: Earliest $EPOCHSECONDS at which the stamp above is worth opening. Keeps the
+#: per-command cost to one integer comparison.
+typeset -gi __woswoar_next_sync=0
+
+#: Set by preexec, consumed by precmd. The two move together, so unlike the bash
+#: hook there is no "the command ran but we never timed it" case and no -1
+#: duration: bash can lose its DEBUG trap to another tool, and there is nothing
+#: to lose here.
+__woswoar_cmd=
+typeset -gi __woswoar_start=0
+#: The last command line zsh stored, which is what HIST_IGNORE_DUPS compares
+#: against. Not "the last command recorded": one dropped by $WOSWOAR_IGNORE is
+#: still in zsh's history, so a repeat of the command before it is not a
+#: duplicate.
+__woswoar_last=
+#: The day whose log file is known to exist already. See __woswoar_record.
+__woswoar_today=
+
+# ---------------------------------------------------------------------------
+# Hot path. Builtins only below this line.
+#
+# The Ctrl-R widget is the one deliberate exception and says so at its own
+# header: it runs on a keypress, not on every prompt.
+# ---------------------------------------------------------------------------
+
+# Escapes $1 into __woswoar_escaped. Mirrors escape() in woswoar/entry.py --
+# these implementations must agree exactly, which is what tests/test_shell_hook.py
+# checks by running each of them against the Python one over one shared corpus.
+#
+# Character-for-character the body in woswoar.bash, deliberately: the two shells
+# agree on all four substitutions, so keeping one text is one less thing that can
+# drift. It carries no `emulate` of its own because its only caller has already
+# emulated, and adding one would make the two bodies differ for no gain.
+#
+# Order matters: backslash first, or the escapes introduced below would
+# themselves be escaped.
+__woswoar_escape() {
+    local value=$1
+    value=${value//\\/\\\\}
+    value=${value//$'\t'/\\t}
+    value=${value//$'\n'/\\n}
+    value=${value//$'\r'/\\r}
+    __woswoar_escaped=$value
+}
+
+# Receives the command line as $1. Fires for every line, including the ones zsh
+# has already decided not to keep -- which is what the middle of this function
+# is about.
+__woswoar_preexec() {
+    # Read before `emulate`, which turns EXTENDED_GLOB off. $HISTORY_IGNORE is
+    # the user's pattern, written in whichever glob dialect their options select;
+    # matching it in a different dialect than zsh itself used would record a
+    # command they told zsh to forget. Verified: `^echo*` matches `ls -l` only
+    # with EXTENDED_GLOB on.
+    local -i extglob=0
+    [[ -o extended_glob ]] && extglob=1
+
+    # Localises options for this function: NO_CLOBBER (which would stop the
+    # append below ever creating a day file), KSH_ARRAYS, SH_WORD_SPLIT,
+    # EXTENDED_GLOB, WARN_CREATE_GLOBAL -- which would otherwise print a line
+    # about `__woswoar_escaped` at the prompt -- and REMATCH_PCRE, which would
+    # reinterpret $WOSWOAR_IGNORE. It does *not* touch the HIST_* options, which
+    # is what makes the tests below work -- checked, not assumed.
+    emulate -L zsh
+    (( extglob )) && setopt extended_glob
+
+    local cmd=$1
+
+    # HIST_IGNORE_SPACE is how a person hides a secret from history, and in
+    # woswoar a missed one is published to a git repository -- so this is the
+    # first rule applied and it errs towards dropping: any leading whitespace,
+    # not just the space zsh itself looks for.
+    [[ -o hist_ignore_space && $cmd == [[:space:]]* ]] && return 0
+
+    # A bare Enter, or a line zsh ran with the history mechanism inactive.
+    [[ -n ${cmd//[[:space:]]/} ]] || return 0
+
+    # Both options mean the same thing to a log that only ever appends: do not
+    # store this line if it repeats the one before it.
+    if [[ -o hist_ignore_dups || -o hist_ignore_all_dups ]]; then
+        [[ $cmd == "$__woswoar_last" ]] && return 0
+    fi
+
+    # `${~}` interprets the value as a pattern. It is not `eval`: no command
+    # substitution is reachable through it, which
+    # `test_a_history_ignore_holding_a_command_substitution_runs_nothing` pins.
+    if [[ -n ${HISTORY_IGNORE-} && $cmd == ${~HISTORY_IGNORE} ]]; then
+        return 0
+    fi
+
+    __woswoar_last=$cmd
+    __woswoar_cmd=$cmd
+
+    # $EPOCHREALTIME is "seconds.fraction" with *ten* fractional digits where
+    # bash gives six, so woswoar.bash's "strip the last three characters"
+    # (`${now%???}`) is wrong here by a factor of 10,000. zsh's own float
+    # arithmetic does not care how many digits there are, and a double carries
+    # ~15.9 significant ones against the 13 this needs.
+    #
+    # The comma substitution is not dead code for a comma-decimal locale. zsh 5.9
+    # formats this parameter with a period whatever LC_NUMERIC says -- bash does
+    # not -- but a comma reaching `$((...))` is the *comma operator*, which would
+    # quietly evaluate to the fraction and call it a timestamp. Free, and the
+    # alternative is a silent 1000x duration on some future zsh.
+    (( __woswoar_start = ${EPOCHREALTIME//,/.} * 1000 ))
+}
+
+__woswoar_precmd() {
+    # The first line, before anything else. `emulate` clobbers $? -- verified:
+    # a function reading it after emulating sees 0 for a command that failed,
+    # which is the same "every command looks successful" bug woswoar.bash
+    # prepends an entry to PROMPT_COMMAND to avoid.
+    local exit_code=$?
+
+    emulate -L zsh
+
+    # Recording first, so a command reaches the repository in the sync it
+    # triggers rather than in the one after it. Two functions rather than one
+    # because `__woswoar_record` returns early from several places and a shell
+    # must still come due for a sync in every one of them.
+    __woswoar_record "$exit_code"
+    __woswoar_maybe_sync
+
+    # zsh restores $? for each precmd_functions entry, so a hook registered
+    # after this one sees the user's status whatever we return -- observed on
+    # 5.9, but observed is not promised. Returning it explicitly costs nothing
+    # and makes the hook correct either way.
+    return $exit_code
+}
+
+__woswoar_record() {
+    local exit_code=$1
+
+    # Taken and cleared in one place, so every path out of this function is
+    # covered by construction. Empty at the prompt where this file was sourced
+    # (preexec had not been registered yet when that line ran) and at every
+    # prompt zsh draws without having run anything.
+    local cmd=$__woswoar_cmd
+    local -i start=$__woswoar_start
+    __woswoar_cmd=
+    [[ -n $cmd ]] || return 0
+
+    # A match sets six parameters, and all six leak into the user's shell -- on
+    # every single command -- unless they are declared here first.
+    local MATCH MBEGIN MEND
+    local -a match mbegin mend
+    if [[ -n $WOSWOAR_IGNORE && $cmd =~ $WOSWOAR_IGNORE ]]; then
+        return 0
+    fi
+
+    local -i duration=$(( ${EPOCHREALTIME//,/.} * 1000 - start ))
+
+    if (( ${#cmd} > __woswoar_max )); then
+        # `${cmd:0:$__woswoar_max}`, with the `$`. zsh reads a bare name in the
+        # length position as a history modifier and fails the whole expansion
+        # with `unrecognized modifier`.
+        cmd=${cmd:0:$__woswoar_max}'...[truncated]'
+    fi
+
+    __woswoar_escape "$cmd"
+    cmd=$__woswoar_escaped
+
+    # Store paths under $HOME as ~/... -- the prefix would otherwise repeat on
+    # nearly every line. Matched anchored rather than with ${PWD/#$HOME/~},
+    # which would rewrite /home/martinuscopy into ~copy when $HOME is
+    # /home/martinus. The ~ means the *recording* user's home, so it is not
+    # expanded on read; see woswoar/entry.py.
+    local cwd=$PWD
+    if [[ $cwd == "$HOME" ]]; then
+        cwd='~'
+    elif [[ -n $HOME && $cwd == "$HOME"/* ]]; then
+        cwd='~'${cwd#"$HOME"}
+    fi
+    __woswoar_escape "$cwd"
+    cwd=$__woswoar_escaped
+
+    local day
+    strftime -s day '%F' $EPOCHSECONDS # local time, matching store.day_for()
+
+    # A file's mode is set when it is created and never again, so the first
+    # write of each day is the only moment this can be got right -- and `>>`
+    # would create it 0644 under the usual umask. Guarded on the day string
+    # rather than testing the file every time: this runs on every command, and
+    # the answer changes once a day.
+    #
+    # In a subshell, so the caller's umask is untouched no matter what: the fork
+    # happens once per day, not once per command. zsh has a fork-free
+    # alternative here -- `zmodload -F zsh/files b:chmod` makes chmod a builtin
+    # -- but the mode still has to be right at creation, so it would replace one
+    # once-a-day fork with a module load in every shell. Kept as bash has it.
+    #
+    # `mkdir -p` as well, because the directory is otherwise only made when the
+    # shell starts, and a shell outlives a lot: an uninstall, a home moved, a
+    # work machine's cleanup. Once a day is the cheapest place to notice.
+    if [[ $day != "$__woswoar_today" ]]; then
+        __woswoar_today=$day
+        (umask 077 && mkdir -p "$__woswoar_logdir" && : >>| "$__woswoar_logdir/$day.tsv") \
+            2>/dev/null
+    fi
+
+    # One O_APPEND write. Linux serialises these under the inode lock, so
+    # concurrent shells on this host -- including a bash and a zsh sharing this
+    # machine id -- cannot interleave lines.
+    #
+    # Two things here are zsh-specific and each is a silent failure on its own:
+    #
+    # `>>|` rather than `>>`, because under `setopt noclobber` an append to a
+    # file that does not exist yet *fails*. A zsh user with noclobber set would
+    # record nothing, ever, while the hook loaded, `doctor` was happy and the
+    # log file was simply never created. `emulate -L zsh` in the caller already
+    # clears NO_CLOBBER; this is the second of two guards because the cost of
+    # both being wrong is silence.
+    #
+    # `{ ... } 2>/dev/null` rather than a redirection on the printf itself.
+    # bash reports a failed redirection to the command's own stderr, so ordering
+    # `2>/dev/null` first is enough there; zsh reports it to the shell's, and
+    # both orders print `no such file or directory` at the user's prompt after
+    # every command. That is the 0.4.1 bug (woswoar.bash:381) in the shape zsh
+    # gives it, and only a surrounding block catches it.
+    {
+        printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$EPOCHSECONDS" "$WOSWOAR_SESSION" "$cwd" "$exit_code" "$duration" "$cmd" \
+            >>| "$__woswoar_logdir/$day.tsv"
+    } 2>/dev/null
+}
+
+# Fires a sync when one is due. Runs on every prompt, and forks on roughly one
+# prompt a minute -- the one deliberate exception to the builtins-only rule.
+# The steady-state cost is the single `((...))` below; everything that touches
+# the filesystem is behind it.
+__woswoar_maybe_sync() {
+    (( WOSWOAR_SYNC_INTERVAL > 0 && EPOCHSECONDS >= __woswoar_next_sync )) || return 0
+
+    # `{ ... } 2>/dev/null`, for the reason spelled out above the append: zsh
+    # puts a failed redirection on the shell's stderr, so a missing stamp file
+    # would otherwise print a path at the user's prompt after every command.
+    local last=
+    { read -r last <"$__woswoar_syncstamp" } 2>/dev/null
+    # A torn or truncated write must not reach `((...))`. `>` is not atomic and
+    # every shell on this machine writes this file, so a value that is not a
+    # number needs no attacker. What it costs here is not what it costs under
+    # bash -- see the note on WOSWOAR_SYNC_INTERVAL above -- but it is still
+    # `bad math expression` at the prompt after every command, and a shell that
+    # stops syncing for the rest of its life.
+    #
+    # Rejected outright rather than stripped to the digits in it: stripping
+    # turns half of `1785...` plus a leftover tail into a *plausible* epoch, and
+    # one in the future stops this shell syncing until the file changes again.
+    #
+    # Tested by removing the digits rather than with `=~`, as at startup: this
+    # runs once a minute in the user's shell, and a regex match would leave
+    # $MATCH, $MBEGIN and $MEND behind unless three more locals were declared
+    # for it.
+    #
+    # No `10#` here, unlike the interval at startup, and the difference is the
+    # point: `emulate -L zsh` has already turned OCTAL_ZEROES off for this
+    # function, so `010` is ten. The startup line runs at file scope under
+    # whatever the user set, where `08` is `bad math expression` and `010` is
+    # eight -- so it needs the prefix and this does not. A `10#` that cannot be
+    # shown to do anything is one more line to keep true.
+    [[ -n $last && -z ${last//[0-9]/} ]] || last=0
+
+    if (( EPOCHSECONDS - last < WOSWOAR_SYNC_INTERVAL )); then
+        __woswoar_next_sync=$(( last + WOSWOAR_SYNC_INTERVAL ))
+        return 0
+    fi
+
+    # Set before the check below rather than in both of its arms: coming due and
+    # finding nothing to do still costs a `stat` on every command until the
+    # interval is put back.
+    __woswoar_next_sync=$(( EPOCHSECONDS + WOSWOAR_SYNC_INTERVAL ))
+
+    # Nothing to sync with, so nothing to fork for. `history/.git`, matching
+    # `sync.is_repo`, not `history/` itself: a clone that died partway leaves the
+    # directory without the repository in it, and `woswoar sync` calls that "not
+    # initialised" -- so testing the directory would have this machine fork an
+    # interpreter a minute, forever, to print that error into /dev/null.
+    [[ -e $__woswoar_dir/history/.git ]] || return 0
+
+    # `( ... & )`: the subshell backgrounds the sync and exits immediately, so
+    # the prompt waits for two forks (~1ms) and never for the sync itself. A
+    # plain `&` here would put it in this shell's job table and report it at the
+    # prompt once a minute, forever.
+    #
+    # The stamp is written *inside* that subshell, which is why it costs no
+    # extra fork -- and under `umask 077`, because a file's mode is fixed when it
+    # is created and `>` would otherwise make it 0644 for `doctor` to flag.
+    #
+    # Stamped before the sync runs, not after it succeeds: a `woswoar` that is
+    # not on PATH must cost one attempt a minute, not one per command.
+    (
+        umask 077
+        printf '%s\n' "$EPOCHSECONDS" >| "$__woswoar_syncstamp"
+        woswoar sync >/dev/null 2>&1 </dev/null &
+    ) 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Ctrl-R. Forks freely -- it runs on a keypress, not on every prompt.
+# ---------------------------------------------------------------------------
+
+__woswoar_widget() {
+    emulate -L zsh
+    local selection
+    selection=$(woswoar search --scope "${WOSWOAR_SCOPE:-global}" --query "$BUFFER" \
+        </dev/tty) || return 0
+    [[ -n $selection ]] || return 0
+    BUFFER=$selection
+    CURSOR=${#BUFFER}
+    # The picker drew over the screen; without this the prompt is left where it
+    # was and the recalled line appears under the picker's wreckage.
+    zle reset-prompt
+}
+
+# ---------------------------------------------------------------------------
+# Wiring
+#
+# All of it. zsh needs none of woswoar.bash's apparatus here: no boot string, no
+# self-removing PROMPT_COMMAND entry, no chaining onto a DEBUG trap, and no
+# exit-status-restoring wrapper, because `precmd_functions` entries each see the
+# user's real $? and `preexec` is handed the command line outright.
+# ---------------------------------------------------------------------------
+
+autoload -Uz add-zsh-hook
+if add-zsh-hook preexec __woswoar_preexec 2>/dev/null; then
+    add-zsh-hook precmd __woswoar_precmd
+else
+    # `add-zsh-hook` is a shipped function, so this is a zsh whose $fpath does
+    # not reach its own function directory. Appending to the arrays is what
+    # add-zsh-hook does anyway; what is lost is only its "already registered"
+    # check, and __WOSWOAR_LOADED above has already made that unreachable.
+    preexec_functions+=(__woswoar_preexec)
+    precmd_functions+=(__woswoar_precmd)
+fi
+
+# Outside the binding guard below, so that `WOSWOAR_NO_BIND=1` leaves a widget
+# you can still `bindkey` to a key of your own. Under bash that falls out for
+# free -- `__woswoar_widget` is an ordinary function and `bind -x` takes its
+# name -- but zle needs the widget declared before any keymap can name it.
+zle -N __woswoar_widget
+
+if [[ -z ${WOSWOAR_NO_BIND:-} ]]; then
+    # Bound at source time, as woswoar.bash is, so put the woswoar line *last*
+    # in ~/.zshrc: Oh My Zsh, Prezto and atuin all bind ^R when they load and
+    # whoever goes last wins. Deferring to the first prompt would make that an
+    # arms race with atuin, which also rebinds -- and losing it silently is
+    # worse than an ordering rule you can see. `WOSWOAR_NO_BIND=1` keeps
+    # another tool's binding instead.
+    #
+    # Three keymaps, mirroring woswoar.bash's three `bind -m`. What each
+    # displaces: `history-incremental-search-backward` in main, `redisplay` in
+    # viins, `redo` in vicmd.
+    bindkey '^R' __woswoar_widget 2>/dev/null
+    bindkey -M viins '^R' __woswoar_widget 2>/dev/null
+    bindkey -M vicmd '^R' __woswoar_widget 2>/dev/null
+fi
+
+# No `__woswoar_maybe_sync` call here, deliberately. zsh runs precmd before the
+# *first* prompt, so a shell where nobody has typed anything yet has already been
+# through `__woswoar_precmd` and has already synced -- which is what makes
+# sitting down and pressing Ctrl-R show current history.
+
+__WOSWOAR_LOADED=1

--- a/woswoar/shell/woswoar.zsh
+++ b/woswoar/shell/woswoar.zsh
@@ -95,8 +95,9 @@ export WOSWOAR_SESSION
 #
 # The value is byte-identical to woswoar.bash's and must stay that way. Every
 # alternative in it was argued for and measured there, and that is where the
-# reasoning lives; `TestTheIgnorePatternIsSharedByBothShells` fails if the two
-# drift, so a fix can never be applied to only one shell.
+# reasoning lives; `tests/test_credentials.py`'s `TestParityWithTheHook` holds
+# *every* hook against `credentials._SHARED`, so a rule can never be added to
+# one shell alone -- nor to both shells and not to the importer.
 : "${WOSWOAR_IGNORE=(TOKEN|SECRET|PASSW|CREDENTIAL|APIKEY|_KEY|_PASS|_AUTH)[A-Za-z0-9_]*=|--([a-z]+-)*((passw|token|secret|credential)[a-z-]*|api-?key|access-?key|auth)([=[:space:]]|\$)|--from-literal=|://[^/[:space:]]+:[^/@[:space:]]+@|://(hooks\.slack\.com|discord(app)?\.com/api/webhooks)/[^[:space:]]|[Aa]uthorization:[[:space:]]*[A-Za-z]|(sshpass|htpasswd|openssl passwd)[[:space:]]|curl[^|;&]*[[:space:]]-u[[:space:]]|mysql[a-z]*[^|;&]*[[:space:]]-p[^-[:space:]]|docker login[^|;&]*[[:space:]]-p|ssh-keygen[^|;&]*[[:space:]]-N[[:space:]]}"
 
 # Appended, not merged into the default above, so that adding one rule of your
@@ -217,7 +218,9 @@ __woswoar_preexec() {
     # not just the space zsh itself looks for.
     [[ -o hist_ignore_space && $cmd == [[:space:]]* ]] && return 0
 
-    # A bare Enter, or a line zsh ran with the history mechanism inactive.
+    # zsh's signal that the history mechanism was inactive: $1 arrives empty.
+    # Not the bare-Enter case, which never reaches here at all -- `preexec` does
+    # not fire for a blank line, checked against 5.9 rather than assumed.
     [[ -n ${cmd//[[:space:]]/} ]] || return 0
 
     # Both options mean the same thing to a log that only ever appends: do not
@@ -328,11 +331,18 @@ __woswoar_record() {
     # rather than testing the file every time: this runs on every command, and
     # the answer changes once a day.
     #
-    # In a subshell, so the caller's umask is untouched no matter what: the fork
-    # happens once per day, not once per command. zsh has a fork-free
-    # alternative here -- `zmodload -F zsh/files b:chmod` makes chmod a builtin
-    # -- but the mode still has to be right at creation, so it would replace one
-    # once-a-day fork with a module load in every shell. Kept as bash has it.
+    # In a subshell, so the caller's umask is untouched no matter what. What it
+    # costs is once per shell *and* then once per day: `__woswoar_today` starts
+    # empty, so this branch also fires at the first recorded command of every
+    # shell, duplicating the `mkdir -p` that startup has just run. Measured at
+    # ~5.4 ms of the 6.8 ms this hook adds to a shell that otherwise starts in
+    # 1.25 ms -- and woswoar.bash pays exactly the same twice, so it is filed
+    # (#183) rather than fixed in one shell here. It is off the per-command
+    # path, which is what this file's fork-count tests are about.
+    #
+    # zsh has a fork-free alternative -- `zmodload -F zsh/files b:chmod` makes
+    # chmod a builtin -- but the mode still has to be right at creation, so it
+    # would trade one fork for a module load in every shell. Kept as bash has it.
     #
     # `mkdir -p` as well, because the directory is otherwise only made when the
     # shell starts, and a shell outlives a lot: an uninstall, a home moved, a


### PR DESCRIPTION
Closes #158.

Adds `woswoar/shell/woswoar.zsh`, `tests/test_shell_hook_zsh.py`, and CI for
both. **Not** wired into `woswoar install` — that is #159, and the issue asks
for the risky part to be reviewed on its own. For now the line goes into
`~/.zshrc` by hand; `docs/shell-integration.md` says so.

## The hook

The capture path really is much simpler. zsh hands `preexec` the command line as
`$1`, newlines intact, so the `history 1 > scratch` → `read < scratch`
apparatus disappears — and with it the scratch file, the `XDG_RUNTIME_DIR`
fallback, the `$WOSWOAR_DIR/run` fallback, the EXIT trap, and the parsing of a
leading history number. `precmd_functions` entries each see the user's real
`$?`, so none of bash's `PROMPT_COMMAND` prepend / boot string / unboot
machinery exists either. `add-zsh-hook precmd` and `add-zsh-hook preexec` is the
whole of the wiring.

What is *not* free is bash's "did the history number advance", which is how
`woswoar.bash` defers to `HISTCONTROL` and `HISTIGNORE` without a second set of
rules. zsh offers no equivalent — all three candidates were tested and all three
fail, as the issue records — so `HIST_IGNORE_SPACE`, `HIST_IGNORE_DUPS`,
`HIST_IGNORE_ALL_DUPS` and `HISTORY_IGNORE` are reimplemented in `preexec`. The
four that are deliberately *not* mirrored are written down in
`docs/shell-integration.md` rather than left to be discovered.

Measured with the same accounting as `TestForkFree`: **3 clones for 3 commands
and 3 for 30** — the record path forks nothing, and the three are startup's
`mkdir` subshell.

## Where the issue turned out to be wrong

Two of its claims did not survive being run, and both are stated the other way
round in the code now.

**`x[$(...)]` is not code execution under zsh.** The issue (and my first draft)
carried bash's arithmetic-injection hazard across. bash runs a command
substitution it finds in an arithmetic array subscript; zsh reads it as an unset
array and calls it zero:

```
$ for sh in zsh bash; do rm -f EVAL; $sh -c 'last='\''x[$(touch EVAL)]'\''; (( 1 - last < 60 ))'; \
    echo "$sh: $(test -e EVAL && echo RAN || echo 'did not run')"; done
zsh: did not run
bash: RAN
```

So `$WOSWOAR_SYNC_INTERVAL` and the sync stamp are still validated, but for
different reasons, and the comments say which: an unvalidated value is
`bad math expression` **on the shell's own stderr** — at the user's prompt after
every command — and it abandons the assignment, so the shell stops syncing too.
That is the 0.4.1 bug's shape. The stamp test now uses a realistic torn write
(`1785321992abc`), because the payload the issue suggested is inert here and a
test built on it passed with the sanitising line deleted.

**`emulate -L zsh` in a sourced file leaks.** `-L` scopes options to the
enclosing *function*, and a sourced file is not one — verified, a `setopt` inside
one is still set after the source returns. So the startup section has no
`emulate` and sticks to constructs that do not care about options; every function
emulates for itself. That is called out at the section header.

Three more things the issue did not mention, each now a test:

- **zsh reports a failed redirection on the shell's stderr, not the command's.**
  `woswoar.bash`'s fix for the 0.4.1 message — putting `2>/dev/null` *before*
  the append — does nothing here, in either order. Only `{ … } 2>/dev/null`
  catches it. Same for the stamp read.
- **`EXTENDED_GLOB` is reset by `emulate`,** and `$HISTORY_IGNORE` is the user's
  pattern in whichever dialect their options select. Matching it in a different
  one records what they told zsh to forget, so the option is read before
  emulating and put back after.
- **`10#` is dead inside a function** (emulate clears `OCTAL_ZEROES`) and a real
  guard at file scope, where `WOSWOAR_SYNC_INTERVAL=08` is otherwise a math
  error at every prompt. It is used in one place and not the other, and the
  comment says why.

## Tests

`tests/test_shell_hook_zsh.py` is a sibling, not a rewrite. What the two hooks
must *agree* on now lives in `test_shell_hook.py` as mixins parameterised by
`(INTERPRETER, HOOK)` — the escape corpus, the mirrored constants, the default
ignore pattern, the fork-scaling measurement — and the zsh suite subclasses them.
One corpus, one set of assertions, two shells. `TestEscapeParity` became
`TestBashEscapeParity` + `TestZshEscapeParity`; no bash test was lost (80 → 82
before the zsh file was added, the two new ones being the shared fork-scaling
claim and `TestTheIgnorePatternIsSharedByBothShells`, which fails if the
credential filter drifts between the two files).

59 new tests. Two fixture bugs found and fixed while mutating:

- `test_the_match_parameters_do_not_leak` used `echo trigger`, which the pattern
  does not match — and zsh sets `$MATCH` only on a match, so it passed with all
  six `local`s deleted.
- `run_shell` puts the script through `textwrap.dedent`, so a lone
  `" echo spaced"` line loses the space that the test is *about*.

Two things fixed in shared code the diff already touches:

- `tests/support.py`: `run_in_pty` threw away bytes read past a step's marker, so
  a shell that printed its output and redrew its prompt in one 64 KiB read left
  the next step waiting for a prompt it had already been handed. Load-dependent:
  green alone, failed under the parallel runner. It now carries the remainder
  forward. This was latent for the bash Ctrl-R test too.
- The zsh suite asserts on the *set* of recorded commands, not their order:
  `recorded()` sorts by `(ts, duration_ms)` and three `echo`s in one second
  differ only by a millisecond. Observed flaking about one run in ten.

### Mutation testing

`python -m tools.mutate`, 27 edits, all caught:

```
  caught    the record line writes nowhere
  caught    preexec reads $2, the lossy form, instead of $1
  caught    __woswoar_escape no longer escapes a newline
  caught    the session id keeps [##16]'s upper case
  caught    the duration uses woswoar.bash's six-digit conversion
  caught    $? is read after `emulate` has already clobbered it
  caught    precmd does not return the status it was given
  caught    $HOME is matched unprefixed, so a sibling directory becomes ~something
  caught    HIST_IGNORE_SPACE is not honoured
  caught    the duplicate check is gone
  caught    HISTORY_IGNORE is not honoured
  caught    EXTENDED_GLOB is not restored after `emulate` turned it off
  caught    the six regex-match parameters are not made local
  caught    the credential filter is not applied
  caught    the zsh hook's ignore pattern drifts from the bash hook's
  caught    __woswoar_max no longer mirrors MAX_CMD_CHARS
  caught    noclobber is defended against by neither `emulate` nor `>>|`
  caught    the day file is created under the ambient umask
  caught    the append is not wrapped in a block, so zsh announces a missing directory
  caught    the wiring has no fallback when add-zsh-hook cannot be autoloaded
  caught    a fork is added to the record path
  caught    the sync interval from the environment is not validated
  caught    the sync stamp read off disk is not validated
  caught    the stamp read is not wrapped in a block, so a missing one is announced
  caught    the background sync is a job of the user's shell
  caught    the Ctrl-R widget runs the selection instead of offering it
  caught    the interval is not normalised, so `08` is octal at file scope
```

The noclobber entry is one edit that removes *both* guards, because they protect
each other: `emulate -L zsh` clears `NO_CLOBBER` and `>>|` overrides it, so
either one alone keeps recording working. That is deliberate defence in depth —
the failure it prevents is a user who records nothing, ever, while every part of
the install looks correct — and the mutation reverts the pair.

## CI

- `lint`: installs zsh and runs `zsh -n woswoar/shell/woswoar.zsh`. **shellcheck
  has no zsh mode**, so the workflow says that in a comment rather than leaving a
  silent gap; `zsh -n` is a parse, not a lint, and that is stated too.
- `hook`: installs zsh beside strace, and runs the zsh suite with `--no-skips`
  as a second step — `--only` matches on a dotted prefix, so
  `tests.test_shell_hook` does not select `tests.test_shell_hook_zsh`.

## Scope left out, on purpose

- `WOSWOAR_BIND_LATE=1`, offered in the issue as optional. `WOSWOAR_NO_BIND=1`
  already covers the case and is now documented for zsh; a second knob with its
  own tests is not worth adding before anyone has asked for it.
- The pathological-pattern timing test (`8000` dashes) has no zsh sibling.
  `${EPOCHREALTIME//[.,]/}` has twenty digits under zsh and overflows a 64-bit
  integer, so the bash version's arithmetic does not port — and the pattern is
  byte-identical and matched by the same libc `regcomp` in both shells, which is
  what the test is about.
- zsh-autosuggestions and Powerlevel10k's instant prompt are documented as known
  rough edges and explicitly marked unverified: neither was available to drive.

## Review

CLAUDE.md rule 1, row 2, as the issue directs. Reviewed as a careful read of the
whole diff against the two named hazards rather than by an agent. It turned up
the `zle -N` placement (moved outside the `WOSWOAR_NO_BIND` guard, so that
switching the binding off still leaves a widget you can `bindkey` yourself), the
dead `10#`, and `WARN_CREATE_GLOBAL` — which breaks nothing but prints a line
about `__woswoar_escaped` at the prompt after every command without `emulate`,
and is now in the hostile-options test.

## Migration

Nothing on disk changes; a zsh machine writes the same v1 records into the same
`logs/hosts/<id>/<day>.tsv`. A machine running both shells shares one host
directory under one machine id, which
`TestAZshAndABashShellShareOneHistory` drives with a real zsh and a real bash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
