### PR TITLE
install: shell detection, so install/doctor/setup handle bash and zsh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,14 @@ jobs:
           floor = search.TRANSFORM_SINCE
           assert got is not None and got >= floor, f'fzf {got} is below {floor}'
           "
+      - name: install zsh
+        # `tests.test_install` drives a real zsh through the line `install`
+        # wrote into a real `.zshrc`, and skips itself without one -- which is
+        # the silently-green shape the `--no-skips` step below exists to catch.
+        run: |
+          sudo apt-get install -y -qq zsh \
+            || { sudo apt-get update -qq && sudo apt-get install -y -qq zsh; }
+          zsh --version
       - name: ssh-keygen is present
         # Signing needs it. Present on ubuntu-latest, asserted rather than
         # assumed for the same reason as bash below: a silently skipped suite
@@ -114,6 +122,10 @@ jobs:
       # above, so here a skip means the install stopped working -- and a green
       # run that ranked nothing at all is exactly the failure worth catching.
       - run: python -m tools.run_tests --only tests.test_search --no-skips
+      # Same reason: the install suite reaches for bash *and* zsh to prove the
+      # rc line it wrote is one the shell actually loads. Both are installed
+      # above, so here a skip means one of them stopped working.
+      - run: python -m tools.run_tests --only tests.test_install --no-skips
 
   hook:
     # Called on every prompt, so the hook gets its own job: the fork-scaling
@@ -239,6 +251,29 @@ jobs:
           echo ci-end-to-end-marker
           EOF
           woswoar list --scope global | grep -q 'ci-end-to-end-marker'
+
+      - name: zsh gets the same treatment, from a $HOME that has a .zshrc
+        # The detection rule decides which files a real `install` writes on a
+        # real home directory, and it is the one thing here that no unit test
+        # can prove about the *packaged* program. `.zshrc` only: that also says
+        # `install` did not go looking for bash on a machine without a .bashrc.
+        run: |
+          set -euxo pipefail
+          sudo apt-get install -y -qq zsh \
+            || { sudo apt-get update -qq && sudo apt-get install -y -qq zsh; }
+          export HOME="$(mktemp -d)"
+          touch "$HOME/.zshrc"
+
+          woswoar install
+          test -f "$HOME/.local/share/woswoar/woswoar.zsh"
+          grep -q 'woswoar' "$HOME/.zshrc"
+          test ! -e "$HOME/.bashrc"
+
+          zsh -f -i <<'EOF'
+          source "$HOME/.zshrc"
+          echo ci-zsh-end-to-end-marker
+          EOF
+          woswoar list --scope global | grep -q 'ci-zsh-end-to-end-marker'
 
           # doctor exits non-zero on a broken install; fzf is absent here, so
           # only check that it runs and reports.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ so <kbd>Ctrl</kbd>+<kbd>T</kbd> turns whatever you found into
 | 🔐 **Encrypted end to end** | commands, paths, hostnames — nothing readable reaches the remote |
 | 🧩 **No server, no database** | a git repo and plain text files you can `grep` |
 | 📦 **Zero Python dependencies** | standard library only — nothing to audit but this repo |
-| ⚡ **~150 µs per command, zero forks** | the hook is pure bash; Python never runs on your prompt |
+| ⚡ **~150 µs per command, zero forks** | the hook is pure shell — bash or zsh; Python never runs on your prompt |
 | 🔎 **fzf as the UI** | the fuzzy finder you already know, not a bespoke TUI |
 | 🚚 **Imports what you have** | bash, zsh and atuin histories, idempotently |
+| 🐚 **Records from bash and zsh** | one history per machine, whichever shell you are standing in |
 | 🧱 **~4300 lines of implementation** | small enough to read in an afternoon |
 | 🐤 **Verifiable on your machine** | `woswoar doctor --prove` demonstrates, not asserts — see [verify it yourself](docs/verify.md) |
 
@@ -65,7 +66,7 @@ one machine. `woswoar` on its own is the only command you have to remember: it
 sets up when there is nothing installed, and afterwards says where this machine
 stands and names the one command to run next, if there is one.
 
-**Needs:** bash 5.0+ (Linux) · Python 3.10+ ·
+**Needs:** bash 5.0+ or zsh 5.0+ (Linux) · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) ·
 [age](https://github.com/FiloSottile/age) and git *(sync only)* — but **not `age`
 as a snap**, which costs about 250 ms per call against 2 ms and turns a `sync`
@@ -115,13 +116,14 @@ among them.
 ## How it works
 
 ```
-bash hook  ──►  plaintext TSV logs  ──►  parse cache  ──►  scope filter  ──►  fzf
+shell hook  ──►  plaintext TSV logs  ──►  parse cache  ──►  scope filter  ──►  fzf
                         │
                         └──►  age-encrypted chunks  ──►  git  ──►  remote
 ```
 
-The hot path is a fork-free bash hook using bash 5 builtins that appends one
-escaped line to a per-day TSV file. Nothing else touches your prompt. Everything
+The hot path is a fork-free shell hook — one for bash built on bash 5 builtins,
+one for zsh built on zsh's — that appends one escaped line to a per-day TSV
+file. Both write into the same per-machine history. Nothing else touches your prompt. Everything
 expensive — parsing, caching, encrypting, git — happens when you search, or when
 the timer fires.
 
@@ -132,7 +134,7 @@ the timer fires.
 | 🔎 [**Searching your history**](docs/searching.md) | the machine column, `^name`, the <kbd>Ctrl</kbd>+<kbd>T</kbd> timeline, the details pane |
 | 📦 [**Installing, upgrading, uninstalling**](docs/install.md) | the first run, `pipx` upgrades, importing atuin, and removing every part of it again |
 | 🔄 [**Adding another machine**](docs/sync.md) | enrolment, `accept`/`grant`/`trust`, background sync, a systemd timer |
-| 🐚 [**Living in your shell**](docs/shell-integration.md) | what it does to your bash, how it coexists with ble.sh, atuin and prompt frameworks, what <kbd>Ctrl</kbd>+<kbd>R</kbd> costs, and what is never recorded |
+| 🐚 [**Living in your shell**](docs/shell-integration.md) | bash and zsh, how it coexists with ble.sh, atuin and prompt frameworks, what <kbd>Ctrl</kbd>+<kbd>R</kbd> costs, and what is never recorded |
 | 🔐 [**Security model**](docs/security.md) | threat model, guarantees, limits |
 | 🐤 [**Verify it yourself**](docs/verify.md) | checks you run on your own machine, none of which ask you to believe a document |
 | 📖 [**Reference**](docs/reference.md) | every command and environment variable |

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,8 +16,9 @@ it again.
 `woswoar install` checks for these and prints the install command for your
 distribution. `woswoar doctor` diagnoses anything else that looks wrong.
 
-There is a **zsh 5.0+** hook too, but `install` does not wire it up — see
-[Living in your shell](shell-integration.md#zsh) for the one line it takes.
+**bash and zsh both work.** `install` writes to every shell whose rc file
+already exists, and never creates one — see
+[Living in your shell](shell-integration.md#zsh).
 
 > [!WARNING]
 > **Do not install `age` as a snap.** It works, and it starts a sandbox on every
@@ -54,10 +55,15 @@ yourself: `install`, `import`, `init`.
 ## Upgrading
 
 > [!TIP]
-> **`pipx upgrade woswoar` for the next release.** The shell hook is a copy
-> rather than the packaged file, but it brings itself up to date on the next
-> background sync, so there is nothing else to run; open a new shell to pick it
-> up.
+> **`pipx upgrade woswoar` for the next release.** The shell hooks are copies
+> rather than the packaged files, but they bring themselves up to date on the
+> next background sync, so there is nothing else to run; open a new shell to
+> pick it up.
+>
+> **Started using a second shell since you installed?** Run `woswoar install`
+> once. The background refresh updates the hooks that are there and deliberately
+> creates none, so a shell woswoar has never been installed for stays that way
+> until you say otherwise.
 >
 > **Coming from 0.6.x or earlier, run `woswoar install` once.** Those versions
 > had no background sync, so there is nothing running that could notice.
@@ -120,9 +126,11 @@ order, and each is independent:
 systemctl --user disable --now woswoar-sync.timer
 rm -f ~/.config/systemd/user/woswoar-sync.{service,timer}
 
-# 2. Remove the hook from your shell. `woswoar install` wrote a marked block;
-#    delete the three lines between the markers, or:
-sed -i '/# >>> woswoar >>>/,/# <<< woswoar <<</d' ~/.bashrc
+# 2. Remove the hook from your shell(s). `woswoar install` wrote a marked block
+#    into each rc file it touched; delete the three lines between the markers, or:
+for rc in ~/.bashrc ~/.zshrc; do
+    [ -f "$rc" ] && sed -i '/# >>> woswoar >>>/,/# <<< woswoar <<</d' "$rc"
+done
 
 # 3. Remove the program.
 pipx uninstall woswoar

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -3,10 +3,14 @@
 woswoar is never the only thing hooked into a real `.bashrc`, and it runs on
 every prompt. Both of those constrain it more than anything else in the design.
 
-There are two hooks: `woswoar.bash`, which `woswoar install` wires up, and
-`woswoar.zsh`, which for now you [source by hand](#zsh). Everything below is
-about the bash one unless it says otherwise; the zsh section covers what is
-genuinely different, and it is almost all about *not* recording.
+There are two hooks, and `woswoar install` wires up whichever ones apply — it
+writes to **every shell whose rc file already exists**, and never creates one.
+So a machine with a `~/.bashrc` and a `~/.zshrc` records from both, into one
+history; a machine with only the first is untouched by the second.
+
+Everything below is about the bash hook unless it says otherwise. [The zsh
+section](#zsh) covers what is genuinely different, and it is almost all about
+*not* recording.
 
 ## Your normal bash is untouched
 
@@ -117,34 +121,41 @@ advertised.
 
 ## zsh
 
-**`woswoar install` does not know about zsh yet.** It writes `woswoar.bash` into
-`~/.local/share/woswoar/` and edits `.bashrc`; the zsh hook ships inside the
-package and stays there. So both the copy and the `.zshrc` line are yours to
-make, and the hook is the one file `woswoar` does not keep up to date for you —
-after `pip install -U woswoar`, repeat the copy.
+`woswoar install` writes `~/.zshrc` if you have one, exactly as it writes
+`~/.bashrc`. Nothing else to do; `woswoar doctor` reports the zsh version, the
+hook and the rc file on their own lines.
 
-Add it **last** in `~/.zshrc`:
-
-```zsh
-source "$(python3 -c 'import pathlib, woswoar
-print(pathlib.Path(woswoar.__file__).parent / "shell" / "woswoar.zsh")')"
+```console
+$ woswoar install
+machine : martin@laptop (60c0326a864478a1)
+logs    : ~/.local/share/woswoar/logs
+hook    : ~/.local/share/woswoar/woswoar.bash  (bash)
+hook    : ~/.local/share/woswoar/woswoar.zsh  (zsh)
+rcfile  : ~/.bashrc (added)
+rcfile  : ~/.zshrc (added)
 ```
 
-That sources it straight out of the package, so an upgrade is picked up by the
-next shell and there is nothing to keep in step — at the cost of a Python start
-in your `.zshrc`. If that matters, copy the file to
-`~/.local/share/woswoar/woswoar.zsh` and source the copy instead, and remember
-that `woswoar doctor` does not check that copy for staleness the way it checks
-the bash one.
+**It never creates an rc file.** A machine that has never run zsh does not
+acquire a `~/.zshrc` because you installed woswoar — that would be a startup
+file zsh now reads, put there by a command about something else. If you are
+about to start using zsh, `woswoar install --shell both` says so out loud and
+creates it. `--shell bash`, `--shell zsh` and `--rcfile` all still name one
+thing exactly.
 
 Everything else is shared: the same machine id, the same
 `logs/hosts/<id>/<day>.tsv`, the same sync. A machine that runs both shells
 records into one history and every <kbd>Ctrl</kbd>+<kbd>R</kbd> in either sees
 the other's commands, with nothing to exchange in between.
 
-**Last, because whoever binds <kbd>Ctrl</kbd>+<kbd>R</kbd> last wins.** Oh My
-Zsh, Prezto and atuin all bind it when they load. `WOSWOAR_NO_BIND=1` keeps
-theirs instead.
+> [!IMPORTANT]
+> **Upgrading woswoar does not add a shell.** The background sync refreshes the
+> hooks that are installed and deliberately creates none — so if you had woswoar
+> on bash and have since started using zsh, run `woswoar install` once. Nothing
+> else needs it.
+
+**Put the woswoar block last in `~/.zshrc`** if you move it, because whoever
+binds <kbd>Ctrl</kbd>+<kbd>R</kbd> last wins: Oh My Zsh, Prezto and atuin all
+bind it when they load. `WOSWOAR_NO_BIND=1` keeps theirs instead.
 
 Needs **zsh 5.0+**. The hook says so and switches itself off on anything older
 rather than half-working.

--- a/tests/support.py
+++ b/tests/support.py
@@ -32,6 +32,7 @@ requires_age = unittest.skipUnless(crypto.available(), "age required")
 requires_git = unittest.skipUnless(shutil.which("git"), "git required")
 requires_ssh_keygen = unittest.skipUnless(shutil.which("ssh-keygen"), "ssh-keygen required")
 requires_bash = unittest.skipUnless(shutil.which("bash"), "bash required")
+requires_zsh = unittest.skipUnless(shutil.which("zsh"), "zsh required")
 requires_fzf = unittest.skipUnless(shutil.which("fzf"), "fzf required")
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -200,7 +200,7 @@ class TestAHookLeftBehindByAnUpgrade(WoswoarTestCase):
     """
 
     def hook(self) -> Path:
-        path = store.data_dir() / main_module.HOOK_NAME
+        path = store.data_dir() / main_module.HOOKS["bash"]
         path.parent.mkdir(parents=True, exist_ok=True)
         return path
 
@@ -224,6 +224,62 @@ class TestAHookLeftBehindByAnUpgrade(WoswoarTestCase):
         self.assertNotIn("older than this woswoar", out)
 
 
+class TestDoctorReportsTheShellsThisMachineUses(WoswoarTestCase):
+    """One version line per shell woswoar is responsible for -- and only those.
+
+    Reporting every shell woswoar *could* support would fail a perfectly good
+    bash-only machine for not having zsh installed, which is a red `doctor` with
+    nothing to fix.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self._saved = {key: os.environ.get(key) for key in ("HOME", "SHELL")}
+        self.addCleanup(self._restore)
+        os.environ["HOME"] = str(self.home)
+        os.environ["SHELL"] = "/bin/bash"
+
+    def _restore(self) -> None:
+        for key, value in self._saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_a_bash_only_machine_is_not_asked_about_zsh(self) -> None:
+        (self.home / ".bashrc").write_text("", encoding="utf-8")
+        support.run_cli("install")
+        out = support.run_cli("doctor").out
+        self.assertRegex(out, r"\] bash ")
+        self.assertNotIn("] zsh ", out)
+
+    def test_doctor_checks_the_zsh_version_when_zsh_is_installed(self) -> None:
+        """The version floor exists because the hook enforces one and switches
+        itself off below it -- silently, from the user's side. This is what says
+        so before they find out."""
+        (self.home / ".zshrc").write_text("", encoding="utf-8")
+        support.run_cli("install")
+        out = support.run_cli("doctor").out
+        self.assertRegex(out, r"\] zsh +\S+ \(5\.0\+ required\)")
+
+    def test_each_installed_shell_gets_its_own_rcfile_line(self) -> None:
+        (self.home / ".bashrc").write_text("", encoding="utf-8")
+        (self.home / ".zshrc").write_text("", encoding="utf-8")
+        support.run_cli("install")
+        out = support.run_cli("doctor").out
+        self.assertIn(f"{self.home}/.bashrc sources the hook", out)
+        self.assertIn(f"{self.home}/.zshrc sources the hook", out)
+
+    def test_a_machine_with_nothing_installed_still_reports_a_shell(self) -> None:
+        """`installed_shells()` is empty before the first `install`, and a doctor
+        that then printed no shell line at all would be least useful exactly when
+        someone is trying to find out what is wrong."""
+        out = support.run_cli("doctor").out
+        self.assertRegex(out, r"\] bash ")
+
+
 class TestReadingThePackagedHook(unittest.TestCase):
     def test_the_fast_path_and_the_fallback_agree(self) -> None:
         """`_hook_bytes` reads the file beside the module and only falls back to
@@ -234,8 +290,10 @@ class TestReadingThePackagedHook(unittest.TestCase):
         """
         from importlib import resources
 
-        via_resources = (resources.files("woswoar") / "shell" / main_module.HOOK_NAME).read_bytes()
-        self.assertEqual(main_module._hook_bytes(), via_resources)
+        via_resources = (
+            resources.files("woswoar") / "shell" / main_module.HOOKS["bash"]
+        ).read_bytes()
+        self.assertEqual(main_module._hook_bytes("bash"), via_resources)
         self.assertTrue(via_resources.startswith(b"# woswoar"), "that is not the hook")
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -13,11 +13,12 @@ import subprocess
 import unittest
 from pathlib import Path
 
-from woswoar import store
-from woswoar.__main__ import main, portable_hook_path
+from woswoar import __main__ as main_module
+from woswoar import cache, store
+from woswoar.__main__ import _BEGIN, main, portable_hook_path
 
 from . import support
-from .support import MACHINE_ID, WoswoarTestCase, make_entry, requires_bash
+from .support import MACHINE_ID, WoswoarTestCase, make_entry, requires_bash, requires_zsh
 
 
 class TestPortableHookPath(unittest.TestCase):
@@ -170,6 +171,278 @@ class TestPrivateByDefault(WoswoarTestCase):
         self.first_run()
         store.logs_dir().chmod(0o755)
         self.assertRegex(support.run_cli("doctor").out, r"\[FAIL\] private")
+
+
+class TestShellDetection(WoswoarTestCase):
+    """Which shells `install` writes to when nobody said (#159).
+
+    The rule is "every shell whose rc file already exists". Both halves of that
+    are load-bearing and each has its own test below, because the two obvious
+    simplifications are both wrong: installing only the first match leaves a
+    user with two shells recording from one of them, and installing
+    unconditionally puts a `~/.zshrc` on the machine of somebody who has never
+    run zsh.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self._saved = {key: os.environ.get(key) for key in ("HOME", "SHELL")}
+        self.addCleanup(self._restore)
+        os.environ["HOME"] = str(self.home)
+        # Never inherited from the machine running the suite: `auto`'s fallback
+        # reads it, so a developer whose login shell is zsh would otherwise get
+        # a different answer from CI.
+        os.environ["SHELL"] = "/bin/bash"
+
+    def _restore(self) -> None:
+        for key, value in self._saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def rcfiles(self, *shells: str) -> None:
+        for shell in shells:
+            (self.home / main_module.RCFILES[shell]).write_text("# mine\n", encoding="utf-8")
+
+    def sourced(self, shell: str) -> bool:
+        """Whether that shell's rc file now sources that shell's hook."""
+        rcfile = self.home / main_module.RCFILES[shell]
+        if not rcfile.is_file():
+            return False
+        return main_module.HOOKS[shell] in rcfile.read_text(encoding="utf-8")
+
+    def test_auto_installs_into_every_existing_rcfile(self) -> None:
+        """A machine with both shells must record from both.
+
+        The fixture needs *both* files: with one, "install into every match" and
+        "install into the first match" give the same answer and the test asserts
+        nothing about which was written.
+        """
+        self.rcfiles("bash", "zsh")
+        self.assertEqual(main(["install"]), 0)
+        self.assertTrue(self.sourced("bash"), "the bash hook was not wired up")
+        self.assertTrue(self.sourced("zsh"), "the zsh hook was not wired up")
+        for shell in ("bash", "zsh"):
+            self.assertTrue((store.data_dir() / main_module.HOOKS[shell]).is_file())
+
+    def test_auto_does_not_create_an_rcfile_that_is_absent(self) -> None:
+        """The half that keeps `install` from making a decision for someone.
+
+        Writing a `~/.zshrc` onto a machine that has never run zsh is not a
+        harmless extra file: it is a startup file that shell will now read, put
+        there by a command the user ran about *bash*.
+        """
+        self.rcfiles("bash")
+        self.assertEqual(main(["install"]), 0)
+        self.assertTrue(self.sourced("bash"))
+        self.assertFalse((self.home / ".zshrc").exists(), "install created a ~/.zshrc")
+        self.assertFalse(
+            (store.data_dir() / main_module.HOOKS["zsh"]).exists(),
+            "a hook was copied for a shell with no rc file",
+        )
+
+    def test_auto_falls_back_to_the_login_shell(self) -> None:
+        """A container or a fresh account has neither file, and still has a shell."""
+        os.environ["SHELL"] = "/usr/bin/zsh"
+        self.assertEqual(main(["install"]), 0)
+        self.assertTrue(self.sourced("zsh"), "the login shell was not consulted")
+        self.assertFalse((self.home / ".bashrc").exists(), "it installed for bash as well")
+
+    def test_an_unknown_login_shell_falls_back_to_bash(self) -> None:
+        """`SHELL=/usr/bin/fish` must not leave the machine with no hook at all.
+
+        bash rather than nothing: its hook is the one that has shipped longest,
+        and a fish user who wanted zsh can say so.
+        """
+        os.environ["SHELL"] = "/usr/bin/fish"
+        self.assertEqual(main(["install"]), 0)
+        self.assertTrue(self.sourced("bash"))
+
+    def test_shell_overrides_what_is_on_the_machine(self) -> None:
+        self.rcfiles("bash")
+        self.assertEqual(main(["install", "--shell", "zsh"]), 0)
+        self.assertTrue(self.sourced("zsh"), "--shell was ignored")
+        self.assertFalse(self.sourced("bash"), "--shell zsh installed bash too")
+
+    def test_shell_both_installs_for_a_shell_with_no_rcfile_yet(self) -> None:
+        """The escape hatch from the rule above, for someone about to start
+        using zsh. Asking for it explicitly is what makes creating the file
+        acceptable here and not in `auto`."""
+        self.assertEqual(main(["install", "--shell", "both"]), 0)
+        self.assertTrue(self.sourced("bash"))
+        self.assertTrue(self.sourced("zsh"))
+
+    def test_rcfile_alone_picks_the_shell_from_its_name(self) -> None:
+        """`--rcfile ~/.zshrc` cannot sensibly mean the bash hook.
+
+        Deciding by detection instead -- which is what #159 suggested -- would
+        hand someone with a `.bashrc` beside it a `.zshrc` that sources
+        `woswoar.bash`: a file zsh reads, sourcing shell code written for the
+        other shell, which loads nothing and says nothing.
+        """
+        self.rcfiles("bash")
+        target = self.home / ".zshrc"
+        self.assertEqual(main(["install", "--rcfile", str(target)]), 0)
+        self.assertIn(main_module.HOOKS["zsh"], target.read_text(encoding="utf-8"))
+        self.assertFalse(self.sourced("bash"), "--rcfile installed a second shell as well")
+
+    def test_rcfile_with_shell_both_is_refused_rather_than_resolved(self) -> None:
+        """Both resolutions are wrong and one of them is silent.
+
+        Two blocks into one file leaves only the second, because each replaces
+        the marked block the last one wrote -- so this would end with a
+        `.bashrc` that sources the zsh hook, and say "added" twice on the way.
+        """
+        self.rcfiles("bash")
+        ran = support.run_cli("install", "--rcfile", str(self.home / ".bashrc"), "--shell", "both")
+        self.assertEqual(ran.code, 1)
+        self.assertIn("--rcfile names one file", ran.err)
+        self.assertNotIn(
+            main_module.HOOKS["zsh"],
+            (self.home / ".bashrc").read_text(encoding="utf-8"),
+            "it wrote the zsh hook into the bash rc file anyway",
+        )
+
+    def test_an_unrecognisable_rcfile_name_installs_one_shell(self) -> None:
+        """`--rcfile /tmp/rc` says nothing about which shell, so detection
+        answers -- but it still means *one* file, never two."""
+        self.rcfiles("bash", "zsh")
+        target = self.home / "rc"
+        self.assertEqual(main(["install", "--rcfile", str(target)]), 0)
+        text = target.read_text(encoding="utf-8")
+        self.assertEqual(text.count(_BEGIN), 1)
+        self.assertIn(main_module.HOOKS["bash"], text)
+
+
+@requires_bash
+@requires_zsh
+class TestBothShellsRecordIntoOneHistory(WoswoarTestCase):
+    """`install`, then a real bash and a real zsh, then one host directory.
+
+    Everything upstream of this is asserted in pieces -- which rc file was
+    written, which hook was copied. This is the piece nobody can assert from a
+    string: that following `install` with both shells present leaves one machine
+    id and one day file, rather than two histories that never meet.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self._saved = {key: os.environ.get(key) for key in ("HOME", "SHELL")}
+        self.addCleanup(self._restore)
+        os.environ["HOME"] = str(self.home)
+        os.environ["SHELL"] = "/bin/bash"
+        for name in (".bashrc", ".zshrc"):
+            (self.home / name).write_text("", encoding="utf-8")
+        self.assertEqual(main(["install"]), 0)
+
+    def _restore(self) -> None:
+        for key, value in self._saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def run_shell(self, argv: list[str], rcfile: str, marker: str) -> None:
+        """One command, in a shell that loads its own rc file the way a login does.
+
+        Sourcing the rc file rather than the hook is the whole point: what is
+        under test is the line `install` wrote into it.
+        """
+        subprocess.run(
+            argv,
+            input=f"source {self.home / rcfile}\necho {marker}\n",
+            text=True,
+            env={
+                "HOME": str(self.home),
+                "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                "TERM": "dumb",
+                "WOSWOAR_DIR": os.environ["WOSWOAR_DIR"],
+                "XDG_CONFIG_HOME": os.environ["XDG_CONFIG_HOME"],
+                "XDG_CACHE_HOME": os.environ["XDG_CACHE_HOME"],
+                "WOSWOAR_SYNC_INTERVAL": "0",
+            },
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=60,
+        )
+
+    def test_both_shells_write_to_one_host_directory(self) -> None:
+        self.run_shell(["bash", "--norc", "-i"], ".bashrc", "from_bash_marker")
+        self.run_shell(["zsh", "-f", "-i"], ".zshrc", "from_zsh_marker")
+
+        hosts = sorted(p.name for p in (store.logs_dir() / "hosts").iterdir())
+        self.assertEqual(hosts, [MACHINE_ID], f"two shells, {len(hosts)} machine ids")
+
+        recorded = {entry.cmd for entry in cache.load_entries()}
+        self.assertIn("echo from_bash_marker", recorded, "the bash rc line did not record")
+        self.assertIn("echo from_zsh_marker", recorded, "the zsh rc line did not record")
+
+
+class TestTheRefreshNeverCreates(WoswoarTestCase):
+    """The hazard #159 names, and the reason this is not a tidy-up.
+
+    `_refresh_hook` runs unattended, from the background sync a prompt starts.
+    If it ever *created* rather than refreshed, the first sync after an upgrade
+    would put a `woswoar.zsh` on a bash-only machine: a file nothing sources,
+    that nobody asked for, from a command nobody ran.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self._home = os.environ.get("HOME")
+        os.environ["HOME"] = str(self.home)
+        self.addCleanup(self._restore)
+        (self.home / ".bashrc").write_text("# mine\n", encoding="utf-8")
+        self.assertEqual(main(["install", "--shell", "bash"]), 0)
+
+    def _restore(self) -> None:
+        if self._home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._home
+
+    def hook(self, shell: str) -> Path:
+        return store.data_dir() / main_module.HOOKS[shell]
+
+    def test_a_refresh_never_creates_a_second_hook(self) -> None:
+        # A `.zshrc` as well, so that *detection* would say zsh -- the refresh
+        # must go on what is installed, not on what the machine looks like.
+        # Without this the test passes against a refresh that consults
+        # `detect_shells`, which is the wrong rule reached by a plausible route.
+        (self.home / ".zshrc").write_text("# mine\n", encoding="utf-8")
+        self.hook("bash").write_bytes(b"# an older woswoar\n")
+
+        self.assertTrue(main_module._refresh_hook(), "the stale bash hook was not refreshed")
+        self.assertEqual(self.hook("bash").read_bytes(), main_module._hook_bytes("bash"))
+        self.assertFalse(self.hook("zsh").exists(), "the refresh planted a hook nobody installed")
+
+    def test_a_stale_zsh_hook_is_refreshed(self) -> None:
+        """The other direction: once zsh *is* installed, it heals like bash.
+
+        Restricting staleness to bash would leave a zsh user running whatever
+        shell code they installed on the day they set up, forever, with
+        `doctor` reporting green.
+        """
+        self.assertEqual(main(["install", "--shell", "zsh"]), 0)
+        self.hook("zsh").write_bytes(b"# an older woswoar\n")
+
+        self.assertTrue(main_module._refresh_hook())
+        self.assertEqual(self.hook("zsh").read_bytes(), main_module._hook_bytes("zsh"))
+
+    def test_a_stale_zsh_hook_makes_doctor_say_so(self) -> None:
+        self.assertEqual(main(["install", "--shell", "zsh"]), 0)
+        self.hook("zsh").write_bytes(b"# an older woswoar\n")
+        ran = support.run_cli("doctor")
+        self.assertIn("older than this woswoar", ran.out)
+        self.assertIn(main_module.HOOKS["zsh"], ran.out)
 
 
 if __name__ == "__main__":

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -236,7 +236,7 @@ class TestTheBareCommandOnAFreshMachine(SetupTestCase):
     def test_a_hook_alone_is_enough_to_be_reported_on_instead(self) -> None:
         """Someone who ran `install` and nothing else has set something up, and
         running `setup` at them would answer a question they did not ask."""
-        hook = Path(os.environ["WOSWOAR_DIR"]) / main_module.HOOK_NAME
+        hook = Path(os.environ["WOSWOAR_DIR"]) / main_module.HOOKS["bash"]
         hook.parent.mkdir(parents=True, exist_ok=True)
         hook.write_text("#", encoding="utf-8")
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -25,7 +25,7 @@ from typing import Any, ClassVar
 from unittest import mock
 
 from woswoar import cache, crypto, progress, prove, search, store, sync
-from woswoar.__main__ import _GRANT_REMEDY, HOOK_NAME, main
+from woswoar.__main__ import _GRANT_REMEDY, HOOKS, main
 from woswoar.__main__ import _hook_bytes as main_hook_bytes
 from woswoar.entry import Entry, format_line
 from woswoar.sync import COMMIT_MESSAGE as COMMIT
@@ -5437,7 +5437,7 @@ class TestAHookLeftBehindByAnUpgradeIsSurfaced(SyncTestCase):
 
     def stale(self, alpha: Fake) -> None:
         with alpha.active():
-            hook = store.data_dir() / HOOK_NAME
+            hook = store.data_dir() / HOOKS["bash"]
             hook.parent.mkdir(parents=True, exist_ok=True)
             hook.write_text("# woswoar, but from last year\n", encoding="utf-8")
 
@@ -5479,14 +5479,14 @@ class TestTheHookKeepsItselfUpToDate(SyncTestCase):
     def install(self, alpha: Fake) -> Path:
         self.run_cli(alpha, "install", "--rcfile", str(self.root / "bashrc"))
         with alpha.active():
-            return store.data_dir() / HOOK_NAME
+            return store.data_dir() / HOOKS["bash"]
 
     def test_a_stale_hook_is_brought_up_to_date_by_a_sync(self) -> None:
         alpha = self.machine("alpha")
         hook = self.install(alpha)
         hook.write_text("# woswoar, but from last year\n", encoding="utf-8")
         self.run_cli(alpha, "sync")
-        self.assertEqual(hook.read_bytes(), main_hook_bytes())
+        self.assertEqual(hook.read_bytes(), main_hook_bytes("bash"))
 
     def test_the_bare_command_stops_reporting_it_afterwards(self) -> None:
         """The report and the repair have to agree, or somebody is told to run
@@ -5503,7 +5503,7 @@ class TestTheHookKeepsItselfUpToDate(SyncTestCase):
         file nothing references would be a confusing way to say that."""
         alpha = self.machine("alpha")
         with alpha.active():
-            hook = store.data_dir() / HOOK_NAME
+            hook = store.data_dir() / HOOKS["bash"]
             self.assertFalse(hook.exists(), "precondition: no hook installed")
         self.run_cli(alpha, "sync")
         with alpha.active():
@@ -5521,7 +5521,7 @@ class TestTheHookKeepsItselfUpToDate(SyncTestCase):
 
         with mock.patch.object(sync, "export", boom):
             self.assertEqual(self.run_cli(alpha, "sync").code, 1)
-        self.assertEqual(hook.read_bytes(), main_hook_bytes())
+        self.assertEqual(hook.read_bytes(), main_hook_bytes("bash"))
 
     def test_a_current_hook_is_left_exactly_alone(self) -> None:
         """Rewriting an identical file once a minute is a pointless write, and

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -27,13 +27,71 @@ _GRANT_REMEDY = (
     "then sync here again. Nothing is lost in the meantime."
 )
 
-HOOK_NAME = "woswoar.bash"
+#: The hook each shell sources, and the file each shell reads at the start of an
+#: interactive session. Two hooks rather than one that branches: the bash one is
+#: built on bash 5 builtins and the zsh one on zsh's, and the interesting half of
+#: either is what its shell does *not* offer.
+#:
+#: Ordered, because it decides the order things are printed and installed in, and
+#: a report whose lines move around between runs is harder to diff than it needs
+#: to be.
+HOOKS = {"bash": "woswoar.bash", "zsh": "woswoar.zsh"}
+RCFILES = {"bash": ".bashrc", "zsh": ".zshrc"}
+
+#: What each shell must be able to do, and how to ask it. bash 5 for
+#: $EPOCHSECONDS and $EPOCHREALTIME; zsh 5 for `zsh/datetime` and
+#: `add-zsh-hook`. Each hook enforces its own floor and switches itself off
+#: below it -- this is how `doctor` says the same thing before you find out.
+_VERSION_QUERY = {
+    "bash": "echo ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}",
+    "zsh": "echo $ZSH_VERSION",
+}
+_VERSION_FLOOR = 5
+
 _BEGIN = "# >>> woswoar >>>"
 _END = "# <<< woswoar <<<"
 _BLOCK = re.compile(re.escape(_BEGIN) + r".*?" + re.escape(_END) + r"\n?", re.DOTALL)
 
 
-def _hook_bytes() -> bytes:
+def rcfile_for(shell: str) -> Path:
+    return Path.home() / RCFILES[shell]
+
+
+def installed_shells() -> list[str]:
+    """Every shell this machine has a hook copied for.
+
+    The hooks in the data directory, not what is on PATH and not what
+    `.bashrc` says: `install` writing the file is what makes a shell one woswoar
+    is responsible for, and it is the same fact `_refresh_hook` acts on.
+    """
+    return [shell for shell in HOOKS if (store.data_dir() / HOOKS[shell]).is_file()]
+
+
+def detect_shells() -> list[str]:
+    """The shells `install` writes to when nobody said which.
+
+    **Every shell whose rc file already exists**, which is the rule that decides
+    the two things this must not do. It must not need a flag from someone who
+    uses both shells -- `install` already edits `.bashrc` without being asked,
+    so an existing `.zshrc` is no different. And it must not *create* a
+    `~/.zshrc` for someone who has never run zsh, which is what "already exists"
+    is doing here and why this is not simply "write both".
+
+    `$SHELL` is the fallback and deliberately not the detector: it names the
+    login shell, and someone whose login shell is zsh but who works in bash
+    would get the hook in the shell they are not typing into. It only decides
+    the case where there is no rc file to go on at all -- a container, a fresh
+    account -- and there bash is the last resort, because it is the shell whose
+    hook has been shipped longest.
+    """
+    present = [shell for shell in HOOKS if rcfile_for(shell).is_file()]
+    if present:
+        return present
+    login = Path(os.environ.get("SHELL", "")).name
+    return [login] if login in HOOKS else ["bash"]
+
+
+def _hook_bytes(shell: str) -> bytes:
     """The hook as this version ships it.
 
     The bytes rather than a path, which is what replaced an `as_file` dance
@@ -52,13 +110,13 @@ def _hook_bytes() -> bytes:
     a filesystem at all, wheel or editable. The fallback is for a zipapp, where
     `__file__` is a path inside the archive and nothing can open it.
     """
-    beside = Path(__file__).resolve().parent / "shell" / HOOK_NAME
+    beside = Path(__file__).resolve().parent / "shell" / HOOKS[shell]
     if beside.is_file():
         return beside.read_bytes()
 
     from importlib import resources
 
-    return (resources.files("woswoar") / "shell" / HOOK_NAME).read_bytes()
+    return (resources.files("woswoar") / "shell" / HOOKS[shell]).read_bytes()
 
 
 def portable_hook_path(target: Path) -> str:
@@ -80,26 +138,46 @@ def portable_hook_path(target: Path) -> str:
         return str(target)
 
 
-def cmd_install(args: argparse.Namespace) -> int:
-    """Set up machine identity, install the hook, and wire up .bashrc."""
-    machine = store.machine()
-    store.private_dir(store.data_dir())
-    target = store.data_dir() / HOOK_NAME
-    target.write_bytes(_hook_bytes())
-    # After the copy, not before: `write_bytes` creates at the ambient umask, so
-    # hardening first would leave the one file install itself writes as the one
-    # file its own migration missed. This is also what re-tightens a tree from
-    # a woswoar that predated owner-only directories -- `install` is the
-    # command people re-run to upgrade.
-    store.harden()
+def shells_from(args: argparse.Namespace) -> list[str]:
+    """Which shells this invocation is about.
 
-    print(f"machine : {machine.name} ({machine.id})")
-    print(f"logs    : {store.logs_dir()}")
-    print(f"hook    : {target}")
+    `--shell` wins outright. Otherwise `--rcfile` decides, because a file named
+    `.zshrc` is not an ambiguous thing to be handed: taking the *detected* shell
+    there would let someone with a `.bashrc` beside it get the bash hook sourced
+    from their zsh startup file, which loads nothing and says nothing. When the
+    name settles nothing either -- `--rcfile /tmp/rc` -- detection has the only
+    other opinion available.
+    """
+    choice = getattr(args, "shell", None) or "auto"
+    rcfile = getattr(args, "rcfile", None)
+    if rcfile and choice == "both":
+        # Refused rather than resolved, because both resolutions are wrong and
+        # one of them is silent: writing two blocks into one file leaves only
+        # the second, since each replaces the marked block the last one wrote --
+        # so `--rcfile ~/.bashrc --shell both` would end with a `.bashrc`
+        # sourcing the *zsh* hook.
+        raise WoswoarError(
+            "--rcfile names one file, so it cannot be combined with --shell both.\n"
+            "Run install once per shell, or drop --rcfile to use each shell's own rc file."
+        )
+    if choice in HOOKS:
+        return [choice]
+    if choice == "both":
+        return list(HOOKS)
+    if rcfile:
+        named = [shell for shell, name in RCFILES.items() if Path(rcfile).name == name]
+        return named or detect_shells()[:1]
+    return detect_shells()
 
-    rcfile = Path(args.rcfile).expanduser() if args.rcfile else Path.home() / ".bashrc"
+
+def _write_block(rcfile: Path, target: Path) -> str:
+    """Put the sourced line into ``rcfile``, and say what that did.
+
+    Creating the file when it is absent is correct *here* and only here: a
+    caller has already decided this shell is one to install for, either by
+    detection -- which needs the file to exist -- or because it was named.
+    """
     block = f'{_BEGIN}\nsource "{portable_hook_path(target)}"\n{_END}\n'
-
     existing = rcfile.read_text(encoding="utf-8") if rcfile.is_file() else ""
     if _BLOCK.search(existing):
         updated = _BLOCK.sub(block, existing)
@@ -110,12 +188,50 @@ def cmd_install(args: argparse.Namespace) -> int:
         action = "added"
 
     if updated == existing:
-        print(f"rcfile  : {rcfile} (already current)")
-    else:
-        rcfile.write_text(updated, encoding="utf-8")
-        print(f"rcfile  : {rcfile} ({action})")
+        return "already current"
+    rcfile.write_text(updated, encoding="utf-8")
+    return action
 
-    print("\nOpen a new shell, or run:  source", target)
+
+def cmd_install(args: argparse.Namespace) -> int:
+    """Set up machine identity, install each shell's hook, and wire up its rcfile."""
+    machine = store.machine()
+    store.private_dir(store.data_dir())
+
+    shells = shells_from(args)
+    targets = {}
+    for shell in shells:
+        target = store.data_dir() / HOOKS[shell]
+        target.write_bytes(_hook_bytes(shell))
+        targets[shell] = target
+    # After the copies, not before: `write_bytes` creates at the ambient umask,
+    # so hardening first would leave the files install itself writes as the ones
+    # its own migration missed. This is also what re-tightens a tree from a
+    # woswoar that predated owner-only directories -- `install` is the command
+    # people re-run to upgrade.
+    store.harden()
+
+    print(f"machine : {machine.name} ({machine.id})")
+    print(f"logs    : {store.logs_dir()}")
+    for shell, target in targets.items():
+        print(f"hook    : {target}" + (f"  ({shell})" if len(shells) > 1 else ""))
+
+    # One `--rcfile` cannot mean two files, and `shells_from` has already
+    # reduced to a single shell when it was given.
+    override = Path(args.rcfile).expanduser() if getattr(args, "rcfile", None) else None
+    for shell, target in targets.items():
+        rcfile = override if override is not None else rcfile_for(shell)
+        print(f"rcfile  : {rcfile} ({_write_block(rcfile, target)})")
+
+    # One line per shell, never `source a b`: a second word there is not a
+    # second file to read, it is `$1` for the first one. The pair only ever
+    # differ by which shell you are standing in, so each is offered on its own.
+    if len(targets) == 1:
+        print("\nOpen a new shell, or run:  source", *targets.values())
+    else:
+        print("\nOpen a new shell. To pick it up in one already open:")
+        for shell, target in targets.items():
+            print(f"    source {target}   # in {shell}")
 
     # The moment someone finds out, so the moment to say it. Recording works
     # without any of these, which is why this warns rather than fails -- but
@@ -307,7 +423,6 @@ def _markers(stream: object | None = None) -> dict[str, str]:
 
 def cmd_doctor(args: argparse.Namespace) -> int:
     import shutil
-    import subprocess
 
     from . import crypto, deps, sync
 
@@ -338,22 +453,18 @@ def cmd_doctor(args: argparse.Namespace) -> int:
             )
         return 0 if ok else 1
 
-    bash = shutil.which("bash")
-    version = ""
-    if bash:
-        try:
-            out = subprocess.run(
-                [bash, "-c", "echo ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"],
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=5,
-            )
-            version = out.stdout.strip()
-        except (OSError, subprocess.SubprocessError):
-            version = ""
-    major = int(version.split(".")[0]) if version and version[0].isdigit() else 0
-    check("bash", major >= 5, f"{version or 'not found'} (5.0+ required)")
+    # The shells this machine has hooks for, or -- on one that has not run
+    # `install` yet -- the ones it would get if it did. Reporting on every shell
+    # woswoar *could* support instead would fail a perfectly good bash-only
+    # machine for not having zsh.
+    for shell in installed_shells() or detect_shells():
+        version = _shell_version(shell)
+        major = int(version.split(".")[0]) if version and version[0].isdigit() else 0
+        check(
+            shell,
+            major >= _VERSION_FLOOR,
+            f"{version or 'not found'} ({_VERSION_FLOOR}.0+ required)",
+        )
 
     fzf = shutil.which("fzf")
     if fzf is None:
@@ -387,21 +498,31 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     has_machine = machine_file.is_file()
     check("machine", has_machine, str(machine_file))
 
-    hook = store.data_dir() / HOOK_NAME
-    if _hook_is_stale():
-        # `install` copies the hook into the data directory rather than sourcing
-        # it out of the package, so upgrading woswoar leaves the old shell code
-        # running -- and nothing said so. That was survivable while the hook only
-        # recorded; syncing lives in it now, so a machine that never re-ran
-        # `install` silently keeps whatever sync arrangement it had.
-        check("hook", False, f"{hook} is older than this woswoar - run 'woswoar install'")
-    else:
-        check("hook", hook.is_file(), str(hook))
+    # `install` copies each hook into the data directory rather than sourcing it
+    # out of the package, so upgrading woswoar leaves the old shell code running
+    # -- and nothing said so. That was survivable while the hook only recorded;
+    # syncing lives in it now, so a machine that never re-ran `install` silently
+    # keeps whatever sync arrangement it had.
+    stale = _stale_hooks()
+    present = installed_shells()
+    if not present:
+        check("hook", False, f"no hook installed in {store.data_dir()}")
+    for shell in present:
+        hook = store.data_dir() / HOOKS[shell]
+        if shell in stale:
+            check("hook", False, f"{hook} is older than this woswoar - run 'woswoar install'")
+        else:
+            check("hook", True, str(hook))
 
-    rcfile = Path.home() / ".bashrc"
-    sourced = rcfile.is_file() and _BEGIN in rcfile.read_text(encoding="utf-8")
-    detail = "sources the hook" if sourced else "has no woswoar block"
-    check("bashrc", sourced, f"{rcfile} {detail}")
+    # One line per rc file, and per *installed* shell rather than per rc file
+    # that exists: a `.zshrc` on a machine woswoar was only ever installed into
+    # bash for is not a problem, and reporting it as one would send someone
+    # looking for a block that is correctly absent.
+    for shell in present or detect_shells():
+        rcfile = rcfile_for(shell)
+        sourced = rcfile.is_file() and _BEGIN in rcfile.read_text(encoding="utf-8")
+        detail = "sources the hook" if sourced else "has no woswoar block"
+        check(RCFILES[shell].lstrip("."), sourced, f"{rcfile} {detail}")
 
     # Not just "is age on PATH". A sandboxed age -- snap, flatpak, anything
     # confined -- answers `--version` perfectly and then cannot open a key,
@@ -869,14 +990,51 @@ def cmd_grant(args: argparse.Namespace) -> int:
     return 0
 
 
-def _hook_is_stale() -> bool:
-    """Whether the installed hook is some older woswoar's copy of it.
+def _shell_version(shell: str) -> str:
+    """What ``shell`` reports as its version, or "" if it cannot be asked.
 
-    False for a missing hook: that is a different problem with a different fix,
-    and `doctor` already has a line for it.
+    Asked of the binary rather than read from a package manager, because the
+    thing that matters is the one that will source the hook. Every failure --
+    not on PATH, refuses to start, times out -- collapses to "" and is reported
+    as "not found": from `doctor`'s side those are one situation, and the
+    remedy for all of them is to install the shell.
     """
-    hook = store.data_dir() / HOOK_NAME
-    return hook.is_file() and hook.read_bytes() != _hook_bytes()
+    import shutil
+    import subprocess
+
+    binary = shutil.which(shell)
+    if not binary:
+        return ""
+    try:
+        out = subprocess.run(
+            [binary, "-c", _VERSION_QUERY[shell]],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return out.stdout.strip()
+
+
+def _stale_hooks() -> list[str]:
+    """Every *installed* shell whose hook is some older woswoar's copy of it.
+
+    Installed, so a missing hook is never stale: that is a different problem
+    with a different fix, and `doctor` already has a line for it. It is also the
+    whole of what keeps `_refresh_hook` from planting a zsh hook on a machine
+    that has never asked for one.
+    """
+    return [
+        shell
+        for shell in installed_shells()
+        if (store.data_dir() / HOOKS[shell]).read_bytes() != _hook_bytes(shell)
+    ]
+
+
+def _hook_is_stale() -> bool:
+    return bool(_stale_hooks())
 
 
 def _refresh_hook() -> bool:
@@ -897,25 +1055,34 @@ def _refresh_hook() -> bool:
     the packaged file's mode as an exposure, because its permission walk uses
     `stat`, which follows links.
 
-    Only ever *re*-writes. A machine with no hook at all has not run `install`,
-    its `.bashrc` sources nothing, and writing a file it does not reference
-    would be a confusing way to say so.
+    Only ever *re*-writes, and now that there are two hooks that rule is
+    load-bearing rather than tidy. This runs unattended, from a background sync
+    a prompt started. A version of it that *created* would put a `woswoar.zsh`
+    on a bash-only machine at the first sync after an upgrade -- a file nothing
+    sources, that nobody asked for, from a command nobody ran. `_stale_hooks`
+    only ever names hooks that are already there, and
+    `test_a_refresh_never_creates_a_second_hook` is what holds that.
     """
-    if not _hook_is_stale():
-        return False
-    hook = store.data_dir() / HOOK_NAME
-    # The mode was set when `install` created it and `write_bytes` truncates
-    # rather than recreates, so it survives -- and the hook is public code
-    # anyway. Failure is not fatal: a read-only data directory is a real
-    # situation and it must not stop the sync this command exists for.
-    try:
-        hook.write_bytes(_hook_bytes())
-    except OSError:
+    refreshed = []
+    for shell in _stale_hooks():
+        hook = store.data_dir() / HOOKS[shell]
+        # The mode was set when `install` created it and `write_bytes` truncates
+        # rather than recreates, so it survives -- and the hook is public code
+        # anyway. Failure is not fatal: a read-only data directory is a real
+        # situation and it must not stop the sync this command exists for. Per
+        # hook, so one unwritable file does not stop the other being fixed.
+        try:
+            hook.write_bytes(_hook_bytes(shell))
+        except OSError:
+            continue
+        refreshed.append(hook)
+    if not refreshed:
         return False
     # Shells already running keep the code they sourced, exactly as they do
     # after a hand-run `install`. New ones get this. Nothing to do about the
     # difference, and nothing anyone needs to do.
-    print(f"updated the shell hook at {hook} to {__version__}")
+    for hook in refreshed:
+        print(f"updated the shell hook at {hook} to {__version__}")
     return True
 
 
@@ -1151,7 +1318,7 @@ def _untouched() -> bool:
     """
     from . import sync
 
-    if (store.data_dir() / HOOK_NAME).is_file() or sync.is_repo():
+    if installed_shells() or sync.is_repo():
         return False
     return not any(store.iter_log_files())
 
@@ -1178,7 +1345,7 @@ def cmd_status(args: argparse.Namespace) -> int:
 
     if _untouched():
         print("Nothing installed here yet -- setting up.\n")
-        return cmd_setup(argparse.Namespace(rcfile=None))
+        return cmd_setup(argparse.Namespace(rcfile=None, shell=None))
 
     loaded = cache.load_columns()
     stamps, _ = loaded.stamps_and_commands()
@@ -1281,13 +1448,33 @@ def cmd_setup(args: argparse.Namespace) -> int:
         print("     everything woswoar needs is installed")
 
     print("\n2/4  Shell hook")
-    cmd_install(argparse.Namespace(rcfile=args.rcfile))
+    # Named before it is written, because it is now more than one file and the
+    # rule that chose them is not obvious from the output alone.
+    chosen = shells_from(args)
+    print(f"     {' and '.join(chosen)} -- {_why_those_shells(args, chosen)}")
+    cmd_install(argparse.Namespace(rcfile=args.rcfile, shell=getattr(args, "shell", None)))
 
     print("\n3/4  Existing history")
     _offer_imports()
 
     print("\n4/4  Sync with your other machines")
     return _offer_remote(args)
+
+
+def _why_those_shells(args: argparse.Namespace, chosen: list[str]) -> str:
+    """One clause saying which rule picked `chosen`, for `setup`'s step 2.
+
+    Worth a line because the answer differs per machine and the wrong one is
+    silent: a hook written into the shell you do not use looks exactly like a
+    hook that works.
+    """
+    if getattr(args, "shell", None) and args.shell != "auto":
+        return f"--shell {args.shell}"
+    if getattr(args, "rcfile", None):
+        return f"from the name of {Path(args.rcfile).name}"
+    if any(rcfile_for(shell).is_file() for shell in chosen):
+        return "found " + " and ".join(f"~/{RCFILES[shell]}" for shell in chosen)
+    return f"no rc file here, so $SHELL ({os.environ.get('SHELL', 'unset')})"
 
 
 def _offer_imports() -> None:
@@ -1660,21 +1847,39 @@ def build_parser() -> argparse.ArgumentParser:
         instead rather than choosing for you.
         """,
     )
-    p_setup.add_argument("--rcfile", help="file to modify (default: ~/.bashrc)")
+    p_setup.add_argument("--rcfile", help="file to modify (default: the rc file of each shell)")
+    p_setup.add_argument(
+        "--shell",
+        choices=["auto", *HOOKS, "both"],
+        default="auto",
+        help="which shell(s) to install for (default: auto -- every shell whose "
+        "rc file already exists, never creating one)",
+    )
     p_setup.set_defaults(func=cmd_setup)
 
     p_install = sub(
         "install",
-        "install the shell hook into .bashrc",
+        "install the shell hook into your rc file(s)",
         """
-        Copies the bash hook and adds a marked block to your rcfile. Safe to
+        Copies each shell's hook and adds a marked block to its rc file. Safe to
         re-run: the block is replaced rather than repeated, which is also how
         to upgrade the hook after installing a new woswoar.
+
+        By default it installs for every shell whose rc file already exists --
+        and it never creates one, so a machine that has never run zsh does not
+        acquire a ~/.zshrc. With neither rc file present it follows $SHELL.
 
         Reports any missing tool (fzf, age, git) and the command to install it.
         """,
     )
-    p_install.add_argument("--rcfile", help="file to modify (default: ~/.bashrc)")
+    p_install.add_argument("--rcfile", help="file to modify (default: the rc file of each shell)")
+    p_install.add_argument(
+        "--shell",
+        choices=["auto", *HOOKS, "both"],
+        default="auto",
+        help="which shell(s) to install for (default: auto -- every shell whose "
+        "rc file already exists, never creating one)",
+    )
     p_install.set_defaults(func=cmd_install)
 
     p_stats = sub(


### PR DESCRIPTION
Closes #159. Depends on #158, which landed as #182.

`install`, `doctor`, `setup` and the self-healing refresh all assumed exactly one
shell. This wires the second one in, so zsh support stops meaning "edit
`~/.zshrc` by hand".

## The detection rule

**Every shell whose rc file already exists**, falling back to `$SHELL` when
there is none.

```console
$ woswoar install
machine : martin@laptop (60c0326a864478a1)
logs    : ~/.local/share/woswoar/logs
hook    : ~/.local/share/woswoar/woswoar.bash  (bash)
hook    : ~/.local/share/woswoar/woswoar.zsh  (zsh)
rcfile  : ~/.bashrc (added)
rcfile  : ~/.zshrc (added)
```

Both halves are load-bearing and each has its own test, because the two obvious
simplifications are both wrong. Installing only the first match leaves someone
with two shells recording from one of them. Installing unconditionally *creates*
a `~/.zshrc` for someone who has never run zsh — a startup file that shell now
reads, put there by a command about something else. `--shell both` is the way to
ask for that on purpose.

`--rcfile` still names one file, and `tests/test_install.py`'s existing cases
pass unchanged, which is the pin #159 asked for.

## Two places I did not do what the issue said

**`--rcfile` takes its shell from the file's own name, not from detection.**
#159 says "inferred from the detected shell". That would hand someone with a
`.bashrc` beside it a `.zshrc` sourcing `woswoar.bash` — a file zsh reads,
loading shell code written for the other shell, silently. `--rcfile ~/.zshrc` is
not an ambiguous thing to be handed. Detection still answers when the name
settles nothing (`--rcfile /tmp/rc`), and `--shell` overrides both.

**`--rcfile --shell both` is refused rather than resolved.** I found this reading
my own diff: each block replaces the marked block the last one wrote, so writing
two into one file leaves only the second — `--rcfile ~/.bashrc --shell both`
would end with a `.bashrc` sourcing the *zsh* hook, saying "added" twice on the
way. Both resolutions are wrong and one is silent, so it errors.

Also fixed while there: with two shells the closing line used to print
`source a b`, where the second word is not a second file but `$1` for the first.
It is one line per shell now.

## The hazard #159 names

`_refresh_hook` runs unattended, from the background sync a prompt starts. It
now refreshes **per installed hook** and still never creates. `_stale_hooks()`
iterates `installed_shells()` — what is on disk — not `detect_shells()`, and the
test uses a fixture with a `.zshrc` present so that detection *would* say zsh:
without that, the test passes against a refresh that consults the wrong rule by
a plausible route.

## doctor

One version line, one hook line and one rc-file line per shell this machine
uses — the shells with hooks installed, or the ones `install` would pick if none
are, so a fresh machine still reports something and a bash-only machine is not
failed for lacking zsh.

```console
[ok] bash         5.3 (5.0+ required)
[ok] zsh          5.9 (5.0+ required)
[ok] hook         ~/.local/share/woswoar/woswoar.bash
[ok] hook         ~/.local/share/woswoar/woswoar.zsh
[ok] bashrc       ~/.bashrc sources the hook
[ok] zshrc        ~/.zshrc sources the hook
```

## Tests

23 in `tests/test_install.py` (was 8) and 4 new in `tests/test_doctor.py`,
including `TestBothShellsRecordIntoOneHistory`: `install`, then a real bash and
a real zsh each sourcing **the rc file install wrote**, then one machine id and
both commands in one history. That is the piece no assertion on a string can
reach.

### Mutation testing

`python -m tools.mutate`, 16 edits, all caught:

```
  caught    auto installs into the first matching rcfile only
  caught    auto stops checking whether the rcfile exists, and creates one
  caught    the $SHELL fallback is gone
  caught    an unknown $SHELL leaves the machine with no hook at all
  caught    --shell is ignored
  caught    --rcfile takes the detected shell rather than the file's own name
  caught    --rcfile stops meaning one shell
  caught    the refresh creates hooks instead of only refreshing them
  caught    staleness is only ever asked about bash
  caught    doctor asks about every shell woswoar knows, installed or not
  caught    doctor's shell check is bash and nothing else
  caught    doctor says nothing about a shell before the first install
  caught    doctor reports one rcfile, the bash one
  caught    --rcfile with --shell both is resolved instead of refused
  caught    install copies the bash hook whatever shell it was asked for
  caught    each shell gets its own machine id
```

## CI

- `test` installs zsh and runs `--only tests.test_install --no-skips`, so the
  suite that drives both real shells cannot go green having skipped.
- `install` gets a second end-to-end leg: a fresh `$HOME` with **only** a
  `.zshrc`, a real `woswoar install` from the built wheel, a real zsh sourcing
  that `.zshrc`, and the command back out of `woswoar list`. It also asserts no
  `.bashrc` appeared — the detection rule deciding files on a real home
  directory is the one thing no unit test proves about the *packaged* program.

## Docs

`docs/shell-integration.md`'s zsh section replaces the hand-install recipe #182
had to ship. `README.md` no longer says bash-only in the requirements, the
feature table or the architecture diagram. `docs/install.md` gains the release
note #159 asks for — **a background refresh will not create a hook that was
never installed, so someone who has started using a second shell since
installing must run `woswoar install` once** — and its uninstall recipe now
handles both rc files without failing on a missing one.

## Migration

Nothing on disk changes. An existing bash-only install is untouched: `auto`
finds `.bashrc`, the refresh still only refreshes what is there, and no zsh file
appears unless a `~/.zshrc` exists **and** `install` is re-run.

## Review

CLAUDE.md rule 1 row 2, as #159 directs — a careful read of the diff against the
refresh hazard rather than an agent. It is what turned up the
`--rcfile --shell both` collision and the `source a b` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
