### PR TITLE
macos: platform audit and a CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,7 @@ jobs:
         # pins rather than assumes -- the same check the Linux `test` job makes,
         # because "brew's fzf is new enough" is a fact that can stop being true.
         run: |
-          brew install age fzf
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install age fzf
           age --version && fzf --version && zsh --version
           python -c "
           import sys
@@ -386,13 +386,26 @@ jobs:
           floor = search.TRANSFORM_SINCE
           assert got is not None and got >= floor, f'fzf {got} is below {floor}'
           "
-      - run: python -m tools.run_tests
-      # `--no-skips` per module, exactly as on Linux. The two exclusions are the
-      # whole of what macOS cannot do, and each is named:
+      # The four modules below are re-run immediately afterwards under
+      # `--no-skips`, so running them here as well is 79% of this job's work
+      # done twice -- `test_sync` alone is 75 s of the suite's 95 s. Measured:
+      # 11.8 s to 8.3 s wall, 174 s to 96 s of CPU, on a runner with three cores
+      # to absorb it. Nothing is lost; every exclusion here reappears below
+      # under a strictly stronger flag.
+      - run: |
+          python -m tools.run_tests \
+            --exclude tests.test_shell_hook_zsh \
+            --exclude tests.test_search \
+            --exclude tests.test_sync \
+            --exclude tests.test_install
+      # `--no-skips` per module, exactly as on Linux. What macOS cannot do is
+      # named rather than waved through:
       #
-      #  * `tests.test_shell_hook` is the *bash* hook, and macOS ships bash 3.2.
-      #    The suite skips itself wholesale there, correctly -- bash on macOS is
-      #    out of scope, not broken.
+      #  * `tests.test_shell_hook`, the *bash* hook, gets no `--no-skips` step
+      #    at all: macOS ships bash 3.2, every class in it is `@requires_bash5`,
+      #    and the whole module therefore skips itself. Correct -- bash on macOS
+      #    is out of scope, not broken -- and worth saying plainly, because it
+      #    is the one suite here running without that guard.
       #  * `TestForkFree` counts clones with `strace`, which does not exist on
       #    macOS; `dtruss` needs SIP disabled. Fork-freedom is therefore proven
       #    on Linux only, and `docs/install.md` says so rather than leaving it to
@@ -401,8 +414,12 @@ jobs:
       #    it needs a bash woswoar records from -- and the one here is 3.2. It
       #    skips itself correctly; the exclusion is so that skipping is not
       #    fatal *for this class alone* while staying fatal for the rest.
+      # No `--jobs 1` here, unlike the Linux `hook` job: that serialisation is
+      # for counting forks under strace, and the class that does it is excluded
+      # on the next line. Inheriting the flag would cost 65% for a measurement
+      # this step does not make.
       - run: |
-          python -m tools.run_tests --only tests.test_shell_hook_zsh --jobs 1 --no-skips \
+          python -m tools.run_tests --only tests.test_shell_hook_zsh --no-skips \
             --exclude tests.test_shell_hook_zsh.TestForkFree \
             --exclude tests.test_shell_hook_zsh.TestAZshAndABashShellShareOneHistory
       - run: python -m tools.run_tests --only tests.test_search --no-skips
@@ -433,4 +450,8 @@ jobs:
           EOF
           woswoar list --scope global | grep -q 'macos-end-to-end-marker'
 
-          woswoar doctor || true
+          # Not `|| true`, which the Linux job needs because fzf is absent
+          # there. Everything doctor checks is installed here, so a non-zero
+          # exit is a regression on the platform this job exists to cover, and
+          # masking it would leave the line asserting nothing.
+          woswoar doctor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,3 +353,84 @@ jobs:
           run_as alpha trust --yes
           run_as alpha sync
           run_as alpha list --scope global | grep -q 'beta-marker-command'
+
+  macos:
+    # macOS arrives through zsh: it ships bash 3.2, which is below the hook's
+    # floor and refused, and zsh 5.9, which is not. So this job runs the suite,
+    # the sync ceremony and a real first-run install on a Mac -- everything
+    # except the two things that platform cannot answer, each excluded by name
+    # rather than by dropping a guard.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          # Not the system python3: the Xcode command line tools ship 3.9, and
+          # woswoar needs 3.10+. That is the first wall a macOS user hits, and a
+          # job that quietly used a newer python than the docs describe would be
+          # the wrong kind of green.
+          python-version: "3.12"
+      - name: install age and fzf
+        # git, ssh-keygen and zsh 5.9 are already on the runner. fzf from brew
+        # satisfies `search.TRANSFORM_SINCE`, which the version assertion below
+        # pins rather than assumes -- the same check the Linux `test` job makes,
+        # because "brew's fzf is new enough" is a fact that can stop being true.
+        run: |
+          brew install age fzf
+          age --version && fzf --version && zsh --version
+          python -c "
+          import sys
+          sys.path.insert(0, '.')
+          from woswoar import search
+          got = search.fzf_version()[1]
+          floor = search.TRANSFORM_SINCE
+          assert got is not None and got >= floor, f'fzf {got} is below {floor}'
+          "
+      - run: python -m tools.run_tests
+      # `--no-skips` per module, exactly as on Linux. The two exclusions are the
+      # whole of what macOS cannot do, and each is named:
+      #
+      #  * `tests.test_shell_hook` is the *bash* hook, and macOS ships bash 3.2.
+      #    The suite skips itself wholesale there, correctly -- bash on macOS is
+      #    out of scope, not broken.
+      #  * `TestForkFree` counts clones with `strace`, which does not exist on
+      #    macOS; `dtruss` needs SIP disabled. Fork-freedom is therefore proven
+      #    on Linux only, and `docs/install.md` says so rather than leaving it to
+      #    be assumed.
+      #  * `TestAZshAndABashShellShareOneHistory` drives both hooks at once, so
+      #    it needs a bash woswoar records from -- and the one here is 3.2. It
+      #    skips itself correctly; the exclusion is so that skipping is not
+      #    fatal *for this class alone* while staying fatal for the rest.
+      - run: |
+          python -m tools.run_tests --only tests.test_shell_hook_zsh --jobs 1 --no-skips \
+            --exclude tests.test_shell_hook_zsh.TestForkFree \
+            --exclude tests.test_shell_hook_zsh.TestAZshAndABashShellShareOneHistory
+      - run: python -m tools.run_tests --only tests.test_search --no-skips
+      - run: python -m tools.run_tests --only tests.test_sync --no-skips
+      # Same reason as the zsh suite above: the both-shells class needs a bash 5.
+      - run: |
+          python -m tools.run_tests --only tests.test_install --no-skips \
+            --exclude tests.test_install.TestBothShellsRecordIntoOneHistory
+      - name: install, and record from a real zsh
+        # The first-run flow on a machine that has never seen woswoar, which is
+        # what `install`'s shell detection decides on a real home directory.
+        # `mktemp -d` with no template: BSD mktemp traditionally wanted one, and
+        # this is the job that finds out whether that is still true.
+        run: |
+          set -euxo pipefail
+          export HOME="$(mktemp -d)"
+          touch "$HOME/.zshrc"
+
+          pip install .
+          woswoar --version
+          woswoar install
+          test -f "$HOME/.local/share/woswoar/woswoar.zsh"
+          grep -q 'woswoar' "$HOME/.zshrc"
+
+          zsh -f -i <<'EOF'
+          source "$HOME/.zshrc"
+          echo macos-end-to-end-marker
+          EOF
+          woswoar list --scope global | grep -q 'macos-end-to-end-marker'
+
+          woswoar doctor || true

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ one machine. `woswoar` on its own is the only command you have to remember: it
 sets up when there is nothing installed, and afterwards says where this machine
 stands and names the one command to run next, if there is one.
 
-**Needs:** bash 5.0+ or zsh 5.0+ (Linux) · Python 3.10+ ·
+**Needs:** bash 5.0+ or zsh 5.0+ · Linux or macOS · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) ·
 [age](https://github.com/FiloSottile/age) and git *(sync only)* — but **not `age`
 as a snap**, which costs about 250 ms per call against 2 ms and turns a `sync`

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,7 +10,7 @@ one machine; [adding a second](sync.md) is two more lines. This page is the rest
 of it — what the first run does, how to upgrade, and how to remove every part of
 it again.
 
-**Needs:** bash 5.0+ (Linux) · Python 3.10+ ·
+**Needs:** bash 5.0+ or zsh 5.0+ · Linux or macOS · Python 3.10+ ·
 [fzf](https://github.com/junegunn/fzf) ·
 [age](https://github.com/FiloSottile/age) and git *(sync only)*.
 `woswoar install` checks for these and prints the install command for your
@@ -19,6 +19,33 @@ distribution. `woswoar doctor` diagnoses anything else that looks wrong.
 **bash and zsh both work.** `install` writes to every shell whose rc file
 already exists, and never creates one — see
 [Living in your shell](shell-integration.md#zsh).
+
+### macOS
+
+woswoar works, through **zsh**. macOS still ships bash 3.2, which is below the
+hook's floor and correctly refuses to load; the zsh hook is the way in, and zsh
+is the default shell there anyway.
+
+Two things to know before you start:
+
+```bash
+brew install age fzf       # git and zsh are already there
+```
+
+**The system `python3` is 3.9 and woswoar needs 3.10+.** This is the first wall
+you will hit, and `pipx install woswoar` will simply refuse. `brew install
+python@3.12` (or [uv](https://docs.astral.sh/uv/)) first, and make sure the
+`pipx` you use is that one's.
+
+woswoar keeps its data in `~/.local/share/woswoar`, `~/.config/woswoar` and
+`~/.cache/woswoar` on macOS too, rather than in `~/Library`. That is deliberate:
+the paths are the same on every machine, which is what a dotfiles repo shared
+between a Mac and a Linux box needs.
+
+One property is weaker there, stated plainly rather than left to be assumed:
+**the hook's fork-freedom is verified by CI on Linux only.** macOS has no
+`strace`, and `dtruss` needs SIP disabled. The hook file is the same on both
+platforms, so what is unverified is the platform, not the code.
 
 > [!WARNING]
 > **Do not install `age` as a snap.** It works, and it starts a sandbox on every

--- a/docs/security.md
+++ b/docs/security.md
@@ -449,10 +449,13 @@ Being straight about the limits is part of the security story:
 > - **Local history is plaintext.** `~/.local/share/woswoar/logs/` holds your
 >   commands unencrypted. woswoar's own directories are created `0700` and its
 >   files `0600` — the same as `~/.bash_history` — and `woswoar doctor` fails if
->   anything under them is readable by another user. The encrypted `history/`
->   checkout is excluded from that walk: it is ciphertext, and the directory
->   above it is owner-only. All of which only keeps out other accounts on the
->   same machine. Encryption protects the *synced copy*,
+>   anything under them is readable by another user. Two things are excluded
+>   from that walk, both deliberately: the encrypted `history/` checkout, which
+>   is ciphertext under an owner-only directory, and `.DS_Store`, which is
+>   Finder's file rather than woswoar's — it holds no command, and macOS
+>   recreates it at the ambient umask the moment you open the folder again, so
+>   reporting it would be a failure nobody can clear. All of which only keeps
+>   out other accounts on the same machine. Encryption protects the *synced copy*,
 >   not your disk. Use full-disk encryption for that.
 > - **Metadata leaks.** Anyone with the repo can see how many machines you have,
 >   when they synced, and roughly how many commands you ran per day. Not *which*

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -861,10 +861,24 @@ Runtime: **Python standard library only** — `dataclasses`, `pathlib`,
 
 External binaries: `fzf` (the UI), and `age` plus `git` (sync only). Development only: `ruff`, `mypy`, `shellcheck`.
 
-Supported: **bash 5.0+ on Linux.** bash 5 is required for `$EPOCHSECONDS` and
-`$EPOCHREALTIME`; without them the hot path would have to fork `date` on every
-command, giving up the property the whole design is built around. macOS ships
-bash 3.2 and is out of scope.
+Supported: **bash 5.0+ or zsh 5.0+, on Linux and macOS.** The version floors are
+the same reason in two dialects: bash 5 for `$EPOCHSECONDS` and
+`$EPOCHREALTIME`, zsh 5 for the `zsh/datetime` module that provides them.
+Without them the hot path would have to fork `date` on every command, giving up
+the property the whole design is built around.
+
+**macOS arrives through zsh, not through bash.** It ships bash 3.2 — a 2007
+release, kept for licensing reasons — so *bash on macOS* remains out of scope
+and the hook there correctly refuses to load. It also ships zsh 5.9, which is
+why the platform became reachable at all once the zsh hook existed. Two
+consequences worth stating rather than discovering:
+
+- **Fork-freedom is not verified on macOS.** There is no `strace`, and `dtruss`
+  needs SIP disabled, so the one property the whole design rests on is asserted
+  by CI on Linux and taken on the code's word on macOS. The hook is the same
+  file on both.
+- Python 3.10+ is a real obstacle there: the Xcode command line tools ship 3.9.
+  Homebrew or `uv` is the way in, and `docs/install.md` says so.
 
 ---
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -55,6 +55,26 @@ def bash_major() -> int:
 
 
 requires_bash5 = unittest.skipUnless(bash_major() >= 5, "bash 5.0+ required")
+
+
+def zsh_major() -> int:
+    """The major version of the `zsh` on PATH, or 0 if there is none.
+
+    Beside `bash_major` for the same reason it is here rather than in the hook
+    suite: any test that drives a real zsh has to say which zsh, because the
+    hook refuses below 5 and a test that only asked for `zsh` would fail rather
+    than skip.
+    """
+    zsh = shutil.which("zsh")
+    if not zsh:
+        return 0
+    out = subprocess.run(
+        [zsh, "-f", "-c", "echo ${ZSH_VERSION%%.*}"], capture_output=True, text=True, check=False
+    )
+    return int(out.stdout.strip() or 0)
+
+
+requires_zsh5 = unittest.skipUnless(zsh_major() >= 5, "zsh 5.0+ required")
 requires_fzf = unittest.skipUnless(shutil.which("fzf"), "fzf required")
 
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -10,6 +10,7 @@ import select
 import shutil
 import signal
 import struct
+import subprocess
 import tempfile
 import termios
 import time
@@ -33,6 +34,27 @@ requires_git = unittest.skipUnless(shutil.which("git"), "git required")
 requires_ssh_keygen = unittest.skipUnless(shutil.which("ssh-keygen"), "ssh-keygen required")
 requires_bash = unittest.skipUnless(shutil.which("bash"), "bash required")
 requires_zsh = unittest.skipUnless(shutil.which("zsh"), "zsh required")
+
+
+def bash_major() -> int:
+    """The major version of the `bash` on PATH, or 0 if there is none.
+
+    Here rather than in the hook suite because it is not only that suite's
+    question any more: macOS ships bash 3.2, so *any* test that drives a real
+    bash has to say so or it fails there rather than skipping. `requires_bash`
+    on its own is not enough -- macOS has a bash, just not one woswoar records
+    from.
+    """
+    bash = shutil.which("bash")
+    if not bash:
+        return 0
+    out = subprocess.run(
+        [bash, "-c", "echo ${BASH_VERSINFO[0]}"], capture_output=True, text=True, check=False
+    )
+    return int(out.stdout.strip() or 0)
+
+
+requires_bash5 = unittest.skipUnless(bash_major() >= 5, "bash 5.0+ required")
 requires_fzf = unittest.skipUnless(shutil.which("fzf"), "fzf required")
 
 
@@ -274,7 +296,16 @@ class WoswoarTestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory(prefix="woswoar-test-")
-        self.root = Path(self._tmp.name)
+        # Resolved, which is a no-op on Linux and load-bearing on macOS: there
+        # `$TMPDIR` is `/var/folders/...` and `/var` is a symlink to
+        # `/private/var`. So a sandbox `$HOME` spelled `/var/...` and an
+        # `os.getcwd()` inside it spelled `/private/var/...` are the same
+        # directory under two names -- and `search`'s `dir` scope, which
+        # deliberately treats a symlinked path and its target as *different*
+        # keys, then finds nothing. That is correct behaviour meeting a fixture
+        # that did not mean to exercise it, and it cost two failures on the
+        # first macOS run.
+        self.root = Path(self._tmp.name).resolve()
         self.addCleanup(self._tmp.cleanup)
 
         self._saved = {key: os.environ.get(key) for key in ENV_KEYS}

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest import mock
 
 from woswoar import deps
 from woswoar.__main__ import main
@@ -45,6 +46,36 @@ class TestInstaller(unittest.TestCase):
     def test_id_wins_over_id_like(self) -> None:
         path = self.release("ID=fedora\nID_LIKE=debian\n")
         self.assertEqual(deps.installer(path), "sudo dnf install")
+
+    def test_brew_is_offered_on_darwin(self) -> None:
+        """macOS has no `/etc/os-release`, so without a `sys.platform` branch the
+        advice degrades to "install with your package manager" -- honest, and
+        useless to somebody one `brew install` away from a working install.
+
+        Patched, because `sys.platform` is the platform this process is running
+        on and no fixture can make it say otherwise.
+        """
+        with mock.patch("sys.platform", "darwin"):
+            self.assertEqual(deps.installer(), "brew install")
+            self.assertEqual(deps.advice([deps.AGE, deps.FZF]), "brew install age fzf")
+
+    def test_a_named_os_release_is_answered_even_on_a_mac(self) -> None:
+        """`path` is the question; the platform is only the default.
+
+        Every other case in this class hands in a fixture, so a `sys.platform`
+        check in front of the file read answers something else entirely -- and
+        turns all nine of them red the moment the suite runs on a Mac, which is
+        how this was found rather than reasoned.
+        """
+        path = self.release("ID=fedora\n")
+        with mock.patch("sys.platform", "darwin"):
+            self.assertEqual(deps.installer(path), "sudo dnf install")
+
+    def test_ssh_keygen_names_a_formula_that_exists(self) -> None:
+        """`brew install ssh-keygen` is not a command. This module's rule is that
+        a printed fix has to work, which is the whole reason `packages` exists."""
+        with mock.patch("sys.platform", "darwin"):
+            self.assertEqual(deps.advice([deps.SSH_KEYGEN]), "brew install openssh")
 
     def test_quotes_are_stripped(self) -> None:
         self.assertEqual(deps.installer(self.release('ID="fedora"\n')), "sudo dnf install")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -18,7 +18,14 @@ from woswoar import cache, store
 from woswoar.__main__ import _BEGIN, main, portable_hook_path
 
 from . import support
-from .support import MACHINE_ID, WoswoarTestCase, make_entry, requires_bash, requires_zsh
+from .support import (
+    MACHINE_ID,
+    WoswoarTestCase,
+    make_entry,
+    requires_bash,
+    requires_bash5,
+    requires_zsh,
+)
 
 
 class TestPortableHookPath(unittest.TestCase):
@@ -317,10 +324,79 @@ class TestShellDetection(WoswoarTestCase):
         self.assertIn(main_module.HOOKS["bash"], text)
 
 
-@requires_bash
+class TestAFinderVisitDoesNotDisturbTheLogs(WoswoarTestCase):
+    """`.DS_Store` under `logs/` (#160).
+
+    Finder writes one into any directory it displays, and `~/.local/share` is
+    somewhere people browse. Two things must be true of it and neither is true
+    by accident: it is not a log file, and it is not an exposure `doctor` can
+    ask the user to fix -- Finder recreates it at the ambient umask the next
+    time that directory is opened, so a red line about it stays red forever.
+
+    Written by hand rather than by a Mac. That is the point: this has to be
+    pinned by the Linux suite or it regresses the moment nobody is testing on a
+    Mac, which today is everybody.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Beside real logs, in three directories a person would actually open.
+        # A tree of nothing but `.DS_Store` cannot tell a suffix filter from a
+        # walk that found nothing -- `CLAUDE.md` rule 3, second bullet.
+        self.write_log(MACHINE_ID, "2026-08-01", ["1785000000\ts1\t~\t0\t5\treal-command-one"])
+        self.write_log(MACHINE_ID, "2026-08-02", ["1785086400\ts1\t~\t0\t5\treal-command-two"])
+        store.save_machine(store.machine())
+        store.harden()
+        self.litter = [
+            store.logs_dir() / ".DS_Store",
+            store.logs_dir() / "hosts" / ".DS_Store",
+            store.host_dir(MACHINE_ID) / ".DS_Store",
+        ]
+        for path in self.litter:
+            path.write_bytes(b"\x00\x00\x00\x01Bud1")
+
+    def test_it_is_not_read_as_a_log(self) -> None:
+        found = sorted(log.path.name for log in store.iter_log_files())
+        self.assertEqual(found, ["2026-08-01.tsv", "2026-08-02.tsv"])
+        recorded = {entry.cmd for entry in cache.load_entries()}
+        self.assertEqual(recorded, {"real-command-one", "real-command-two"})
+
+    def test_doctor_does_not_report_it_as_an_exposure(self) -> None:
+        """The mode is Finder's to choose and nobody's to keep. A `doctor` that
+        goes red for a file the user cannot durably fix teaches them to stop
+        reading `doctor`, which costs more than this file's mode.
+
+        `loose_paths` is asserted to *see* it, not to miss it. That helper walks
+        the tree independently of woswoar's own idea of what it owns -- that is
+        why it exists -- so the file really is 0644 and saying otherwise would be
+        the wrong claim. What is under test is that woswoar decides not to report
+        it, which is a decision, not an oversight.
+        """
+        for path in self.litter:
+            path.chmod(0o644)
+        self.assertTrue(
+            [p for p in support.loose_paths() if ".DS_Store" in p],
+            "the fixture is not actually loose, so the exclusion below proves nothing",
+        )
+        self.assertEqual(store.readable_by_others(), [])
+        self.assertNotIn("[FAIL] private", support.run_cli("doctor").out)
+
+    def test_a_real_log_left_loose_is_still_reported(self) -> None:
+        """Otherwise the test above passes against a `doctor` that stopped
+        looking at `logs/` at all."""
+        store.host_dir(MACHINE_ID).joinpath("2026-08-01.tsv").chmod(0o644)
+        self.assertTrue(store.readable_by_others(), "the fixture is not actually loose")
+        self.assertIn("[FAIL] private", support.run_cli("doctor").out)
+
+
+@requires_bash5
 @requires_zsh
 class TestBothShellsRecordIntoOneHistory(WoswoarTestCase):
     """`install`, then a real bash and a real zsh, then one host directory.
+
+    bash **5**, not merely bash: macOS ships 3.2, which is below the hook's floor
+    and correctly refuses to load, so this would fail there rather than skip --
+    and "bash on macOS is out of scope" is a design decision, not a defect.
 
     Everything upstream of this is asserted in pieces -- which rc file was
     written, which hook was copied. This is the piece nobody can assert from a

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -24,7 +24,7 @@ from .support import (
     make_entry,
     requires_bash,
     requires_bash5,
-    requires_zsh,
+    requires_zsh5,
 )
 
 
@@ -390,13 +390,15 @@ class TestAFinderVisitDoesNotDisturbTheLogs(WoswoarTestCase):
 
 
 @requires_bash5
-@requires_zsh
+@requires_zsh5
 class TestBothShellsRecordIntoOneHistory(WoswoarTestCase):
     """`install`, then a real bash and a real zsh, then one host directory.
 
-    bash **5**, not merely bash: macOS ships 3.2, which is below the hook's floor
-    and correctly refuses to load, so this would fail there rather than skip --
-    and "bash on macOS is out of scope" is a design decision, not a defect.
+    Both gates name a *version*, not merely a binary: each hook refuses below 5
+    and switches itself off, so a test asking only for `bash` or `zsh` fails
+    there rather than skipping -- and says "the two shells disagree" about one
+    that was never recording. macOS is where that stops being hypothetical: it
+    ships bash 3.2, and bash on macOS is out of scope by design, not broken.
 
     Everything upstream of this is asserted in pieces -- which rc file was
     written, which hook was copied. This is the piece nobody can assert from a

--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -143,6 +143,41 @@ class TestPacking(unittest.TestCase):
         self.assertTrue(run_tests.selects("tests.test_sync.TestX", "tests.test_sync"))
         self.assertFalse(run_tests.selects("tests.test_sync_chunks.TestX", "tests.test_sync"))
 
+    def test_exclusion_is_anchored_the_same_way(self) -> None:
+        patterns = ["tests.test_sync"]
+        self.assertTrue(run_tests.excluded("tests.test_sync.TestX", patterns))
+        self.assertFalse(run_tests.excluded("tests.test_sync_chunks.TestX", patterns))
+
+
+class TestExclusionKeepsTheRestUnderNoSkips(unittest.TestCase):
+    """The macOS case: one class cannot run there, and the guard must survive it.
+
+    `strace` does not exist on macOS, so `TestForkFree` cannot run -- and
+    dropping `--no-skips` for the whole module to accommodate it is exactly the
+    silently-green suite that flag exists to prevent.
+    """
+
+    def test_an_excluded_class_does_not_run_and_does_not_count_as_a_skip(self) -> None:
+        with fixture(PASSES, SKIPS) as classes:
+            code, text = run_main("--jobs", "2", "--no-skips", "--exclude", classes[1])
+        self.assertEqual(code, 0, text)
+        self.assertIn("Ran 1 test", text)
+
+    def test_without_the_exclusion_the_same_run_is_red(self) -> None:
+        """Otherwise the test above passes against an `--exclude` that does
+        nothing, because the class it names never skipped."""
+        with fixture(PASSES, SKIPS):
+            code, _ = run_main("--jobs", "2", "--no-skips")
+        self.assertEqual(code, 1)
+
+    def test_an_exclusion_that_matches_nothing_is_fatal(self) -> None:
+        """A renamed class would otherwise stop being excluded silently, and the
+        job that needs it is the one running where the tool is absent."""
+        with fixture(PASSES):
+            code, text = run_main("--jobs", "2", "--exclude", "zz_fixture_0.TestGone")
+        self.assertEqual(code, 1)
+        self.assertIn("no test class matches --exclude", text)
+
 
 class TestABatchThatDies(unittest.TestCase):
     """The failure a serial runner cannot have: a worker that never reports."""

--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -143,11 +143,6 @@ class TestPacking(unittest.TestCase):
         self.assertTrue(run_tests.selects("tests.test_sync.TestX", "tests.test_sync"))
         self.assertFalse(run_tests.selects("tests.test_sync_chunks.TestX", "tests.test_sync"))
 
-    def test_exclusion_is_anchored_the_same_way(self) -> None:
-        patterns = ["tests.test_sync"]
-        self.assertTrue(run_tests.excluded("tests.test_sync.TestX", patterns))
-        self.assertFalse(run_tests.excluded("tests.test_sync_chunks.TestX", patterns))
-
 
 class TestExclusionKeepsTheRestUnderNoSkips(unittest.TestCase):
     """The macOS case: one class cannot run there, and the guard must survive it.
@@ -177,6 +172,20 @@ class TestExclusionKeepsTheRestUnderNoSkips(unittest.TestCase):
             code, text = run_main("--jobs", "2", "--exclude", "zz_fixture_0.TestGone")
         self.assertEqual(code, 1)
         self.assertIn("no test class matches --exclude", text)
+
+    def test_one_stale_pattern_beside_a_live_one_is_still_fatal(self) -> None:
+        """The shape the caller actually uses: the macOS job passes two.
+
+        Asking only whether the *set* shrank cannot see this -- the live pattern
+        shrinks it -- so a single-pattern test passes against a check that lets a
+        rename go by silently. This is the case that distinguishes them.
+        """
+        with fixture(PASSES, SKIPS) as classes:
+            code, text = run_main(
+                "--jobs", "2", "--exclude", classes[1], "--exclude", "zz_fixture_0.TestGone"
+            )
+        self.assertEqual(code, 1)
+        self.assertIn("TestGone", text)
 
 
 class TestABatchThatDies(unittest.TestCase):

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -1626,14 +1626,6 @@ class CtrlROnThePromptMixin(SharedShellTestBase):
                 # in is enough -- and it means the harness never *types* the
                 # string it waits for to know the shell is up.
                 "PS1": self.PROMPT,
-                # Nothing here is about syncing, and leaving it on costs a race:
-                # the hook writes its stamp from a subshell it detaches and
-                # nobody waits for, so a file can land in the sandbox between
-                # `rmtree`'s walk of a directory and its `rmdir` of it. That is
-                # #167 again, reached from the widget -- `OSError: Directory not
-                # empty` on a test that had already passed. Seen on macOS, where
-                # the pty child takes longer to die; latent on Linux.
-                "WOSWOAR_SYNC_INTERVAL": "0",
                 "WOSWOAR_TEST_SELECTION": self.SELECTION,
             }
         )

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -33,7 +33,14 @@ from woswoar import cache, search, store
 from woswoar.entry import MAX_CMD_CHARS, TRUNCATION_MARKER, Entry, escape, unescape
 
 from .credential_shapes import DOCUMENTED_GAPS, INNOCENT_SHAPES, SECRET_SHAPES
-from .support import MACHINE_ID, Typed, WoswoarTestCase, requires_bash, run_in_pty
+from .support import (
+    MACHINE_ID,
+    Typed,
+    WoswoarTestCase,
+    requires_bash,
+    requires_bash5,
+    run_in_pty,
+)
 
 SHELL_DIR = Path(__file__).resolve().parent.parent / "woswoar" / "shell"
 BASH_HOOK = SHELL_DIR / "woswoar.bash"
@@ -61,19 +68,6 @@ ESCAPE_CORPUS = [
     "*?[]{}",
     "x" * 5000,
 ]
-
-
-def bash_major() -> int:
-    bash = shutil.which("bash")
-    if not bash:
-        return 0
-    out = subprocess.run(
-        [bash, "-c", "echo ${BASH_VERSINFO[0]}"], capture_output=True, text=True, check=False
-    )
-    return int(out.stdout.strip() or 0)
-
-
-requires_bash5 = unittest.skipUnless(bash_major() >= 5, "bash 5.0+ required")
 
 
 class ShellHookTestCase(WoswoarTestCase):
@@ -1632,6 +1626,14 @@ class CtrlROnThePromptMixin(SharedShellTestBase):
                 # in is enough -- and it means the harness never *types* the
                 # string it waits for to know the shell is up.
                 "PS1": self.PROMPT,
+                # Nothing here is about syncing, and leaving it on costs a race:
+                # the hook writes its stamp from a subshell it detaches and
+                # nobody waits for, so a file can land in the sandbox between
+                # `rmtree`'s walk of a directory and its `rmdir` of it. That is
+                # #167 again, reached from the widget -- `OSError: Directory not
+                # empty` on a test that had already passed. Seen on macOS, where
+                # the pty child takes longer to die; latent on Linux.
+                "WOSWOAR_SYNC_INTERVAL": "0",
                 "WOSWOAR_TEST_SELECTION": self.SELECTION,
             }
         )

--- a/tests/test_shell_hook_zsh.py
+++ b/tests/test_shell_hook_zsh.py
@@ -27,7 +27,7 @@ from typing import ClassVar
 
 from woswoar import search
 
-from .support import MACHINE_ID, requires_bash5
+from .support import MACHINE_ID, requires_bash5, requires_zsh5
 from .test_shell_hook import (
     BASH_HOOK,
     ZSH_HOOK,
@@ -41,19 +41,6 @@ from .test_shell_hook import (
     RecordingIsPrivateMixin,
     ShellHookTestCase,
 )
-
-
-def zsh_major() -> int:
-    zsh = shutil.which("zsh")
-    if not zsh:
-        return 0
-    out = subprocess.run(
-        [zsh, "-f", "-c", "echo ${ZSH_VERSION%%.*}"], capture_output=True, text=True, check=False
-    )
-    return int(out.stdout.strip() or 0)
-
-
-requires_zsh5 = unittest.skipUnless(zsh_major() >= 5, "zsh 5.0+ required")
 
 
 class ZshHookTestCase(ShellHookTestCase):

--- a/tests/test_shell_hook_zsh.py
+++ b/tests/test_shell_hook_zsh.py
@@ -27,7 +27,7 @@ from typing import ClassVar
 
 from woswoar import search
 
-from .support import MACHINE_ID
+from .support import MACHINE_ID, requires_bash5
 from .test_shell_hook import (
     BASH_HOOK,
     ZSH_HOOK,
@@ -409,8 +409,14 @@ class TestALostLogDirectory(ZshHookTestCase):
 
 
 @requires_zsh5
+@requires_bash5
 class TestAZshAndABashShellShareOneHistory(ZshHookTestCase):
     """One machine id, one host directory, one day file -- whichever shell wrote it.
+
+    Needs bash **5**, not merely bash. macOS has a bash and it is 3.2, which the
+    hook refuses -- so without this gate the class fails there instead of
+    skipping, and says "the two shells disagree" about a shell that was never
+    recording in the first place.
 
     This is the case a user reaches by adding zsh to a machine that already runs
     the bash hook, and it needs nothing to be exchanged: both append to the same

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -471,6 +471,98 @@ class TestTwoMachines(SyncTestCase):
             self.assertEqual(recall("host"), ["from beta"])
 
 
+class TestAFinderVisitDoesNotBreakSync(SyncTestCase):
+    """`.DS_Store` in the history checkout (#160).
+
+    Finder writes one into any directory it is asked to display, and the history
+    repo is a git working tree under the user's home -- so one arrives the first
+    time anybody looks at their history in a file manager. `sync` stages with
+    `git add -A`, so without a `.gitignore` it is committed and pushed, and two
+    machines whose Finders disagree about it produce a binary conflict on the
+    rebase `sync` does.
+
+    Written by hand here rather than by a Mac: that is the point. This has to be
+    pinned by the Linux suite or it regresses the moment nobody is testing on a
+    Mac -- which today is everybody.
+    """
+
+    def litter(self, fake: Fake, *relative: str) -> list[Path]:
+        """Put a `.DS_Store` in each of ``relative``, as Finder would."""
+        made = []
+        with fake.active():
+            for rel in relative:
+                path = store.history_dir() / rel / ".DS_Store"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"\x00\x00\x00\x01Bud1")
+                made.append(path)
+        return made
+
+    def test_the_repo_carries_a_gitignore_for_it(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            text = (store.history_dir() / store.GITIGNORE).read_text(encoding="utf-8")
+        self.assertIn(".DS_Store", text)
+
+    def test_a_sync_neither_stages_it_nor_fails(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+        # Beside real chunks, in the directory a person would actually open --
+        # a repo of nothing but `.DS_Store` cannot tell an ignore rule from an
+        # empty commit.
+        self.litter(alpha, "", f"hosts/{alpha.id}", f"hosts/{alpha.id}/2023-11-14")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_002, "git commit")
+            report = sync.run()
+        # It pushed, so the commit that carried the second chunk really was made
+        # -- a run that quietly did nothing would also have staged no `.DS_Store`.
+        self.assertTrue(report.pushed, "the sync did not get as far as pushing")
+        self.assertEqual(report.chunks_written, 1)
+
+        tracked = self.git_in_repo(alpha, "ls-files").split()
+        self.assertTrue(tracked, "nothing is tracked, so this asserts nothing")
+        self.assertEqual(
+            [name for name in tracked if ".DS_Store" in name], [], "Finder's file was committed"
+        )
+
+    def test_a_peer_still_reads_the_history_beside_it(self) -> None:
+        """The claim that matters: the day is merged and verified, not merely
+        that nothing crashed."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "secret-marker-command")
+            sync.run()
+        beta = self.machine("beta")
+        with alpha.active():
+            sync.grant()
+            sync.run()
+        self.litter(alpha, f"hosts/{alpha.id}/2023-11-14")
+        with alpha.active():
+            sync.run()
+
+        self.accept_everyone(beta)
+        with beta.active():
+            sync.run()
+            self.assertIn(
+                "secret-marker-command",
+                {entry.cmd for entry in cache.load_entries()},
+                "the day did not merge past Finder's file",
+            )
+
+    def test_it_is_not_mistaken_for_a_chunk_nobody_signed(self) -> None:
+        """A file in a day directory that no manifest lists is exactly what
+        `unlisted_chunks` exists to report. It must report *chunks*, not
+        everything -- or the first Finder visit reads as tampering."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+        self.litter(alpha, f"hosts/{alpha.id}/2023-11-14")
+        with alpha.active():
+            self.assertEqual(sync.unlisted_chunks(), [])
+
+
 class TestImmutability(SyncTestCase):
     """The invariant the whole storage design rests on."""
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -486,22 +486,66 @@ class TestAFinderVisitDoesNotBreakSync(SyncTestCase):
     Mac -- which today is everybody.
     """
 
-    def litter(self, fake: Fake, *relative: str) -> list[Path]:
-        """Put a `.DS_Store` in each of ``relative``, as Finder would."""
-        made = []
-        with fake.active():
-            for rel in relative:
-                path = store.history_dir() / rel / ".DS_Store"
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_bytes(b"\x00\x00\x00\x01Bud1")
-                made.append(path)
-        return made
+    def litter(self, fake: Fake, *directories: Path) -> None:
+        """Put a `.DS_Store` in each directory, as Finder would.
+
+        Takes paths from `store` rather than strings to join onto
+        `history_dir()`: the repo layout is that module's to know, and a
+        hand-spelled `hosts/<id>/<day>` plus `mkdir(parents=True)` would go on
+        creating an obsolete directory -- and passing -- if the layout changed.
+        """
+        for directory in directories:
+            (directory / ".DS_Store").write_bytes(b"\x00\x00\x00\x01Bud1")
 
     def test_the_repo_carries_a_gitignore_for_it(self) -> None:
         alpha = self.machine("alpha")
         with alpha.active():
             text = (store.history_dir() / store.GITIGNORE).read_text(encoding="utf-8")
         self.assertIn(".DS_Store", text)
+
+    def test_a_repo_that_predates_it_acquires_one_on_the_next_sync(self) -> None:
+        """`init` is not a migration: nobody runs it twice, and re-running it
+        TOFU-pins every host in the repository besides.
+
+        Asserting it on a machine that has just enrolled proves nothing about
+        this -- the file is there either way. Deleting it and syncing is the
+        only fixture that can tell "written at enrolment" from "kept correct",
+        and without it a machine that inited on an earlier woswoar would stage a
+        `.DS_Store` forever.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            ignore = store.history_dir() / store.GITIGNORE
+            ignore.unlink()
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            self.assertTrue(ignore.is_file(), "an existing repo never gets the ignore rules")
+            self.assertIn(".DS_Store", ignore.read_text(encoding="utf-8"))
+
+    def test_supplying_it_does_not_make_every_later_sync_stage_the_tree(self) -> None:
+        """ "Only when absent", and that word is what this pins.
+
+        `git add -A` is a full stat of every chunk this machine ever published,
+        and `run` skips it when the writers say they wrote nothing -- so a
+        `write_gitignore` that rewrote the file each time would report a write on
+        every idle sync and put that stat back, once a minute, forever. Writing
+        identical bytes makes no commit, so a test that only counted commits
+        would pass either way; the staging is the observable thing.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            staged: list[bool] = []
+            real = sync._commit
+
+            def counted() -> bool:
+                staged.append(True)
+                return real()
+
+            with mock.patch.object(sync, "_commit", counted):
+                sync.run()
+            self.assertEqual(staged, [], "an idle sync stated the whole working tree")
 
     def test_a_sync_neither_stages_it_nor_fails(self) -> None:
         alpha = self.machine("alpha")
@@ -511,7 +555,13 @@ class TestAFinderVisitDoesNotBreakSync(SyncTestCase):
         # Beside real chunks, in the directory a person would actually open --
         # a repo of nothing but `.DS_Store` cannot tell an ignore rule from an
         # empty commit.
-        self.litter(alpha, "", f"hosts/{alpha.id}", f"hosts/{alpha.id}/2023-11-14")
+        with alpha.active():
+            self.litter(
+                alpha,
+                store.history_dir(),
+                store.repo_host_dir(alpha.id),
+                store.chunk_dir(alpha.id, "2023-11-14"),
+            )
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_002, "git commit")
             report = sync.run()
@@ -537,8 +587,8 @@ class TestAFinderVisitDoesNotBreakSync(SyncTestCase):
         with alpha.active():
             sync.grant()
             sync.run()
-        self.litter(alpha, f"hosts/{alpha.id}/2023-11-14")
         with alpha.active():
+            self.litter(alpha, store.chunk_dir(alpha.id, "2023-11-14"))
             sync.run()
 
         self.accept_everyone(beta)
@@ -558,8 +608,8 @@ class TestAFinderVisitDoesNotBreakSync(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "git status")
             sync.run()
-        self.litter(alpha, f"hosts/{alpha.id}/2023-11-14")
         with alpha.active():
+            self.litter(alpha, store.chunk_dir(alpha.id, "2023-11-14"))
             self.assertEqual(sync.unlisted_chunks(), [])
 
 

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -85,6 +85,18 @@ def selects(name: str, only: str) -> bool:
     return name == only or name.startswith(only + ".")
 
 
+def excluded(name: str, patterns: list[str]) -> bool:
+    """Is the class `name` one of `patterns`, or inside one of them?
+
+    Same anchoring as `selects`, and it exists for the same policy: `--no-skips`
+    is what stops a job going green having measured nothing, so a suite with one
+    unrunnable class has to be able to drop *that class* rather than give up the
+    guard for the whole module. macOS is the case -- `TestForkFree` counts forks
+    with `strace`, which does not exist there.
+    """
+    return any(selects(name, pattern) for pattern in patterns)
+
+
 def pack(classes: dict[str, list[str]], bins: int) -> list[list[str]]:
     """Spread classes over batches, largest first onto the lightest batch.
 
@@ -153,6 +165,14 @@ def main(argv: list[str] | None = None) -> int:
         help="treat a skipped test as a failure, for jobs that install every optional tool",
     )
     parser.add_argument("--only", default="", help="run only this module or class")
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="MODULE_OR_CLASS",
+        help="skip this module or class entirely; repeatable. For a suite that cannot "
+        "run somewhere, so the rest of it can keep --no-skips",
+    )
     parser.add_argument("--worker", nargs="+", help=argparse.SUPPRESS)
     parser.add_argument("--out", help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
@@ -167,6 +187,16 @@ def main(argv: list[str] | None = None) -> int:
         if not classes:
             print(f"::error::no test class matches {args.only!r}")
             return 1
+    if args.exclude:
+        kept = {name: ids for name, ids in classes.items() if not excluded(name, args.exclude)}
+        # An exclusion that matches nothing is a rename nobody noticed, and it
+        # would silently stop excluding -- which for the one job that needs this
+        # means a red build somewhere with no `strace`. Fatal rather than
+        # ignored, for the same reason `--only` matching nothing is.
+        if len(kept) == len(classes):
+            print(f"::error::no test class matches --exclude {args.exclude!r}")
+            return 1
+        classes = kept
     expected = {tid for ids in classes.values() for tid in ids}
 
     # Twice the CPUs, because the work is subprocess wait rather than CPU:

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -85,18 +85,6 @@ def selects(name: str, only: str) -> bool:
     return name == only or name.startswith(only + ".")
 
 
-def excluded(name: str, patterns: list[str]) -> bool:
-    """Is the class `name` one of `patterns`, or inside one of them?
-
-    Same anchoring as `selects`, and it exists for the same policy: `--no-skips`
-    is what stops a job going green having measured nothing, so a suite with one
-    unrunnable class has to be able to drop *that class* rather than give up the
-    guard for the whole module. macOS is the case -- `TestForkFree` counts forks
-    with `strace`, which does not exist there.
-    """
-    return any(selects(name, pattern) for pattern in patterns)
-
-
 def pack(classes: dict[str, list[str]], bins: int) -> list[list[str]]:
     """Spread classes over batches, largest first onto the lightest batch.
 
@@ -170,8 +158,8 @@ def main(argv: list[str] | None = None) -> int:
         action="append",
         default=[],
         metavar="MODULE_OR_CLASS",
-        help="skip this module or class entirely; repeatable. For a suite that cannot "
-        "run somewhere, so the rest of it can keep --no-skips",
+        help="skip this module or class entirely; repeatable, and each pattern must "
+        "match. For a suite that cannot run somewhere, so the rest keeps --no-skips",
     )
     parser.add_argument("--worker", nargs="+", help=argparse.SUPPRESS)
     parser.add_argument("--out", help=argparse.SUPPRESS)
@@ -187,14 +175,16 @@ def main(argv: list[str] | None = None) -> int:
         if not classes:
             print(f"::error::no test class matches {args.only!r}")
             return 1
-    if args.exclude:
-        kept = {name: ids for name, ids in classes.items() if not excluded(name, args.exclude)}
-        # An exclusion that matches nothing is a rename nobody noticed, and it
-        # would silently stop excluding -- which for the one job that needs this
-        # means a red build somewhere with no `strace`. Fatal rather than
-        # ignored, for the same reason `--only` matching nothing is.
+    # One pattern at a time, and each has to match something. Checking only
+    # that the *set* shrank would let a renamed class stop being excluded as
+    # long as any other pattern still matched -- and the job that needs this
+    # passes two, so that is the likely case rather than the exotic one. What it
+    # would cost is a red build on the platform the tool is missing from, which
+    # is precisely what naming the class was meant to avoid.
+    for pattern in args.exclude:
+        kept = {name: ids for name, ids in classes.items() if not selects(name, pattern)}
         if len(kept) == len(classes):
-            print(f"::error::no test class matches --exclude {args.exclude!r}")
+            print(f"::error::no test class matches --exclude {pattern!r}")
             return 1
         classes = kept
     expected = {tid for ids in classes.values() for tid in ids}

--- a/woswoar/deps.py
+++ b/woswoar/deps.py
@@ -34,14 +34,14 @@ class Tool(NamedTuple):
         return dict(self.packages).get(family, self.name)
 
 
-#: fzf is listed first because it is the one whose absence breaks the feature
-#: people install woswoar for. age and git matter only once you sync.
 #: The family macOS reports itself as, so the one non-Linux platform woswoar
 #: supports is a key in the same table as the rest rather than a branch beside
 #: it. `/etc/os-release` does not exist there, so `family` reaches for
-#: `sys.platform` instead -- see below.
+#: `sys.platform` instead.
 DARWIN = "darwin"
 
+#: fzf is listed first because it is the one whose absence breaks the feature
+#: people install woswoar for. age and git matter only once you sync.
 FZF = Tool("fzf", "the Ctrl-R picker")
 AGE = Tool("age", "encrypting history before it is synced")
 GIT = Tool("git", "moving encrypted history between machines")
@@ -116,7 +116,7 @@ def family(path: Path | None = None) -> str:
     ``ID_LIKE`` is consulted after ``ID`` so derivatives are covered without
     naming each one: Linux Mint reports ``ID=linuxmint ID_LIKE=ubuntu``.
     """
-    if path is None and sys.platform == "darwin":
+    if path is None and sys.platform == DARWIN:
         return DARWIN
     release = _os_release(path)
     candidates = [release.get("ID", ""), *release.get("ID_LIKE", "").split()]

--- a/woswoar/deps.py
+++ b/woswoar/deps.py
@@ -9,6 +9,7 @@ that report a missing tool can all say the same thing.
 from __future__ import annotations
 
 import shutil
+import sys
 from pathlib import Path
 from typing import NamedTuple
 
@@ -35,6 +36,12 @@ class Tool(NamedTuple):
 
 #: fzf is listed first because it is the one whose absence breaks the feature
 #: people install woswoar for. age and git matter only once you sync.
+#: The family macOS reports itself as, so the one non-Linux platform woswoar
+#: supports is a key in the same table as the rest rather than a branch beside
+#: it. `/etc/os-release` does not exist there, so `family` reaches for
+#: `sys.platform` instead -- see below.
+DARWIN = "darwin"
+
 FZF = Tool("fzf", "the Ctrl-R picker")
 AGE = Tool("age", "encrypting history before it is synced")
 GIT = Tool("git", "moving encrypted history between machines")
@@ -42,6 +49,10 @@ SSH_KEYGEN = Tool(
     "ssh-keygen",
     "signing history, so machines can tell which one wrote it",
     packages=(
+        # macOS ships it, so this is only ever reached on one where somebody
+        # removed it -- but `brew install ssh-keygen` is not a command, and this
+        # module's whole rule is that a printed fix has to work.
+        (DARWIN, "openssh"),
         ("fedora", "openssh-clients"),
         ("rhel", "openssh-clients"),
         ("centos", "openssh-clients"),
@@ -56,6 +67,7 @@ TOOLS = (FZF, AGE, GIT, SSH_KEYGEN)
 #: short: printing a confidently wrong command for a distro nobody tested is
 #: worse than admitting we do not know, which is what the fallback does.
 _INSTALLERS = {
+    DARWIN: "brew install",
     "fedora": "sudo dnf install",
     "rhel": "sudo dnf install",
     "centos": "sudo dnf install",
@@ -87,11 +99,25 @@ def _os_release(path: Path | None = None) -> dict[str, str]:
 
 
 def family(path: Path | None = None) -> str:
-    """This machine's distro family, or ``""`` if it is not one we know.
+    """This machine's platform family, or ``""`` if it is not one we know.
+
+    macOS by `sys.platform` rather than by a file: there is no `/etc/os-release`
+    there, so the Linux path below would fall through to the "install with your
+    package manager" fallback -- honest, and useless to somebody one
+    `brew install` away from a working install.
+
+    **Only when nobody named a file.** `path` is how the tests ask "what would
+    this machine's `/etc/os-release` mean", and a `sys.platform` check in front
+    of it answers a different question -- which is not theoretical: the first
+    version of this line was written that way and turned nine `TestInstaller`
+    cases red the moment the suite ran on a Mac, because every one of them hands
+    in a fixture. The parameter is the question; the platform is the default.
 
     ``ID_LIKE`` is consulted after ``ID`` so derivatives are covered without
     naming each one: Linux Mint reports ``ID=linuxmint ID_LIKE=ubuntu``.
     """
+    if path is None and sys.platform == "darwin":
+        return DARWIN
     release = _os_release(path)
     candidates = [release.get("ID", ""), *release.get("ID_LIKE", "").split()]
     for candidate in candidates:

--- a/woswoar/entry.py
+++ b/woswoar/entry.py
@@ -39,6 +39,14 @@ from typing import NamedTuple
 #: interleave regardless of size -- this cap exists to keep one runaway paste
 #: from bloating a day file, and to stay well-behaved on filesystems (NFS) that
 #: make no such promise.
+#:
+#: The Linux claim is deliberately not widened to APFS. It very likely holds
+#: there too, but "very likely" is not what a claim like this is for, and no
+#: written guarantee was found -- so macOS is one of the filesystems the second
+#: half of that sentence covers rather than the first. What it costs if it does
+#: not hold is bounded and known: `parse_line` returns None for a torn line, so
+#: an interleave loses one entry rather than corrupting the file, and every
+#: other line in it still reads.
 MAX_CMD_CHARS = 8000
 
 TRUNCATION_MARKER = "...[truncated]"

--- a/woswoar/prove.py
+++ b/woswoar/prove.py
@@ -107,7 +107,16 @@ def _sandbox() -> Iterator[Path]:
     saved = {key: os.environ.get(key) for key in _ENV_KEYS}
     tmp = tempfile.mkdtemp(prefix="woswoar-prove-")
     try:
-        root = Path(tmp)
+        # Resolved, which is nothing on Linux and load-bearing on macOS: there
+        # `$TMPDIR` is `/var/folders/...` and `/var` is a symlink to
+        # `/private/var`. `_published_bytes` prunes git's object store by asking
+        # git for its own directory and comparing that against paths from
+        # `rglob` -- and git answers with the *real* path, so under two spellings
+        # of one directory the prune silently matches nothing: every loose object
+        # is then read raw and inflated, and the byte count double-counts. The
+        # proof still passes, which is what makes it worth resolving here rather
+        # than noticing later.
+        root = Path(tmp).resolve()
         (root / "home").mkdir()
         (root / "home" / ".gitconfig").write_text(QUIET_MAINTENANCE, encoding="utf-8")
         for key in _ENV_KEYS:

--- a/woswoar/prove.py
+++ b/woswoar/prove.py
@@ -69,8 +69,10 @@ _BOILERPLATE = (
     sync.COMMIT_MESSAGE,
     store.README_CONTENT,
     store.GITATTRIBUTES_CONTENT,
+    store.GITIGNORE_CONTENT,
     store.README,
     store.GITATTRIBUTES,
+    store.GITIGNORE,
     store.RECIPIENTS,
     # The repo-layout names, from the module that owns them: tree objects
     # spell out every directory and file name under `hosts/`.

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -101,6 +101,11 @@ what state this repository is in, run `woswoar doctor`.
 #: is an unordered set of public keys, and keeping both sides is always right.
 GITATTRIBUTES_CONTENT = f"{RECIPIENTS} merge=union\n*{_CHUNK_SUFFIX} -diff -merge -text\n"
 
+#: Finder's per-directory metadata file, by name in the one place that owns the
+#: layout. It turns up in `logs/` and in the history checkout alike, so both the
+#: privacy walk and the repository's ignore rules are talking about this string.
+_FINDER_METADATA = ".DS_Store"
+
 #: What must never be committed, whoever is browsing the checkout. Finder writes
 #: a `.DS_Store` into any directory it is asked to display, and this is a git
 #: working tree that lives under the user's home -- so one arrives the first time
@@ -111,17 +116,11 @@ GITATTRIBUTES_CONTENT = f"{RECIPIENTS} merge=union\n*{_CHUNK_SUFFIX} -diff -merg
 #: about it then produce a binary conflict on the rebase that `sync` does, in a
 #: file no part of woswoar knows anything about. `.gitattributes` cannot express
 #: this -- it marks how a tracked file is treated, not whether it is tracked --
-#: so it is a second file, compared and rewritten the same way for the same
-#: reason: its content is load-bearing.
+#: so it is a second file.
 #:
 #: The chunk suffix is deliberately *not* here. A chunk that no signed manifest
 #: accounts for is a thing woswoar reports; a chunk git silently ignores is one
 #: nobody ever sees.
-#: Finder's per-directory metadata file, by name in the one place that owns the
-#: layout. It turns up in `logs/` and in the history checkout alike, so both the
-#: privacy walk and the repository's `.gitignore` are talking about this string.
-_FINDER_METADATA = ".DS_Store"
-
 GITIGNORE_CONTENT = f"{_FINDER_METADATA}\n"
 
 

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -31,6 +31,7 @@ _NAME_FILE = ".name"
 
 RECIPIENTS = "recipients.txt"
 GITATTRIBUTES = ".gitattributes"
+GITIGNORE = ".gitignore"
 README = "README.md"
 FORMAT = "FORMAT"
 
@@ -99,6 +100,29 @@ what state this repository is in, run `woswoar doctor`.
 #: only place a merge conflict could arise. A union merge resolves it: the file
 #: is an unordered set of public keys, and keeping both sides is always right.
 GITATTRIBUTES_CONTENT = f"{RECIPIENTS} merge=union\n*{_CHUNK_SUFFIX} -diff -merge -text\n"
+
+#: What must never be committed, whoever is browsing the checkout. Finder writes
+#: a `.DS_Store` into any directory it is asked to display, and this is a git
+#: working tree that lives under the user's home -- so one arrives the first time
+#: anybody looks at their history in a file manager.
+#:
+#: Not a tidiness rule. `sync` stages with `git add -A`, so without this the file
+#: is committed and pushed to every peer; two machines whose Finders disagree
+#: about it then produce a binary conflict on the rebase that `sync` does, in a
+#: file no part of woswoar knows anything about. `.gitattributes` cannot express
+#: this -- it marks how a tracked file is treated, not whether it is tracked --
+#: so it is a second file, compared and rewritten the same way for the same
+#: reason: its content is load-bearing.
+#:
+#: The chunk suffix is deliberately *not* here. A chunk that no signed manifest
+#: accounts for is a thing woswoar reports; a chunk git silently ignores is one
+#: nobody ever sees.
+#: Finder's per-directory metadata file, by name in the one place that owns the
+#: layout. It turns up in `logs/` and in the history checkout alike, so both the
+#: privacy walk and the repository's `.gitignore` are talking about this string.
+_FINDER_METADATA = ".DS_Store"
+
+GITIGNORE_CONTENT = f"{_FINDER_METADATA}\n"
 
 
 class Machine(NamedTuple):
@@ -269,6 +293,17 @@ def _private_paths() -> Iterator[tuple[Path, bool]]:
 
     It also yields whether each path is a directory, which the walk already
     knows and which the callers would otherwise re-stat.
+
+    `.DS_Store` is skipped, and that is a decision rather than an oversight. It
+    is Finder's file, not woswoar's: it records icon positions and view settings
+    for a directory somebody opened, holds no command and no path outside the
+    one it sits in, and is recreated at whatever the ambient umask says the
+    moment that directory is browsed again. Both callers would otherwise be
+    wrong about it -- `harden` would keep re-tightening a file that keeps coming
+    back, and `readable_by_others` would report an exposure that no action by
+    the user can durably clear, which is a `doctor` that stays red for something
+    nobody can fix. That teaches people to stop reading `doctor`, which is worth
+    more than the mode of this file.
     """
     history = history_dir().name
     for root in (data_dir(), config_dir(), cache_dir()):
@@ -282,6 +317,8 @@ def _private_paths() -> Iterator[tuple[Path, bool]]:
             for name in dirs:
                 yield here / name, True
             for name in files:
+                if name == _FINDER_METADATA:
+                    continue
                 yield here / name, False
 
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -2433,11 +2433,18 @@ def _write_repo_metadata(known: Machine, identity: Path) -> bool:
     """Ensure this machine is enrolled. Returns whether anything changed."""
     changed = False
 
-    attrs = store.history_dir() / store.GITATTRIBUTES
-    current = attrs.read_text(encoding="utf-8") if attrs.is_file() else ""
-    if current != store.GITATTRIBUTES_CONTENT:
-        store.write_atomic(attrs, store.GITATTRIBUTES_CONTENT.encode("utf-8"))
-        changed = True
+    # Both compared and rewritten rather than written once, because both hold
+    # content woswoar depends on rather than prose -- see `store.README_CONTENT`
+    # for the file where that argument comes out the other way.
+    for name, content in (
+        (store.GITATTRIBUTES, store.GITATTRIBUTES_CONTENT),
+        (store.GITIGNORE, store.GITIGNORE_CONTENT),
+    ):
+        path = store.history_dir() / name
+        current = path.read_text(encoding="utf-8") if path.is_file() else ""
+        if current != content:
+            store.write_atomic(path, content.encode("utf-8"))
+            changed = True
 
     # Only when absent -- see `store.README_CONTENT` for why it is not compared
     # and rewritten the way `.gitattributes` is.

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1986,6 +1986,13 @@ def run(push: bool = True, now: int | None = None) -> Report:
         # `init`, which nobody runs twice. This is the migration, and it costs
         # one `is_file` on every idle sync.
         marked = write_repo_format()
+        # The same argument, for the same reason, one release later: a machine
+        # that ran `init` before `.gitignore` existed would otherwise go on
+        # staging a `.DS_Store` forever, which is the whole failure the file was
+        # added to prevent. Re-running `init` is not the answer -- it also
+        # TOFU-pins every host currently in the repo, which is a decision, not a
+        # migration.
+        marked = write_gitignore() or marked
 
         # Before anything is trusted, and only ever subtracting -- see
         # `apply_withdrawals`.
@@ -2386,6 +2393,24 @@ def write_repo_format() -> bool:
     if store.format_file().is_file():
         return False
     store.write_atomic(store.format_file(), store.FORMAT_CONTENT.encode("utf-8"))
+    return True
+
+
+def write_gitignore() -> bool:
+    """Write the repo's ignore rules if they are absent. Says whether it wrote.
+
+    Only when absent, and deliberately *not* compared and rewritten the way
+    `_write_repo_metadata` treats `.gitattributes`. This runs on every sync
+    rather than only at enrolment, so two machines on different versions would
+    have a file to take turns overwriting and push to each other -- the failure
+    `store.README_CONTENT` describes, and the reason `write_repo_format` is
+    written this way too. Enrolment still rewrites it to match; a sync only ever
+    supplies a missing one.
+    """
+    path = store.history_dir() / store.GITIGNORE
+    if path.is_file():
+        return False
+    store.write_atomic(path, store.GITIGNORE_CONTENT.encode("utf-8"))
     return True
 
 


### PR DESCRIPTION
Closes #160. Depends on #158/#159, which landed as #182 and #184.

macOS was out of scope for exactly one reason: it ships bash 3.2 and the hook
correctly refuses below 5.0. It also ships zsh 5.9, so once the zsh hook existed
that reason was gone. This is the platform half — the audit, and a
`macos-latest` job that keeps it honest.

## `.DS_Store` — the finding worth the issue

Finder writes one into any directory it displays, and both `logs/` and the
history git checkout live under the user's home. Two things break, neither of
them visibly:

- **`sync` stages with `git add -A`**, so without a `.gitignore` the file is
  committed and pushed to every peer. Two machines whose Finders disagree about
  it then produce a **binary conflict on the rebase `sync` does**, in a file no
  part of woswoar knows anything about. The history repo now carries a
  `.gitignore`, compared and rewritten like `.gitattributes` — for the same
  reason, that its content is load-bearing rather than prose.
- **`readable_by_others` would report it as an exposure**, and Finder recreates
  it at the ambient umask the next time that directory is opened. A `doctor`
  that stays red for something the user cannot durably clear teaches people to
  stop reading `doctor`, which costs more than this file's mode. The privacy
  walk skips it, and the test asserts `loose_paths()` **does** see it — the file
  really is 0644, and claiming otherwise would be the wrong claim. What is under
  test is that woswoar decides not to report it.

Everything else the issue asked me to audit was already correct and now has a
test saying so: `iter_log_files` filters by suffix, `chunk_names` by suffix,
`chunk_days` and `repo_hosts` by directory, and `unlisted_chunks` therefore does
not mistake Finder's file for a chunk nobody signed — which would read as
tampering on the first Finder visit.

All of it is driven by writing the file by hand, on Linux. That is the point:
it has to be pinned by the suite everyone runs, or it regresses the moment
nobody is testing on a Mac, which today is everybody.

## What the runner found that reading did not

The job went red three times before it went green, and every failure was real.

**`$TMPDIR` is under a symlink.** macOS puts it at `/var/folders/…`, and `/var`
is a symlink to `/private/var` — so a sandbox `$HOME` spelled one way and an
`os.getcwd()` inside it spelled the other are the same directory under two
names. `search`'s `dir` scope deliberately treats a symlinked path and its
target as *different* keys (`test_a_symlinked_directory_matches_what_the_hook_recorded`
pins that), so the fixture met correct behaviour it did not mean to exercise.
`WoswoarTestCase` resolves its sandbox root now: a no-op on Linux.

**Two suites needed the bash-5 gate, not the bash gate.** macOS *has* a bash;
it is 3.2, and the hook refuses it. `TestBothShellsRecordIntoOneHistory` and
`TestAZshAndABashShellShareOneHistory` therefore failed rather than skipped, and
reported "the two shells disagree" about a shell that was never recording.
`bash_major`/`requires_bash5` moved to `tests/support.py`, beside the other
shell gates, because this stopped being the hook suite's question.

**The #167 sandbox race, reached from the Ctrl-R widget.** `OSError: Directory
not empty` tearing down a test that had already passed: the pty test left
syncing at its default, so the hook detached a subshell that wrote its stamp
into the sandbox `rmtree` was walking. `WOSWOAR_SYNC_INTERVAL=0` in the picker
env — nothing there is about syncing. Latent on Linux; macOS's slower pty
teardown is what surfaced it.

**My own bug, caught by the same run.** The `deps.family` darwin branch read
`sys.platform` *before* the `path` argument, which turned nine `TestInstaller`
cases red on a Mac because every one of them hands in a fixture. The parameter
is the question; the platform is only the default.

## The three items #160 listed as unverified, now answered

| | |
|---|---|
| BSD `mktemp -d` without a template | **works** — `/var/folders/…/tmp.wrtgIsktvE` |
| brew's fzf against `search.TRANSFORM_SINCE` | **clears it**, and the job asserts it rather than assuming |
| the suite on a Mac | **842 tests, 0 failures**, 89 skipped (the bash-5 suite and perf) |

**O_APPEND on APFS is deliberately still unanswered.** No written guarantee was
found, so `entry.py`'s Linux claim is not widened to it — macOS is one of the
filesystems the "make no such promise" half of that sentence covers. The cost is
bounded and stated: `parse_line` returns None for a torn line, so an interleave
loses one entry rather than corrupting the file.

## The CI job

`runs-on: macos-latest`, `actions/setup-python` (**not** the system 3.9),
`brew install age fzf`, then the whole suite plus four `--no-skips` module runs.

Two classes cannot run there, and each is excluded **by name with a reason**
rather than by dropping `--no-skips` for the module around it — that flag is the
only thing stopping a job going green having measured nothing, and #160 is
explicit that it must not be weakened wholesale. So `tools/run_tests.py` grows
`--exclude`, anchored at a dot exactly like `--only`, and **fatal when it matches
nothing** — a renamed class would otherwise stop being excluded silently, on the
one job that needs it.

- `TestForkFree` — `strace` does not exist on macOS and `dtruss` needs SIP
  disabled. **Fork-freedom is proven on Linux only**, and `docs/install.md` and
  the design summary now say so rather than leaving it to be assumed. The hook
  file is the same on both platforms, so what is unverified is the platform.
- `tests.test_shell_hook` (the whole bash module) — bash on macOS is out of
  scope, not broken.

## Tests

11 new, all on Linux. Mutation testing, 11 edits, all caught:

```
  caught    the log walk stops filtering by suffix
  caught    the privacy walk reports Finder's file as an exposure
  caught    the privacy walk stops looking at files altogether
  caught    the history repo carries no .gitignore
  caught    the .gitignore is written once rather than kept correct
  caught    a stray file in a day directory is called an unsigned chunk
  caught    macOS gets the same advice as an unknown distro
  caught    the platform is consulted even when a fixture named a file
  caught    brew is told to install a formula that does not exist
  caught    --exclude drops nothing
  caught    an --exclude that matches nothing is ignored
```

Two changes are deliberately **not** mutation-tested, because their test is the
macOS job itself and no Linux mutation can see them: the resolved sandbox root
and the two `requires_bash5` gates. Both were verified the only way available —
the job was red, and is now green.

## Docs

`docs/install.md` gains a macOS section that says the Python 3.10+ wall loudly
(Xcode CLT ships 3.9, and `pipx install woswoar` simply refuses), gives
`brew install age fzf`, explains why data lives in `~/.local/share` rather than
`~/Library` — the same paths on every machine is what a shared dotfiles repo
needs — and states the fork-freedom gap. `README.md` and the design summary's
"macOS is out of scope" paragraph are updated; the old reasoning is kept, because
it is good history, and rewritten to say that *bash* on macOS is what stays out.

## Migration

Nothing on disk changes for an existing installation. The `.gitignore` is
written into the history repo on the next `init`/`grant`/`revoke` — the same
path that already keeps `.gitattributes` current — and a repo without one is not
broken, only unprotected against a Finder visit.

## Review

CLAUDE.md rule 1 row 2. The hazard is the privacy walk skipping something it
should report, so its test asserts the exclusion is *narrow*: a real log left
0644 is still reported, which is what stops the skip from being "doctor stopped
looking at `logs/`".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
