### PR TITLE
release: 0.10.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -45,7 +45,7 @@ body:
     id: version
     attributes:
       label: "`woswoar --version`"
-      placeholder: woswoar 0.9.0
+      placeholder: woswoar 0.10.0
     validations:
       required: true
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -120,7 +120,7 @@ venv.
 
 To track the tip instead of releases, the git URL is still there —
 `pipx install "git+https://github.com/martinus/woswoar.git@main"`, or `@stable`
-for the most recent tag, or `@v0.9.0` to pin exactly. That form needs `git` on
+for the most recent tag, or `@v0.10.0` to pin exactly. That form needs `git` on
 the machine; `pipx install woswoar` does not.
 </details>
 

--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"


### PR DESCRIPTION
Bumps `__version__` to **0.10.0**. Step 1 of the two in
[CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#cutting-a-release); the tag is
step 2 and is a separate, deliberate act.

## Why 0.10.0 and not 0.9.1

Ten commits since `v0.9.0`, and two of them are capabilities woswoar did not
have:

| | |
|---|---|
| #182 | **zsh recording.** A second hook, `woswoar.zsh` — not a port of the bash one: zsh hands `preexec` the command line, so the `history 1` capture and everything around it disappears, and the history rules bash gives for free are reimplemented |
| #184 | **`install` handles both shells.** Writes to every shell whose rc file already exists, and never creates one |
| #185 | **macOS.** A `macos-latest` CI job, a `.DS_Store` audit, `brew install` advice |
| #186 | `mkdir` runs once a day rather than twice per shell — zsh 9.2 ms → 3.2 ms, bash 7.3 ms → 5.3 ms |
| #181 | the history repo records which layout it is |
| #174, #176, #178, #179, #180 | docs, contributor guide, a recorded demo |

## What an upgrading user has to know

**Nothing, unless they want zsh.** `pipx upgrade woswoar` and the hooks that are
installed bring themselves up to date on the next background sync, as they
already did.

**Someone who now wants zsh recording must run `woswoar install` once.** The
background refresh updates the hooks that are there and deliberately creates
none — a version that created would plant a `woswoar.zsh` on a bash-only machine
from a command nobody ran. `docs/install.md` says so under *Upgrading*, and it
is worth putting in the release notes by hand, since generated notes are PR
titles.

## Two other version strings

Both are examples rather than facts, and both now name a release that exists and
is current: the `@v0.9.0` pin syntax in `docs/install.md`, and the placeholder in
the bug-report template.

## Rehearsed

`python -m build` + `twine check` both pass, and a real `pip install` of the
built wheel into a clean venv gives `woswoar 0.10.0`, ships **both** hooks
(`woswoar/shell/woswoar.bash`, `woswoar/shell/woswoar.zsh`), and wires up both
rc files on a fresh `$HOME`. The full suite is green, as are lint, mypy,
shellcheck and `zsh -n`.

PyPI is the one step that cannot be undone, so nothing is tagged until this is
merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)