### PR TITLE
search: the host scope's prompt names the machine

### DIFF
--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -67,13 +67,23 @@ Switch scope without leaving the picker:
 | <kbd>Ctrl</kbd>+<kbd>O</kbd> | **dir** — this directory and below |
 
 <kbd>Ctrl</kbd>+<kbd>R</kbd> inside the picker walks the same four in that order.
-The prompt says which one you are in — and for `dir` it says *which* directory,
-`woswoar (dir ~/src/woswoar)`, because the word on its own does not answer the
-question you switched scope to ask. A long path is cut from the left, keeping
-the end that identifies it. A path spelled with anything beyond letters, digits
-and `._-/~ ` is left off entirely rather than escaped — the label crosses fzf's
-action parser and a shell on its way to the screen, and going quiet there costs
-you only what every earlier release showed anyway.
+
+**The prompt says which scope you are in, and for two of them *which one*:**
+`woswoar (dir ~/src/woswoar)` and `woswoar (host thinkpad)`. Those are the two
+where the word alone does not answer the question you switched scope to ask —
+and for `host` the prompt is the only place it can, because below two machines
+the machine column is not drawn at all.
+
+`global` and `session` add nothing, deliberately. `global` is every machine,
+which is what the word says; a count of them describes your history rather than
+the scope. `session` is the shell you are typing into, and its id is a hex pair
+nobody recognises.
+
+A long label is cut from the left, keeping the end that identifies it — the
+tail of a path, and the host half of `user@host`. A label spelled with anything
+beyond letters, digits and `._-/~ ` is left off entirely rather than escaped:
+it crosses fzf's action parser and a shell on its way to the screen, and going
+quiet costs you only what every release before 0.10 showed anyway.
 
 **`dir` spans machines, and that is deliberate.** `~/src/woswoar` on your laptop
 and on your desktop is the same project, and that cross-machine question is the

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -827,13 +827,20 @@ class TestCtrlRCyclesTheScope(unittest.TestCase):
                     self.assertEqual(self.next_scope(prompt), search._NEXT[scope])
 
     def test_it_repaints_the_prompt_it_reads_back(self) -> None:
-        """`change-prompt` is not decoration: the next press reads it."""
+        """`change-prompt` is not decoration: the next press reads it.
+
+        Against `_prompt_for` rather than a literal `woswoar (host) `. This
+        class is not sandboxed -- it drives the emitted shell and nothing else --
+        so a literal made the assertion depend on whether the machine running
+        the suite happens to have a name woswoar can show. It named the
+        developer's laptop the day `host` gained a label.
+        """
         out = run_binding(
             search._cycle_binding("woswoar", "", " --host-width 0"),
             "transform:",
             "woswoar (global) ",
         )
-        self.assertIn("change-prompt(woswoar (host) )", out)
+        self.assertIn(f"change-prompt({search._prompt_for('host')})", out)
 
     def test_the_reload_keeps_the_colour_and_the_width(self) -> None:
         """A cycle that dropped either would change the layout mid-picker, and
@@ -1776,6 +1783,78 @@ class DirScopeCase(WoswoarTestCase):
         return sorted(recalled(scope))
 
 
+class TestTheMachineInThePrompt(WoswoarTestCase):
+    """`host` narrows to this machine, and nothing on screen said which one.
+
+    Below two machines `host_width_for` draws no machine column at all, so in
+    that scope the prompt was the only place the answer could go -- and being
+    ssh'd somewhere is exactly when Ctrl-H gets pressed. Asked for right after
+    `dir` gained its label: "the other search scopes show nothing, e.g. host
+    could show the current host".
+    """
+
+    def name_this_machine(self, name: str) -> None:
+        """Give this machine a display name, the way `save_machine` does."""
+        store.save_machine(store.machine()._replace(name=name))
+
+    def test_it_names_this_machine(self) -> None:
+        self.name_this_machine("martinus@thinkpad")
+        self.assertEqual(search._prompt_for("host"), "woswoar (host thinkpad) ")
+
+    def test_it_shows_the_half_the_machine_column_would_show(self) -> None:
+        """`user@host` on one person's machines differs in the host, which is
+        why the column tries that half first. The prompt and the column must not
+        disagree about the same machine.
+        """
+        self.name_this_machine("martinus@thinkpad")
+        machine_id = store.machine().id
+        self.assertEqual(
+            search._prompt_for("host"),
+            f"woswoar (host {search.host_labels({machine_id})[machine_id]}) ",
+        )
+
+    def test_a_machine_with_no_name_yet_is_not_named_by_its_id(self) -> None:
+        """`host_label` falls back to eight hex characters, which is right for a
+        column that has to say *something* per row and answers nothing here."""
+        machine_id = store.machine().id
+        (store.host_dir(machine_id) / ".name").unlink(missing_ok=True)
+        self.assertEqual(search._prompt_for("host"), "woswoar (host) ")
+
+    def test_building_the_prompt_does_not_mint_an_identity(self) -> None:
+        """`store.machine()` *generates* one when the file is absent. Building a
+        label is not a reason to write a machine id to disk -- and the four
+        direct keys are built whatever scope the picker opens in, so this would
+        run for someone who never presses Ctrl-H.
+        """
+        store.machine_file().unlink(missing_ok=True)
+        self.assertEqual(search._prompt_for("host"), "woswoar (host) ")
+        self.assertFalse(store.machine_file().exists(), "asking for a prompt created an identity")
+
+    def test_a_machine_name_the_parsers_would_read_is_not_shown(self) -> None:
+        """The name is a person's to choose and reaches the same two parsers the
+        directory does -- `woswoar rename` writes whatever it is given."""
+        self.name_this_machine("box$(whoami)")
+        self.assertEqual(search._prompt_for("host"), "woswoar (host) ")
+
+    def test_the_cycle_repaints_it_too(self) -> None:
+        """Through a real `sh`: landing on `host` by cycling and by Ctrl-H must
+        leave the same string, or the next press reads a different scope."""
+        self.name_this_machine("martinus@thinkpad")
+        binding = search._cycle_binding("woswoar", "", " --host-width 0")
+        out = run_binding(binding, "transform:", "woswoar (global) ")
+        painted = out.split("change-prompt(", 1)[1].split(")+change-preview", 1)[0]
+        self.assertEqual(painted, search._prompt_for("host"))
+
+    def test_the_prompt_it_paints_is_still_read_back_as_host(self) -> None:
+        """A machine name is user text in the string the scope is kept in --
+        the same hazard the directory label had, and `~/src/session-manager` is
+        the shape that used to misroute it."""
+        self.name_this_machine("session-manager")
+        binding = search._cycle_binding("woswoar", "", " --host-width 0")
+        out = run_binding(binding, "transform:", search._prompt_for("host"))
+        self.assertIn(f"--scope {search._NEXT['host']})", out)
+
+
 class TestTheDirectoryInThePrompt(DirScopeCase):
     """`woswoar (dir)` said which scope you were in and not which directory.
 
@@ -1794,12 +1873,18 @@ class TestTheDirectoryInThePrompt(DirScopeCase):
         self.stand_in(self.home / "src/woswoar")
         self.assertEqual(search._prompt_for("dir"), "woswoar (dir ~/src/woswoar) ")
 
-    def test_no_other_scope_gains_a_label(self) -> None:
-        """There is nothing for them to add: `global` is every machine, `host`
-        is this one, `session` is this shell. Only `dir` answers a question the
-        word itself does not."""
+    def test_global_and_session_gain_nothing(self) -> None:
+        """A decision, not an omission.
+
+        `global` is every machine, which is what the word says -- a count of
+        them describes the history rather than the scope, and moves under
+        someone as they sync. `session` is the shell being typed into, and its
+        id is `<second>-<pid>` in hex, which nobody recognises.
+
+        `host` is deliberately absent from this list; it has its own class.
+        """
         self.stand_in(self.home)
-        for scope in ("global", "host", "session"):
+        for scope in ("global", "session"):
             with self.subTest(scope=scope):
                 self.assertEqual(search._prompt_for(scope), f"woswoar ({scope}) ")
 

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -177,7 +177,7 @@ def host_label(host_id: str) -> str:
     is what the host directory is called.
     """
     name = make_inert(store.host_name(host_id)).strip()
-    return name or host_id[:8]
+    return name or host_id_placeholder(host_id)
 
 
 def host_labels(hosts: set[str]) -> dict[str, str]:
@@ -283,12 +283,12 @@ def _here_label() -> str:
     return keys[0] if keys else "this directory"
 
 
-#: How much of the prompt a directory may take. The prompt and the query share
-#: one line, so every character here is one fewer to type in.
+#: How much of the prompt a label may take. The prompt and the query share one
+#: line, so every character here is one fewer to type in.
 _PROMPT_LABEL_MAX = 28
 
-#: What a directory may be spelled with to reach the prompt: letters and digits
-#: in any script, and the six punctuation marks a path is actually made of.
+#: What a label may be spelled with to reach the prompt: letters and digits in
+#: any script, and the six punctuation marks a path or a machine name is made of.
 #:
 #: An allowlist, and that is the whole point. The label passes through two
 #: languages on its way to the screen, and a denylist has to be right about
@@ -301,34 +301,86 @@ _PROMPT_LABEL_MAX = 28
 #: silently renamed `~/50%-off` to `~/500ff` and truncated the action string
 #: outright for a name ending in `%`, and it missed the fzf layer entirely.
 #:
-#: Deciding what may pass is a fact about paths; deciding what may not is a fact
-#: about two parsers, and only one of those stays true when fzf gains a feature.
+#: Deciding what may pass is a fact about paths and hostnames; deciding what may
+#: not is a fact about two parsers, and only one of those stays true when fzf
+#: gains a feature.
 _PROMPT_SAFE_PUNCTUATION = frozenset("._-/~ ")
 
 
-def _prompt_label() -> str:
-    """The current directory, as the prompt should show it -- or "" for silence.
+def _safe_for_prompt(label: str) -> str:
+    """``label`` if the prompt can carry it verbatim, else "".
 
-    Silence rather than escaping when the path is spelled with anything else:
-    falling back to `woswoar (dir)`, which is what every release before this one
-    showed for every directory, costs the person with a `(` in a directory name
-    nothing they had. Escaping through two parsers to gain them a label is the
-    trade the other way round, and the layer that would get it wrong runs on
-    every keypress.
+    Silence rather than escaping: falling back to `woswoar (dir)`, which is what
+    every release before 0.10 showed for every directory, costs the person with
+    a `(` in a name nothing they had. Escaping through two parsers to gain them
+    a label is the trade the other way round, and the layer that would get it
+    wrong runs on every keypress.
 
     Cut from the left, because `.../woswoar/tests` says which directory it is
-    and `~/src/very/deep/...` does not.
+    and `~/src/very/deep/...` does not -- and because a machine called
+    `martinus@DT-24YY` is told apart by its end too, which is the argument
+    `_ELLIPSIS` already makes for the machine column.
     """
-    # `_here()` rather than `_here_label()`, which answers "this directory" when
-    # there is none -- a sentence, in a slot the rest of this reads as a path.
-    # An empty tuple is that case, and silence is the right answer to it.
-    keys = _here()
-    label = keys[0] if keys else ""
     if not label or any(
         not char.isalnum() and char not in _PROMPT_SAFE_PUNCTUATION for char in label
     ):
         return ""
     return _clip(label, _PROMPT_LABEL_MAX)
+
+
+def _prompt_suffix(scope: Scope) -> str:
+    """What follows the scope name in the prompt, or "" where nothing does.
+
+    Two of the four scopes have something to add and two do not, and the two
+    that do not are a decision rather than an omission:
+
+    `global` is every machine, which is what the word says; a count of them is a
+    fact about the history rather than about the scope, and it would change
+    under someone as they sync.
+
+    `session` is this shell -- the one being typed into. Its id is
+    `<start second>-<pid>` in hex, which nobody recognises, and "which shell am
+    I in" is not a question the person holding the keyboard has.
+
+    `host` is the one that needed it. Below two machines the machine column is
+    not drawn at all (`host_width_for`), so in that scope nothing on screen says
+    *which* machine -- and being ssh'd somewhere is exactly when you press
+    Ctrl-H.
+    """
+    if scope == "dir":
+        # `_here()` rather than `_here_label()`, which answers "this directory"
+        # when there is none -- a sentence, in a slot the rest of this reads as
+        # a path. An empty tuple is that case, and silence is the answer to it.
+        keys = _here()
+        return _safe_for_prompt(keys[0] if keys else "")
+    if scope == "host":
+        return _safe_for_prompt(_this_machine_label())
+    return ""
+
+
+def _this_machine_label() -> str:
+    """This machine, spelled as the machine column spells it -- or "".
+
+    Guarded on the file existing rather than asking `store.machine()` outright,
+    which *generates* an identity when there is none. Building a prompt is not a
+    reason to write a machine id to disk, even though the `host` scope goes on
+    to read one a moment later: a label is the last thing that should create
+    state.
+
+    `host_labels` rather than the raw name, so the prompt and the column agree
+    on which half of `user@host` to show. An id where a name should be means no
+    `.name` file has arrived yet, and eight hex characters answer nothing.
+    """
+    if not store.machine_file().is_file():
+        return ""
+    machine_id = store.machine().id
+    label = host_labels({machine_id})[machine_id]
+    return "" if label == host_id_placeholder(machine_id) else label
+
+
+def host_id_placeholder(host_id: str) -> str:
+    """What `host_label` falls back to when a machine has no name yet."""
+    return host_id[:8]
 
 
 def _prompt_for(scope: Scope) -> str:
@@ -339,11 +391,8 @@ def _prompt_for(scope: Scope) -> str:
     matches the grammar that function documents. `_timeline_binding` is the one
     that does the latter: it prepends `timeline `, and the arms name both.
     """
-    if scope == "dir":
-        label = _prompt_label()
-        if label:
-            return f"woswoar (dir {label}) "
-    return f"woswoar ({scope}) "
+    suffix = _prompt_suffix(scope)
+    return f"woswoar ({scope} {suffix}) " if suffix else f"woswoar ({scope}) "
 
 
 def empty_note(scope: Scope) -> str | None:
@@ -1083,14 +1132,20 @@ def _cycle_binding(self_cmd: str, dedup_flag: str, width: str) -> str:
 
     The prompt is a second variable for the same reason. `_prompt_for` cannot be
     asked here what to paint, because which scope this lands on is not known
-    until the shell has run -- so the one scope with anything to add supplies its
-    arm, and every other falls through to its own name. Landing on `dir` by
-    cycling and by pressing Ctrl-O must show the same prompt, or the next press
-    reads a different scope from each.
+    until the shell has run -- so every scope with something to add supplies an
+    arm and the rest fall through to their own name. Landing on a scope by
+    cycling and by pressing its direct key must leave the same prompt, or the
+    next press reads a different scope from each.
+
+    Built from `SCOPES` rather than naming `dir`, which is what it named while
+    `dir` was the only labelled scope. `host` is the second, and a third would
+    otherwise be a silent no-op here while the direct key painted it.
     """
-    label = _prompt_label()
-    arm = f'case "$n" in dir) p="dir {label}" ;; *) p=$n ;; esac; ' if label else ""
-    prompt = "woswoar ($p) " if label else "woswoar ($n) "
+    labelled = {scope: _prompt_suffix(scope) for scope in SCOPES}
+    labelled = {scope: suffix for scope, suffix in labelled.items() if suffix}
+    arms = "".join(f'{scope}) p="{scope} {suffix}" ;; ' for scope, suffix in labelled.items())
+    arm = f'case "$n" in {arms}*) p=$n ;; esac; ' if arms else ""
+    prompt = "woswoar ($p) " if arms else "woswoar ($n) "
     switch = _switch_to(self_cmd, "$n", dedup_flag, width, prompt, row=_ESCAPED_N)
     script = _scope_case("n", _NEXT) + arm + f'printf "{switch}"'
     return f"--bind=ctrl-r:transform:{script}"


### PR DESCRIPTION
Follow-up to #188, which gave `dir` a label and left the other three bare —
reading as an omission for the one scope that had an answer.

```
woswoar (global)              woswoar (host thinkpad)
woswoar (session)             woswoar (dir ~/src/woswoar)
```

## Why `host`, and why not the other two

**`host` is the scope where the prompt is the only place the answer can go.**
`host_width_for` draws no machine column below two machines, so on a
single-machine install nothing on screen names it — and with several, the column
repeats the same name on every row while the prompt says it once. Being ssh'd
somewhere is exactly when Ctrl-H gets pressed.

**`global` and `session` stay bare, deliberately, and there is a test saying so.**
`global` is every machine, which is what the word says; a count of them
describes your history rather than the scope, and moves under you as you sync.
`session` is the shell you are typing into — its id is `<start second>-<pid>` in
hex, which nobody recognises, and "which shell am I in" is not a question the
person holding the keyboard has.

## What it reuses

- **The same allowlist**, because a machine name is a person's to choose and
  reaches the same two parsers a path does. `woswoar (host box$(whoami))` is not
  a prompt; that machine shows `woswoar (host)`.
- **`host_labels`, not the raw name**, so the prompt and the machine column agree
  on which half of `user@host` to show — the column tries the host half first
  because that is what differs between one person's machines.
- **The cycle key's arms are built from `SCOPES`** rather than naming `dir`,
  which is what they did while `dir` was the only labelled scope. A third
  labelled scope would otherwise be a silent no-op there while its direct key
  painted it.

## Two things this found

**Building a prompt could mint an identity.** `store.machine()` *generates* one
when the file is absent, and the four direct keys are built whatever scope the
picker opens in — so a bare `woswoar search` would have written a machine id to
disk to draw a label it never showed. Guarded on the file existing;
`test_building_the_prompt_does_not_mint_an_identity` is the pin.

**A test was reading the developer's laptop.** `test_it_repaints_the_prompt_it_reads_back`
asserted the literal `woswoar (host) `. That class is not sandboxed — it drives
the emitted shell and nothing else — so the moment `host` gained a label the
assertion started depending on whether the machine running the suite has a name
woswoar can show. It compares against `_prompt_for("host")` now.

## Tests

Seven new, including the round trip through a real `sh`: a machine named
`session-manager` painted into the prompt must still read back as `host`, which
is the same hazard the directory label had. Mutation testing, 8 edits, all
caught — among them "the cycle key names `dir` alone" and "the machine name
skips the allowlist the directory goes through".

🤖 Generated with [Claude Code](https://claude.com/claude-code)