### PR TITLE
shell: read the EXIT trap without forking (#190)

### DIFF
--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -377,12 +377,18 @@ the comment above it said otherwise. Measured over 100 shells: zsh 9.2 ms → 3.
 ms, bash 7.3 ms → 5.3 ms, against 1.8 ms and 1.9 ms for the same shell with no
 hook at all.
 
-**A warm zsh shell reaches zero forks. A warm bash shell forks four times**, and
-none of them is the record path: two `trap -p` subshells — one to see whether the
-EXIT trap is free, one to read any prior DEBUG trap — the subshell that creates
-the scratch file under `umask 077`, and the `rm` in the EXIT trap that removes it
-again. That is the price of `history 1` capture, and it is why the bash column
-above is higher.
+**A warm zsh shell reaches zero forks. A warm bash shell forks three times**, and
+none of them is the record path: a `$(trap -p DEBUG)` subshell to read any prior
+DEBUG trap, the subshell that creates the scratch file under `umask 077`, and the
+`rm` in the EXIT trap that removes it again. That is the price of `history 1`
+capture, and it is why the bash column above is higher.
+
+It was four until #190: asking whether the EXIT trap was already owned cost a
+second `trap -p` subshell, ~330 µs of a shell, where writing the answer to the
+scratch file and reading it back with `$(<file)` — which bash compiles into an
+open, not a subshell — costs ~12 µs. The DEBUG one is left alone on purpose,
+because its output reaches an `eval` and the scratch file is exactly what a
+stranger owns in issue #24's threat model.
 
 No index, no SQLite — a parse cache that only re-reads what changed is enough,
 and CI re-measures it on every push.

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -185,11 +185,19 @@ terminal, which is #183.
 The result is verified rather than asserted: CI runs the hook under `strace` with
 3 commands and with 30, and requires the clone count to be *identical*. Flat, not
 zero, which is the property that actually matters. A warm zsh shell does reach
-zero; a warm bash shell forks four times at startup, and all four are bash's own
-apparatus rather than the record path — two `trap -p` subshells (one to see
-whether the EXIT trap is free, one to read any prior DEBUG trap), the subshell
-that creates the scratch file under `umask 077`, and the `rm` in the EXIT trap
-that removes it again.
+zero; a warm bash shell forks three times at startup, and all three are bash's own
+apparatus rather than the record path — a `$(trap -p DEBUG)` to read any prior
+DEBUG trap, the subshell that creates the scratch file under `umask 077`, and the
+`rm` in the EXIT trap that removes it again. The count is asserted, not only its
+flatness, because #190's fork was at startup and a flat count cannot see one.
+
+There were four until #190. The fourth asked whether the EXIT trap was free, and
+now writes `trap -p EXIT` to the scratch file and reads it back — bash compiles
+`$(<file)` into an open rather than a subshell, which is ~330 µs a shell. The
+DEBUG one stays: its output reaches an `eval`, and issue #24's threat model has a
+stranger owning the scratch file whenever `XDG_RUNTIME_DIR` names a directory
+they can write. That costs them your commands today, and would cost you code
+execution if `eval`'s input came off the same disk.
 
 ### Sharing the shell with everything else
 

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -984,9 +984,11 @@ class CloneScalingMixin(SharedShellTestBase):
         self.assertEqual(few, many, f"{few} stamp reads for 3 commands, {many} for 30")
 
     def test_clone_count_does_not_scale_with_commands(self) -> None:
-        # Not "zero forks": startup legitimately runs mkdir, and bash two
-        # `trap -p` subshells besides. What matters is that the per-command path
-        # adds nothing, so the count must be identical for 3 and for 30 commands.
+        # Not "zero forks": startup legitimately runs mkdir, and bash a
+        # `$(trap -p DEBUG)` subshell besides. What matters is that the
+        # per-command path adds nothing, so the count must be identical for 3
+        # and for 30 commands. `TestForkFree.STARTUP_FORKS` is what pins the
+        # startup ones; nothing here can see them.
         self.warm_up()
         few = self.clone_count(3, self.NO_SYNC)
         many = self.clone_count(30, self.NO_SYNC)
@@ -1001,6 +1003,41 @@ class CloneScalingMixin(SharedShellTestBase):
 @unittest.skipUnless(shutil.which("strace"), "strace required")
 class TestForkFree(CloneScalingMixin, ShellHookTestCase):
     """The bash-specific half: which PROMPT_COMMAND shapes can leave a fork behind."""
+
+    #: Every fork a warm bash shell is still allowed, named. A count is the only
+    #: way to pin #190 -- the substitution it removed was at *startup*, so every
+    #: other test in this class, which compares 3 commands against 30, passes
+    #: with the fix reverted.
+    #:
+    #: Named rather than a bare `3` because the number on its own says nothing
+    #: about which fork came back, and this assertion is meant to be read by
+    #: whoever it fails on. If a fourth is ever genuinely wanted, this list is
+    #: where the argument for it goes.
+    STARTUP_FORKS: ClassVar[tuple[str, ...]] = (
+        "the `(umask 077 && : >...)` subshell that creates the scratch file",
+        "the `$(trap -p DEBUG)` in the boot string, once at the first prompt",
+        "the `rm` the EXIT trap runs when the shell ends",
+    )
+
+    def test_startup_does_not_fork_to_read_the_exit_trap(self) -> None:
+        """#190: `$(trap -p EXIT)` was 331us of the ~3.4ms the hook costs a shell.
+
+        Both scratch-file branches, because the redirect writes to a file whose
+        directory is chosen by the branch above it -- a fallback that landed
+        somewhere unwritable would fail the redirect, and the fork this counts
+        would come back as a different bug.
+        """
+        self.warm_up()
+        allowed = len(self.STARTUP_FORKS)
+        detail = "".join(f"\n  - {reason}" for reason in self.STARTUP_FORKS)
+        for label, extra in (("runtime dir", {}), ("fallback", {"XDG_RUNTIME_DIR": ""})):
+            with self.subTest(scratch=label):
+                count = self.clone_count(3, {**self.NO_SYNC, **extra})
+                self.assertEqual(
+                    count,
+                    allowed,
+                    f"{label}: {count} forks in a warm shell, not {allowed}:{detail}",
+                )
 
     def test_neither_scratch_file_branch_forks_per_command(self) -> None:
         # `CloneScalingMixin` already makes the bare claim for both shells; this

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -130,7 +130,12 @@ fi
 # model has a stranger owning this file whenever XDG_RUNTIME_DIR names a
 # directory they can write: today that costs them reading your commands, and
 # routing eval's input back through the file would make it running your code.
-trap -p EXIT >"$__woswoar_scratch"
+#
+# `2>/dev/null` ahead of the redirect rather than after it, which is not a
+# style choice: redirections are applied left to right, so stderr has to be
+# gone *before* the one that can fail, or bash announces the failure on the
+# terminal at every shell startup. The substitution this replaces was silent.
+trap -p EXIT 2>/dev/null >"$__woswoar_scratch"
 if [[ -z $(<"$__woswoar_scratch") ]]; then
     # shellcheck disable=SC2064  # expand the path now, not at exit
     trap "rm -f -- '$__woswoar_scratch'" EXIT

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -113,7 +113,25 @@ fi
 
 # Only claim the EXIT trap if nothing else owns it; clobbering a user's trap
 # would be a far worse bug than leaving one scratch file behind.
-if [[ -z $(trap -p EXIT) ]]; then
+#
+# Through the scratch file rather than `$(trap -p EXIT)`, which is a fork --
+# measured at 331us against 12us for the redirect plus the read, because bash
+# turns `$(<file)` into an open rather than a subshell. That was ~10% of the
+# ~3.4ms this hook costs a shell, spent before the first prompt. See #190.
+#
+# Safe here because the file was created and truncated three lines up, so it is
+# ours, empty and writable, and a redirect that failed anyway would leave it
+# empty -- which claims the trap, exactly as a substitution that could not fork
+# already did. What is left in it does not survive: `__woswoar_record` truncates
+# it with `history 1` before anything reads it.
+#
+# Deliberately *not* done to the `trap -p DEBUG` in `__woswoar_boot`, which is
+# the same fork at the same price. That spec reaches an `eval`, and #24's threat
+# model has a stranger owning this file whenever XDG_RUNTIME_DIR names a
+# directory they can write: today that costs them reading your commands, and
+# routing eval's input back through the file would make it running your code.
+trap -p EXIT >"$__woswoar_scratch"
+if [[ -z $(<"$__woswoar_scratch") ]]; then
     # shellcheck disable=SC2064  # expand the path now, not at exit
     trap "rm -f -- '$__woswoar_scratch'" EXIT
 fi


### PR DESCRIPTION
Closes #190, in the half the issue calls "a legitimate half". The DEBUG site is
left alone on purpose, and the reason is below — it is a security argument, not
a scope one.

## What changed

`woswoar.bash` decided whether anything already owned the EXIT trap with
`[[ -z $(trap -p EXIT) ]]`, which is a fork in every interactive shell. It now
writes the answer to the scratch file — created and truncated three lines
earlier, so it is ours, empty and writable — and reads it back with `$(<file)`,
which bash compiles into an open rather than a subshell.

`2>/dev/null` goes *ahead of* the redirect rather than after it. Redirections
apply left to right, so with it after, a redirect that failed would print
`bash: …: No such file or directory` on the terminal at startup, where the
substitution it replaces was silent:

```console
$ bash -c 'trap -p EXIT >/nonexistent/x 2>/dev/null; echo rc=$?'
bash: line 1: /nonexistent/x: No such file or directory
rc=1
$ bash -c 'trap -p EXIT 2>/dev/null >/nonexistent/x; echo rc=$?'
rc=1
```

## Measured

Fork count for a warm bash shell, `strace -f -c -e trace=clone,clone3,vfork,fork`,
through the test harness's sandbox: **4 → 3**. The three left are named in
`TestForkFree.STARTUP_FORKS`.

Wall clock, 300 shells per round, three rounds, the two hooks differing only in
these lines:

| round | before | after | delta |
|---|---|---|---|
| 0 | 3.781 ms | 3.398 ms | 0.382 ms |
| 1 | 3.688 ms | 3.365 ms | 0.323 ms |
| 2 | 3.603 ms | 3.402 ms | 0.201 ms |

Which agrees with the issue's microbenchmark of 331 µs against 12 µs.

## Why the `trap -p DEBUG` site is not also changed

The issue asks whether a redirect-and-read at the DEBUG site can preserve #57's
distinction between "there is no prior trap" and "I could not look". It can —
`{ builtin trap -p DEBUG; printf .; } > "$scratch"` keeps the sentinel, and both
`test_a_prior_trap_survives_a_scratch_file_that_cannot_be_written` and
`test_a_trap_that_could_not_be_read_installs_nothing` still pass with it. That is
not the reason to decline.

The reason is the sentence the hook already carries: taking the `eval`'s input
off disk is "after #24 only defence in depth". #24's threat model is a stranger
who owns the scratch file, which happens whenever `XDG_RUNTIME_DIR` names a
directory they can write — `: >` truncates their pre-created file without
changing its owner or its mode. Today that costs them **reading your commands**.
Routing `eval "parts=($spec)"`'s input back through the same file makes it
**running your code**, at your first prompt. That is a change to a security
claim for 331 µs, and it is not a trade worth making.

The EXIT site carries none of this: its result is tested for emptiness, never
evaluated. A stranger who controls the file can at worst make woswoar decline
the EXIT trap and leave a scratch file behind.

## Test

`TestForkFree.test_startup_does_not_fork_to_read_the_exit_trap`, both
scratch-file branches. A count rather than a comparison, because every other
test in that class compares 3 commands against 30 and this fork was at
*startup* — all of them pass with the fix reverted. `STARTUP_FORKS` names the
three that remain so a failure says which one came back.

Mutation-tested per rule 3, `python -m tools.mutate`:

```
  caught    the EXIT trap is read by a command substitution again, as before #190
  caught    the file is written but read back through a fork
```

The second is the one worth having: writing the spec out and then still forking
to read it back is no cheaper, and nothing else in the suite notices.

## Not covered by a test, deliberately

The `2>/dev/null` ordering. Making the redirect fail needs the scratch file to
vanish between two adjacent lines of the same shell, which is not something a
test can arrange; the same is true of the `fork`-under-`RLIMIT_NPROC` trigger
that `test_a_trap_that_could_not_be_read_installs_nothing` documents and works
around by calling the function directly, and there is no equivalent here because
this is a top-level line.

## Also

`docs/shell-integration.md` and `docs/woswoar_design_summary.md` both said "forks
four times" and enumerated the two `trap -p` subshells; both now say three and
record why the DEBUG one stays. A comment in
`test_clone_count_does_not_scale_with_commands` said the same thing.

## Review

Rule 1, middle row — behaviour on a path every user reaches, no stored data and
no security claim changed. A careful read of the diff against the issue's own
"constraint that makes the obvious fix wrong", which is what produced both the
decision above and the `2>/dev/null` ordering. No agents.

## Not done here

The issue's "Related" note — moving `run/`'s `mkdir` into the scratch-file
fallback branch that needs it. It is a one-time fork on a cold shell rather than
a per-shell cost, it touches the recording path, and it was deliberately deferred
once already in the #186 review. It does not belong in a change whose whole
argument is that it is two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)