### PR TITLE
docs: install does create an rc file when there is none (#191)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -17,7 +17,8 @@ it again.
 distribution. `woswoar doctor` diagnoses anything else that looks wrong.
 
 **bash and zsh both work.** `install` writes to every shell whose rc file
-already exists, and never creates one — see
+already exists, and never adds a shell you were not already using. With no rc
+file at all it follows `$SHELL` and creates that one — see
 [Living in your shell](shell-integration.md#zsh).
 
 ### macOS

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -4,9 +4,10 @@ woswoar is never the only thing hooked into a real `.bashrc`, and it runs on
 every prompt. Both of those constrain it more than anything else in the design.
 
 There are two hooks, and `woswoar install` wires up whichever ones apply — it
-writes to **every shell whose rc file already exists**, and never creates one.
-So a machine with a `~/.bashrc` and a `~/.zshrc` records from both, into one
-history; a machine with only the first is untouched by the second.
+writes to **every shell whose rc file already exists**, and never adds a shell
+you were not already using. So a machine with a `~/.bashrc` and a `~/.zshrc`
+records from both, into one history; a machine with only the first is untouched
+by the second.
 
 Everything below is about the bash hook unless it says otherwise. [The zsh
 section](#zsh) covers what is genuinely different, and it is almost all about
@@ -152,12 +153,23 @@ rcfile  : ~/.bashrc (added)
 rcfile  : ~/.zshrc (added)
 ```
 
-**It never creates an rc file.** A machine that has never run zsh does not
-acquire a `~/.zshrc` because you installed woswoar — that would be a startup
-file zsh now reads, put there by a command about something else. If you are
-about to start using zsh, `woswoar install --shell both` says so out loud and
-creates it. `--shell bash`, `--shell zsh` and `--rcfile` all still name one
-thing exactly.
+**It never acquires a second shell for you.** A machine that has a `~/.bashrc`
+and has never run zsh does not come out of `install` with a `~/.zshrc` — that
+would be a startup file zsh now reads, put there by a command about something
+else. If you are about to start using zsh, `woswoar install --shell both` says
+so out loud and creates it. `--shell bash`, `--shell zsh` and `--rcfile` all
+still name one thing exactly.
+
+The one file it does create is on the path where there is nothing to find at
+all: with **no** rc file for either shell, `install` follows `$SHELL` and writes
+that one, creating it. A fresh container or a brand-new account has no rc file
+by definition, and an `install` that reported success having written nowhere
+would be worse than a `.zshrc` you can see in the output:
+
+```console
+$ HOME=$(mktemp -d) SHELL=/usr/bin/zsh woswoar install | grep rcfile
+rcfile  : /tmp/tmp.132qiShODE/.zshrc (added)
+```
 
 Everything else is shared: the same machine id, the same
 `logs/hosts/<id>/<day>.tsv`, the same sync. A machine that runs both shells

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -252,8 +252,16 @@ class TestShellDetection(WoswoarTestCase):
         )
 
     def test_auto_falls_back_to_the_login_shell(self) -> None:
-        """A container or a fresh account has neither file, and still has a shell."""
+        """A container or a fresh account has neither file, and still has a shell.
+
+        This is also the one path on which `install` *creates* an rc file, and
+        the sentence in `docs/shell-integration.md` that says so points here.
+        `sourced` is not enough on its own to say that: a machine that already
+        had a `~/.zshrc` would satisfy it too, so the fixture -- neither file
+        present -- is what makes the file's existence afterwards mean creation.
+        """
         os.environ["SHELL"] = "/usr/bin/zsh"
+        self.assertFalse((self.home / ".zshrc").exists(), "the fixture already had one")
         self.assertEqual(main(["install"]), 0)
         self.assertTrue(self.sourced("zsh"), "the login shell was not consulted")
         self.assertFalse((self.home / ".bashrc").exists(), "it installed for bash as well")

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -1853,7 +1853,7 @@ def build_parser() -> argparse.ArgumentParser:
         choices=["auto", *HOOKS, "both"],
         default="auto",
         help="which shell(s) to install for (default: auto -- every shell whose "
-        "rc file already exists, never creating one)",
+        "rc file already exists, or $SHELL when there is none)",
     )
     p_setup.set_defaults(func=cmd_setup)
 
@@ -1865,9 +1865,10 @@ def build_parser() -> argparse.ArgumentParser:
         re-run: the block is replaced rather than repeated, which is also how
         to upgrade the hook after installing a new woswoar.
 
-        By default it installs for every shell whose rc file already exists --
-        and it never creates one, so a machine that has never run zsh does not
-        acquire a ~/.zshrc. With neither rc file present it follows $SHELL.
+        By default it installs for every shell whose rc file already exists, so
+        a machine that has never run zsh does not acquire a ~/.zshrc. With
+        neither rc file present it follows $SHELL and creates that one --
+        otherwise a fresh account would get nothing.
 
         Reports any missing tool (fzf, age, git) and the command to install it.
         """,
@@ -1878,7 +1879,7 @@ def build_parser() -> argparse.ArgumentParser:
         choices=["auto", *HOOKS, "both"],
         default="auto",
         help="which shell(s) to install for (default: auto -- every shell whose "
-        "rc file already exists, never creating one)",
+        "rc file already exists, or $SHELL when there is none)",
     )
     p_install.set_defaults(func=cmd_install)
 


### PR DESCRIPTION
Closes #191.

## What was wrong

Three pages said `woswoar install` never creates an rc file. It does, on the one
path where there is none to find: `detect_shells` falls back to `$SHELL` when
neither `~/.bashrc` nor `~/.zshrc` exists, and writing to a file that is not
there creates it. Reproduced on this branch:

```console
$ HOME=$(mktemp -d) SHELL=/usr/bin/zsh woswoar install | grep rcfile
rcfile  : /tmp/tmp.132qiShODE/.zshrc (added)
```

The fallback is right and deliberate — a container or a fresh account would
otherwise get an `install` that reported success having written nowhere. Only
the sentence describing it was wrong.

## What it says now

The guarantee people actually want, which is the one the code keeps: **`install`
never adds a shell you were not already using.** A machine with a `~/.bashrc`
that has never run zsh does not come out of `install` with a `~/.zshrc`. That is
what `test_auto_does_not_create_an_rcfile_that_is_absent` pins, and it is true.

The zsh section additionally spells out the creating case, with the console
transcript above, because "never adds a second shell" on its own still leaves a
reader guessing what happens on a machine with no rc file at all.

## Two more places than the issue names

The issue lists `docs/install.md:20` and `docs/shell-integration.md:7` and
`:145`. `woswoar install --help` and `woswoar setup --help` carried the same
claim — "every shell whose rc file already exists, never creating one" — and
`install --help`'s longer text put "it never creates one" one sentence before
"with neither rc file present it follows `$SHELL`", which contradicts itself in
the same paragraph. Fixed here under rule 4: same claim, same size, and `--help`
is read by more people than `docs/`.

## Test

No behaviour changed, so there is nothing new to guard. What the docs now assert
was already covered by `test_auto_falls_back_to_the_login_shell`, which starts
from a home directory with neither rc file and then requires `~/.zshrc` to
source the hook — so the file existing afterwards can only mean `install` made
it. That was implicit; the docstring now says it, and an assertion that the
fixture really starts without the file makes the reasoning fail loudly rather
than quietly if someone adds a `~/.zshrc` to the fixture later.

## Review

Rule 1, bottom row — prose and two `--help` strings, no new state and no path
whose behaviour changes. Re-read the diff; no agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)