### PR TITLE
zsh: take down a stale ghost suggestion on recall (#192)

### DIFF
--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -227,16 +227,24 @@ keeps working. zsh hands each `precmd` entry your real `$?`, so an
 exit-code-colouring prompt downstream is unaffected — none of the
 `PROMPT_COMMAND` apparatus the bash hook needs exists here.
 
-Two known rough edges, neither of them verified against an install of the thing
-in question:
+Both of the following were driven against a real install, on zsh 5.9 (#192):
 
-- **zsh-autosuggestions** wraps the widgets it knows about, and one defined
-  after it loads is not among them, so the ghost suggestion may linger after
-  <kbd>Ctrl</kbd>+<kbd>R</kbd>. The remedy is
-  `ZSH_AUTOSUGGEST_CLEAR_WIDGETS+=(__woswoar_widget)`.
+- **zsh-autosuggestions** needs nothing from you. Its ghost suggestion used to
+  linger after <kbd>Ctrl</kbd>+<kbd>R</kbd> — the recalled line was drawn as
+  `echo PICKEDbait`, with the tail of the previous line's suggestion still on
+  it — because the suggestion lives in `$POSTDISPLAY` and survives a widget that
+  does not clear it. The hook now clears it when it replaces your line. This
+  page used to advise `ZSH_AUTOSUGGEST_CLEAR_WIDGETS+=(__woswoar_widget)`;
+  **that never worked**, in any position in your `.zshrc`, because the add-on
+  refuses to wrap any widget whose name begins with `_` and that rule is
+  hard-coded rather than read from `ZSH_AUTOSUGGEST_IGNORE_WIDGETS`. Delete the
+  line if you added it.
 - **Powerlevel10k's instant prompt** captures output written before the first
   prompt and warns about it. The hook prints at load time in exactly one case —
-  the machine has no identity yet, so run `woswoar install`.
+  the machine has no identity yet, so run `woswoar install`. Confirmed: with no
+  `~/.config/woswoar/machine`, the second and every later shell shows p10k's
+  "console output produced during zsh initialization" warning with woswoar's
+  line under it. Once `install` has run, the hook is silent and so is p10k.
 
 ### macOS
 

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -1690,24 +1690,19 @@ class TestThePtyHarness(unittest.TestCase):
         self.assertIn("41 123", chunks[1])
 
 
-class CtrlROnThePromptMixin(SharedShellTestBase):
-    """The one property that keeps a recalled command from running by itself.
+class PickerStubMixin(SharedShellTestBase):
+    """A shell under a pty whose `woswoar search` is a fixed answer.
 
-    Every other test of the widget checks a piece of it from the outside: what
-    the picker would print, what the cycle binding decides. None of them press
-    the key, because the key does nothing without a terminal -- readline does no
-    line editing on a pipe, and neither does zle. So the claim the whole feature
-    rests on, that a selection arrives *on the prompt for editing* and is never
-    executed, was guarded by nothing at all.
+    The fixture only, with no test of its own, because more than one claim
+    needs a real line editor with a stubbed picker behind it -- `CtrlR`'s "the
+    selection does not run" below, and the zsh suite's "a stale ghost
+    suggestion does not survive the recall". Kept apart from the first of those
+    so the second does not inherit and re-run it under another class's name,
+    which makes a failure report name the wrong test.
 
-    Here it is driven: a real shell, a real line editor, a real pty, the real
-    hook. What is stubbed is the picker itself -- the widget's contract with it
-    is one line on stdout, and fzf choosing that line needs its own test rather
-    than a share of this one.
-
-    Shared between the two suites because none of it is shell-specific once the
-    interpreter and the hook are class attributes: `bind -x` and `zle -N` differ,
-    but what they must *do* does not.
+    What is stubbed is the picker itself: the widget's contract with it is one
+    line on stdout, and fzf choosing that line needs its own test rather than a
+    share of these.
     """
 
     #: What the picker hands back, and what running it would print. Two strings
@@ -1748,8 +1743,8 @@ class CtrlROnThePromptMixin(SharedShellTestBase):
         return self.shell_env(
             {
                 "PATH": f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
-                # Not `dumb`, which the rest of this file uses: this is the one
-                # test that wants readline to behave as it does for a person.
+                # Not `dumb`, which the rest of this file uses: these are the
+                # tests that want readline to behave as it does for a person.
                 "TERM": "xterm",
                 # Both shells default PS1 only when it is unset, so handing it
                 # in is enough -- and it means the harness never *types* the
@@ -1758,6 +1753,25 @@ class CtrlROnThePromptMixin(SharedShellTestBase):
                 "WOSWOAR_TEST_SELECTION": self.SELECTION,
             }
         )
+
+
+class CtrlROnThePromptMixin(PickerStubMixin):
+    """The one property that keeps a recalled command from running by itself.
+
+    Every other test of the widget checks a piece of it from the outside: what
+    the picker would print, what the cycle binding decides. None of them press
+    the key, because the key does nothing without a terminal -- readline does no
+    line editing on a pipe, and neither does zle. So the claim the whole feature
+    rests on, that a selection arrives *on the prompt for editing* and is never
+    executed, was guarded by nothing at all.
+
+    Here it is driven: a real shell, a real line editor, a real pty, the real
+    hook.
+
+    Shared between the two suites because none of it is shell-specific once the
+    interpreter and the hook are class attributes: `bind -x` and `zle -N` differ,
+    but what they must *do* does not.
+    """
 
     def test_the_selection_arrives_for_editing_and_does_not_run(self) -> None:
         steps = [

--- a/tests/test_shell_hook_zsh.py
+++ b/tests/test_shell_hook_zsh.py
@@ -27,7 +27,7 @@ from typing import ClassVar
 
 from woswoar import search
 
-from .support import MACHINE_ID, requires_bash5, requires_zsh5
+from .support import MACHINE_ID, Typed, requires_bash5, requires_zsh5, run_in_pty
 from .test_shell_hook import (
     BASH_HOOK,
     ZSH_HOOK,
@@ -37,6 +37,7 @@ from .test_shell_hook import (
     CtrlROnThePromptMixin,
     DefaultIgnorePatternMixin,
     EscapeParityMixin,
+    PickerStubMixin,
     PromptSyncMixin,
     RecordingIsPrivateMixin,
     ShellHookTestCase,
@@ -564,6 +565,73 @@ class TestCtrlRLandsOnThePrompt(CtrlROnThePromptMixin, ZshHookTestCase):
         the documentation now points zsh users at it too."""
         out = self.run_shell("bindkey '^R'\n", env_extra={"WOSWOAR_NO_BIND": "1", "TERM": "xterm"})
         self.assertNotIn("__woswoar_widget", out)
+
+
+@requires_zsh5
+class TestTheGhostSuggestionIsTakenDown(PickerStubMixin, ZshHookTestCase):
+    """#192: a recalled command must not be drawn with somebody else's ghost on it.
+
+    zsh-autosuggestions parks its suggestion in `$POSTDISPLAY`, which zle draws
+    after the cursor and which survives a widget that does not clear it. So
+    replacing `$BUFFER` from the picker left the tail of the *previous* line's
+    suggestion glued to the recalled one -- `echo PICKEDbait` on screen.
+
+    **The add-on is not installed to test this**, and that is a choice worth
+    stating. It was driven against a real zsh-autosuggestions 85919cd by hand,
+    which is what established the symptom and, more usefully, that the remedy
+    the docs used to print does not work. What CI needs from that is the
+    mechanism, and the mechanism is `$POSTDISPLAY` -- a zle parameter, not
+    anything of the add-on's. Making CI clone two third-party zsh projects to
+    reach the same assertion buys a slower, more fragile job and no more
+    coverage, which is the trade #192 asked whoever did this to make and say.
+
+    A stand-in that only *sets* the parameter is also a stronger fixture than
+    the add-on: the real one fetches asynchronously, so a suggestion is present
+    when the key is pressed only if the fetch has landed, and a test whose
+    fixture is a race passes for the wrong reason on a loaded runner.
+    """
+
+    #: Written by `_ghost` and by nothing else. Spelled with the `GHO''ST`
+    #: split so the literal never appears in what the harness types: a terminal
+    #: echoes its input, so a marker the test typed cannot witness anything.
+    #: `CLAUDE.md` rule 3, fourth bullet.
+    BAIT = "GHOST"
+
+    #: `_read_until` stops at its marker, so a marker *before* the value reads
+    #: back an empty string no matter what the value is -- which is a test that
+    #: passes either way. It goes last, after the closing bracket.
+    PROBE = (
+        "_ghost() { POSTDISPLAY=GHO''ST }\n"
+        # The `EN''D` split has to sit *outside* the double quotes: inside them
+        # `''` is two literal apostrophes, and the marker the harness waits for
+        # would be a string the shell never prints.
+        "_read() { print -r -- \"PD<$POSTDISPLAY>\"EN''D; zle -R }\n"
+        "zle -N _ghost\n"
+        "zle -N _read\n"
+        "bindkey '^N' _ghost\n"
+        "bindkey '^P' _read\n"
+    )
+
+    def test_a_stale_suggestion_does_not_survive_the_recall(self) -> None:
+        steps = [
+            Typed("", self.PROMPT),
+            Typed(f"source {self.HOOK}; echo LOAD''ED\n", "LOADED"),
+            Typed("", self.PROMPT),
+            Typed(f"{self.PROBE}echo PROB''ED\n", "PROBED"),
+            Typed("", self.PROMPT),
+            # Ctrl-N parks the ghost, Ctrl-P reads it back. Reading it *before*
+            # the recall is what stops this passing on a shell where the
+            # parameter was never set: "empty afterwards" is the assertion, and
+            # it is satisfied trivially by a fixture that produced no ghost.
+            Typed("\x0e\x10", "END"),
+            Typed("\x12", self.SELECTION),
+            Typed("\x10", "END"),
+        ]
+        *_, before, _recall, after = run_in_pty(
+            self.INTERPRETER, steps, env=self.picker_env(), timeout=30.0
+        )
+        self.assertIn(f"PD<{self.BAIT}>", before, "no ghost was parked, so this proves nothing")
+        self.assertIn("PD<>", after, f"the ghost survived the recall: {after!r}")
 
 
 if __name__ == "__main__":

--- a/woswoar/shell/woswoar.zsh
+++ b/woswoar/shell/woswoar.zsh
@@ -472,6 +472,26 @@ __woswoar_widget() {
     [[ -n $selection ]] || return 0
     BUFFER=$selection
     CURSOR=${#BUFFER}
+
+    # Ghost text an autosuggestion add-on parked after the cursor described the
+    # line that *was* here, so replacing $BUFFER makes it stale -- and nothing
+    # else takes it down. The recalled command is then drawn with the tail of
+    # somebody else's suggestion glued to it: `echo PICKEDbait`, observed
+    # against zsh-autosuggestions 85919cd with zsh 5.9.
+    #
+    # Cleared here rather than left to the add-on, and rather than to the
+    # `ZSH_AUTOSUGGEST_CLEAR_WIDGETS+=(__woswoar_widget)` that
+    # `docs/shell-integration.md` used to advise, because that remedy cannot
+    # work: `_zsh_autosuggest_bind_widgets` skips every widget matching `_*`,
+    # and that pattern is hard-coded in its local `ignore_widgets` rather than
+    # taken from the configurable `ZSH_AUTOSUGGEST_IGNORE_WIDGETS`. A name
+    # beginning with `_` is therefore unreachable from a user's .zshrc, in any
+    # order. Driven both ways; see `TestTheGhostSuggestionIsTakenDown`.
+    #
+    # A plain assignment, so it costs nothing and needs no add-on installed:
+    # POSTDISPLAY is zle's own parameter, empty in a shell that has none.
+    POSTDISPLAY=
+
     # The picker drew over the screen; without this the prompt is left where it
     # was and the recalled line appears under the picker's wreckage.
     zle reset-prompt


### PR DESCRIPTION
Closes #192. Both notes were driven against real installs, on zsh 5.9. One is
correct as written; the other described a real symptom and printed a remedy
that **cannot work**, so this fixes it in the hook instead.

## zsh-autosuggestions — symptom real, remedy impossible

Driven from a real `$ZDOTDIR/.zshrc` against zsh-autosuggestions `85919cd`, with
a history entry to suggest from, reading `$POSTDISPLAY` back through an
unwrapped probe widget rather than off the screen (`_read_until` stops at its
marker, so "no ghost in this chunk" and "no ghost" are different answers):

| `.zshrc` | `$POSTDISPLAY` before <kbd>Ctrl</kbd>+<kbd>R</kbd> | after |
|---|---|---|
| no remedy | `bait` | **`bait`** |
| `ZSH_AUTOSUGGEST_CLEAR_WIDGETS+=(__woswoar_widget)` after the woswoar line | `bait` | **`bait`** |
| …before the woswoar line | `bait` | **`bait`** |
| …plus emptying `ZSH_AUTOSUGGEST_IGNORE_WIDGETS` | `bait` | **`bait`** |

So the symptom is real — the recalled line is drawn as `echo PICKEDbait` — and
the remedy this page has been printing since #182 does nothing in any position.

The reason is in `_zsh_autosuggest_bind_widgets`:

```zsh
ignore_widgets=(
	.\*
	_\*                                  # <- hard-coded
	...
	$ZSH_AUTOSUGGEST_IGNORE_WIDGETS      # <- the configurable one
)
for widget in ${${(f)"$(builtin zle -la)"}:#${(j:|:)~ignore_widgets}}; do
```

Every widget whose name begins with `_` is skipped **before**
`ZSH_AUTOSUGGEST_CLEAR_WIDGETS` is consulted, and that `_\*` is a literal in a
local array rather than something a `.zshrc` can reach. `__woswoar_widget` is
therefore unreachable from any user configuration — which is the last row of the
table, where removing `_\*` from the *documented* variable still changes nothing.
Confirmed directly, too: `${widgets[__woswoar_widget]}` is `user:__woswoar_widget`
after a full startup, and `autosuggest-orig-__woswoar_widget` does not exist.

### The fix

`__woswoar_widget` clears `$POSTDISPLAY` itself, right after it replaces
`$BUFFER`. That is what the add-on's own `clear` action does
(`_zsh_autosuggest_clear` is `POSTDISPLAY=` and nothing else), it needs no
configuration, and it leaves no stale state — `_zsh_autosuggest_accept` guards
on `$#POSTDISPLAY`, so an empty one is already its "nothing to accept" case.

Ordered *after* the early `return 0`s on purpose: escaping the picker leaves
`$BUFFER` alone, and a ghost that still describes the line on screen is still
correct.

Verified end to end against the real add-on, same harness, hook with and
without the line:

```
### before the fix
  before Ctrl-R: 'PD<bait>BF<echo ghost>END'
  after  Ctrl-R: 'PD<bait>BF<echo PICKED>END'
### after the fix
  before Ctrl-R: 'PD<bait>BF<echo ghost>END'
  after  Ctrl-R: 'PD<>BF<echo PICKED>END'
```

## Powerlevel10k — correct as written

Instant prompt enabled, `POWERLEVEL9K_INSTANT_PROMPT=verbose`, the preamble at
the top of `.zshrc`, and no `~/.config/woswoar/machine`:

| shell | p10k warned | hook printed |
|---|---|---|
| 1 (builds the instant-prompt cache) | no | yes |
| 2 | **yes** | yes |
| 3 | **yes** | yes |
| 4, with an identity (control) | no | no |

p10k's "console output produced during zsh initialization follows" fires with
woswoar's `not initialised yet` line under it, exactly as documented, and goes
away once `install` has run. The paragraph now says so as a fact instead of a
guess. Nothing to change in the code.

(Two things this cost, if anyone repeats it: the instant-prompt cache is only
dumped from the *second* prompt onwards and asynchronously, so a shell killed
the moment its last marker appears never leaves one — the harness has to idle
at a prompt. And `--no-globalrcs`, or you measure `/etc/zshrc`.)

## The CI question the issue asked to be decided out loud

**The add-ons are not installed in CI**, and the regression test uses a
stand-in. #192 asked whoever did this to choose between a test and a corrected
paragraph and say why; this is both, with the dependency left out.

What CI needs from the experiment above is the mechanism, and the mechanism is
`$POSTDISPLAY` — a zle parameter, not anything of the add-on's. A stand-in
widget that parks a ghost is also a *stronger* fixture than the real thing: the
add-on fetches asynchronously, so a suggestion is present when the key is
pressed only if the fetch has landed, and a test whose fixture is a race passes
for the wrong reason on a loaded runner. Cloning two third-party zsh projects
per job would buy a slower, more fragile pipeline and no more coverage.

`TestTheGhostSuggestionIsTakenDown` drives a real zsh, a real zle and a real
pty, parks a ghost, presses <kbd>Ctrl</kbd>+<kbd>R</kbd>, and reads
`$POSTDISPLAY` back **on both sides of the keypress** — the "before" read is
what stops "empty afterwards" being true of a fixture that never produced one.

Mutation-tested per rule 3:

```
  caught    the widget no longer clears POSTDISPLAY, as before #192
  caught    the stand-in parks no ghost, so there is nothing for the recall to clear
```

The second is the fixture check rule 3's last paragraph asks for, not a second
look at the same line.

## One refactor, and why

`CtrlROnThePromptMixin` carried both the stubbed-picker fixture and its own
test. The new class needs the first and not the second, and inheriting the pair
re-ran "the selection does not run" under a second class name — a failure would
then name the wrong test. Split into `PickerStubMixin` (fixture, no tests) with
`CtrlROnThePromptMixin` extending it. No test changed.

## Review

Rule 1, middle row — behaviour on a path a user reaches, no stored data and no
security claim. A careful read of the diff plus the end-to-end run against the
real add-on above, which is the specific hazard: that the fix works on the thing
it is about and not only on the stand-in. No agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)