### PR TITLE
docs: write down the package's shape, and pin the import graph

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,15 @@ passed review, and guarded nothing:
 Prefer driving the real thing over asserting on a mock. The suite already runs a
 real `bash` for the shell hook and real `age` and `git` for sync; follow that.
 
+## Before moving code
+
+[`docs/architecture.md`](docs/architecture.md) is the map: which module may
+import which, the two costs that shape most of the odd-looking decisions, and the
+five shapes the codebase keeps reusing. The layering is not a convention —
+[`tests/test_architecture.py`](tests/test_architecture.py) holds it against the
+real import graph, so a new edge between modules is a deliberate one-line edit
+and a sentence in the pull request.
+
 ## Comments explain *why*
 
 The comment density here is deliberate and is most of the value of the codebase.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,7 +168,7 @@ exists so that nobody has to rediscover it.
 grammar, trust and pinning, manifests, the chunk codec, and git plumbing — plus
 the orchestration that drives them and the status queries `doctor` asks. The
 visible symptom is `sync.Report`: seventeen fields, each a failure from a
-different one of those layers, rendered by eleven consecutive `if` blocks in
+different one of those layers, rendered by twelve consecutive `if` blocks in
 `cmd_sync`. A new failure mode therefore means editing `Report`, `run`,
 `cmd_sync` and `test_sync.py` together.
 
@@ -189,8 +189,18 @@ why everything that wants `logs_dir()` currently depends on the chunk layout too
 counts; `deps.report` returns prose; `progress` uses a `Protocol` with two
 implementations. Each is defensible alone. Together they mean there is no answer
 to "how should a new check report itself?", which is the gap `doctor` falls into
-— four of its checks come from `sync` as `IdentityStatus` values and the other
-nine are derived inline in the CLI.
+— four of its lines come from `sync` as `IdentityStatus` values, and the rest of
+its eighteen `check` calls are derived inline in the CLI, where only a test that
+greps stdout can reach them.
 
-These are tracked as issues rather than fixed in passing; the layering is what
-makes them fixable one at a time.
+These are tracked as issues rather than fixed in passing, and the layering above
+is what makes them fixable one at a time. The order is not the order they are
+listed in — the two cheap ones come first because they make the expensive one
+smaller:
+
+| | issue |
+|---|---|
+| 1 | [#200](https://github.com/martinus/woswoar/issues/200) — split the repo layout out of `store.py`. Mechanical, and it takes the chunk layout out of `search`'s dependency cone. |
+| 2 | [#199](https://github.com/martinus/woswoar/issues/199) — one shape for outcome reporting, `doctor` first. This is what shrinks `Report`. |
+| 3 | [#202](https://github.com/martinus/woswoar/issues/202) — lift the installer and the setup wizard out of `__main__.py`. |
+| 4 | [#201](https://github.com/martinus/woswoar/issues/201) — split `sync.py`, in slices, after the three above. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,196 @@
+# Architecture
+
+How the code is arranged, and the handful of ideas it keeps reusing.
+
+This is the contributor's companion to the [design summary](woswoar_design_summary.md).
+That document is about the *product*: the record format, the sync protocol, the
+encryption, and the measurements behind each. This one is about the *package* —
+which module may know about which, what the recurring shapes are called, and
+where the arrangement is currently under strain. Read that one to understand
+what woswoar does; read this one before moving code.
+
+---
+
+## Layers
+
+```
+errors ─┬─ credentials ─┐
+        └─ crypto ──────┼─ sync ─┐
+entry ──┬─ store ───────┘        ├─ prove
+        ├─ cache ── search ──────┼─ __main__
+        └─ importer ─────────────┘
+deps, progress ─────────────────── (leaves, asked things by anyone)
+```
+
+| layer | modules | what it may know |
+|---|---|---|
+| format | `entry`, `errors` | nothing else in the package |
+| platform | `store`, `crypto`, `deps`, `progress`, `credentials` | the format layer |
+| derived | `cache` | the two above |
+| domains | `search`, `sync`, `importer` | everything below, and **never each other** |
+| composition | `prove`, `__main__` | everything |
+
+Three rules follow, and [`tests/test_architecture.py`](../tests/test_architecture.py)
+holds all three against the real import graph rather than against the `import`
+lines, so a lazy import inside a function correctly counts as no edge at all:
+
+1. **No cycles.** Every box is movable on its own, which is the whole point of
+   drawing them.
+2. **Domains do not import domains.** `search` must not reach `sync` or
+   `importer`; `sync` must not reach `search`. Where they appear to need each
+   other, what they actually need is something further down — `entry.home_relative`
+   lives in the format layer today precisely because `search` needed it and it
+   was in `importer`.
+3. **The table is exact.** A new edge is a one-line edit to `LAYERS` and a
+   sentence in the pull request. That edit is the review.
+
+`errors`, `deps` and `progress` are deliberately leaves. Each is asked things by
+the layers above without knowing anything about them, so any module can raise a
+`WoswoarError`, report a missing tool, or tick a counter without dragging a
+domain in behind it.
+
+---
+
+## Two costs shape everything
+
+Most of the non-obvious code in this repository is one of these two constraints
+showing through. Knowing which one you are looking at is usually enough to
+explain a decision that reads as strange.
+
+**A keypress is a cold process.** Ctrl-R runs `woswoar list` in a fresh
+interpreter, so anything imported at the top of the CLI module is paid for on
+every search — about 29 ms of a ~105 ms total. That is why `sync` is imported
+inside fourteen functions rather than at the top of `__main__.py`, why
+`store.write_atomic` imports `tempfile` at the point of use (3.1 ms), why
+`_hook_bytes` reaches `importlib.resources` only as a fallback (8.7 ms), and why
+`cache.Cache` is a plain class rather than a dataclass (~4 ms, via `inspect`).
+Each of those has its measurement in the comment beside it;
+`tests/test_architecture.py` pins the ones that are otherwise only a convention,
+and `tests/test_perf.py` guards the total they add up to.
+
+**The repository is append-only.** Nothing under `history/` is ever modified or
+deleted — `compact` is the single, opt-in exception — so a wrong byte is
+permanent. That is why `export` extends the manifest it last signed rather than
+listing the directory, why the recipient file uses tombstones rather than
+deletions, and why every access-changing command fetches *before* it reads
+`recipients.txt`. See the design summary for the reasoning; the shape to
+recognise here is that these operations are ordered, and the ordering is the
+correctness argument.
+
+---
+
+## The five recurring shapes
+
+None of these is exotic. They are worth naming only because they recur, and
+because a new module that invents a sixth spelling of one of them costs the next
+reader more than the code itself does.
+
+### 1. Truth and derived
+
+`logs/` is the plaintext history and the only irreplaceable thing woswoar owns.
+`history/`, `cache.txt` and `state.json` are all derived from it or from the
+remote, and can be rebuilt.
+
+The consequence is a **degradation rule**, and it is the reason so many readers
+in this codebase swallow errors that look like they should be raised: anything
+reading a derived artefact degrades towards "do the work again" rather than
+failing. `cache.load` answers an empty cache for any damage at all;
+`State.load` degrades field by field, with a comment on each saying which
+direction of wrongness is the cheap one; `store.repo_format` reads garbage as
+"unmarked" specifically so that four bytes written by anyone with push access
+cannot stop every machine syncing.
+
+If you are writing a reader, decide which side of this line its input is on
+before you decide what it does with a bad value.
+
+### 2. One place spells it
+
+The single most common comment in this repository is some form of "there used to
+be two of these". `store.ENV_KEYS` ("three copies of this tuple existed before it
+moved here"), `sync.signing_public` ("`export`, `compact` and `signing_status`
+each had their own"), `sync._append_recipient_line` ("the only writer"),
+`sync._parse` ("the file's grammar, stated once"), `search.KEYS` (one table for
+the `--bind` and the header that advertises it), `entry._INERT_TABLE` (reads its
+replacements out of `_ESCAPES` so a round trip cannot drift).
+
+The failure this prevents is always the same and always silent: two copies of a
+fact, one of them updated.
+
+### 3. Choke points
+
+The strongest version of the rule above. Where an invariant has to hold at every
+call site, the code is arranged so that violating it is *not expressible*, and
+the test is written against the seam rather than against each caller. The
+argument for testing the seam is in the design summary and is not hypothetical:
+the first attempt at the `age` rule converted two call sites and missed a third,
+and only a seam test would have caught it.
+
+| invariant | seam | what it replaced |
+|---|---|---|
+| a chunk is never read unverified | `sync.open_chunk` | `compact` reading chunks directly, which laundered planted ones |
+| `age` is never handed a path in `$HOME` | `crypto._run` | per-function conversion, which missed `encrypt_to_recipients` |
+| a peer's history is neutralised once | `cache._read_from`, via `parse_line(inert=True)` | neutralising per display site, forgotten once already |
+| access never widens without a human | `__main__._confirm` | one `isatty` branch copied per command |
+| access changes fetch before they act | `sync._access_change` | the ordering copied per command |
+
+Adding a row here is a good thing. Adding a *caller* that bypasses one is the
+thing to catch in review.
+
+### 4. Decide in the domain, render in the CLI
+
+150 of the package's 158 `print` calls are in `__main__.py`, and that is
+deliberate. Anything a message asserts should be decided by a value the domain
+returns, so that a test can reach it without grepping stdout:
+`sync.Reader`, `sync.Candidate`, `sync.Newcomer` and `sync.IdentityStatus` all
+exist for exactly this reason and say so. `Reader.display_name` is a method
+rather than a rule about remembering `!r`, which is the same idea one notch
+further in.
+
+This is the pattern with the most unfinished business — see below.
+
+### 5. Comment as decision record
+
+Every non-obvious choice carries the alternative that was rejected and, where the
+choice was about speed or size, the measurement that decided it. This is not
+decoration: it is how a reader tells a deliberate oddity from an accident, and
+it is what stops a "cleanup" reintroducing a bug that was fixed two years ago.
+Match the density. [`CLAUDE.md`](../CLAUDE.md) and
+[`CONTRIBUTING.md`](../CONTRIBUTING.md) have the rest of the working rules.
+
+---
+
+## Where the shape is under strain
+
+The layering above is real and holds. The *sizes* do not, and this section
+exists so that nobody has to rediscover it.
+
+**`sync.py` is 3234 lines holding five separable concerns** — the recipient-file
+grammar, trust and pinning, manifests, the chunk codec, and git plumbing — plus
+the orchestration that drives them and the status queries `doctor` asks. The
+visible symptom is `sync.Report`: seventeen fields, each a failure from a
+different one of those layers, rendered by eleven consecutive `if` blocks in
+`cmd_sync`. A new failure mode therefore means editing `Report`, `run`,
+`cmd_sync` and `test_sync.py` together.
+
+**`__main__.py` is 2102 lines and inverts pattern 4 in two places.** An installer
+(`installed_shells`, `detect_shells`, `shells_from`, `_hook_bytes`,
+`_write_block`, `_stale_hooks`, `_refresh_hook`) and a setup wizard
+(`_importable`, `_untouched`, `_offer_imports`, `_offer_remote`) are both
+subsystems living in the argparse module, reachable by a test only through
+stdout. The wizard builds `argparse.Namespace` objects by hand to call sibling
+commands, which is the CLI using its own argument format as an internal API.
+
+**`store.py` carries three vocabularies**: paths under `logs/`, paths under
+`history/`, and filesystem primitives. The middle one is `sync`'s alone, which is
+why everything that wants `logs_dir()` currently depends on the chunk layout too.
+
+**Outcome reporting has five spellings.** `sync` returns a `Report` dataclass and
+`IdentityStatus` records; `search.empty_note` returns prose; `importer` returns
+counts; `deps.report` returns prose; `progress` uses a `Protocol` with two
+implementations. Each is defensible alone. Together they mean there is no answer
+to "how should a new check report itself?", which is the gap `doctor` falls into
+— four of its checks come from `sync` as `IdentityStatus` values and the other
+nine are derived inline in the CLI.
+
+These are tracked as issues rather than fixed in passing; the layering is what
+makes them fixable one at a time.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -194,9 +194,12 @@ its eighteen `check` calls are derived inline in the CLI, where only a test that
 greps stdout can reach them.
 
 These are tracked as issues rather than fixed in passing, and the layering above
-is what makes them fixable one at a time. The order is not the order they are
-listed in — the two cheap ones come first because they make the expensive one
-smaller:
+is what makes them fixable one at a time.
+[#203](https://github.com/martinus/woswoar/issues/203) carries the argument for
+treating them as one piece of work — they are two half-finished ideas rather than
+four chores — along with what "done" looks like and what must not change on the
+way. The order is not the order they are listed in above: the two cheap ones come
+first because they make the expensive one smaller.
 
 | | issue |
 |---|---|

--- a/docs/woswoar_design_summary.md
+++ b/docs/woswoar_design_summary.md
@@ -399,6 +399,16 @@ Deferring the `importer` import was kept for the same reason plus one more: it
 matches how `sync` is already handled, and it moved importing the CLI module
 from 26.6 to 24.6 ms.
 
+> That deferral has since been undone, and this paragraph is left as the record
+> of why it was made. `build_parser` reads `importer.KINDS` to populate the
+> `import` subcommand's choices, and the parser is built on every invocation, so
+> the CLI imports the module at the top level again. Re-measured: 0.75 ms of the
+> ~15 ms it takes to import `__main__`, against the 2 ms above on a different
+> machine. Restoring it means moving `KINDS` somewhere cheaper, which is a
+> millisecond of fifteen — the case the convergence rule at the end of
+> `CLAUDE.md` says to state and leave alone. `sync`, `crypto` and `prove` are
+> still deferred, and `tests/test_architecture.py` now holds them there.
+
 Going meaningfully below this needs a structural change, and both candidates are
 worse than the problem:
 

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -1,0 +1,196 @@
+"""The shape of the package, pinned where it is otherwise only a convention.
+
+Two facts about this codebase are load-bearing and, until this file, were held
+up by nothing but comments scattered across the modules that happen to obey
+them.
+
+**The layering.** ``entry`` is the record format and imports nothing; ``store``
+is the filesystem below it; ``cache`` and ``search`` sit on those; ``sync``,
+``importer`` and ``prove`` are domains that nothing else may import. The graph
+has no cycles, which is what makes any of the boxes movable one at a time.
+Nothing enforced it, so the first accidental edge would have been found by
+somebody trying to move a module, months later.
+
+**The Ctrl-R budget.** ``docs/woswoar_design_summary.md`` measures a search at
+~105 ms end to end, of which ~29 ms is importing the CLI module. That number
+holds because the expensive things are imported lazily, at the call site, each
+with a measured comment beside it -- ``sync`` inside each of the fourteen
+commands in `__main__` that need it, ``tempfile`` in `store.write_atomic`
+(3.1 ms), ``importlib.resources`` in `__main__._hook_bytes` (8.7 ms), and
+``dataclasses`` avoided outright in `cache.Cache` (~4 ms, via ``inspect``).
+Every one of those is a comment asking a future reader to remember something.
+`tests/test_perf.py` measures the *result* and would catch a regression as a
+blown budget with no indication of the cause; this catches the cause and names
+it.
+
+Each check starts a fresh interpreter, and has to: this suite imports almost the
+whole package before any test runs -- ``tests/support.py`` alone pulls in
+``__main__``, ``crypto`` and ``store`` -- so ``sys.modules`` in this process
+answers a question about the test runner rather than about the package.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+#: Every intra-package import each module pulls in, transitively, at import
+#: time. Measured rather than read off the ``import`` lines, because a lazy
+#: import inside a function is not an edge and a re-export is.
+#:
+#: Compared for equality, not containment. An edge that is genuinely wanted is a
+#: one-line edit here and a sentence in the pull request, which is the review
+#: this is for; a table that only caught *additions* would silently rot as
+#: modules lost dependencies and stop describing the package it claims to pin.
+#:
+#: The four leaves are leaves on purpose. `errors` holds the exception every
+#: layer raises, and `deps` and `progress` are asked things by the layers above
+#: without knowing anything about them -- so each of them stays importable from
+#: anywhere without dragging a domain along.
+LAYERS: dict[str, set[str]] = {
+    "entry": set(),
+    "errors": set(),
+    "deps": set(),
+    "progress": set(),
+    "credentials": {"errors"},
+    "crypto": {"errors"},
+    "store": {"entry"},
+    "cache": {"entry", "store"},
+    "search": {"cache", "entry", "store"},
+    "importer": {"credentials", "entry", "errors", "store"},
+    "sync": {"crypto", "entry", "errors", "progress", "store"},
+    "prove": {"crypto", "deps", "entry", "errors", "progress", "store", "sync"},
+    "__main__": {"cache", "credentials", "entry", "errors", "importer", "search", "store"},
+}
+
+#: What a keypress must not pay for. Each is deferred deliberately somewhere,
+#: with the measurement in the comment that defers it, and each is reachable
+#: from `__main__` by one careless top-level ``import``.
+#:
+#: ``sqlite3`` is here for a different reason from the rest: nothing measured it,
+#: but it is the atuin importer's, it is large, and the only thing keeping it off
+#: this path is that `importer` opens the database inside a function.
+DEFERRED_ON_THE_SEARCH_PATH = (
+    "subprocess",
+    "tempfile",
+    "shutil",
+    "dataclasses",
+    "inspect",
+    "importlib.resources",
+    "sqlite3",
+)
+
+
+def _imported_by(module: str) -> tuple[set[str], set[str]]:
+    """``(woswoar modules, stdlib modules)`` importing ``module`` pulls in.
+
+    A fresh interpreter per call, and the difference against what was already
+    loaded rather than the whole of ``sys.modules``: ``site`` and whatever a
+    distribution puts in ``sitecustomize`` are not this package's doing, and a
+    test that counted them would fail on somebody else's machine for a reason
+    that has nothing to do with the change they made.
+
+    Run from the checkout, so the ``woswoar`` being measured is the one in this
+    working tree. Without ``cwd`` it would be whichever copy the subprocess found
+    first -- which for a non-editable install is the one in site-packages, so the
+    test would pass on a tree whose imports had changed and not been installed.
+    """
+    code = (
+        "import sys\n"
+        "before = set(sys.modules)\n"
+        f"import woswoar.{module}\n"
+        "after = set(sys.modules) - before\n"
+        "print(' '.join(sorted(m for m in after if m.startswith('woswoar.'))))\n"
+        "print(' '.join(sorted(m for m in after if not m.startswith('woswoar'))))\n"
+    )
+    done = subprocess.run(
+        [sys.executable, "-c", code], cwd=REPO, capture_output=True, text=True, check=False
+    )
+    if done.returncode != 0:
+        raise AssertionError(f"importing woswoar.{module} failed:\n{done.stderr}")
+    package, stdlib = done.stdout.splitlines()
+    return (
+        {name.removeprefix("woswoar.") for name in package.split()} - {module},
+        set(stdlib.split()),
+    )
+
+
+class TestTheLayering(unittest.TestCase):
+    def test_every_module_imports_exactly_what_the_table_says(self) -> None:
+        """The whole graph at once, so a new edge is a failure naming both ends.
+
+        Subtests rather than one assertion over the whole dict: a wrong edge in
+        `sync` should not hide a wrong edge in `search`, and the module name is
+        what makes the failure readable.
+        """
+        for module, expected in LAYERS.items():
+            with self.subTest(module=module):
+                package, _ = _imported_by(module)
+                self.assertEqual(package, expected)
+
+    def test_the_table_covers_every_module(self) -> None:
+        """Otherwise a module added without an entry is pinned by nothing, and
+        the file above still passes -- which is the way this check dies."""
+        source = REPO / "woswoar"
+        present = {p.stem for p in source.glob("*.py")} - {"__init__"}
+        self.assertEqual(present, set(LAYERS))
+
+    def test_the_graph_has_no_cycles(self) -> None:
+        """Stated directly rather than left implied by the table.
+
+        The table would catch a cycle, but only as two edges a reader has to put
+        together themselves -- and "no cycles" is the property that makes the
+        layers mean anything, so it is worth a failure that says so. Computed
+        from `LAYERS`, which the test above ties to the real imports.
+        """
+        for module in LAYERS:
+            for dependency in LAYERS[module]:
+                self.assertNotIn(
+                    module,
+                    LAYERS[dependency],
+                    f"{module} and {dependency} import each other",
+                )
+
+
+class TestTheSearchPathStaysCheap(unittest.TestCase):
+    """Ctrl-R runs `woswoar list` in a fresh interpreter, so every module the CLI
+    imports at the top level is paid for on every keypress.
+
+    The design document budgets ~29 ms for that import against ~105 ms for the
+    whole search. `tests/test_perf.py` guards the total; these guard the reasons
+    it holds, which is what a person reading a failure needs.
+    """
+
+    def test_the_cli_does_not_import_sync_crypto_or_prove(self) -> None:
+        """`sync` alone was measured at ~2 ms of the CLI module's import, and it
+        drags `crypto` and `progress` behind it. Every command that needs it says
+        `from . import sync` inside the function instead -- fourteen call sites,
+        any one of which could have been written at the top of the file with
+        nothing to notice."""
+        package, _ = _imported_by("__main__")
+        self.assertEqual(package & {"sync", "crypto", "prove"}, set())
+
+    def test_the_cli_does_not_import_the_expensive_stdlib(self) -> None:
+        """Each of these is deferred at a call site with its cost written beside
+        it -- `tempfile` 3.1 ms in `store.write_atomic`, `importlib.resources`
+        8.7 ms in `__main__._hook_bytes`, `dataclasses` ~4 ms avoided in
+        `cache.Cache`. A top-level import of any of them is invisible in review
+        and shows up as a slower keypress."""
+        _, stdlib = _imported_by("__main__")
+        self.assertEqual(sorted(stdlib.intersection(DEFERRED_ON_THE_SEARCH_PATH)), [])
+
+    def test_search_reaches_none_of_the_domains(self) -> None:
+        """`search` is the module Ctrl-R is made of. It may see `cache`, `store`
+        and `entry` and nothing else -- notably not `importer`, which is where
+        `home_relative` used to live and whose move into `entry` is documented
+        there as a measured cost of pulling that module onto this path."""
+        package, _ = _imported_by("search")
+        self.assertEqual(package, {"cache", "entry", "store"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two facts about this codebase are load-bearing and, until now, were held up by
nothing but comments in the modules that happen to obey them: the **layering**
(no cycles, domains never import domains) and the **lazy-import discipline**
that keeps the Ctrl-R budget at ~29 ms of module import. The first accidental
edge would have been found by somebody trying to move a module, months later.

## What is here

**`docs/architecture.md`** — the contributor's companion to the design summary,
which stays the document about the *product*. It has the layer table and its
three rules, the two costs that explain most of the odd-looking decisions in the
tree (a keypress is a cold process; the repository is append-only), the five
shapes the codebase keeps reusing — truth/derived, "one place spells it", choke
points, decide-in-the-domain, comment-as-decision-record — and an honest closing
section on where the sizes are under strain.

**`tests/test_architecture.py`** — holds the graph against the *real* imports
rather than the `import` lines, so a lazy import inside a function correctly
counts as no edge and a re-export counts as one. The `LAYERS` table is compared
for equality, so a wanted new edge is a one-line edit and a sentence in a PR.
It also pins what a keypress must not pay for: `sync`, `crypto`, `prove`, and
the stdlib modules deferred with measurements beside them.

Reachability: linked from `CONTRIBUTING.md`, which the README links, so
`TestNothingIsMovedOutOfSight` is satisfied.

## Mutation testing

`python -m tools.mutate` against a table of six edits, baseline green:

```
  caught    the CLI imports sync at the top level
  caught    the CLI imports subprocess at the top level
  caught    search imports the atuin importer at the top level
  caught    store grows an edge back up into cache
  caught    a cycle is written into the table to make the graph test pass
  caught    a new module is added without a table entry
```

The cycle mutation is on the table rather than on a source file, and
deliberately: a real cycle forces somebody to write it into `LAYERS` to get the
first test green, and that edit is the moment the second test refuses it.

## Found while measuring, and fixed here

The design summary claimed the `importer` import was deferred out of the CLI
module ("26.6 to 24.6 ms"). It is not — `build_parser` reads `importer.KINDS`
for the `import` subcommand's choices and the parser is built on every
invocation, so `__main__` imports it at the top level again. Re-measured at
**0.75 ms of the ~15 ms** it takes to import `__main__` on this machine.

Corrected in place rather than chased: restoring the deferral means moving
`KINDS` somewhere cheaper, and a millisecond of fifteen is exactly the case the
convergence rule at the end of `CLAUDE.md` says to state and leave alone. The
paragraph is kept as the record of why the deferral was made. `sync`, `crypto`
and `prove` are still deferred and the new test now holds them there.

## Found and not fixed

`__main__.py:1292` has a redundant `from . import importer` inside `_importable`,
left over from when the module-level import was not there. Harmless — it rebinds
an already-imported module — but it reads as a deferral that is not happening.
Not touched, because this PR changes no code and it needs no test of its own.

## Not in scope

The four strains named at the end of the new document — `sync.py` at 3234 lines,
the installer and wizard inside `__main__.py`, `store.py`'s three vocabularies,
and the five spellings of outcome reporting — are filed as issues rather than
started here. The layering is what makes them fixable one at a time.

Preflight is green: `ruff check`, `ruff format --check`, `mypy`, `shellcheck`,
875 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
