### PR TITLE
docs: a tracking issue carries `tracking` and no priority

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,14 @@ Priority is *implementation order*, not just severity. When ranking, weigh:
 State the reasoning in the issue when the ranking is not obvious from the title.
 If new information changes the picture, relabel the issue and say why.
 
+**One exception, and it follows from that sentence.** An issue that only
+*contains* other issues carries `tracking` and no priority at all. Priority is
+implementation order, and a container has none — its children have it, and they
+are what someone actually picks up. A tracking issue given a `P2` sits in the
+ordered list above as a peer of the four issues inside it, so working that list
+top-down reaches a card with nothing to do on it. Keep the argument, the order
+and the definition of done in the tracking issue; keep the priority on the work.
+
 ## 6. Never discard a change you cannot get back
 
 `git checkout -- <file>`, `git restore`, `git stash` and `git reset --hard` have

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,10 @@ reach for the wrong fix is doing the main thing.
   PR description rather than fixing it quietly or filing an issue nobody will
   do. The bar for filing is in [`CLAUDE.md`](CLAUDE.md) rule 4.
 - Every issue carries exactly one priority label, `P0`–`P3`, and they sort
-  lexically so the open list reads as an implementation order.
+  lexically so the open list reads as an implementation order. The exception is
+  an issue that only contains other issues: it carries `tracking` and no
+  priority, because priority *is* the implementation order and a container has
+  none.
 
 Nothing is merged without the maintainer saying so, including by the maintainer's
 own agents.


### PR DESCRIPTION
Follow-up to #198, which filed #199–#202 and the tracking issue #203 over them.

## The problem

Rule 5 says priority *is* implementation order. That makes a priority label on a
container a category error, and it showed up immediately — `#203` sat in the
ordered list as a peer of the four issues inside it:

```
P2  #197  fleet: nothing shows which machines have accepted which
P2  #199  arch: give outcome reporting one shape, starting with doctor
P2  #200  arch: split the history-repo layout out of store.py
P2  #201  arch: sync.py holds five separable concerns behind one run()
P2  #202  arch: the installer and the setup wizard live inside __main__.py
P2  #203  arch: make the package refactorable — tracking issue for #199-#202
```

Working that list top-down reaches a card with nothing to do on it, and `#203`'s
`P2` reads as "do this at the same time as the things it contains".

## What changed

- A `tracking` label exists (grey, like `duplicate`), and `#203` carries it with
  no priority. It is now out of the ordered list; its four children keep their
  `P2` and their stated order.
- `CLAUDE.md` rule 5 gains the exception, phrased as following from the sentence
  already there rather than as a new rule to remember.
- `CONTRIBUTING.md` gains the same sentence in its shorter form, because it is
  the same rules written for humans and the two are deliberately kept as one
  source so they cannot drift.

Documentation only — no code, no tests. Preflight green.

## The alternative, for the record

The cheaper version was to drop `P2` from `#203` and add no vocabulary at all,
which also takes it out of the ordered list. The label earns its place at the
second tracking issue rather than the first: without it there is no way to ask
for the containers, and an unlabelled issue is indistinguishable from one
somebody forgot to triage — which is exactly the state rule 5 exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
