### PR TITLE
arch: split the history-repo layout out of store.py

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,22 +13,41 @@ what woswoar does; read this one before moving code.
 
 ## Layers
 
+Who sits on whom. Indentation is "imports"; the three at the bottom are what the
+domains are made of.
+
 ```
-errors ─┬─ credentials ─┐
-        └─ crypto ──────┼─ sync ─┐
-entry ──┬─ store ───────┘        ├─ prove
-        ├─ cache ── search ──────┼─ __main__
-        └─ importer ─────────────┘
-deps, progress ─────────────────── (leaves, asked things by anyone)
+entry, errors        the record format, and the exception every layer raises
+  store              logs/, machine identity, the filesystem primitives
+    archive          history/ -- the repo layout    (sync and prove only)
+    cache            the parse index
+      search         Ctrl-R
+  crypto             age and ssh-keygen
+  credentials
+    importer         bash, zsh, atuin
+deps, progress       leaves: asked things by anyone, knowing nobody
+
+sync      <- archive, crypto, progress, store, entry, errors
+prove     <- sync, and everything sync is made of, plus deps
+__main__  <- search, cache, importer, store, entry, errors
+             (sync, crypto, archive and prove only inside the commands
+              that need them -- see "Two costs shape everything")
 ```
 
 | layer | modules | what it may know |
 |---|---|---|
 | format | `entry`, `errors` | nothing else in the package |
 | platform | `store`, `crypto`, `deps`, `progress`, `credentials` | the format layer |
-| derived | `cache` | the two above |
+| derived | `cache`, `archive` | the two above |
 | domains | `search`, `sync`, `importer` | everything below, and **never each other** |
 | composition | `prove`, `__main__` | everything |
+
+`store` and `archive` are the two halves of the filesystem: `store` owns
+``logs/`` — the plaintext truth — plus the primitives and machine identity;
+`archive` owns the layout of the encrypted repository under ``history/`` and its
+self-description. Only `sync` and `prove` may reach `archive`. `history_dir` is
+the one path that stays in `store`, because `store._private_paths` has to prune
+that directory by name when it walks for `harden` and `readable_by_others`.
 
 Three rules follow, and [`tests/test_architecture.py`](../tests/test_architecture.py)
 holds all three against the real import graph rather than against the `import`
@@ -180,9 +199,15 @@ subsystems living in the argparse module, reachable by a test only through
 stdout. The wizard builds `argparse.Namespace` objects by hand to call sibling
 commands, which is the CLI using its own argument format as an internal API.
 
-**`store.py` carries three vocabularies**: paths under `logs/`, paths under
-`history/`, and filesystem primitives. The middle one is `sync`'s alone, which is
-why everything that wants `logs_dir()` currently depends on the chunk layout too.
+**`store.py` used to carry three vocabularies** — paths under `logs/`, paths
+under `history/`, and the filesystem primitives — so everything that wanted
+`logs_dir()` also depended on the chunk layout. The middle one is
+`woswoar/archive.py` now (#200), and `cache` and `search` no longer reach it.
+What is left in `store` that does not belong to it is four per-machine files
+`sync` owns — `state_file`, `sync_stamp_file`, `sync_failure_file`,
+`signing_key_file`. They stayed deliberately: none of them is *in* the
+repository, so filing them under `archive` would be worse than leaving them, and
+their home is whatever #201 carves out of `sync`.
 
 **Outcome reporting has five spellings.** `sync` returns a `Report` dataclass and
 `IdentityStatus` records; `search.empty_note` returns prose; `importer` returns
@@ -203,7 +228,7 @@ first because they make the expensive one smaller.
 
 | | issue |
 |---|---|
-| 1 | [#200](https://github.com/martinus/woswoar/issues/200) — split the repo layout out of `store.py`. Mechanical, and it takes the chunk layout out of `search`'s dependency cone. |
+| 1 | ~~[#200](https://github.com/martinus/woswoar/issues/200) — split the repo layout out of `store.py`~~ — **done**, as `woswoar/archive.py`. |
 | 2 | [#199](https://github.com/martinus/woswoar/issues/199) — one shape for outcome reporting, `doctor` first. This is what shrinks `Report`. |
 | 3 | [#202](https://github.com/martinus/woswoar/issues/202) — lift the installer and the setup wizard out of `__main__.py`. |
 | 4 | [#201](https://github.com/martinus/woswoar/issues/201) — split `sync.py`, in slices, after the three above. |

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -59,11 +59,12 @@ LAYERS: dict[str, set[str]] = {
     "credentials": {"errors"},
     "crypto": {"errors"},
     "store": {"entry"},
+    "archive": {"entry", "store"},
     "cache": {"entry", "store"},
     "search": {"cache", "entry", "store"},
     "importer": {"credentials", "entry", "errors", "store"},
-    "sync": {"crypto", "entry", "errors", "progress", "store"},
-    "prove": {"crypto", "deps", "entry", "errors", "progress", "store", "sync"},
+    "sync": {"archive", "crypto", "entry", "errors", "progress", "store"},
+    "prove": {"archive", "crypto", "deps", "entry", "errors", "progress", "store", "sync"},
     "__main__": {"cache", "credentials", "entry", "errors", "importer", "search", "store"},
 }
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 from unittest import mock
 
-from woswoar import cache, crypto, progress, prove, search, store, sync
+from woswoar import archive, cache, crypto, progress, prove, search, store, sync
 from woswoar.__main__ import _GRANT_REMEDY, HOOKS, main
 from woswoar.__main__ import _hook_bytes as main_hook_bytes
 from woswoar.entry import Entry, format_line
@@ -148,12 +148,12 @@ class Fake:
         text and is still shown quoted beside a fingerprint.
         """
         key = crypto.generate_identity().public
-        with store.recipients_file().open("a", encoding="utf-8") as handle:
+        with archive.recipients_file().open("a", encoding="utf-8") as handle:
             handle.write(f"{key}\n")
         if name:
             host = secrets.token_hex(8)
             verify_key = crypto.generate_signing_key(self.root / f"signer-{host}")
-            store.write_atomic(store.signer_public(host), f"{verify_key}\n{key}\n".encode())
+            store.write_atomic(archive.signer_public(host), f"{verify_key}\n{key}\n".encode())
             store.write_atomic(store.name_file(host), f"{name}\n".encode())
         return key
 
@@ -243,7 +243,7 @@ class SyncTestCase(unittest.TestCase):
         aged = time.time() - sync.RACY_WINDOW_NS / 1e9 - 60
         with machine.active():
             for day in days:
-                os.utime(store.chunk_dir(host.id, day), (aged, aged))
+                os.utime(archive.chunk_dir(host.id, day), (aged, aged))
 
     def run_cli(self, fake: Fake, *argv: str, tty: bool = False) -> support.Ran:
         """Drive the real CLI as ``fake``. Both streams -- see `support.run_cli`."""
@@ -500,7 +500,7 @@ class TestAFinderVisitDoesNotBreakSync(SyncTestCase):
     def test_the_repo_carries_a_gitignore_for_it(self) -> None:
         alpha = self.machine("alpha")
         with alpha.active():
-            text = (store.history_dir() / store.GITIGNORE).read_text(encoding="utf-8")
+            text = (store.history_dir() / archive.GITIGNORE).read_text(encoding="utf-8")
         self.assertIn(".DS_Store", text)
 
     def test_a_repo_that_predates_it_acquires_one_on_the_next_sync(self) -> None:
@@ -515,7 +515,7 @@ class TestAFinderVisitDoesNotBreakSync(SyncTestCase):
         """
         alpha = self.machine("alpha")
         with alpha.active():
-            ignore = store.history_dir() / store.GITIGNORE
+            ignore = store.history_dir() / archive.GITIGNORE
             ignore.unlink()
             alpha.record("2023-11-14", 1_700_000_001, "git status")
             sync.run()
@@ -559,8 +559,8 @@ class TestAFinderVisitDoesNotBreakSync(SyncTestCase):
             self.litter(
                 alpha,
                 store.history_dir(),
-                store.repo_host_dir(alpha.id),
-                store.chunk_dir(alpha.id, "2023-11-14"),
+                archive.repo_host_dir(alpha.id),
+                archive.chunk_dir(alpha.id, "2023-11-14"),
             )
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_002, "git commit")
@@ -588,7 +588,7 @@ class TestAFinderVisitDoesNotBreakSync(SyncTestCase):
             sync.grant()
             sync.run()
         with alpha.active():
-            self.litter(alpha, store.chunk_dir(alpha.id, "2023-11-14"))
+            self.litter(alpha, archive.chunk_dir(alpha.id, "2023-11-14"))
             sync.run()
 
         self.accept_everyone(beta)
@@ -609,7 +609,7 @@ class TestAFinderVisitDoesNotBreakSync(SyncTestCase):
             alpha.record("2023-11-14", 1_700_000_001, "git status")
             sync.run()
         with alpha.active():
-            self.litter(alpha, store.chunk_dir(alpha.id, "2023-11-14"))
+            self.litter(alpha, archive.chunk_dir(alpha.id, "2023-11-14"))
             self.assertEqual(sync.unlisted_chunks(), [])
 
 
@@ -659,7 +659,7 @@ class TestImmutability(SyncTestCase):
         # invariant. Classified by store, not by a regex copied here: a
         # hand-maintained pattern would silently stop matching if the layout
         # changed, leaving this vacuously true while real chunks were rewritten.
-        chunks = {p for p in rewritten if store.is_chunk_path(p)}
+        chunks = {p for p in rewritten if archive.is_chunk_path(p)}
         self.assertEqual(sorted(chunks), [], f"chunks were rewritten: {sorted(chunks)}")
 
         # And the only things that were rewritten are the ones allowed to be.
@@ -691,8 +691,8 @@ class TestImmutability(SyncTestCase):
                 if ": " in line
             )
             stored = int(counts["size-pack"]) * 1024 + int(counts["size"]) * 1024
-            chunk_bytes = sum(c.path.stat().st_size for c in store.iter_chunks(alpha.id))
-            chunks = len(list(store.iter_chunks(alpha.id)))
+            chunk_bytes = sum(c.path.stat().st_size for c in archive.iter_chunks(alpha.id))
+            chunks = len(list(archive.iter_chunks(alpha.id)))
 
         self.assertEqual(chunks, syncs, "each sync must produce exactly one chunk")
         # Chunks are written once and never rewritten, so git stores each
@@ -822,7 +822,7 @@ class TestGrantConfirmation(SyncTestCase):
         alpha = self.machine("alpha", display="box")
         with alpha.active():
             key = sync.recipients()[0]
-            path = store.recipients_file()
+            path = archive.recipients_file()
             path.write_text(f"{key}\n{key}{sync._LABEL_SEP}box\n", encoding="utf-8")
             self.assertEqual(sync.recipients(), [key])
             # And it is still usable, which is the point of deduplicating.
@@ -950,7 +950,7 @@ class TestRevokeSubtraction(SyncTestCase):
         with alpha.active():
             mine = sync.recipients()
             gone = crypto.generate_identity().public
-            store.recipients_file().write_text(
+            archive.recipients_file().write_text(
                 f"-{gone}{sync._LABEL_SEP}revoked\n{gone}{sync._LABEL_SEP}old-laptop\n"
                 + "".join(f"{key}\n" for key in mine),
                 encoding="utf-8",
@@ -972,7 +972,7 @@ class TestRevokeSubtraction(SyncTestCase):
 
             # And appending the line by hand, which is all push access buys,
             # does not bring it back either.
-            with store.recipients_file().open("a", encoding="utf-8") as handle:
+            with archive.recipients_file().open("a", encoding="utf-8") as handle:
                 handle.write(f"{gone}{sync._LABEL_SEP}back-again\n")
             self.assertNotIn(gone, sync.recipients())
 
@@ -990,7 +990,7 @@ class TestRevokeSubtraction(SyncTestCase):
 
         with alpha.active():
             sync.grant(approved=[reader.key for reader in sync.readers()])
-            sealed = store.name_seal(store.machine().id)
+            sealed = archive.name_seal(store.machine().id)
             # Opens for beta here, which is what makes the failure below a
             # consequence of the revocation rather than of never having access.
             crypto.decrypt_with_file(sealed.read_bytes(), beta_identity)
@@ -1056,7 +1056,7 @@ class TestRevokeSubtraction(SyncTestCase):
         with alpha.active():
             # Only one recipient, and it is not this machine -- so `is_mine`
             # does not catch it and the emptiness guard is what has to.
-            store.recipients_file().write_text("", encoding="utf-8")
+            archive.recipients_file().write_text("", encoding="utf-8")
             only = alpha.append_recipient(name="only-one")
             (other,) = sync.readers()
             with self.assertRaises(sync.SyncError) as caught:
@@ -1190,13 +1190,13 @@ class TestARevokedMachineCannotPublish(SyncTestCase):
             day = "2023-11-14"
             with sync.lock():
                 sync._fetch_and_rebase(sync.read_repo())
-                pub = store.day_key_public(alpha.id, day)
+                pub = archive.day_key_public(alpha.id, day)
                 entry = Entry(1_700_000_900, alpha.id, "s1", "~", 0, 5, "planted-under-alpha")
                 sealed = crypto.encrypt_to(
                     sync.pack((format_line(entry) + "\n").encode("utf-8")),
                     pub.read_text(encoding="utf-8").strip(),
                 )
-                target = store.chunk_dir(alpha.id, day) / "9999999999-ffffff.age"
+                target = archive.chunk_dir(alpha.id, day) / "9999999999-ffffff.age"
                 target.parent.mkdir(parents=True, exist_ok=True)
                 target.write_bytes(sealed)
                 sync._commit()
@@ -1247,7 +1247,7 @@ class TestExportNeverSignsWhatItDidNotWrite(SyncTestCase):
             alpha.record("2023-11-14", 1_700_000_001, "ours")
             sync.run()
 
-            planted = store.chunk_dir(alpha.id, "2023-11-14") / "9999999999-ffffff.age"
+            planted = archive.chunk_dir(alpha.id, "2023-11-14") / "9999999999-ffffff.age"
             planted.write_bytes(b"whatever an attacker likes")
 
             alpha.record("2023-11-14", 1_700_000_002, "ours too")
@@ -1268,9 +1268,11 @@ class TestExportNeverSignsWhatItDidNotWrite(SyncTestCase):
         with alpha.active():
             sync.grant()
             entry = Entry(1_700_000_900, alpha.id, "s1", "~", 0, 5, "planted")
-            pub = store.day_key_public(alpha.id, "2023-11-14").read_text(encoding="utf-8").strip()
+            pub = archive.day_key_public(alpha.id, "2023-11-14").read_text(encoding="utf-8").strip()
             sealed = crypto.encrypt_to(sync.pack((format_line(entry) + "\n").encode("utf-8")), pub)
-            (store.chunk_dir(alpha.id, "2023-11-14") / "9999999999-ffffff.age").write_bytes(sealed)
+            (archive.chunk_dir(alpha.id, "2023-11-14") / "9999999999-ffffff.age").write_bytes(
+                sealed
+            )
             alpha.record("2023-11-14", 1_700_000_002, "ours too")
             sync.run(now=1_900_000_000)
 
@@ -1358,7 +1360,7 @@ class TestCrashDebrisIsNotCalledAnIntruder(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "one")
             sync.run()
-            before = set(store.chunk_names(alpha.id, "2023-11-14"))
+            before = set(archive.chunk_names(alpha.id, "2023-11-14"))
 
             alpha.record("2023-11-14", 1_700_000_002, "two")
 
@@ -1370,7 +1372,7 @@ class TestCrashDebrisIsNotCalledAnIntruder(SyncTestCase):
                 mock.patch.object(sync, "write_manifest", die),
             ):
                 sync.run()
-            left = set(store.chunk_names(alpha.id, "2023-11-14")) - before
+            left = set(archive.chunk_names(alpha.id, "2023-11-14")) - before
         self.assertEqual(len(left), 1, "precondition: a chunk was left unsigned")
         return alpha, left.pop()
 
@@ -1415,7 +1417,7 @@ class TestDoctorFindsAChunkNobodySigned(SyncTestCase):
 
     def planted(self, machine: Fake, host: Fake, name: str = "1700000000-dead.age") -> None:
         with machine.active():
-            (store.chunk_dir(host.id, self.DAY) / name).write_bytes(b"not a chunk anyone signed")
+            (archive.chunk_dir(host.id, self.DAY) / name).write_bytes(b"not a chunk anyone signed")
 
     def test_it_is_found_after_sync_has_stopped_saying_so(self) -> None:
         alpha, beta = self.history_across_days(days=1, per_day=2)
@@ -1474,7 +1476,7 @@ class TestDoctorFindsAChunkNobodySigned(SyncTestCase):
         alpha, beta = self.history_across_days(days=1, per_day=2)
         with beta.active():
             sync.run()
-            store.day_manifest(alpha.id, self.DAY).write_text("wrecked", encoding="utf-8")
+            archive.day_manifest(alpha.id, self.DAY).write_text("wrecked", encoding="utf-8")
             self.assertEqual(sync.unlisted_chunks(), [])
 
     def test_a_host_this_machine_has_not_pinned_is_not_even_checked(self) -> None:
@@ -1763,9 +1765,9 @@ class TestChunkNaming(support.WoswoarTestCase):
         exactly once in CI, as one missing chunk.
         """
         made: set[Path] = set()
-        store.chunk_dir("host", "2023-11-14").mkdir(parents=True, exist_ok=True)
+        archive.chunk_dir("host", "2023-11-14").mkdir(parents=True, exist_ok=True)
         for _ in range(2000):
-            path = store.new_chunk("host", "2023-11-14", 1_700_000_000)
+            path = archive.new_chunk("host", "2023-11-14", 1_700_000_000)
             self.assertNotIn(path, made)
             made.add(path)
             path.write_bytes(b"x")  # only an existing file can be collided with
@@ -1783,11 +1785,11 @@ class TestLayout(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "git status")
             sync.run()
-            chunk = next(iter(store.iter_chunks(alpha.id)))
+            chunk = next(iter(archive.iter_chunks(alpha.id)))
             relpath = chunk.path.relative_to(store.history_dir()).as_posix()
 
         self.assertEqual(relpath.split("/")[:3], ["hosts", alpha.id, "2023-11-14"])
-        self.assertTrue(store.is_chunk_path(relpath), relpath)
+        self.assertTrue(archive.is_chunk_path(relpath), relpath)
 
     def test_sealed_history_is_smaller_than_the_plaintext_it_carries(self) -> None:
         """A day's worth of one machine's commands, compacted into one chunk.
@@ -1808,7 +1810,7 @@ class TestLayout(SyncTestCase):
             sync.run()
             plaintext = store.log_file(alpha.id, "2023-11-14").stat().st_size
             sync.compact(before="2023-11-15")
-            sealed = sum(c.path.stat().st_size for c in store.iter_chunks(alpha.id))
+            sealed = sum(c.path.stat().st_size for c in archive.iter_chunks(alpha.id))
 
         self.assertLess(sealed, plaintext // 2, f"sealed={sealed} plaintext={plaintext}")
 
@@ -1820,12 +1822,12 @@ class TestCompact(SyncTestCase):
             for i in range(5):
                 alpha.record("2023-11-14", 1_700_000_000 + i, f"command {i}")
                 sync.run()
-            before = len(list(store.iter_chunks(alpha.id)))
+            before = len(list(archive.iter_chunks(alpha.id)))
             self.assertEqual(before, 5)
 
             days, replaced, _ = sync.compact(before="2023-11-15")
             self.assertEqual((days, replaced), (1, 5))
-            self.assertEqual(len(list(store.iter_chunks(alpha.id))), 1)
+            self.assertEqual(len(list(archive.iter_chunks(alpha.id))), 1)
 
     def test_a_before_in_the_future_is_refused(self) -> None:
         """Issue #69: the only trigger that repeats indefinitely.
@@ -1842,13 +1844,13 @@ class TestCompact(SyncTestCase):
             for i, cmd in enumerate(("git status", "make -j8")):
                 alpha.record("2023-11-14", 1_700_000_001 + i, cmd)
                 sync.run()
-            before = {c.name for c in store.iter_chunks(alpha.id)}
+            before = {c.name for c in archive.iter_chunks(alpha.id)}
 
         with alpha.active():
             with self.assertRaises(sync.SyncError) as refused:
                 sync.compact(before="2099-01-01")
             self.assertIn("in the future", str(refused.exception))
-            self.assertEqual({c.name for c in store.iter_chunks(alpha.id)}, before)
+            self.assertEqual({c.name for c in archive.iter_chunks(alpha.id)}, before)
 
             # A finished day is still fine, so the guard is on the future and
             # not on the flag.
@@ -1869,11 +1871,11 @@ class TestCompact(SyncTestCase):
                 sync.run()
                 alpha.record("2023-11-14", 1_700_000_001 + i, f"finished {i}")
                 sync.run()
-            live = {c.name for c in store.iter_chunks(alpha.id) if c.day == today}
+            live = {c.name for c in archive.iter_chunks(alpha.id) if c.day == today}
 
             self.assertEqual(sync.compact()[0], 1, "the finished day was not compacted")
             self.assertEqual(
-                {c.name for c in store.iter_chunks(alpha.id) if c.day == today},
+                {c.name for c in archive.iter_chunks(alpha.id) if c.day == today},
                 live,
                 "the default compacted a day still being written",
             )
@@ -2268,10 +2270,10 @@ class TestChunkAuthenticity(SyncTestCase):
         """Flipping bytes in a real chunk must not merely fail to decrypt."""
         alpha, beta = self.enrolled_pair()
         with alpha.active():
-            before = {c.name for c in store.iter_chunks(alpha.id)}
+            before = {c.name for c in archive.iter_chunks(alpha.id)}
             alpha.record("2023-11-14", 1_700_000_002, "cargo build")
             sync.run(now=2_000_000_000)
-            fresh = ({c.name for c in store.iter_chunks(alpha.id)} - before).pop()
+            fresh = ({c.name for c in archive.iter_chunks(alpha.id)} - before).pop()
 
         def flip(work: Path) -> None:
             target = work / "hosts" / alpha.id / "2023-11-14" / fresh
@@ -2337,7 +2339,7 @@ class TestChunkAuthenticity(SyncTestCase):
                 sync.compact(before="2023-11-15")
             self.assertIn("refusing to compact", str(caught.exception))
             # And it is still there, not silently dropped.
-            self.assertTrue(list(store.iter_chunks(alpha.id)))
+            self.assertTrue(list(archive.iter_chunks(alpha.id)))
 
 
 class TestExportWillNotDisownItsOwnHistory(SyncTestCase):
@@ -2358,7 +2360,7 @@ class TestExportWillNotDisownItsOwnHistory(SyncTestCase):
             )
             self.assertEqual(len(before), 1)
 
-            store.day_manifest(alpha.id, "2023-11-14").write_text("wrecked", encoding="utf-8")
+            archive.day_manifest(alpha.id, "2023-11-14").write_text("wrecked", encoding="utf-8")
             alpha.record("2023-11-14", 1_700_000_002, "published later")
             report = sync.run(now=1_900_000_000)
 
@@ -2372,7 +2374,7 @@ class TestExportWillNotDisownItsOwnHistory(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "day one")
             sync.run()
-            store.day_manifest(alpha.id, "2023-11-14").write_text("wrecked", encoding="utf-8")
+            archive.day_manifest(alpha.id, "2023-11-14").write_text("wrecked", encoding="utf-8")
 
             # Both days have something to publish, so both are attempted; only
             # the one whose signed list is unreadable is held back. A day with
@@ -2393,14 +2395,14 @@ class TestTheMergeWatermark(SyncTestCase):
     directions, depending only on iteration order.
     """
 
-    def alpha_with_two_chunks(self) -> tuple[Fake, Fake, list[store.Chunk]]:
+    def alpha_with_two_chunks(self) -> tuple[Fake, Fake, list[archive.Chunk]]:
         alpha = self.machine("alpha")
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "first command")
             sync.run(now=1_700_000_500)
             alpha.record("2023-11-14", 1_700_000_002, "second command")
             sync.run(now=1_700_000_600)
-            chunks = sorted(store.iter_chunks(alpha.id), key=lambda c: c.name)
+            chunks = sorted(archive.iter_chunks(alpha.id), key=lambda c: c.name)
         beta = self.machine("beta")
         with alpha.active():
             sync.grant()
@@ -2545,7 +2547,7 @@ class TestCompactionDoesNotDuplicateOnPeers(SyncTestCase):
             # Named below the compacted chunk, which took ts 1_700_000_502.
             alpha.record("2023-11-14", 1_700_000_009, "written after compaction")
             sync.run(now=1_700_000_400)
-            names = sorted(c.name for c in store.iter_chunks(alpha.id))
+            names = sorted(c.name for c in archive.iter_chunks(alpha.id))
         self.assertLess(names[0], names[1], "the fixture no longer builds the case")
 
         with beta.active():
@@ -2689,9 +2691,9 @@ class TestADecompressionBomb(SyncTestCase):
 
             # A chunk alpha signs, holding a payload that unpacks far too big.
             day = "2023-11-14"
-            pub = store.day_key_public(alpha.id, day).read_text(encoding="utf-8").strip()
+            pub = archive.day_key_public(alpha.id, day).read_text(encoding="utf-8").strip()
             sealed = crypto.encrypt_to(zlib.compress(b"\n" * (sync.MAX_CHUNK_BYTES * 2), 9), pub)
-            path = store.chunk_dir(alpha.id, day) / "1900000000-ffffff.age"
+            path = archive.chunk_dir(alpha.id, day) / "1900000000-ffffff.age"
             path.write_bytes(sealed)
             listed = sync.read_manifest(alpha.id, day, sync.signing_public())
             listed[path.name] = sync.Entry(sync.digest_of(sealed))
@@ -2910,8 +2912,8 @@ class TestTheRepoExplainsItself(SyncTestCase):
         alpha = self.machine("alpha")
         with alpha.active():
             committed = sync.git("ls-files").splitlines()
-            self.assertIn(store.README, committed, "the README was not committed")
-            text = (store.history_dir() / store.README).read_text(encoding="utf-8")
+            self.assertIn(archive.README, committed, "the README was not committed")
+            text = (store.history_dir() / archive.README).read_text(encoding="utf-8")
         self.assertIn("github.com/martinus/woswoar", text, "no link to the project")
         self.assertIn("Do not edit", text)
 
@@ -2920,7 +2922,7 @@ class TestTheRepoExplainsItself(SyncTestCase):
         self.machine("alpha")
         beta = self.machine("beta")
         with beta.active():
-            self.assertTrue((store.history_dir() / store.README).is_file())
+            self.assertTrue((store.history_dir() / archive.README).is_file())
 
     def test_it_is_written_once_and_then_left_alone(self) -> None:
         """A machine on another version must not rewrite a peer's wording.
@@ -2932,7 +2934,7 @@ class TestTheRepoExplainsItself(SyncTestCase):
         """
         alpha = self.machine("alpha")
         with alpha.active():
-            readme = store.history_dir() / store.README
+            readme = store.history_dir() / archive.README
             readme.write_text("written by another version\n", encoding="utf-8")
             sync._commit()
 
@@ -3013,7 +3015,7 @@ class TestRecipientsPublishNoNames(SyncTestCase):
                 timeout=60,
             )
             with_comment = key.with_suffix(".pub").read_text(encoding="utf-8").strip()
-            store.recipients_file().write_text(
+            archive.recipients_file().write_text(
                 f"{with_comment}{sync._LABEL_SEP}martinus@box\n", encoding="utf-8"
             )
 
@@ -3033,7 +3035,7 @@ class TestRecipientsPublishNoNames(SyncTestCase):
         """
         # A user name that cannot occur in the repo for any other reason. The
         # earlier fixture used "martinus", which is also the owner of the
-        # project URL in `store.README_CONTENT` -- so this failed on a string
+        # project URL in `archive.README_CONTENT` -- so this failed on a string
         # that names no machine, and would have kept failing for every user
         # whose account happens to match a word in a committed file.
         alpha = self.machine("alpha", display="zqoperator@secret-box")
@@ -3054,8 +3056,8 @@ class TestRecipientsPublishNoNames(SyncTestCase):
         # into is exactly what the constant says, so nothing can ever be
         # interpolated into it.
         with alpha.active():
-            readme = (store.history_dir() / store.README).read_text(encoding="utf-8")
-        self.assertEqual(readme, store.README_CONTENT)
+            readme = (store.history_dir() / archive.README).read_text(encoding="utf-8")
+        self.assertEqual(readme, archive.README_CONTENT)
 
     def test_no_name_is_written_into_recipients_at_all(self) -> None:
         """#22: the label used to be `$USER@$(uname -n)`, in cleartext.
@@ -3066,7 +3068,7 @@ class TestRecipientsPublishNoNames(SyncTestCase):
         """
         alpha = self.machine("alpha", display="martinus@secret-box")
         with alpha.active():
-            written = store.recipients_file().read_text(encoding="utf-8")
+            written = archive.recipients_file().read_text(encoding="utf-8")
         self.assertNotIn("secret-box", written)
         self.assertNotIn("martinus", written)
         self.assertNotIn(sync._LABEL_SEP, written)
@@ -3093,7 +3095,7 @@ class TestAnOrphanedDayKey(SyncTestCase):
 
         with beta.active():
             sync.run()
-            victim = store.day_key(alpha.id, "2023-11-14")
+            victim = archive.day_key(alpha.id, "2023-11-14")
             self.assertTrue(victim.is_file(), "beta cannot even see the key; premise is wrong")
             victim.unlink()
             sync._commit()
@@ -3101,8 +3103,8 @@ class TestAnOrphanedDayKey(SyncTestCase):
 
         with alpha.active():
             sync.run()
-            self.assertFalse(store.day_key(alpha.id, "2023-11-14").is_file())
-            self.assertTrue(store.day_key_public(alpha.id, "2023-11-14").is_file())
+            self.assertFalse(archive.day_key(alpha.id, "2023-11-14").is_file())
+            self.assertTrue(archive.day_key_public(alpha.id, "2023-11-14").is_file())
 
         # What was published before the deletion is still readable by a machine
         # that had already merged it. That is what makes "copy the key back from
@@ -3117,15 +3119,15 @@ class TestAnOrphanedDayKey(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "before")
             sync.run()
-            before = {c.name for c in store.iter_chunks(alpha.id)}
+            before = {c.name for c in archive.iter_chunks(alpha.id)}
 
-            store.day_key(alpha.id, "2023-11-14").unlink()
+            archive.day_key(alpha.id, "2023-11-14").unlink()
             alpha.record("2023-11-14", 1_700_000_002, "after")
             report = sync.run()
 
             self.assertEqual(report.chunks_written, 0)
             self.assertEqual(report.orphaned, {"2023-11-14"})
-            self.assertEqual({c.name for c in store.iter_chunks(alpha.id)}, before)
+            self.assertEqual({c.name for c in archive.iter_chunks(alpha.id)}, before)
 
     def test_the_lines_stay_pending_rather_than_being_lost(self) -> None:
         """Refusing must not consume them: `logs/` is the only copy left."""
@@ -3133,15 +3135,15 @@ class TestAnOrphanedDayKey(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "before")
             sync.run()
-            sealed = store.day_key(alpha.id, "2023-11-14").read_bytes()
-            store.day_key(alpha.id, "2023-11-14").unlink()
+            sealed = archive.day_key(alpha.id, "2023-11-14").read_bytes()
+            archive.day_key(alpha.id, "2023-11-14").unlink()
             alpha.record("2023-11-14", 1_700_000_002, "after")
             sync.run()
 
             # Put the sealed half back, which is what copying it from another
             # clone amounts to, and the pending line publishes on the next
             # ordinary sync.
-            store.write_atomic(store.day_key(alpha.id, "2023-11-14"), sealed)
+            store.write_atomic(archive.day_key(alpha.id, "2023-11-14"), sealed)
             report = sync.run()
             self.assertEqual(report.orphaned, set())
             self.assertGreater(report.chunks_written, 0)
@@ -3154,7 +3156,7 @@ class TestAnOrphanedDayKey(SyncTestCase):
             # fail loudly and the test would pass for the wrong reason. This is
             # the silent case -- a usable public half whose secret is gone.
             stale = crypto.generate_identity()
-            pub = store.day_key_public(alpha.id, "2023-11-14")
+            pub = archive.day_key_public(alpha.id, "2023-11-14")
             pub.parent.mkdir(parents=True, exist_ok=True)
             pub.write_text(stale.public + "\n", encoding="utf-8")
 
@@ -3163,7 +3165,7 @@ class TestAnOrphanedDayKey(SyncTestCase):
 
             self.assertEqual(report.orphaned, set())
             self.assertEqual(report.chunks_written, 1)
-            self.assertTrue(store.day_key(alpha.id, "2023-11-14").is_file())
+            self.assertTrue(archive.day_key(alpha.id, "2023-11-14").is_file())
             self.assertNotEqual(
                 pub.read_text(encoding="utf-8").strip(),
                 stale.public,
@@ -3196,8 +3198,10 @@ class TestAnOrphanedDayKey(SyncTestCase):
             ):
                 sync.day_public_key(store.machine(), "2023-11-14")
 
-            self.assertTrue(store.day_key(alpha.id, "2023-11-14").is_file(), "sealed half missing")
-            self.assertFalse(store.day_key_public(alpha.id, "2023-11-14").is_file())
+            self.assertTrue(
+                archive.day_key(alpha.id, "2023-11-14").is_file(), "sealed half missing"
+            )
+            self.assertFalse(archive.day_key_public(alpha.id, "2023-11-14").is_file())
             self.assertFalse(
                 sync.orphaned_day_key(alpha.id, "2023-11-14"),
                 "an interrupted mint produced the destructive state",
@@ -3213,7 +3217,7 @@ class TestAnOrphanedDayKey(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-14", 1_700_000_001, "before")
             sync.run()
-            store.day_key(alpha.id, "2023-11-14").unlink()
+            archive.day_key(alpha.id, "2023-11-14").unlink()
             alpha.record("2023-11-14", 1_700_000_002, "after")
 
         said = self.run_cli(alpha, "sync").err
@@ -3236,7 +3240,7 @@ class TestAnOrphanedDayKey(SyncTestCase):
             alpha.record("2023-11-14", 1_700_000_001, "ours")
             sync.run()
 
-            pub = store.day_key_public(alpha.id, "2099-01-01")
+            pub = archive.day_key_public(alpha.id, "2099-01-01")
             pub.parent.mkdir(parents=True, exist_ok=True)
             pub.write_text(crypto.generate_identity().public + "\n", encoding="utf-8")
 
@@ -3252,14 +3256,14 @@ class TestAnOrphanedDayKey(SyncTestCase):
                 for i in range(2):
                     alpha.record(day, 1_700_000_001 + i, f"{day}-{i}")
                     sync.run()
-            store.day_key(alpha.id, "2023-11-14").unlink()
+            archive.day_key(alpha.id, "2023-11-14").unlink()
 
             days, replaced, _ = sync.compact(before="2023-12-01")
 
             self.assertEqual(days, 1, "the healthy day was not compacted")
             self.assertGreater(replaced, 0)
             self.assertGreater(
-                len(list(store.chunk_dir(alpha.id, "2023-11-14").iterdir())),
+                len(list(archive.chunk_dir(alpha.id, "2023-11-14").iterdir())),
                 1,
                 "the unreadable day was touched",
             )
@@ -3274,7 +3278,7 @@ class TestAnOrphanedDayKey(SyncTestCase):
             code, healthy, _ = self.run_cli(alpha, "doctor")
             self.assertIn("[ok] day keys", healthy)
 
-            store.day_key(alpha.id, "2023-11-14").unlink()
+            archive.day_key(alpha.id, "2023-11-14").unlink()
             self.assertEqual(sync.orphaned_days(), [(alpha.id, "2023-11-14")])
 
             code, text, _ = self.run_cli(alpha, "doctor")
@@ -3308,8 +3312,8 @@ class TestADeletedManifest(SyncTestCase):
     def test_nothing_is_written_for_the_day(self) -> None:
         alpha = self.published_day()
         with alpha.active():
-            path = store.day_manifest(alpha.id, "2023-11-14")
-            before = {c.name for c in store.iter_chunks(alpha.id)}
+            path = archive.day_manifest(alpha.id, "2023-11-14")
+            before = {c.name for c in archive.iter_chunks(alpha.id)}
             self.assertTrue(any(name in path.read_text(encoding="utf-8") for name in before))
 
             path.unlink()
@@ -3318,7 +3322,7 @@ class TestADeletedManifest(SyncTestCase):
 
             self.assertEqual(report.chunks_written, 0)
             self.assertEqual(report.manifest_missing, {"2023-11-14"})
-            self.assertEqual({c.name for c in store.iter_chunks(alpha.id)}, before)
+            self.assertEqual({c.name for c in archive.iter_chunks(alpha.id)}, before)
             # The disowning itself: a replacement would name only this run.
             self.assertFalse(path.exists(), "a replacement manifest was signed")
 
@@ -3330,7 +3334,7 @@ class TestADeletedManifest(SyncTestCase):
         beta = self.machine("beta")
         alpha = self.published_day()
         with alpha.active():
-            path = store.day_manifest(alpha.id, "2023-11-14")
+            path = archive.day_manifest(alpha.id, "2023-11-14")
             original = path.read_bytes()
             path.unlink()
             alpha.record("2023-11-14", 1_700_000_002, "second")
@@ -3360,7 +3364,7 @@ class TestADeletedManifest(SyncTestCase):
         """
         alpha = self.published_day()
         with alpha.active():
-            planted = store.chunk_dir(alpha.id, "2023-11-20")
+            planted = archive.chunk_dir(alpha.id, "2023-11-20")
             planted.mkdir(parents=True, exist_ok=True)
             (planted / "9999999999-ffffff.age").write_bytes(b"whatever an attacker likes")
 
@@ -3369,12 +3373,12 @@ class TestADeletedManifest(SyncTestCase):
 
             self.assertEqual(report.manifest_missing, set())
             self.assertEqual(report.chunks_written, 1)
-            self.assertTrue(store.day_manifest(alpha.id, "2023-11-20").exists())
+            self.assertTrue(archive.day_manifest(alpha.id, "2023-11-20").exists())
 
     def test_sync_says_which_day_and_how_to_get_it_back(self) -> None:
         alpha = self.published_day()
         with alpha.active():
-            store.day_manifest(alpha.id, "2023-11-14").unlink()
+            archive.day_manifest(alpha.id, "2023-11-14").unlink()
             alpha.record("2023-11-14", 1_700_000_002, "second")
 
         said = self.run_cli(alpha, "sync").err
@@ -3402,7 +3406,7 @@ class TestADeletedManifest(SyncTestCase):
             _, healthy, _ = self.run_cli(alpha, "doctor")
             self.assertIn("[ok] manifests", healthy)
 
-            store.day_manifest(alpha.id, "2023-11-14").unlink()
+            archive.day_manifest(alpha.id, "2023-11-14").unlink()
             self.assertEqual(sync.days_missing_a_manifest(), ["2023-11-14"])
 
             code, text, _ = self.run_cli(alpha, "doctor")
@@ -3433,7 +3437,7 @@ class TestASingleChunkStaysUnderTheReadersCap(SyncTestCase):
             self.assertEqual(report.lines_exported, 200)
 
             secret = sync.open_day_key(store.machine(), alpha.id, "2023-11-14")
-            for chunk in store.iter_chunks(alpha.id):
+            for chunk in archive.iter_chunks(alpha.id):
                 plain = sync.unpack(crypto.decrypt_with_secret(chunk.path.read_bytes(), secret))
                 self.assertLessEqual(len(plain), 512, f"{chunk.name} is over the budget")
 
@@ -3474,13 +3478,13 @@ class TestASingleChunkStaysUnderTheReadersCap(SyncTestCase):
                     with mock.patch.object(sync, "MAX_EXPORT_BYTES", 512):
                         sync.run()
 
-            before = {c.name for c in store.iter_chunks(alpha.id)}
+            before = {c.name for c in archive.iter_chunks(alpha.id)}
             with mock.patch.object(sync, "MAX_EXPORT_BYTES", 512):
                 days, replaced, skipped = sync.compact(before="2023-12-01")
 
             self.assertEqual((days, replaced), (0, 0), "an over-budget day was merged")
             self.assertEqual(skipped, 1)
-            self.assertEqual({c.name for c in store.iter_chunks(alpha.id)}, before)
+            self.assertEqual({c.name for c in archive.iter_chunks(alpha.id)}, before)
 
     def test_a_day_within_the_budget_still_compacts(self) -> None:
         alpha = self.machine("alpha")
@@ -3761,7 +3765,7 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
         """
         alpha, beta = self.merged_pair()
         with beta.active():
-            stray = store.chunk_dir(alpha.id, "2023-11-14") / "not-a-chunk"
+            stray = archive.chunk_dir(alpha.id, "2023-11-14") / "not-a-chunk"
             stray.write_bytes(b"disturb the day's stamp")
             stray.unlink()
 
@@ -3836,7 +3840,7 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
         alpha, beta, compacted = self.compacted_and_growing()
         with alpha.active():
             readable = next(
-                name for name in store.chunk_names(alpha.id, self.DAY) if name != compacted
+                name for name in archive.chunk_names(alpha.id, self.DAY) if name != compacted
             )
 
         with beta.active(), mock.patch.object(sync, "open_chunk", self.damaged(compacted)):
@@ -3863,7 +3867,7 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
         """
         alpha, beta, _compacted = self.compacted_and_growing()
         with beta.active():
-            (store.chunk_dir(alpha.id, self.DAY) / "1700000000-dead.age").write_bytes(b"x")
+            (archive.chunk_dir(alpha.id, self.DAY) / "1700000000-dead.age").write_bytes(b"x")
 
             report = sync.run()
             self.assertIn(f"{alpha.id}/{self.DAY}", report.unauthenticated)
@@ -3899,7 +3903,7 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
             self.assertEqual(len(beta.entries()), 4)
             backup = store.history_dir().with_name("history.backup")
             shutil.copytree(store.history_dir(), backup, symlinks=True)
-            first = min(store.chunk_names(alpha.id, self.DAY))
+            first = min(archive.chunk_names(alpha.id, self.DAY))
 
         with alpha.active():
             alpha.record(self.DAY, 1_700_000_009, "the fifth")
@@ -3922,7 +3926,7 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
 
             # ...and something unmerged in the directory, or the day has
             # nothing fresh and is skipped before any of this is reached.
-            (store.chunk_dir(alpha.id, self.DAY) / "1700000000-dead.age").write_bytes(b"x")
+            (archive.chunk_dir(alpha.id, self.DAY) / "1700000000-dead.age").write_bytes(b"x")
 
         self.settle(beta, alpha, self.DAY)
         with beta.active(), mock.patch.object(sync, "open_chunk", self.damaged(first)):
@@ -3951,7 +3955,7 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
         """
         alpha, beta, compacted = self.compacted_and_growing()
         with alpha.active():
-            (store.chunk_dir(alpha.id, self.DAY) / compacted).unlink()
+            (archive.chunk_dir(alpha.id, self.DAY) / compacted).unlink()
             sync._commit()
             sync._push(sync.read_repo())
 
@@ -3997,7 +4001,7 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
             for i in range(2):
                 alpha.record(self.DAY, 1_700_000_700 + i, f"later {i}")
                 sync.run()
-            names = store.chunk_names(alpha.id, self.DAY)
+            names = archive.chunk_names(alpha.id, self.DAY)
 
         with beta.active(), mock.patch.object(sync, "open_chunk", self.damaged(names[-1])):
             report = sync.run()
@@ -4049,7 +4053,7 @@ class TestADayIsWhatItsManifestSays(SyncTestCase):
         alpha, beta = self.history_across_days(days=1, per_day=2)
         with beta.active():
             sync.run()
-            (store.chunk_dir(alpha.id, self.DAY) / "1700000000-dead.age").write_bytes(b"x")
+            (archive.chunk_dir(alpha.id, self.DAY) / "1700000000-dead.age").write_bytes(b"x")
         self.settle(beta, alpha, self.DAY)
 
         # Said once, because the day did change -- and that pass is the one
@@ -4080,7 +4084,7 @@ class TestADayIsWhatItsManifestSays(SyncTestCase):
             sync.run()
 
         with alpha.active():
-            live = set(store.chunk_names(alpha.id, self.DAY))
+            live = set(archive.chunk_names(alpha.id, self.DAY))
         self.assertEqual(self.remembered(beta, alpha), live, "names of chunks that are gone")
         with beta.active():
             self.assertEqual(len(beta.commands()), 6, "compaction lost history")
@@ -4153,7 +4157,7 @@ class TestADayIsWhatItsManifestSays(SyncTestCase):
         with alpha.active():
             alpha.record(self.DAY, 1_700_000_003, "a third line")
             sync.run()
-            store.day_manifest(alpha.id, self.DAY).write_text("wrecked", encoding="utf-8")
+            archive.day_manifest(alpha.id, self.DAY).write_text("wrecked", encoding="utf-8")
             sync._commit()
             sync._push(sync.read_repo())
 
@@ -4169,7 +4173,7 @@ class TestADayIsWhatItsManifestSays(SyncTestCase):
             # match, so the day keeps being looked at.
             self.assertNotEqual(
                 sync.State.load().merged_at.get(f"{alpha.id}/{self.DAY}"),
-                store.day_stamp(alpha.id, self.DAY),
+                archive.day_stamp(alpha.id, self.DAY),
                 "an unverifiable manifest settled the day",
             )
             # And nothing was written twice.
@@ -4191,13 +4195,13 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
     def listed(self, machine: Fake) -> list[str]:
         """The days one sync actually lists the chunks of."""
         days: list[str] = []
-        real = store.chunk_names
+        real = archive.chunk_names
 
         def counted(machine_id: str, day: str) -> list[str]:
             days.append(day)
             return real(machine_id, day)
 
-        with machine.active(), mock.patch.object(store, "chunk_names", counted):
+        with machine.active(), mock.patch.object(archive, "chunk_names", counted):
             sync.run()
         return days
 
@@ -4280,7 +4284,7 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
         """
         alpha, beta = self.pair()
         with beta.active():
-            stray = store.chunk_dir(alpha.id, "2023-11-14") / "not-a-chunk"
+            stray = archive.chunk_dir(alpha.id, "2023-11-14") / "not-a-chunk"
             stray.write_bytes(b"something landed in the directory")
         self.assertEqual(self.listed(beta), ["2023-11-14"])
         self.settle(beta, alpha, "2023-11-14")
@@ -4303,11 +4307,11 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
         with alpha.active():
             alpha.record("2023-11-15", 1_700_100_002, "arrived mid-listing")
             sync.run()
-            source = store.chunk_dir(alpha.id, "2023-11-15")
-            late = max(store.chunk_names(alpha.id, "2023-11-15"))
+            source = archive.chunk_dir(alpha.id, "2023-11-15")
+            late = max(archive.chunk_names(alpha.id, "2023-11-15"))
             payload = (source / late).read_bytes()
 
-        real = store.chunk_names
+        real = archive.chunk_names
         dropped = False
 
         def racing(machine_id: str, day: str) -> list[str]:
@@ -4316,10 +4320,10 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
             if day == "2023-11-15" and not dropped:
                 dropped = True
                 names = [name for name in names if name != late]
-                (store.chunk_dir(machine_id, day) / late).write_bytes(payload)
+                (archive.chunk_dir(machine_id, day) / late).write_bytes(payload)
             return names
 
-        with beta.active(), mock.patch.object(store, "chunk_names", racing):
+        with beta.active(), mock.patch.object(archive, "chunk_names", racing):
             sync.run()
         self.assertTrue(dropped, "the race was never reached")
 
@@ -4334,12 +4338,12 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
         """`state.json` is read and compared every sync, so what goes in it lasts.
 
         A directory named like a day but holding no chunk is not a day (see
-        `store.iter_chunk_days`). Stamping one would leave a permanent entry for
+        `archive.iter_chunk_days`). Stamping one would leave a permanent entry for
         something that was never there -- and this file already only grows.
         """
         alpha, beta = self.pair()
         with beta.active():
-            hollow = store.chunk_dir(alpha.id, "2023-11-20")
+            hollow = archive.chunk_dir(alpha.id, "2023-11-20")
             hollow.mkdir(parents=True, exist_ok=True)
         # Old enough that the racy window is not what is keeping it unstamped.
         self.settle(beta, alpha, "2023-11-20")
@@ -4388,8 +4392,8 @@ class TestWalkingAPeersChunks(SyncTestCase):
         """
         alpha, _beta = self.stocked()
         with alpha.active():
-            by_day = list(store.iter_chunk_days(alpha.id))
-            flat = [(chunk.day, chunk.name) for chunk in store.iter_chunks(alpha.id)]
+            by_day = list(archive.iter_chunk_days(alpha.id))
+            flat = [(chunk.day, chunk.name) for chunk in archive.iter_chunks(alpha.id)]
 
         self.assertEqual(
             [(day, name) for day, names in by_day for name in names],
@@ -4413,11 +4417,11 @@ class TestWalkingAPeersChunks(SyncTestCase):
         """
         alpha, _beta = self.stocked()
         with alpha.active():
-            directory = store.chunk_dir(alpha.id, "2023-11-14")
+            directory = archive.chunk_dir(alpha.id, "2023-11-14")
             (directory / "1700000000-abcdef.age.tmp").write_bytes(b"half a chunk")
             (directory / "notes.txt").write_text("not a chunk", encoding="utf-8")
 
-            names = dict(store.iter_chunk_days(alpha.id))["2023-11-14"]
+            names = dict(archive.iter_chunk_days(alpha.id))["2023-11-14"]
         self.assertTrue(all(name.endswith(".age") for name in names), names)
         self.assertEqual(len(names), 2)
 
@@ -4432,14 +4436,14 @@ class TestWalkingAPeersChunks(SyncTestCase):
         """
         alpha, _beta = self.stocked()
         with alpha.active():
-            hollow = store.chunk_dir(alpha.id, "2023-11-20")
+            hollow = archive.chunk_dir(alpha.id, "2023-11-20")
             hollow.mkdir(parents=True, exist_ok=True)
 
-            self.assertNotIn("2023-11-20", dict(store.iter_chunk_days(alpha.id)))
+            self.assertNotIn("2023-11-20", dict(archive.iter_chunk_days(alpha.id)))
             self.assertFalse(sync.has_chunks(alpha.id, "2023-11-20"))
 
             (hollow / "1700000000-abcdef.age.tmp").write_bytes(b"half a chunk")
-            self.assertNotIn("2023-11-20", dict(store.iter_chunk_days(alpha.id)))
+            self.assertNotIn("2023-11-20", dict(archive.iter_chunk_days(alpha.id)))
             self.assertFalse(
                 sync.has_chunks(alpha.id, "2023-11-20"), "a stray file counted as a chunk"
             )
@@ -4457,13 +4461,13 @@ class TestWalkingAPeersChunks(SyncTestCase):
         """
         alpha, _beta = self.stocked()
         walked: list[str] = []
-        real = store.iter_chunk_days
+        real = archive.iter_chunk_days
 
         def spy(machine_id: str) -> Iterator[tuple[str, list[str]]]:
             walked.append(machine_id)
             return real(machine_id)
 
-        with alpha.active(), mock.patch.object(store, "iter_chunk_days", spy):
+        with alpha.active(), mock.patch.object(archive, "iter_chunk_days", spy):
             self.assertTrue(sync.has_chunks(alpha.id, "2023-11-14"))
             sync.orphaned_days()
 
@@ -4479,9 +4483,9 @@ class TestWalkingAPeersChunks(SyncTestCase):
         """They sit in the same host directory, and neither holds chunks."""
         alpha, _beta = self.stocked()
         with alpha.active():
-            siblings = {p.name for p in store.repo_host_dir(alpha.id).iterdir() if p.is_dir()}
+            siblings = {p.name for p in archive.repo_host_dir(alpha.id).iterdir() if p.is_dir()}
             self.assertTrue({"keys", "manifests"} <= siblings, siblings)
-            self.assertEqual({day for day, _ in store.iter_chunk_days(alpha.id)}, set(self.DAYS))
+            self.assertEqual({day for day, _ in archive.iter_chunk_days(alpha.id)}, set(self.DAYS))
 
     def test_an_idle_merge_builds_nothing_per_chunk(self) -> None:
         """The saving itself, asserted where a future change would undo it.
@@ -4491,14 +4495,14 @@ class TestWalkingAPeersChunks(SyncTestCase):
         the names does.
         """
         _alpha, beta = self.stocked()
-        real = store.iter_chunks
+        real = archive.iter_chunks
         used = []
 
-        def spy(machine_id: str) -> Iterator[store.Chunk]:
+        def spy(machine_id: str) -> Iterator[archive.Chunk]:
             used.append(machine_id)
             return real(machine_id)
 
-        with beta.active(), mock.patch.object(store, "iter_chunks", spy):
+        with beta.active(), mock.patch.object(archive, "iter_chunks", spy):
             report = sync.run()
         self.assertEqual(report.chunks_merged, 0)
         self.assertEqual(used, [], "merge built Chunk objects for an idle sync")
@@ -4676,7 +4680,7 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
             crypto.public_half(key).unlink()
             fresh = crypto.generate_signing_key(key)
 
-            published = store.signer_public(alpha.id)
+            published = archive.signer_public(alpha.id)
             sync.run()  # nothing new to export: the signer is all there is
 
             self.assertIn(fresh, published.read_text(encoding="utf-8"))
@@ -4689,7 +4693,7 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
         # And it reached the remote, which is the point of publishing it.
         beta = self.machine("beta")
         with beta.active():
-            self.assertIn(fresh, store.signer_public(alpha.id).read_text(encoding="utf-8"))
+            self.assertIn(fresh, archive.signer_public(alpha.id).read_text(encoding="utf-8"))
 
     def test_a_day_that_can_never_be_exported_does_not_cost_a_stat_every_run(self) -> None:
         """The state where answering "probably wrote" would undo the whole fix.
@@ -4707,7 +4711,7 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
 
             # The sealed half gone: `export` refuses the day rather than
             # re-minting a key peers could never open. See `orphaned_day_key`.
-            store.day_key(alpha.id, "2023-11-14").unlink()
+            archive.day_key(alpha.id, "2023-11-14").unlink()
             alpha.record("2023-11-14", 1_700_000_002, "make -j8")
 
             first = self.git_calls()
@@ -4735,7 +4739,7 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
             # leaves behind.
             # Into the day directory the sync above already made, because that
             # is where a run that died after `write_atomic` would have left it.
-            stray = store.chunk_dir(alpha.id, "2023-11-14") / "1700000009-abcdef.age"
+            stray = archive.chunk_dir(alpha.id, "2023-11-14") / "1700000009-abcdef.age"
             stray.write_bytes(b"debris from a run that did not finish")
 
             # An idle sync leaves it alone, which is the whole point.
@@ -4808,8 +4812,8 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
             sync.run()
             # A commit that never reached the remote -- what a compaction, or a
             # run that died between committing and pushing, leaves behind.
-            store.recipients_file().write_text(
-                store.recipients_file().read_text(encoding="utf-8") + "\n", "utf-8"
+            archive.recipients_file().write_text(
+                archive.recipients_file().read_text(encoding="utf-8") + "\n", "utf-8"
             )
             sync.git("commit", "-qam", "unpushed")
             calls = self.git_calls()
@@ -4839,7 +4843,7 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
             # Asserted at the git level rather than through `commands()`: alpha
             # cloned before beta existed and has not been told beta is real, so
             # it holds the chunk without yet being willing to read it.
-            self.assertTrue(list(store.chunk_dir(beta.id, "2023-11-14").glob("*.age")))
+            self.assertTrue(list(archive.chunk_dir(beta.id, "2023-11-14").glob("*.age")))
         # And once it is told, the history the rebase brought in is readable.
         self.accept_everyone(alpha)
         with alpha.active():
@@ -5107,15 +5111,15 @@ class TestInitFinishesTheJob(SyncTestCase):
         # machines can see it.
         with alpha.active():
             sync.run()
-            self.assertIn(beta.id, store.repo_hosts())
-            self.assertTrue(store.chunk_names(beta.id, "2023-11-15"))
+            self.assertIn(beta.id, archive.repo_hosts())
+            self.assertTrue(archive.chunk_names(beta.id, "2023-11-15"))
 
     def test_no_sync_still_joins_without_exchanging_anything(self) -> None:
         beta = self.joining_machine()
         out = self.run_cli(beta, "init", str(self.origin), "--new-identity", "--no-sync").out
         self.assertIn("Next: 'woswoar sync'", out)
         with beta.active():
-            self.assertEqual(list(store.chunk_days(beta.id)), [])
+            self.assertEqual(list(archive.chunk_days(beta.id)), [])
 
     def test_a_failed_first_sync_does_not_fail_the_join(self) -> None:
         """The join is done and durable by the time the sync runs -- identity
@@ -5161,7 +5165,7 @@ class TestAHostCannotClaimAnotherMachinesKey(SyncTestCase):
     `accept` shows a machine's age recipient and its signing key one above the
     other. That they belong to one machine comes from the `owner` line in
     `hosts/<id>/signer.pub` -- a file anyone with push access can write. The
-    mapping was built with `setdefault` over `store.repo_hosts()`, which is
+    mapping was built with `setdefault` over `archive.repo_hosts()`, which is
     sorted, and host ids are locally chosen hex: so a directory whose id sorts
     first could name *your* recipient and win it.
 
@@ -5182,7 +5186,7 @@ class TestAHostCannotClaimAnotherMachinesKey(SyncTestCase):
         """
         host = "0" * 16
         verify_key = crypto.generate_signing_key(self.root / f"signer-{host}")
-        store.write_atomic(store.signer_public(host), f"{verify_key}\n{victim_key}\n".encode())
+        store.write_atomic(archive.signer_public(host), f"{verify_key}\n{victim_key}\n".encode())
         store.write_atomic(store.name_file(host), b"martin@laptop\n")
         return host
 
@@ -5808,7 +5812,7 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
 
     def marker(self, fake: Fake) -> str:
         with fake.active():
-            path = store.format_file()
+            path = archive.format_file()
             return path.read_text(encoding="utf-8") if path.is_file() else ""
 
     def publish_marker(self, fake: Fake, content: str | None) -> None:
@@ -5824,11 +5828,11 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
         with fake.active():
             sync.run()
             if content is None:
-                store.format_file().unlink()
-                sync.git("rm", "--quiet", "--cached", store.FORMAT)
+                archive.format_file().unlink()
+                sync.git("rm", "--quiet", "--cached", archive.FORMAT)
             else:
-                store.write_atomic(store.format_file(), content.encode("utf-8"))
-                sync.git("add", store.FORMAT)
+                store.write_atomic(archive.format_file(), content.encode("utf-8"))
+                sync.git("add", archive.FORMAT)
             sync.git("commit", "--quiet", "-m", "the marker, as another version left it")
             sync.git("push", "--quiet", "origin", "HEAD")
         self.assertEqual(self.marker(fake), content or "", "the fixture did not take")
@@ -5839,11 +5843,11 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
 
     def mark_future(self, fake: Fake) -> None:
         """A layout this woswoar does not know, as a newer one would write it."""
-        self.publish_marker(fake, store.format_content(store.REPO_FORMAT + 1))
+        self.publish_marker(fake, archive.format_content(archive.REPO_FORMAT + 1))
 
     def test_a_new_repo_records_its_format(self) -> None:
         alpha = self.machine("alpha")
-        self.assertEqual(self.marker(alpha), store.FORMAT_CONTENT)
+        self.assertEqual(self.marker(alpha), archive.FORMAT_CONTENT)
 
     def test_an_existing_repo_acquires_the_marker_on_sync(self) -> None:
         """The migration itself: a repository written before the marker existed
@@ -5859,12 +5863,12 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
             # has to be enough on its own to make this run commit and push.
             sync.run()
 
-        self.assertEqual(self.marker(alpha), store.FORMAT_CONTENT)
+        self.assertEqual(self.marker(alpha), archive.FORMAT_CONTENT)
         self.assertIn(
-            store.FORMAT, self.git_in_repo(alpha, "ls-tree", "--name-only", "HEAD").split()
+            archive.FORMAT, self.git_in_repo(alpha, "ls-tree", "--name-only", "HEAD").split()
         )
         self.assertIn(
-            store.FORMAT,
+            archive.FORMAT,
             self.git_in_repo(alpha, "ls-tree", "--name-only", "origin/HEAD").split(),
             "the marker never reached the remote, so no other machine sees it",
         )
@@ -5906,12 +5910,12 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
             # Nothing merged, and nothing published either.
             self.assertEqual(beta.commands(), {"beta was here"}, "alpha's history was merged")
             self.assertEqual(
-                list(store.iter_chunks(beta.id)), [], "it published into a repo it cannot read"
+                list(archive.iter_chunks(beta.id)), [], "it published into a repo it cannot read"
             )
 
         message = str(caught.exception)
-        self.assertIn(str(store.REPO_FORMAT + 1), message, message)
-        self.assertIn(str(store.REPO_FORMAT), message, message)
+        self.assertIn(str(archive.REPO_FORMAT + 1), message, message)
+        self.assertIn(str(archive.REPO_FORMAT), message, message)
 
     def test_content_that_does_not_parse_is_not_a_wedge(self) -> None:
         """Anyone who can push can write this file, so garbage in it must not be
@@ -5933,8 +5937,8 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
                 b"woswoar-repo-two\n",
                 "woswoar-repo-\u00b2\n".encode(),
             ):
-                store.write_atomic(store.format_file(), junk)
-                self.assertIsNone(store.repo_format(), junk.decode(errors="replace"))
+                store.write_atomic(archive.format_file(), junk)
+                self.assertIsNone(archive.repo_format(), junk.decode(errors="replace"))
                 # Not just the parse: the whole sync path has to survive it.
                 sync.run()
 
@@ -5960,7 +5964,7 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
             # thing this test needs not to have happened yet.
             sync.git("fetch", "--quiet", "origin")
             sync.git("reset", "--hard", "--quiet", "origin/HEAD")
-            self.assertFalse(store.format_file().is_file(), "the fixture still has the marker")
+            self.assertFalse(archive.format_file().is_file(), "the fixture still has the marker")
 
             # Committed locally and deliberately not pushed, so alpha's marker
             # lands on the remote first and beta's arrives on top of it.
@@ -5974,7 +5978,7 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
             sync.run()
 
         for machine in (alpha, beta):
-            self.assertEqual(self.marker(machine), store.FORMAT_CONTENT)
+            self.assertEqual(self.marker(machine), archive.FORMAT_CONTENT)
             self.assertNotIn(
                 "<<<<<<<",
                 self.marker(machine),
@@ -5988,7 +5992,7 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
         alpha = self.machine("alpha")
         self.mark_future(alpha)
         with alpha.active():
-            before = store.recipients_file().read_text(encoding="utf-8")
+            before = archive.recipients_file().read_text(encoding="utf-8")
 
         with self.assertRaises(sync.SyncError):
             self.machine("beta")
@@ -5997,7 +6001,7 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
             sync.git("fetch", "--quiet", "origin")
             sync.git("reset", "--hard", "--quiet", "origin/HEAD")
             self.assertEqual(
-                store.recipients_file().read_text(encoding="utf-8"),
+                archive.recipients_file().read_text(encoding="utf-8"),
                 before,
                 "the newcomer enrolled into a repo it had already been told to refuse",
             )
@@ -6010,11 +6014,11 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
         self.mark_future(alpha)
 
         with alpha.active():
-            sealed = store.day_key(alpha.id, "2023-11-14").read_bytes()
+            sealed = archive.day_key(alpha.id, "2023-11-14").read_bytes()
             with self.assertRaises(sync.SyncError):
                 sync.grant()
             self.assertEqual(
-                store.day_key(alpha.id, "2023-11-14").read_bytes(),
+                archive.day_key(alpha.id, "2023-11-14").read_bytes(),
                 sealed,
                 "the day key was re-sealed into a repo this version cannot read",
             )
@@ -6028,7 +6032,7 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
             for i in range(3):
                 alpha.record("2023-11-14", 1_700_000_001 + i, f"command {i}")
                 sync.run()
-            chunks = len(list(store.iter_chunks(alpha.id)))
+            chunks = len(list(archive.iter_chunks(alpha.id)))
         self.assertGreater(chunks, 1, "nothing to compact, so the fixture proves nothing")
         self.mark_future(alpha)
 
@@ -6036,7 +6040,7 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
             with self.assertRaises(sync.SyncError):
                 sync.compact(before="2023-11-15")
             self.assertEqual(
-                len(list(store.iter_chunks(alpha.id))), chunks, "chunks were deleted anyway"
+                len(list(archive.iter_chunks(alpha.id))), chunks, "chunks were deleted anyway"
             )
 
     def test_doctor_reports_the_format_the_repo_is(self) -> None:
@@ -6044,7 +6048,7 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
         never mentions it. `doctor` is where it becomes visible."""
         alpha = self.machine("alpha")
         self.assertRegex(
-            self.run_cli(alpha, "doctor").out, rf"\[ok\] repo format\s+{store.REPO_FORMAT}\b"
+            self.run_cli(alpha, "doctor").out, rf"\[ok\] repo format\s+{archive.REPO_FORMAT}\b"
         )
 
     def test_doctor_says_what_a_refused_repo_needs(self) -> None:
@@ -6056,5 +6060,5 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
 
         out = self.run_cli(alpha, "doctor").out
         self.assertRegex(out, r"\[FAIL\] repo format")
-        self.assertIn(str(store.REPO_FORMAT + 1), out)
+        self.assertIn(str(archive.REPO_FORMAT + 1), out)
         self.assertIn("upgrade woswoar", out)

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -664,7 +664,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
 
 def cmd_init(args: argparse.Namespace) -> int:
-    from . import crypto, sync
+    from . import archive, crypto, sync
 
     known, identity, pinned = sync.initialise(
         remote=args.remote,
@@ -675,7 +675,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     print(f"identity : {identity}")
     print(f"repo     : {store.history_dir()}")
     print(f"remote   : {sync.remote_summary()}")
-    print(f"\nRecipients now enrolled ({store.recipients_file()}):")
+    print(f"\nRecipients now enrolled ({archive.recipients_file()}):")
     # By fingerprint, not by a truncated key. A prefix of a key looks checkable
     # and is not -- it is the abbreviation `grant` stopped using for exactly
     # that reason, and this is the listing someone reads first.

--- a/woswoar/archive.py
+++ b/woswoar/archive.py
@@ -1,0 +1,446 @@
+"""The layout of the history repository: ciphertext only, every file write-once.
+
+Split from :mod:`woswoar.store`, which now owns ``logs/`` and the filesystem
+primitives. The two were one module, so everything that wanted ``logs_dir()``
+also depended on the chunk layout, the manifest paths and the repo format
+marker -- `cache` and `search` among them, neither of which has any business
+knowing what a chunk directory is called.
+
+The boundary is deliberate and narrow: `store.history_dir` stays where it is,
+because `store._private_paths` has to *prune* that directory by name -- see that
+docstring for the measurement. So `store` knows the directory exists; this
+module knows what is inside it.
+
+What belongs here is the repository's **layout and its self-description**: the
+names, the paths, the format marker, and the boilerplate that says which shape a
+directory is. What does not belong here is the *history* -- a chunk, a manifest
+and a seal are content, and reading one is `sync`'s. That line is worth being
+exact about, because it is the only rule a later change has for deciding where a
+new function goes: `repo_format` reads a file and is still layout, since what it
+reads is the statement of the shape rather than anything recorded in it.
+
+The point of gathering the paths at all is that a hand-typed one cannot drift
+out of step with the thing that decides the shape -- the argument `iter_day_keys`
+and `day_of_key` below already make for their own suffixes.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+from collections.abc import Iterator
+from pathlib import Path
+from typing import NamedTuple
+
+from . import store
+
+# The three directory names a repo path is built from. Public because
+# `prove._BOILERPLATE` asserts on them: it proves no layout name reaches the
+# remote in the clear, and the names have to come from whoever owns the layout
+# rather than a second copy hand-typed in the test. The suffixes below are
+# private because `prove` reaches them through `signer_public("x").name`.
+#
+# `HOSTS` is spelled here and again in `store`, and that is deliberate rather
+# than an oversight. `logs/hosts/` and `history/hosts/` agree today, but they
+# are two formats: `REPO_FORMAT` versions this one alone, so a future layout
+# that renamed the repo's host directory would have to be expressible without
+# also renaming the plaintext tree -- which one shared constant cannot say.
+HOSTS = "hosts"
+KEYS = "keys"
+MANIFESTS = "manifests"
+_CHUNK_SUFFIX = ".age"
+_PUB_SUFFIX = ".pub"
+RECIPIENTS = "recipients.txt"
+GITATTRIBUTES = ".gitattributes"
+GITIGNORE = ".gitignore"
+README = "README.md"
+FORMAT = "FORMAT"
+#: The layout of the *repository* -- `recipients.txt`, `hosts/<id>/keys/`,
+#: `manifests/`, `<day>/<ts>-<rand>.age`. Every other format woswoar owns already
+#: says which one it is: the cache carries `woswoar-cache-2`, a manifest carries
+#: `woswoar-manifest-v1` inside the bytes it signs. The repo was the exception,
+#: and it is the one an upgrade cannot be retrofitted onto later -- a machine
+#: still running the old version would not write the marker, so by the time a
+#: layout change needs one it is too late by definition.
+#:
+#: Deliberately not `woswoar.__version__`. The program version moved sixteen
+#: times in a fortnight and this has moved zero times; coupling them means a
+#: meaningless bump on every release and no signal on the one release where it
+#: matters.
+REPO_FORMAT = 1
+_FORMAT_PREFIX = "woswoar-repo-"
+
+
+def format_content(version: int = REPO_FORMAT) -> str:
+    """What the marker says for ``version``. The one place the prefix is spelt.
+
+    Takes a version because the tests need to write one this build does not
+    understand, and hand-typing `woswoar-repo-2` there would put a second copy
+    of the prefix outside this module -- where it would go on parsing after a
+    rename, as `None`, and quietly stop testing the refusal.
+    """
+    return f"{_FORMAT_PREFIX}{version}\n"
+
+
+FORMAT_CONTENT = format_content()
+#: What a stranger finding the repository sees first, and what its owner sees in
+#: three years having forgotten what it was. Deliberately says nothing about
+#: whose it is: the host directories are opaque hex precisely so the archive does
+#: not name machines, and a README that undid that would be worse than none.
+#:
+#: Written only when absent, unlike `.gitattributes`, which is compared and
+#: rewritten to match. Both are written by `init` rather than by `sync`, so the
+#: cost of getting this wrong is bounded -- but a machine on a newer version
+#: would still rewrite a peer's wording the next time anyone ran `init`, and the
+#: older one would put it back. `.gitattributes` earns that because its content
+#: is load-bearing: `merge=union` on `recipients.txt` is what makes two machines
+#: enrolling at once conflict-free. Prose does not.
+README_CONTENT = """# woswoar history
+
+Encrypted shell history, written by [woswoar](https://github.com/martinus/woswoar).
+
+Every `.age` file here is ciphertext. There is nothing readable in this
+repository, including the directory names -- they are random hex so that an
+archive of it does not publish which machines exist.
+
+## Do not edit this by hand
+
+Chunks are written once and never rewritten, and each machine signs a list of
+what it published each day. A file that no signed list accounts for is refused
+by every other machine and reported. Editing or deleting one here does not
+remove history -- other machines keep their own copies -- and will make them
+report the repository as tampered with.
+
+To take a machine's access away, run `woswoar revoke` from another one. To see
+what state this repository is in, run `woswoar doctor`.
+"""
+
+#: `recipients.txt` is the one file every machine appends to, so it is also the
+#: only place a merge conflict could arise. A union merge resolves it: the file
+#: is an unordered set of public keys, and keeping both sides is always right.
+GITATTRIBUTES_CONTENT = f"{RECIPIENTS} merge=union\n*{_CHUNK_SUFFIX} -diff -merge -text\n"
+#: What must never be committed, whoever is browsing the checkout. Finder writes
+#: a `.DS_Store` into any directory it is asked to display, and this is a git
+#: working tree that lives under the user's home -- so one arrives the first time
+#: anybody looks at their history in a file manager.
+#:
+#: Not a tidiness rule. `sync` stages with `git add -A`, so without this the file
+#: is committed and pushed to every peer; two machines whose Finders disagree
+#: about it then produce a binary conflict on the rebase that `sync` does, in a
+#: file no part of woswoar knows anything about. `.gitattributes` cannot express
+#: this -- it marks how a tracked file is treated, not whether it is tracked --
+#: so it is a second file.
+#:
+#: The chunk suffix is deliberately *not* here. A chunk that no signed manifest
+#: accounts for is a thing woswoar reports; a chunk git silently ignores is one
+#: nobody ever sees.
+GITIGNORE_CONTENT = f"{store.FINDER_METADATA}\n"
+
+
+def recipients_file() -> Path:
+    return store.history_dir() / RECIPIENTS
+
+
+def format_file() -> Path:
+    """Which shape this repository is, in plaintext at its root.
+
+    Plaintext, and it has to be: a machine reads this *before* it knows how to
+    find the day keys, so a version of it sealed to a key is a fact you can only
+    learn by already understanding the layout it describes.
+
+    It says nothing an observer could not get from the directory listing anyway
+    -- `docs/security.md` has always put the shape and size of the repository
+    outside what encryption hides.
+    """
+    return store.history_dir() / FORMAT
+
+
+def repo_format() -> int | None:
+    """The version the repository claims, or ``None`` when nothing legible does.
+
+    ``None`` is "the shape that predates the marker", which is this shape -- so
+    an absent file reads as compatible and every existing installation goes on
+    working untouched. That is the whole migration.
+
+    Unreadable *content* answers ``None`` too, rather than refusing. The file
+    sits in a repository anyone with push access can write, so treating garbage
+    as a fatal disagreement would hand any of them a way to stop every machine
+    syncing by writing four bytes -- while a legible number is a statement made
+    deliberately by a newer woswoar, and is worth stopping for. `State.load`
+    degrades the same way, for the same reason.
+    """
+    try:
+        text = format_file().read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not text.startswith(_FORMAT_PREFIX):
+        return None
+    try:
+        return int(text[len(_FORMAT_PREFIX) :])
+    except ValueError:
+        # `int` in a `try`, and not `str.isdigit` before it: those are different
+        # questions, and the gap between them is this function's whole promise.
+        # `"²".isdigit()` is True and `int("²")` raises, so a marker holding
+        # `woswoar-repo-²` crashed every sync with an unhandled ValueError --
+        # four bytes, writable by anyone with push access, exactly the wedge the
+        # docstring above says cannot happen.
+        return None
+
+
+def repo_host_dir(machine_id: str) -> Path:
+    return store.history_dir() / HOSTS / machine_id
+
+
+def name_seal(machine_id: str) -> Path:
+    """Sealed friendly name, so other machines can label this host's entries."""
+    return repo_host_dir(machine_id) / "name.age"
+
+
+def signer_public(machine_id: str) -> Path:
+    """A host's published verify key, and the recipient that owns the host.
+
+    Two lines, and the second is why this file exists at all rather than the
+    verify key living in `recipients.txt`: revocation names an *age recipient*,
+    while chunks live under a *host id*, and nothing else in the repo joins the
+    two. It could not go in `recipients.txt` either -- an age recipient may
+    itself be an SSH key, `ssh-ed25519 AAAA... comment`, so a second key in that
+    field could not be told from the first one's comment.
+
+    Anyone who can push can rewrite this, so nothing here is believed. It is
+    what `trust` *shows* a human, once; what is believed afterwards is the copy
+    pinned in local state.
+    """
+    return repo_host_dir(machine_id) / "signer.pub"
+
+
+def day_manifest(machine_id: str, day: str) -> Path:
+    """The signed list of a host-day's chunks.
+
+    Deliberately not one signature per chunk, which is what made the first
+    attempt at this unusable: a signature costs a subprocess, and a machine
+    waiting for `grant` re-checks everything it has not merged on every timer
+    tick. One manifest per host-day turns that from once per chunk into once per
+    day -- about 3.6 s over a year of three machines, against nearly two minutes.
+
+    Rewritten as the day goes on, so it lives outside the `hosts/<id>/<day>/`
+    chunk directories that `is_chunk_path` marks write-once. Only the owning
+    host ever writes it, so it cannot conflict, and it needs no merge driver.
+    """
+    return repo_host_dir(machine_id) / MANIFESTS / day
+
+
+def day_key(machine_id: str, day: str) -> Path:
+    """The day's identity, sealed to every recipient."""
+    return repo_host_dir(machine_id) / KEYS / f"{day}{_CHUNK_SUFFIX}"
+
+
+def day_key_public(machine_id: str, day: str) -> Path:
+    """The day's public key, in the clear.
+
+    Public keys are not secret, and keeping this alongside means writing a chunk
+    never has to open the sealed key first.
+    """
+    return repo_host_dir(machine_id) / KEYS / f"{day}{_PUB_SUFFIX}"
+
+
+def chunk_dir(machine_id: str, day: str) -> Path:
+    """``hosts/<id>/2026-07-29`` -- one directory per day.
+
+    Sharding by day keeps any directory to a day's worth of chunks, but the
+    date is *one* path component rather than three. Every commit rewrites the
+    tree object for each level it touches, so nesting ``2026/07/29`` costs two
+    extra tree objects on every single sync forever, for a directory that holds
+    exactly as many entries either way. Magnitudes are in
+    docs/woswoar_design_summary.md, which is re-measured as a whole; repeating
+    them here is how they go stale.
+    """
+    return repo_host_dir(machine_id) / day
+
+
+def new_chunk(machine_id: str, day: str, ts: int) -> Path:
+    """A chunk path that has never existed before.
+
+    Zero-padded seconds sort chronologically as strings, so a day's chunks are
+    walked oldest-first. That ordering is a convenience, not a guarantee: two
+    chunks written in the same second differ only by the random suffix, which is
+    why what a machine has merged is recorded as a *set* of names rather than a
+    high-water mark.
+
+    Uniqueness is a guarantee, not a probability. A collision would silently
+    overwrite an already-sealed chunk, destroying committed history in a design
+    whose whole premise is that chunks are written once and never modified --
+    entropy alone left that to chance, which
+    tests/test_sync.py::TestChunkNaming now pins. Checking the filesystem is
+    sound because both writers of a host's chunks, `sync.run` and
+    `sync.compact`, hold the same lock.
+    """
+    directory = chunk_dir(machine_id, day)
+    while True:
+        path = directory / f"{ts:010d}-{secrets.token_hex(3)}{_CHUNK_SUFFIX}"
+        if not path.exists():
+            return path
+
+
+class Chunk(NamedTuple):
+    day: str
+    #: Filename only. Sorts chronologically, and is what `State.merged` records.
+    name: str
+    path: Path
+
+
+def chunk_names(machine_id: str, day: str) -> list[str]:
+    """The chunk filenames in one host-day, sorted. Empty if there are none.
+
+    The unit the layout is actually asked about: what counts as a chunk is
+    decided here, so a partial write or an editor's leftover in a day directory
+    is not one. Callers that want a single day must not reach it by walking the
+    host -- `has_chunks` did, and turned a 0.09 ms question into a 4.6 ms one on
+    an archive of 20k chunks, once per orphaned day.
+
+    Listing is what walking an archive costs now that nothing builds a `Path`
+    per file: 4.96 ms for one peer's 20k chunks, against 0.18 ms to stat its 40
+    day directories, which is why `day_stamp` exists.
+
+    `os.scandir` swallows the same errors `Path.glob` did: a day directory that
+    has gone away, or that cannot be read, has no chunks to offer.
+    """
+    try:
+        with os.scandir(chunk_dir(machine_id, day)) as entries:
+            return sorted(e.name for e in entries if e.is_file() and e.name.endswith(_CHUNK_SUFFIX))
+    except OSError:
+        return []
+
+
+def chunk_days(machine_id: str) -> list[str]:
+    """The day directories one host publishes into, in order.
+
+    One `scandir` of the host, and no listing of the days themselves -- which is
+    what lets a caller decide *per day* whether it needs the names at all.
+    """
+    try:
+        with os.scandir(repo_host_dir(machine_id)) as entries:
+            return sorted(e.name for e in entries if e.is_dir() and _is_day(e.name))
+    except OSError:
+        return []
+
+
+def day_stamp(machine_id: str, day: str) -> int | None:
+    """When this day directory last gained or lost a file. ``None`` if absent.
+
+    A directory's mtime moves when an entry is added to or removed from it,
+    which is exactly what a fetch bringing in a chunk does -- so a day whose
+    stamp is unchanged since it was last merged has nothing new in it, without
+    listing it -- see `chunk_names` for what that saves.
+
+    Nanoseconds, and compared for equality rather than order: a directory
+    restored from a backup can be older than the stamp that was recorded, and
+    "older" still means "different, look again".
+    """
+    try:
+        return os.stat(chunk_dir(machine_id, day)).st_mtime_ns
+    except OSError:
+        return None
+
+
+def iter_chunk_days(machine_id: str) -> Iterator[tuple[str, list[str]]]:
+    """``(day, chunk filenames)`` for one host: days in order, names sorted.
+
+    Each day appears exactly once, with all of its chunks, and days with none at
+    all are not days. `sync._merge_host` reaches the same two halves separately
+    -- `chunk_days` then, per day it has to look at, `chunk_names` -- because it
+    can decide from the day alone that it needs no names.
+    """
+    for day in chunk_days(machine_id):
+        # A day directory with nothing in it is not a day with no new chunks --
+        # it is not a day at all, and saying so keeps every caller from having
+        # to ask.
+        if names := chunk_names(machine_id, day):
+            yield day, names
+
+
+def iter_chunks(machine_id: str) -> Iterator[Chunk]:
+    """Every sealed chunk belonging to one host, oldest first.
+
+    The flat view of `iter_chunk_days`, for the callers that want the paths.
+    """
+    root = repo_host_dir(machine_id)
+    for day, names in iter_chunk_days(machine_id):
+        for name in names:
+            yield Chunk(day=day, name=name, path=root / day / name)
+
+
+def _is_day(name: str) -> bool:
+    """``2026-07-29``. Distinguishes day directories from ``keys``."""
+    parts = name.split("-")
+    return len(parts) == 3 and all(p.isdigit() for p in parts)
+
+
+def iter_day_keys(machine_id: str) -> Iterator[Path]:
+    """Every sealed day key belonging to one host.
+
+    Exists so callers never have to spell out the keys directory or the chunk
+    suffix themselves -- those are this module's to know, and a hand-typed copy
+    would silently stop matching rather than fail loudly if the layout changed.
+    """
+    keys = repo_host_dir(machine_id) / KEYS
+    if not keys.is_dir():
+        return
+    yield from sorted(keys.glob(f"*{_CHUNK_SUFFIX}"))
+
+
+def day_key_days(machine_id: str) -> tuple[set[str], set[str]]:
+    """``(sealed, public)`` day strings for one host, from a single listing.
+
+    One readdir rather than a `glob` plus a stat per key: the caller asks this
+    for every host in the repo, so the cost grows with the archive forever --
+    measured on a two-year, five-machine tree, 1.9ms against 36ms.
+
+    Both sets from one pass because the only question worth asking is how they
+    differ, and pulling them apart is what let two callers drift over whether a
+    missing sealed half mattered.
+    """
+    sealed: set[str] = set()
+    public: set[str] = set()
+    try:
+        names = os.listdir(repo_host_dir(machine_id) / KEYS)
+    except OSError:
+        return sealed, public
+    for name in names:
+        if name.endswith(_CHUNK_SUFFIX):
+            sealed.add(name.removesuffix(_CHUNK_SUFFIX))
+        elif name.endswith(_PUB_SUFFIX):
+            public.add(name.removesuffix(_PUB_SUFFIX))
+    return sealed, public
+
+
+def is_chunk_path(relpath: str) -> bool:
+    """Whether a repo-relative path is a write-once chunk.
+
+    Key material and name seals live outside this shape and are deliberately
+    rewritable, so telling them apart is a property of the layout rather than
+    something a caller should pattern-match for itself.
+    """
+    parts = relpath.split("/")
+    return (
+        len(parts) == 4
+        and parts[0] == HOSTS
+        and _is_day(parts[2])
+        and parts[3].endswith(_CHUNK_SUFFIX)
+    )
+
+
+def repo_hosts() -> list[str]:
+    """Machine ids present in the history repo."""
+    root = store.history_dir() / HOSTS
+    if not root.is_dir():
+        return []
+    return sorted(p.name for p in root.iterdir() if p.is_dir())
+
+
+def day_of_key(path: Path) -> str:
+    """``hosts/<id>/keys/2026-07-29.age`` -> ``2026-07-29``.
+
+    The inverse of `day_key`, and here rather than at the caller for the same
+    reason `iter_day_keys` is: the suffix is this module's to know.
+    """
+    return path.name.removesuffix(_CHUNK_SUFFIX)

--- a/woswoar/prove.py
+++ b/woswoar/prove.py
@@ -33,7 +33,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
-from . import crypto, deps, store, sync
+from . import archive, crypto, deps, store, sync
 from .entry import Entry
 from .errors import WoswoarError
 
@@ -67,20 +67,20 @@ _BOILERPLATE = (
     sync.COMMIT_NAME,
     sync.COMMIT_EMAIL,
     sync.COMMIT_MESSAGE,
-    store.README_CONTENT,
-    store.GITATTRIBUTES_CONTENT,
-    store.GITIGNORE_CONTENT,
-    store.README,
-    store.GITATTRIBUTES,
-    store.GITIGNORE,
-    store.RECIPIENTS,
+    archive.README_CONTENT,
+    archive.GITATTRIBUTES_CONTENT,
+    archive.GITIGNORE_CONTENT,
+    archive.README,
+    archive.GITATTRIBUTES,
+    archive.GITIGNORE,
+    archive.RECIPIENTS,
     # The repo-layout names, from the module that owns them: tree objects
     # spell out every directory and file name under `hosts/`.
-    store._HOSTS,
-    store._KEYS,
-    store._MANIFESTS,
-    store.signer_public("x").name,
-    store.name_seal("x").name,
+    archive.HOSTS,
+    archive.KEYS,
+    archive.MANIFESTS,
+    archive.signer_public("x").name,
+    archive.name_seal("x").name,
     # git's own vocabulary in refs and config.
     "main",
     "master",
@@ -189,11 +189,11 @@ def _pushed_plaintext(origin: Path, known: store.Machine, day: str) -> bytes:
     if not tip:
         raise WoswoarError("the sandbox remote holds no commit")
     history = store.history_dir()
-    sealed_rel = store.day_key(known.id, day).relative_to(history)
+    sealed_rel = archive.day_key(known.id, day).relative_to(history)
     sealed = _git_bytes("cat-file", "blob", f"{tip}:{sealed_rel}", cwd=origin)
     day_secret = sync.open_day_key_bytes(known, sealed)
 
-    chunk_rel = store.chunk_dir(known.id, day).relative_to(history)
+    chunk_rel = archive.chunk_dir(known.id, day).relative_to(history)
     listing = _git_bytes("ls-tree", "-r", "--name-only", tip, str(chunk_rel), cwd=origin).decode(
         "utf-8"
     )

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -1,9 +1,12 @@
-"""Filesystem layout, machine identity, and log file access.
+"""Filesystem layout under ``logs/``, machine identity, and the primitives.
 
-The plaintext logs under ``$WOSWOAR_DIR/logs`` are the working copy and the only
-thing milestone 1 touches. ``history/`` (the git working tree, ciphertext only)
-and ``state.json`` belong to sync and mirror this same ``hosts/<id>/`` shape,
-which is why the layout is defined here in one place.
+The plaintext logs under ``$WOSWOAR_DIR/logs`` are the working copy and the
+truth. This module owns where they live, how a file woswoar writes gets its
+owner-only mode, and the small shared file operations everything above uses.
+
+The *repository* under ``history/`` lives in :mod:`woswoar.archive`, whose
+docstring has the reasoning. Only `history_dir` stays here, and its own
+docstring says why.
 """
 
 from __future__ import annotations
@@ -22,106 +25,14 @@ from .entry import Entry, format_line, parse_line
 _LOGS = "logs"
 _HISTORY = "history"
 _HOSTS = "hosts"
-_KEYS = "keys"
-_MANIFESTS = "manifests"
 _LOG_SUFFIX = ".tsv"
-_CHUNK_SUFFIX = ".age"
-_PUB_SUFFIX = ".pub"
 _NAME_FILE = ".name"
 
-RECIPIENTS = "recipients.txt"
-GITATTRIBUTES = ".gitattributes"
-GITIGNORE = ".gitignore"
-README = "README.md"
-FORMAT = "FORMAT"
-
-#: The layout of the *repository* -- `recipients.txt`, `hosts/<id>/keys/`,
-#: `manifests/`, `<day>/<ts>-<rand>.age`. Every other format woswoar owns already
-#: says which one it is: the cache carries `woswoar-cache-2`, a manifest carries
-#: `woswoar-manifest-v1` inside the bytes it signs. The repo was the exception,
-#: and it is the one an upgrade cannot be retrofitted onto later -- a machine
-#: still running the old version would not write the marker, so by the time a
-#: layout change needs one it is too late by definition.
-#:
-#: Deliberately not `woswoar.__version__`. The program version moved sixteen
-#: times in a fortnight and this has moved zero times; coupling them means a
-#: meaningless bump on every release and no signal on the one release where it
-#: matters.
-REPO_FORMAT = 1
-_FORMAT_PREFIX = "woswoar-repo-"
-
-
-def format_content(version: int = REPO_FORMAT) -> str:
-    """What the marker says for ``version``. The one place the prefix is spelt.
-
-    Takes a version because the tests need to write one this build does not
-    understand, and hand-typing `woswoar-repo-2` there would put a second copy
-    of the prefix outside this module -- where it would go on parsing after a
-    rename, as `None`, and quietly stop testing the refusal.
-    """
-    return f"{_FORMAT_PREFIX}{version}\n"
-
-
-FORMAT_CONTENT = format_content()
-
-#: What a stranger finding the repository sees first, and what its owner sees in
-#: three years having forgotten what it was. Deliberately says nothing about
-#: whose it is: the host directories are opaque hex precisely so the archive does
-#: not name machines, and a README that undid that would be worse than none.
-#:
-#: Written only when absent, unlike `.gitattributes`, which is compared and
-#: rewritten to match. Both are written by `init` rather than by `sync`, so the
-#: cost of getting this wrong is bounded -- but a machine on a newer version
-#: would still rewrite a peer's wording the next time anyone ran `init`, and the
-#: older one would put it back. `.gitattributes` earns that because its content
-#: is load-bearing: `merge=union` on `recipients.txt` is what makes two machines
-#: enrolling at once conflict-free. Prose does not.
-README_CONTENT = """# woswoar history
-
-Encrypted shell history, written by [woswoar](https://github.com/martinus/woswoar).
-
-Every `.age` file here is ciphertext. There is nothing readable in this
-repository, including the directory names -- they are random hex so that an
-archive of it does not publish which machines exist.
-
-## Do not edit this by hand
-
-Chunks are written once and never rewritten, and each machine signs a list of
-what it published each day. A file that no signed list accounts for is refused
-by every other machine and reported. Editing or deleting one here does not
-remove history -- other machines keep their own copies -- and will make them
-report the repository as tampered with.
-
-To take a machine's access away, run `woswoar revoke` from another one. To see
-what state this repository is in, run `woswoar doctor`.
-"""
-
-#: `recipients.txt` is the one file every machine appends to, so it is also the
-#: only place a merge conflict could arise. A union merge resolves it: the file
-#: is an unordered set of public keys, and keeping both sides is always right.
-GITATTRIBUTES_CONTENT = f"{RECIPIENTS} merge=union\n*{_CHUNK_SUFFIX} -diff -merge -text\n"
 
 #: Finder's per-directory metadata file, by name in the one place that owns the
 #: layout. It turns up in `logs/` and in the history checkout alike, so both the
 #: privacy walk and the repository's ignore rules are talking about this string.
-_FINDER_METADATA = ".DS_Store"
-
-#: What must never be committed, whoever is browsing the checkout. Finder writes
-#: a `.DS_Store` into any directory it is asked to display, and this is a git
-#: working tree that lives under the user's home -- so one arrives the first time
-#: anybody looks at their history in a file manager.
-#:
-#: Not a tidiness rule. `sync` stages with `git add -A`, so without this the file
-#: is committed and pushed to every peer; two machines whose Finders disagree
-#: about it then produce a binary conflict on the rebase that `sync` does, in a
-#: file no part of woswoar knows anything about. `.gitattributes` cannot express
-#: this -- it marks how a tracked file is treated, not whether it is tracked --
-#: so it is a second file.
-#:
-#: The chunk suffix is deliberately *not* here. A chunk that no signed manifest
-#: accounts for is a thing woswoar reports; a chunk git silently ignores is one
-#: nobody ever sees.
-GITIGNORE_CONTENT = f"{_FINDER_METADATA}\n"
+FINDER_METADATA = ".DS_Store"
 
 
 class Machine(NamedTuple):
@@ -316,7 +227,7 @@ def _private_paths() -> Iterator[tuple[Path, bool]]:
             for name in dirs:
                 yield here / name, True
             for name in files:
-                if name == _FINDER_METADATA:
+                if name == FINDER_METADATA:
                     continue
                 yield here / name, False
 
@@ -543,63 +454,27 @@ def iter_log_files(host_id: str | None = None) -> Iterator[LogFile]:
 
 
 # ---------------------------------------------------------------------------
-# The history repo: ciphertext only, and every file in it is write-once.
+# The next five: `history_dir`, which names the repository without knowing
+# anything inside it, and the four per-machine files sync keeps deliberately
+# *outside* it -- progress, a stamp, a failure note, a signing key. Only these
+# five; the logs vocabulary resumes at `day_of_log` below.
+#
+# The four are here rather than in `archive` because none of them is in the
+# repository, and a module named for the archive is the wrong place to file a
+# thing whose whole point is that it is not published. Their real home is
+# whatever #201 carves out of `sync`, which is the only caller any of them has.
 # ---------------------------------------------------------------------------
 
 
 def history_dir() -> Path:
-    """The git working tree. Contains sealed chunks and nothing readable."""
+    """The git working tree. Contains sealed chunks and nothing readable.
+
+    Here rather than in `archive`, which owns everything inside it, because
+    `_private_paths` has to prune this directory by name -- see its docstring
+    for the measurement. `store` knows the directory exists; `archive` knows
+    what is in it.
+    """
     return data_dir() / _HISTORY
-
-
-def recipients_file() -> Path:
-    return history_dir() / RECIPIENTS
-
-
-def format_file() -> Path:
-    """Which shape this repository is, in plaintext at its root.
-
-    Plaintext, and it has to be: a machine reads this *before* it knows how to
-    find the day keys, so a version of it sealed to a key is a fact you can only
-    learn by already understanding the layout it describes.
-
-    It says nothing an observer could not get from the directory listing anyway
-    -- `docs/security.md` has always put the shape and size of the repository
-    outside what encryption hides.
-    """
-    return history_dir() / FORMAT
-
-
-def repo_format() -> int | None:
-    """The version the repository claims, or ``None`` when nothing legible does.
-
-    ``None`` is "the shape that predates the marker", which is this shape -- so
-    an absent file reads as compatible and every existing installation goes on
-    working untouched. That is the whole migration.
-
-    Unreadable *content* answers ``None`` too, rather than refusing. The file
-    sits in a repository anyone with push access can write, so treating garbage
-    as a fatal disagreement would hand any of them a way to stop every machine
-    syncing by writing four bytes -- while a legible number is a statement made
-    deliberately by a newer woswoar, and is worth stopping for. `State.load`
-    degrades the same way, for the same reason.
-    """
-    try:
-        text = format_file().read_text(encoding="utf-8").strip()
-    except OSError:
-        return None
-    if not text.startswith(_FORMAT_PREFIX):
-        return None
-    try:
-        return int(text[len(_FORMAT_PREFIX) :])
-    except ValueError:
-        # `int` in a `try`, and not `str.isdigit` before it: those are different
-        # questions, and the gap between them is this function's whole promise.
-        # `"²".isdigit()` is True and `int("²")` raises, so a marker holding
-        # `woswoar-repo-²` crashed every sync with an unhandled ValueError --
-        # four bytes, writable by anyone with push access, exactly the wedge the
-        # docstring above says cannot happen.
-        return None
 
 
 def state_file() -> Path:
@@ -633,15 +508,6 @@ def sync_failure_file() -> Path:
     return data_dir() / "sync-failure.json"
 
 
-def repo_host_dir(machine_id: str) -> Path:
-    return history_dir() / _HOSTS / machine_id
-
-
-def name_seal(machine_id: str) -> Path:
-    """Sealed friendly name, so other machines can label this host's entries."""
-    return repo_host_dir(machine_id) / "name.age"
-
-
 def signing_key_file() -> Path:
     """This machine's signing key. Local, and never published or synced.
 
@@ -653,259 +519,9 @@ def signing_key_file() -> Path:
     return config_dir() / "signing_key"
 
 
-def signer_public(machine_id: str) -> Path:
-    """A host's published verify key, and the recipient that owns the host.
-
-    Two lines, and the second is why this file exists at all rather than the
-    verify key living in `recipients.txt`: revocation names an *age recipient*,
-    while chunks live under a *host id*, and nothing else in the repo joins the
-    two. It could not go in `recipients.txt` either -- an age recipient may
-    itself be an SSH key, `ssh-ed25519 AAAA... comment`, so a second key in that
-    field could not be told from the first one's comment.
-
-    Anyone who can push can rewrite this, so nothing here is believed. It is
-    what `trust` *shows* a human, once; what is believed afterwards is the copy
-    pinned in local state.
-    """
-    return repo_host_dir(machine_id) / "signer.pub"
-
-
-def day_manifest(machine_id: str, day: str) -> Path:
-    """The signed list of a host-day's chunks.
-
-    Deliberately not one signature per chunk, which is what made the first
-    attempt at this unusable: a signature costs a subprocess, and a machine
-    waiting for `grant` re-checks everything it has not merged on every timer
-    tick. One manifest per host-day turns that from once per chunk into once per
-    day -- about 3.6 s over a year of three machines, against nearly two minutes.
-
-    Rewritten as the day goes on, so it lives outside the `hosts/<id>/<day>/`
-    chunk directories that `is_chunk_path` marks write-once. Only the owning
-    host ever writes it, so it cannot conflict, and it needs no merge driver.
-    """
-    return repo_host_dir(machine_id) / _MANIFESTS / day
-
-
-def day_key(machine_id: str, day: str) -> Path:
-    """The day's identity, sealed to every recipient."""
-    return repo_host_dir(machine_id) / _KEYS / f"{day}{_CHUNK_SUFFIX}"
-
-
-def day_key_public(machine_id: str, day: str) -> Path:
-    """The day's public key, in the clear.
-
-    Public keys are not secret, and keeping this alongside means writing a chunk
-    never has to open the sealed key first.
-    """
-    return repo_host_dir(machine_id) / _KEYS / f"{day}{_PUB_SUFFIX}"
-
-
-def chunk_dir(machine_id: str, day: str) -> Path:
-    """``hosts/<id>/2026-07-29`` -- one directory per day.
-
-    Sharding by day keeps any directory to a day's worth of chunks, but the
-    date is *one* path component rather than three. Every commit rewrites the
-    tree object for each level it touches, so nesting ``2026/07/29`` costs two
-    extra tree objects on every single sync forever, for a directory that holds
-    exactly as many entries either way. Magnitudes are in
-    docs/woswoar_design_summary.md, which is re-measured as a whole; repeating
-    them here is how they go stale.
-    """
-    return repo_host_dir(machine_id) / day
-
-
-def new_chunk(machine_id: str, day: str, ts: int) -> Path:
-    """A chunk path that has never existed before.
-
-    Zero-padded seconds sort chronologically as strings, so a day's chunks are
-    walked oldest-first. That ordering is a convenience, not a guarantee: two
-    chunks written in the same second differ only by the random suffix, which is
-    why what a machine has merged is recorded as a *set* of names rather than a
-    high-water mark.
-
-    Uniqueness is a guarantee, not a probability. A collision would silently
-    overwrite an already-sealed chunk, destroying committed history in a design
-    whose whole premise is that chunks are written once and never modified --
-    entropy alone left that to chance, which
-    tests/test_sync.py::TestChunkNaming now pins. Checking the filesystem is
-    sound because both writers of a host's chunks, `sync.run` and
-    `sync.compact`, hold the same lock.
-    """
-    directory = chunk_dir(machine_id, day)
-    while True:
-        path = directory / f"{ts:010d}-{secrets.token_hex(3)}{_CHUNK_SUFFIX}"
-        if not path.exists():
-            return path
-
-
-class Chunk(NamedTuple):
-    day: str
-    #: Filename only. Sorts chronologically, and is what `State.merged` records.
-    name: str
-    path: Path
-
-
-def chunk_names(machine_id: str, day: str) -> list[str]:
-    """The chunk filenames in one host-day, sorted. Empty if there are none.
-
-    The unit the layout is actually asked about: what counts as a chunk is
-    decided here, so a partial write or an editor's leftover in a day directory
-    is not one. Callers that want a single day must not reach it by walking the
-    host -- `has_chunks` did, and turned a 0.09 ms question into a 4.6 ms one on
-    an archive of 20k chunks, once per orphaned day.
-
-    Listing is what walking an archive costs now that nothing builds a `Path`
-    per file: 4.96 ms for one peer's 20k chunks, against 0.18 ms to stat its 40
-    day directories, which is why `day_stamp` exists.
-
-    `os.scandir` swallows the same errors `Path.glob` did: a day directory that
-    has gone away, or that cannot be read, has no chunks to offer.
-    """
-    try:
-        with os.scandir(chunk_dir(machine_id, day)) as entries:
-            return sorted(e.name for e in entries if e.is_file() and e.name.endswith(_CHUNK_SUFFIX))
-    except OSError:
-        return []
-
-
-def chunk_days(machine_id: str) -> list[str]:
-    """The day directories one host publishes into, in order.
-
-    One `scandir` of the host, and no listing of the days themselves -- which is
-    what lets a caller decide *per day* whether it needs the names at all.
-    """
-    try:
-        with os.scandir(repo_host_dir(machine_id)) as entries:
-            return sorted(e.name for e in entries if e.is_dir() and _is_day(e.name))
-    except OSError:
-        return []
-
-
-def day_stamp(machine_id: str, day: str) -> int | None:
-    """When this day directory last gained or lost a file. ``None`` if absent.
-
-    A directory's mtime moves when an entry is added to or removed from it,
-    which is exactly what a fetch bringing in a chunk does -- so a day whose
-    stamp is unchanged since it was last merged has nothing new in it, without
-    listing it -- see `chunk_names` for what that saves.
-
-    Nanoseconds, and compared for equality rather than order: a directory
-    restored from a backup can be older than the stamp that was recorded, and
-    "older" still means "different, look again".
-    """
-    try:
-        return os.stat(chunk_dir(machine_id, day)).st_mtime_ns
-    except OSError:
-        return None
-
-
-def iter_chunk_days(machine_id: str) -> Iterator[tuple[str, list[str]]]:
-    """``(day, chunk filenames)`` for one host: days in order, names sorted.
-
-    Each day appears exactly once, with all of its chunks, and days with none at
-    all are not days. `sync._merge_host` reaches the same two halves separately
-    -- `chunk_days` then, per day it has to look at, `chunk_names` -- because it
-    can decide from the day alone that it needs no names.
-    """
-    for day in chunk_days(machine_id):
-        # A day directory with nothing in it is not a day with no new chunks --
-        # it is not a day at all, and saying so keeps every caller from having
-        # to ask.
-        if names := chunk_names(machine_id, day):
-            yield day, names
-
-
-def iter_chunks(machine_id: str) -> Iterator[Chunk]:
-    """Every sealed chunk belonging to one host, oldest first.
-
-    The flat view of `iter_chunk_days`, for the callers that want the paths.
-    """
-    root = repo_host_dir(machine_id)
-    for day, names in iter_chunk_days(machine_id):
-        for name in names:
-            yield Chunk(day=day, name=name, path=root / day / name)
-
-
-def _is_day(name: str) -> bool:
-    """``2026-07-29``. Distinguishes day directories from ``keys``."""
-    parts = name.split("-")
-    return len(parts) == 3 and all(p.isdigit() for p in parts)
-
-
-def iter_day_keys(machine_id: str) -> Iterator[Path]:
-    """Every sealed day key belonging to one host.
-
-    Exists so callers never have to spell out the keys directory or the chunk
-    suffix themselves -- those are this module's to know, and a hand-typed copy
-    would silently stop matching rather than fail loudly if the layout changed.
-    """
-    keys = repo_host_dir(machine_id) / _KEYS
-    if not keys.is_dir():
-        return
-    yield from sorted(keys.glob(f"*{_CHUNK_SUFFIX}"))
-
-
-def day_key_days(machine_id: str) -> tuple[set[str], set[str]]:
-    """``(sealed, public)`` day strings for one host, from a single listing.
-
-    One readdir rather than a `glob` plus a stat per key: the caller asks this
-    for every host in the repo, so the cost grows with the archive forever --
-    measured on a two-year, five-machine tree, 1.9ms against 36ms.
-
-    Both sets from one pass because the only question worth asking is how they
-    differ, and pulling them apart is what let two callers drift over whether a
-    missing sealed half mattered.
-    """
-    sealed: set[str] = set()
-    public: set[str] = set()
-    try:
-        names = os.listdir(repo_host_dir(machine_id) / _KEYS)
-    except OSError:
-        return sealed, public
-    for name in names:
-        if name.endswith(_CHUNK_SUFFIX):
-            sealed.add(name.removesuffix(_CHUNK_SUFFIX))
-        elif name.endswith(_PUB_SUFFIX):
-            public.add(name.removesuffix(_PUB_SUFFIX))
-    return sealed, public
-
-
-def is_chunk_path(relpath: str) -> bool:
-    """Whether a repo-relative path is a write-once chunk.
-
-    Key material and name seals live outside this shape and are deliberately
-    rewritable, so telling them apart is a property of the layout rather than
-    something a caller should pattern-match for itself.
-    """
-    parts = relpath.split("/")
-    return (
-        len(parts) == 4
-        and parts[0] == _HOSTS
-        and _is_day(parts[2])
-        and parts[3].endswith(_CHUNK_SUFFIX)
-    )
-
-
-def repo_hosts() -> list[str]:
-    """Machine ids present in the history repo."""
-    root = history_dir() / _HOSTS
-    if not root.is_dir():
-        return []
-    return sorted(p.name for p in root.iterdir() if p.is_dir())
-
-
 def day_of_log(relpath: str) -> str:
     """``hosts/<id>/2026-07-29.tsv`` -> ``2026-07-29``."""
     return relpath.rsplit("/", 1)[-1].removesuffix(_LOG_SUFFIX)
-
-
-def day_of_key(path: Path) -> str:
-    """``hosts/<id>/keys/2026-07-29.age`` -> ``2026-07-29``.
-
-    The inverse of `day_key`, and here rather than at the caller for the same
-    reason `iter_day_keys` is: the suffix is this module's to know.
-    """
-    return path.name.removesuffix(_CHUNK_SUFFIX)
 
 
 def append_entries(machine_id: str, entries: list[Entry]) -> dict[str, int]:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -36,7 +36,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NamedTuple
 
-from . import crypto, progress, store
+from . import archive, crypto, progress, store
 from .entry import make_inert
 from .errors import WoswoarError
 from .store import Machine
@@ -179,7 +179,7 @@ _REVOKED = "-"
 
 
 def _recipient_lines() -> list[str]:
-    path = store.recipients_file()
+    path = archive.recipients_file()
     if not path.is_file():
         return []
     return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
@@ -237,7 +237,7 @@ def _append_recipient_line(line: str) -> None:
     newline rule in two places on the one file every machine in the fleet
     writes and that ``merge=union`` makes unforgiving about stray lines.
     """
-    path = store.recipients_file()
+    path = archive.recipients_file()
     existing = path.read_text(encoding="utf-8") if path.is_file() else ""
     separator = "" if not existing or existing.endswith("\n") else "\n"
     store.write_atomic(path, f"{existing}{separator}{line}\n".encode())
@@ -323,7 +323,7 @@ def _host_owners() -> Owners:
 
     Everything `signer.pub` says is untrusted, and this used to keep the first
     claim in sorted order and drop the rest -- `setdefault` over
-    `store.repo_hosts()`. Host ids are chosen locally, so anyone who can push
+    `archive.repo_hosts()`. Host ids are chosen locally, so anyone who can push
     could add a directory whose id sorts first, name *your* recipient as its
     owner, and win the mapping for it (#110). `accept` would then print that
     host's verify key directly beneath your own real, checkable age
@@ -335,7 +335,7 @@ def _host_owners() -> Owners:
     other. Silently picking one is what made a contradiction look like a fact.
     """
     claims: dict[str, list[str]] = {}
-    for host_id in store.repo_hosts():
+    for host_id in archive.repo_hosts():
         signer = read_signer(host_id)
         if signer is not None:
             claims.setdefault(signer.owner, []).append(host_id)
@@ -467,7 +467,7 @@ class State:
     #: "<host>/<day>" -> the day directory's mtime when every chunk its signed
     #: manifest listed had been merged. A day whose stamp still matches has gained nothing since, so
     #: it needs no listing at all -- and listing is what a peer's whole archive
-    #: costs on a timer that fires every minute. See `store.day_stamp`.
+    #: costs on a timer that fires every minute. See `archive.day_stamp`.
     #:
     #: Named for what it means: a day merged *completely*, not one looked at.
     #: One left short by an unopenable key or a chunk that would not
@@ -696,7 +696,7 @@ def trust_status(known: Machine) -> IdentityStatus:
     if not is_repo():
         return IdentityStatus(True, "no history repo yet")
     accepted = accepted_hosts(State.load())
-    others = [host for host in store.repo_hosts() if host != known.id]
+    others = [host for host in archive.repo_hosts() if host != known.id]
     waiting = [host for host in others if host not in accepted]
     detail = f"{len(others) - len(waiting)} of {len(others)} other machine(s) accepted"
     if waiting:
@@ -719,7 +719,8 @@ def orphaned_day_key(host_id: str, day: str) -> bool:
     side of this -- a sealed key with no public half is simply re-minted.
     """
     return (
-        store.day_key_public(host_id, day).is_file() and not store.day_key(host_id, day).is_file()
+        archive.day_key_public(host_id, day).is_file()
+        and not archive.day_key(host_id, day).is_file()
     )
 
 
@@ -740,7 +741,7 @@ def has_chunks(host_id: str, day: str) -> bool:
     186 ms rather than 3.8 ms for 40 orphaned days at 20k chunks, in exactly the
     state `doctor` exists to find.
     """
-    return bool(store.chunk_names(host_id, day))
+    return bool(archive.chunk_names(host_id, day))
 
 
 def orphaned_days() -> list[tuple[str, str]]:
@@ -756,8 +757,8 @@ def orphaned_days() -> list[tuple[str, str]]:
     them and a test can assert on the day rather than search for it.
     """
     found = []
-    for host_id in store.repo_hosts():
-        sealed, public = store.day_key_days(host_id)
+    for host_id in archive.repo_hosts():
+        sealed, public = archive.day_key_days(host_id)
         for day in sorted(public - sealed):
             if has_chunks(host_id, day):
                 found.append((host_id, day))
@@ -771,7 +772,7 @@ def manifest_gone(host_id: str, day: str) -> bool:
     so every caller pairs it with "did this machine publish this day", which is
     its own export watermark.
     """
-    return not store.day_manifest(host_id, day).exists()
+    return not archive.day_manifest(host_id, day).exists()
 
 
 def unlisted_chunks() -> list[tuple[str, str, int]]:
@@ -797,11 +798,11 @@ def unlisted_chunks() -> list[tuple[str, str, int]]:
     """
     state = State.load()
     found: list[tuple[str, str, int]] = []
-    for host_id in store.repo_hosts():
+    for host_id in archive.repo_hosts():
         verify_key = state.signers.get(host_id)
         if verify_key is None:
             continue
-        for day, names in store.iter_chunk_days(host_id):
+        for day, names in archive.iter_chunk_days(host_id):
             claimed = _manifest_names(host_id, day)
             if not set(names) - claimed:
                 continue
@@ -824,7 +825,7 @@ def _manifest_names(host_id: str, day: str) -> set[str]:
     unauthenticated rather than as a stray file.
     """
     try:
-        blob = store.day_manifest(host_id, day).read_text(encoding="utf-8")
+        blob = archive.day_manifest(host_id, day).read_text(encoding="utf-8")
     except OSError:
         return set()
     _, _, body = blob.partition(_MANIFEST_SEPARATOR)
@@ -867,21 +868,21 @@ def day_public_key(known: Machine, day: str) -> str:
     that already has chunks -- those are sealed to the old key, and a new one
     cannot help them.
     """
-    pub_path = store.day_key_public(known.id, day)
-    if pub_path.is_file() and store.day_key(known.id, day).is_file():
+    pub_path = archive.day_key_public(known.id, day)
+    if pub_path.is_file() and archive.day_key(known.id, day).is_file():
         return pub_path.read_text(encoding="utf-8").strip()
 
     identity = crypto.generate_identity()
     sealed = crypto.encrypt_to_recipients(identity.secret.encode("utf-8"), recipients())
     # Sealed half first: see `orphaned_day_key`.
-    store.write_atomic(store.day_key(known.id, day), sealed)
+    store.write_atomic(archive.day_key(known.id, day), sealed)
     store.write_atomic(pub_path, (identity.public + "\n").encode("utf-8"))
     return identity.public
 
 
 def open_day_key(known: Machine, host_id: str, day: str) -> str:
     """Recover a day's private identity so its chunks can be read."""
-    sealed_path = store.day_key(host_id, day)
+    sealed_path = archive.day_key(host_id, day)
     try:
         sealed = sealed_path.read_bytes()
     except OSError as exc:
@@ -921,7 +922,7 @@ class Signer(NamedTuple):
 
 def read_signer(host_id: str) -> Signer | None:
     try:
-        lines = store.signer_public(host_id).read_text(encoding="utf-8").splitlines()
+        lines = archive.signer_public(host_id).read_text(encoding="utf-8").splitlines()
     except OSError:
         return None
     if len(lines) < 2 or not lines[0].strip() or not lines[1].strip():
@@ -942,7 +943,7 @@ def publish_signer(known: Machine) -> bool:
     if current is not None and current.verify_key == verify_key:
         return False
     store.write_atomic(
-        store.signer_public(known.id),
+        archive.signer_public(known.id),
         f"{verify_key}\n{_own_recipient(known)}\n".encode(),
     )
     return True
@@ -1050,10 +1051,10 @@ def _trust_candidates() -> list[Candidate]:
 
     # Every host, before the loop: `trust` is *always* about a machine this
     # one has never merged, so without this it never had a name to show.
-    learn_names(known, store.repo_hosts())
+    learn_names(known, archive.repo_hosts())
 
     out: list[Candidate] = []
-    for host_id in store.repo_hosts():
+    for host_id in archive.repo_hosts():
         if host_id == known.id:
             continue
         signer = read_signer(host_id)
@@ -1205,7 +1206,7 @@ def write_manifest(known: Machine, day: str, entries: dict[str, Entry]) -> None:
     body = _manifest_body(known.id, day, entries)
     signature = crypto.sign(body.encode("utf-8"), store.signing_key_file(), _MANIFEST_MAGIC)
     blob = signature.decode("utf-8").strip() + _MANIFEST_SEPARATOR + body
-    store.write_atomic(store.day_manifest(known.id, day), blob.encode("utf-8"))
+    store.write_atomic(archive.day_manifest(known.id, day), blob.encode("utf-8"))
 
 
 def read_manifest(host_id: str, day: str, verify_key: str) -> dict[str, Entry]:
@@ -1219,7 +1220,7 @@ def read_manifest(host_id: str, day: str, verify_key: str) -> dict[str, Entry]:
     produce any of these shapes at will.
     """
     try:
-        blob = store.day_manifest(host_id, day).read_text(encoding="utf-8")
+        blob = archive.day_manifest(host_id, day).read_text(encoding="utf-8")
     except OSError:
         return {}
 
@@ -1440,7 +1441,7 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
         # orphaned day cost a fork a minute for as long as it stayed that way,
         # on a path issue #50 is already about. `day in on_disk` first because
         # it is a dict lookup and the other two are stats.
-        on_disk = set(store.chunk_names(known.id, day))
+        on_disk = set(archive.chunk_names(known.id, day))
         if on_disk and orphaned_day_key(known.id, day):
             # See `orphaned_day_key` for what this state is. A fresh key would
             # let this sync succeed and say nothing while the day's existing
@@ -1492,7 +1493,7 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
             public = day_public_key(known, day)
             for piece in split_for_export(data, MAX_EXPORT_BYTES):
                 sealed = crypto.encrypt_to(pack(piece), public)
-                written = store.new_chunk(known.id, day, now)
+                written = archive.new_chunk(known.id, day, now)
                 store.write_atomic(written, sealed)
                 listed[written.name] = Entry(digest_of(sealed))
 
@@ -1545,7 +1546,7 @@ def merge(known: Machine, state: State, report: Report) -> None:
     # Our own plaintext is already the source of truth, so it is dropped here
     # rather than skipped in the loop: the phase names the machine being read,
     # and `_merge_host` counts that machine's days underneath it.
-    others = [host for host in store.repo_hosts() if host != known.id]
+    others = [host for host in archive.repo_hosts() if host != known.id]
     for host_id in others:
         progress.phase(f"reading history from {name_for(host_id).text}")
         report.hosts_seen.add(host_id)
@@ -1651,12 +1652,12 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
     # manifest, and a manifest costs a subprocess. Over a year of three machines
     # that is the difference between ~3.6s and nearly two minutes.
     # Names rather than `Chunk` objects, and paths built only for the chunks
-    # actually read -- see `store.chunk_names` for what that is worth here.
+    # actually read -- see `archive.chunk_names` for what that is worth here.
     #
     # Materialised for its length alone, so the counter can say how far along a
     # first sync is. An idle sync skips every one of these on the stamp check
     # below, and never gets far enough into the wait for anything to be shown.
-    days = list(store.chunk_days(host_id))
+    days = list(archive.chunk_days(host_id))
     for done, chunk_day in enumerate(days):
         progress.tick(done, len(days), "days")
         key = f"{host_id}/{chunk_day}"
@@ -1664,11 +1665,11 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         # Read before the listing, not after: a chunk arriving between the two
         # would otherwise be covered by a stamp taken after it landed, and not
         # looked at until something else changed the directory.
-        stamp = store.day_stamp(host_id, chunk_day)
+        stamp = archive.day_stamp(host_id, chunk_day)
         if stamp is not None and state.merged_at.get(key) == stamp:
             continue
 
-        names = store.chunk_names(host_id, chunk_day)
+        names = archive.chunk_names(host_id, chunk_day)
         # `get`, not `setdefault`: a day this machine only ever *looks* at --
         # never granted, or a manifest it cannot verify -- must not gain an
         # empty record that is then written out on every sync forever.
@@ -1697,7 +1698,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             # has a reason to read the manifest.
             #
             # `names` because an empty directory is not a day (see
-            # `store.iter_chunk_days`), and stamping one would put a permanent
+            # `archive.iter_chunk_days`), and stamping one would put a permanent
             # entry in `state.json` for something that is not there.
             _stamp(state, key, stamp, settled=bool(names))
             continue
@@ -1705,7 +1706,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
         listed = read_manifest(host_id, chunk_day, verify_key)
         day = _Day(host_id, chunk_day, listed, already)
         pending = names if day.rewrite else fresh
-        directory = store.chunk_dir(host_id, chunk_day)
+        directory = archive.chunk_dir(host_id, chunk_day)
         #: Chunk names whose plaintext reached `day`.
         taken: list[str] = []
 
@@ -1936,7 +1937,7 @@ def _merge_name(known: Machine, host_id: str) -> None:
     local = store.name_file(host_id)
     if local.is_file():
         return
-    sealed = store.name_seal(host_id)
+    sealed = archive.name_seal(host_id)
     if not sealed.is_file():
         return
     try:
@@ -1960,7 +1961,7 @@ def run(push: bool = True, now: int | None = None) -> Report:
         raise SyncError("no history repo yet; run 'woswoar init' first")
 
     known = store.machine()
-    if not store.recipients_file().is_file():
+    if not archive.recipients_file().is_file():
         raise SyncError("no recipients.txt in the history repo; run 'woswoar init'")
 
     repo = read_repo()
@@ -2364,7 +2365,7 @@ def initialise(
     # the design and silence would make it invisible.
     state = State.load()
     pinned: list[str] = []
-    for host_id in store.repo_hosts():
+    for host_id in archive.repo_hosts():
         signer = read_signer(host_id)
         if signer is not None and host_id not in state.signers:
             state.signers[host_id] = signer.verify_key
@@ -2387,12 +2388,12 @@ def write_repo_format() -> bool:
     *older* is still this shape, and a repo that says something newer has
     already been refused by `require_known_repo_format` before anything reaches
     here. Rewriting it would also give two machines on different versions a file
-    to take turns overwriting, which is the failure `store.README_CONTENT`
+    to take turns overwriting, which is the failure `archive.README_CONTENT`
     describes for prose and which matters more for a version.
     """
-    if store.format_file().is_file():
+    if archive.format_file().is_file():
         return False
-    store.write_atomic(store.format_file(), store.FORMAT_CONTENT.encode("utf-8"))
+    store.write_atomic(archive.format_file(), archive.FORMAT_CONTENT.encode("utf-8"))
     return True
 
 
@@ -2403,14 +2404,14 @@ def write_gitignore() -> bool:
     `_write_repo_metadata` treats `.gitattributes`. This runs on every sync
     rather than only at enrolment, so two machines on different versions would
     have a file to take turns overwriting and push to each other -- the failure
-    `store.README_CONTENT` describes, and the reason `write_repo_format` is
+    `archive.README_CONTENT` describes, and the reason `write_repo_format` is
     written this way too. Enrolment still rewrites it to match; a sync only ever
     supplies a missing one.
     """
-    path = store.history_dir() / store.GITIGNORE
+    path = store.history_dir() / archive.GITIGNORE
     if path.is_file():
         return False
-    store.write_atomic(path, store.GITIGNORE_CONTENT.encode("utf-8"))
+    store.write_atomic(path, archive.GITIGNORE_CONTENT.encode("utf-8"))
     return True
 
 
@@ -2426,13 +2427,13 @@ def repo_format_status() -> IdentityStatus:
     The detail names both numbers, because the fix is "upgrade this machine" and
     neither is visible anywhere else.
     """
-    found = store.repo_format()
+    found = archive.repo_format()
     if found is None:
-        return IdentityStatus(True, f"{store.REPO_FORMAT} - unmarked, the next sync records it")
-    if found > store.REPO_FORMAT:
+        return IdentityStatus(True, f"{archive.REPO_FORMAT} - unmarked, the next sync records it")
+    if found > archive.REPO_FORMAT:
         return IdentityStatus(
             False,
-            f"repo is format {found}, this woswoar understands {store.REPO_FORMAT}"
+            f"repo is format {found}, this woswoar understands {archive.REPO_FORMAT}"
             " - upgrade woswoar here ('pipx upgrade woswoar'); until then nothing"
             " is published or merged",
         )
@@ -2459,11 +2460,11 @@ def _write_repo_metadata(known: Machine, identity: Path) -> bool:
     changed = False
 
     # Both compared and rewritten rather than written once, because both hold
-    # content woswoar depends on rather than prose -- see `store.README_CONTENT`
+    # content woswoar depends on rather than prose -- see `archive.README_CONTENT`
     # for the file where that argument comes out the other way.
     for name, content in (
-        (store.GITATTRIBUTES, store.GITATTRIBUTES_CONTENT),
-        (store.GITIGNORE, store.GITIGNORE_CONTENT),
+        (archive.GITATTRIBUTES, archive.GITATTRIBUTES_CONTENT),
+        (archive.GITIGNORE, archive.GITIGNORE_CONTENT),
     ):
         path = store.history_dir() / name
         current = path.read_text(encoding="utf-8") if path.is_file() else ""
@@ -2471,11 +2472,11 @@ def _write_repo_metadata(known: Machine, identity: Path) -> bool:
             store.write_atomic(path, content.encode("utf-8"))
             changed = True
 
-    # Only when absent -- see `store.README_CONTENT` for why it is not compared
+    # Only when absent -- see `archive.README_CONTENT` for why it is not compared
     # and rewritten the way `.gitattributes` is.
-    readme = store.history_dir() / store.README
+    readme = store.history_dir() / archive.README
     if not readme.is_file():
-        store.write_atomic(readme, store.README_CONTENT.encode("utf-8"))
+        store.write_atomic(readme, archive.README_CONTENT.encode("utf-8"))
         changed = True
 
     if write_repo_format():
@@ -2490,7 +2491,7 @@ def _write_repo_metadata(known: Machine, identity: Path) -> bool:
     if publish_signer(known):
         changed = True
 
-    seal = store.name_seal(known.id)
+    seal = archive.name_seal(known.id)
     if not seal.is_file():
         store.write_atomic(
             seal,
@@ -2855,9 +2856,9 @@ def _reseal(identity: Path, keys: list[str]) -> tuple[int, int]:
     # nobody but the machine that made one ever needs it, which is exactly why a
     # revoked machine keeping its copy buys it nothing.
     sealed: list[Path] = []
-    for host_id in store.repo_hosts():
-        sealed.extend(store.iter_day_keys(host_id))
-        sealed.append(store.name_seal(host_id))
+    for host_id in archive.repo_hosts():
+        sealed.extend(archive.iter_day_keys(host_id))
+        sealed.append(archive.name_seal(host_id))
 
     resealed = skipped = 0
     # Two `age` invocations per file that is ours -- open, then seal to the new
@@ -2998,7 +2999,7 @@ def find_reader(fingerprint: str) -> Reader:
 
 def _still_readable(host_id: str) -> list[str]:
     """Days this host has both a key for and a log it may still append to."""
-    keyed = {store.day_of_key(path) for path in store.iter_day_keys(host_id)}
+    keyed = {archive.day_of_key(path) for path in archive.iter_day_keys(host_id)}
     logged = {store.day_of_log(log.relpath) for log in store.iter_log_files(host_id)}
     return sorted(keyed & logged)
 
@@ -3068,7 +3069,7 @@ def compact(before: str | None = None) -> tuple[int, int, int]:
 
     Holds the same lock `run` does, and must: this is the one operation that
     unlinks chunks, and the timer fires every minute. It is also what makes
-    `store.new_chunk`'s uniqueness check sound, since that check assumes no
+    `archive.new_chunk`'s uniqueness check sound, since that check assumes no
     other process is creating chunks for this host concurrently.
 
     ``before`` defaults to today, and may not be later than it: compaction is
@@ -3101,8 +3102,8 @@ def compact(before: str | None = None) -> tuple[int, int, int]:
         require_known_repo_format()
 
         verify_key = signing_public()
-        by_day: dict[str, list[store.Chunk]] = {}
-        for chunk in store.iter_chunks(known.id):
+        by_day: dict[str, list[archive.Chunk]] = {}
+        for chunk in archive.iter_chunks(known.id):
             if chunk.day < before:
                 by_day.setdefault(chunk.day, []).append(chunk)
 
@@ -3174,7 +3175,7 @@ def compact(before: str | None = None) -> tuple[int, int, int]:
                 skipped += 1
                 continue
 
-            merged = store.new_chunk(known.id, day, int(chunks[-1].name.split("-")[0]))
+            merged = archive.new_chunk(known.id, day, int(chunks[-1].name.split("-")[0]))
             sealed = crypto.encrypt_to(pack(plain), crypto.public_of(secret))
             store.write_atomic(merged, sealed)
             for chunk in chunks:


### PR DESCRIPTION
Closes #200. First of the four in #203, and the one the other three get easier after.

`store.py` carried three vocabularies — paths under `logs/`, paths under
`history/`, and the filesystem primitives — so every module that wanted
`logs_dir()` also depended on the chunk layout, the manifest paths and the repo
format marker. The middle one is `woswoar/archive.py` now.

## The result

`store.py` goes 951 → 507 lines. The measured import cones:

```
store    -> entry
archive  -> entry, store          (new)
cache    -> entry, store          unchanged, and no longer reaches the chunk layout
search   -> cache, entry, store   unchanged, likewise
sync     -> archive, crypto, entry, errors, progress, store
prove    -> archive, crypto, deps, entry, errors, progress, store, sync
__main__ -> cache, credentials, entry, errors, importer, search, store
```

`__main__`'s module-level set is deliberately unchanged — `archive` joined
`cmd_init`'s existing lazy import rather than the top of the file. #203's
criterion was that `LAYERS` gains rows and no module gains an edge; it gains one
row, and the two modules that lose a dependency are exactly the ones the issue
named.

**It is a little faster.** Moving the `README_CONTENT` / `GITATTRIBUTES_CONTENT`
/ `FORMAT_CONTENT` construction off the Ctrl-R path takes `store`'s module-body
exec from 171.6 µs to 113.5 µs (best of 30). Not visible end to end, and not why
it was done.

## It is a pure move

#203 asks that a move change only imports. Every changed line in `tests/`
classified: 320 are `store.` → `archive.` rewrites, imports, or the `LAYERS`
edit. The other 10 are the `LAYERS` row and four reflow artifacts from two lines
crossing 100 chars. **No assertion changed.** Four `mock.patch.object(store, …)`
targets were repointed at `archive`, which is the same category — the patched
attribute moved.

## Three decisions worth calling out

**Named `archive.py`, not `repo.py` as the issue said.** `repo` is bound as a
local or parameter in ten places in `sync.py`, `git()` included, so a module of
that name would be shadowed at every one of them. "Archive" is already this
repo's own word for the encrypted tree — `store`'s comments and `README_CONTENT`
both use it.

**Function names untouched**, including the now-redundant `repo_hosts`,
`repo_format`, `repo_host_dir`. Renaming would ride along free, but keeping them
identical is what lets this be reviewed as a mechanical prefix change. A rename
is a separate, greppable commit.

**`state_file`, `sync_stamp_file`, `sync_failure_file` and `signing_key_file`
stayed in `store`**, though every production caller is in `sync.py`. They are
per-machine files that are emphatically *not* in the repository — their own
docstrings say "deliberately outside the repo" and "never published or synced" —
so filing them under a module named for the archive would be a worse error than
leaving them. Their home is whatever #201 carves out of `sync`; noted there and
in `docs/architecture.md`.

## /simplify — applied

Four agents, deduped. The findings were all about the new prose and the boundary,
not the moved code.

- **The pruning measurement was copied.** `archive.py`'s docstring restated the
  238 ms / 1.4 ms figure that lives in `store._private_paths`. Removed; it now
  points, which is what `history_dir`'s docstring already did correctly.
- **`"Nothing here reads or writes content"` was false** — `repo_format` reads a
  file, `format_content` produces one, and three `*_CONTENT` constants are the
  literal bytes written into the repo. Replaced with the rule the code actually
  follows: `archive` owns the layout *and the repository's self-description*;
  the history — chunks, manifests, seals — is content and is `sync`'s. That is
  also the rule #201 needs to place the manifest reader, which the old sentence
  would have answered wrongly.
- **`HOSTS` is no longer shared.** It was made public in `store` so `archive`
  could import it back. But `logs/hosts/` and `history/hosts/` are two formats
  that agree today, and `REPO_FORMAT` versions only one of them — one constant
  cannot express renaming either alone. `store._HOSTS` is private again and
  `archive` has its own, so the repo layout is now movable without touching
  `store` at all. `prove`'s comment "the repo-layout names, from the module that
  owns them" became true again as a side effect.
- **The split rationale was written four times** — both module docstrings, the
  `store` banner, and a `LAYERS` comment. Kept once, in `archive.py`.
- **The `store` banner claimed the rest of the file**, putting `day_of_log`,
  `append_entries` and `existing_keys` on sync's side of the line. Bounded, and
  it now says why those four files are there and where they are going.
- **`docs/architecture.md` described the pre-split shape.** Diagram, table and
  strain section updated; #200 ticked in the order table. The diagram was also
  redrawn — the ASCII edges had become unreadable and implied edges that do not
  exist.

## /simplify — skipped

One finding: move the four sync-only files into `archive.py` too. Skipped for
the reason above — they are not in the repository, and the altitude reviewer
independently agreed that leaving them is correct scope for this issue.

Noted and not acted on: `is_chunk_path` has no production callers, only two tests
asserting the write-once invariant. Pre-existing, and deciding what counts as a
chunk path is the layout module's job, so it stays.

Preflight green: `ruff check`, `ruff format --check`, `mypy`, `shellcheck`, 875 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
