### PR TITLE
arch: the installer and the wizard leave __main__.py (#202)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,13 +25,16 @@ entry, errors        the record format, and the exception every layer raises
   crypto             age and ssh-keygen
   credentials
     importer         bash, zsh, atuin
+  install            which shells get a hook, and keeping it current
+    setup            what the guided first run asks
 deps, progress,      leaves: asked things by anyone, knowing nobody
 report
 
 sync      <- archive, crypto, progress, report, store, entry, errors
 doctor    <- report, search, cache, crypto, deps, store, entry, errors
 prove     <- sync, and everything sync is made of, plus deps and report
-__main__  <- search, cache, importer, report, store, entry, errors
+__main__  <- search, cache, importer, install, setup, report, store,
+             entry, errors
              (sync, crypto, archive, doctor and prove only inside the
               commands that need them -- see "Two costs shape everything")
 ```
@@ -41,8 +44,8 @@ __main__  <- search, cache, importer, report, store, entry, errors
 | format | `entry`, `errors` | nothing else in the package |
 | platform | `store`, `crypto`, `deps`, `progress`, `report`, `credentials` | the format layer |
 | derived | `cache`, `archive` | the two above |
-| domains | `search`, `sync`, `importer` | everything below, and **never each other** |
-| composition | `doctor`, `prove`, `__main__` | everything |
+| domains | `search`, `sync`, `importer`, `install` | everything below, and **never each other** |
+| composition | `setup`, `doctor`, `prove`, `__main__` | everything |
 
 `store` and `archive` are the two halves of the filesystem: `store` owns
 ``logs/`` — the plaintext truth — plus the primitives and machine identity;
@@ -85,7 +88,8 @@ interpreter, so anything imported at the top of the CLI module is paid for on
 every search — about 29 ms of a ~105 ms total. That is why `sync` is imported
 inside fourteen functions rather than at the top of `__main__.py`, why
 `store.write_atomic` imports `tempfile` at the point of use (3.1 ms), why
-`_hook_bytes` reaches `importlib.resources` only as a fallback (8.7 ms), and why
+`install.hook_bytes` reaches `importlib.resources` only as a fallback
+(8.7 ms), and why
 `cache.Cache` is a plain class rather than a dataclass (~4 ms, via `inspect`).
 Each of those has its measurement in the comment beside it;
 `tests/test_architecture.py` pins the ones that are otherwise only a convention,
@@ -206,13 +210,30 @@ and one call site, so each slice #201 carves out of this module takes its own
 kinds with it instead of leaving a 143-line method behind that binds all five
 concerns at once.
 
-**`__main__.py` is 1813 lines and inverts pattern 4 in two places.** An installer
-(`installed_shells`, `detect_shells`, `shells_from`, `_hook_bytes`,
-`_write_block`, `_stale_hooks`, `_refresh_hook`) and a setup wizard
-(`_importable`, `_untouched`, `_offer_imports`, `_offer_remote`) are both
-subsystems living in the argparse module, reachable by a test only through
-stdout. The wizard builds `argparse.Namespace` objects by hand to call sibling
-commands, which is the CLI using its own argument format as an internal API.
+**`__main__.py` was 1813 lines and inverted pattern 4 in two places.** #202 has
+split both out. `install.py` owns which shells woswoar is responsible for, what
+their hooks contain and how they are kept current — including `refresh_hook`,
+which is policy that runs unattended from a background sync and was held up by a
+single test asserting on stdout.
+
+`setup.py` is smaller than its name suggests, and the boundary is worth stating
+because the obvious reading is wrong. It holds what the wizard works out *without
+asking* — which histories exist, whether anything is set up here, which rule
+picked the shells — plus the two `input` primitives. The questions' wording and
+the four numbered steps stay in `__main__`, because a dialog prints each
+paragraph before the `input` under it: its prose and its control flow are one
+thing. Separating them needs the four commands passed in as callables, which is a
+different change from this one.
+
+What stayed is the dispatch: `cmd_setup` still calls install, import, init and
+sync in order, because running CLI commands is the CLI's job and a module below
+it that called back up would be a cycle. What is gone is the way it called them —
+four hand-built `argparse.Namespace` objects, where a flag added to `install`
+had to be remembered three screens away and `getattr(args, "shell", None)`
+swallowed the omission. Each command now has a keyword-argument half that
+`cmd_setup` and the command itself both go through, so mypy names the call site
+that forgot one. The test for the wizard was forging a namespace too, and had
+been missing `shell` entirely since it was written.
 
 **`store.py` used to carry three vocabularies** — paths under `logs/`, paths
 under `history/`, and the filesystem primitives — so everything that wanted
@@ -263,5 +284,5 @@ first because they make the expensive one smaller.
 |---|---|
 | 1 | ~~[#200](https://github.com/martinus/woswoar/issues/200) — split the repo layout out of `store.py`~~ — **done**, as `woswoar/archive.py`. |
 | 2 | ~~[#199](https://github.com/martinus/woswoar/issues/199) — one shape for outcome reporting~~ — **done**, in three parts: `report.Check`, `report.Notice`, and `sync.Outcome` collapsing `Report`'s seventeen fields to seven. |
-| 3 | [#202](https://github.com/martinus/woswoar/issues/202) — lift the installer and the setup wizard out of `__main__.py`. |
+| 3 | ~~[#202](https://github.com/martinus/woswoar/issues/202) — lift the installer and the setup wizard out of `__main__.py`~~ — **done**, as `woswoar/install.py` and `woswoar/setup.py`. |
 | 4 | [#201](https://github.com/martinus/woswoar/issues/201) — split `sync.py`, in slices, after the three above. |

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -16,7 +16,7 @@ somebody trying to move a module, months later.
 holds because the expensive things are imported lazily, at the call site, each
 with a measured comment beside it -- ``sync`` inside each of the fourteen
 commands in `__main__` that need it, ``tempfile`` in `store.write_atomic`
-(3.1 ms), ``importlib.resources`` in `__main__._hook_bytes` (8.7 ms), and
+(3.1 ms), ``importlib.resources`` in `install.hook_bytes` (8.7 ms), and
 ``dataclasses`` avoided outright in `cache.Cache` (~4 ms, via ``inspect``).
 Every one of those is a comment asking a future reader to remember something.
 `tests/test_perf.py` measures the *result* and would catch a regression as a
@@ -63,9 +63,17 @@ LAYERS: dict[str, set[str]] = {
     "crypto": {"errors"},
     "store": {"entry"},
     "archive": {"entry", "store"},
+    #: The installer decides and the CLI prints, so this reaches `report` for
+    #: `Check` and nothing else above `store`. `subprocess` is asked for inside
+    #: `shell_version`, because `__main__` imports this module at the top for the
+    #: parser and a keypress must not pay for a fork it will not make.
+    "install": {"entry", "errors", "report", "store"},
     "cache": {"entry", "store"},
     "search": {"cache", "entry", "store"},
     "importer": {"credentials", "entry", "errors", "store"},
+    #: `importer` and `sync` are deliberately absent: the wizard asks about them
+    #: inside the two functions that need them.
+    "setup": {"entry", "errors", "install", "report", "store"},
     "sync": {"archive", "crypto", "entry", "errors", "progress", "report", "store"},
     #: `sync` is deliberately absent: `doctor` reaches it inside the two checks
     #: that need it, so asking what is wrong with an installation does not pay
@@ -88,6 +96,13 @@ LAYERS: dict[str, set[str]] = {
         "entry",
         "errors",
         "importer",
+        #: `install` and not `setup`: the parser reads `install.HOOKS` for the
+        #: `--shell` choices, so a keypress pays for that module whatever it
+        #: does. Nothing needs `setup` until a command runs, so the four
+        #: functions that want it say so themselves -- 90 us that Ctrl-R does
+        #: not spend. Measured while reviewing #202, which had it at the top
+        #: with a comment claiming the parser needed it.
+        "install",
         "report",
         "search",
         "store",
@@ -204,7 +219,7 @@ class TestTheSearchPathStaysCheap(unittest.TestCase):
     def test_the_cli_does_not_import_the_expensive_stdlib(self) -> None:
         """Each of these is deferred at a call site with its cost written beside
         it -- `tempfile` 3.1 ms in `store.write_atomic`, `importlib.resources`
-        8.7 ms in `__main__._hook_bytes`, `dataclasses` ~4 ms avoided in
+        8.7 ms in `install.hook_bytes`, `dataclasses` ~4 ms avoided in
         `cache.Cache`. A top-level import of any of them is invisible in review
         and shows up as a slower keypress."""
         _, stdlib = _imported_by("__main__")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -16,8 +16,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from woswoar import __main__ as main_module
-from woswoar import crypto, report, store
+from woswoar import crypto, install, report, store
 
 from . import support
 from .support import WoswoarTestCase, requires_age
@@ -200,7 +199,7 @@ class TestAHookLeftBehindByAnUpgrade(WoswoarTestCase):
     """
 
     def hook(self) -> Path:
-        path = store.data_dir() / main_module.HOOKS["bash"]
+        path = store.data_dir() / install.HOOKS["bash"]
         path.parent.mkdir(parents=True, exist_ok=True)
         return path
 
@@ -289,7 +288,7 @@ class TestDoctorReportsTheShellsThisMachineUses(WoswoarTestCase):
 
 class TestReadingThePackagedHook(unittest.TestCase):
     def test_the_fast_path_and_the_fallback_agree(self) -> None:
-        """`_hook_bytes` reads the file beside the module and only falls back to
+        """`install.hook_bytes` reads the file beside the module and only falls back to
         `importlib.resources` when there is none -- 8.7 ms saved on a sync that
         now runs once a minute. Two routes to one file is two chances to read a
         different one, and the fallback is exercised by nothing else here: it is
@@ -297,10 +296,8 @@ class TestReadingThePackagedHook(unittest.TestCase):
         """
         from importlib import resources
 
-        via_resources = (
-            resources.files("woswoar") / "shell" / main_module.HOOKS["bash"]
-        ).read_bytes()
-        self.assertEqual(main_module._hook_bytes("bash"), via_resources)
+        via_resources = (resources.files("woswoar") / "shell" / install.HOOKS["bash"]).read_bytes()
+        self.assertEqual(install.hook_bytes("bash"), via_resources)
         self.assertTrue(via_resources.startswith(b"# woswoar"), "that is not the hook")
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7,15 +7,17 @@ which differs the moment two machines disagree about the username.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import os
 import shutil
 import subprocess
 import unittest
 from pathlib import Path
 
-from woswoar import __main__ as main_module
-from woswoar import cache, store
-from woswoar.__main__ import _BEGIN, main, portable_hook_path
+from woswoar import cache, install, store
+from woswoar.__main__ import main
+from woswoar.install import portable_hook_path
 
 from . import support
 from .support import (
@@ -212,14 +214,14 @@ class TestShellDetection(WoswoarTestCase):
 
     def rcfiles(self, *shells: str) -> None:
         for shell in shells:
-            (self.home / main_module.RCFILES[shell]).write_text("# mine\n", encoding="utf-8")
+            (self.home / install.RCFILES[shell]).write_text("# mine\n", encoding="utf-8")
 
     def sourced(self, shell: str) -> bool:
         """Whether that shell's rc file now sources that shell's hook."""
-        rcfile = self.home / main_module.RCFILES[shell]
+        rcfile = self.home / install.RCFILES[shell]
         if not rcfile.is_file():
             return False
-        return main_module.HOOKS[shell] in rcfile.read_text(encoding="utf-8")
+        return install.HOOKS[shell] in rcfile.read_text(encoding="utf-8")
 
     def test_auto_installs_into_every_existing_rcfile(self) -> None:
         """A machine with both shells must record from both.
@@ -233,7 +235,7 @@ class TestShellDetection(WoswoarTestCase):
         self.assertTrue(self.sourced("bash"), "the bash hook was not wired up")
         self.assertTrue(self.sourced("zsh"), "the zsh hook was not wired up")
         for shell in ("bash", "zsh"):
-            self.assertTrue((store.data_dir() / main_module.HOOKS[shell]).is_file())
+            self.assertTrue((store.data_dir() / install.HOOKS[shell]).is_file())
 
     def test_auto_does_not_create_an_rcfile_that_is_absent(self) -> None:
         """The half that keeps `install` from making a decision for someone.
@@ -247,7 +249,7 @@ class TestShellDetection(WoswoarTestCase):
         self.assertTrue(self.sourced("bash"))
         self.assertFalse((self.home / ".zshrc").exists(), "install created a ~/.zshrc")
         self.assertFalse(
-            (store.data_dir() / main_module.HOOKS["zsh"]).exists(),
+            (store.data_dir() / install.HOOKS["zsh"]).exists(),
             "a hook was copied for a shell with no rc file",
         )
 
@@ -301,7 +303,7 @@ class TestShellDetection(WoswoarTestCase):
         self.rcfiles("bash")
         target = self.home / ".zshrc"
         self.assertEqual(main(["install", "--rcfile", str(target)]), 0)
-        self.assertIn(main_module.HOOKS["zsh"], target.read_text(encoding="utf-8"))
+        self.assertIn(install.HOOKS["zsh"], target.read_text(encoding="utf-8"))
         self.assertFalse(self.sourced("bash"), "--rcfile installed a second shell as well")
 
     def test_rcfile_with_shell_both_is_refused_rather_than_resolved(self) -> None:
@@ -316,7 +318,7 @@ class TestShellDetection(WoswoarTestCase):
         self.assertEqual(ran.code, 1)
         self.assertIn("--rcfile names one file", ran.err)
         self.assertNotIn(
-            main_module.HOOKS["zsh"],
+            install.HOOKS["zsh"],
             (self.home / ".bashrc").read_text(encoding="utf-8"),
             "it wrote the zsh hook into the bash rc file anyway",
         )
@@ -328,8 +330,8 @@ class TestShellDetection(WoswoarTestCase):
         target = self.home / "rc"
         self.assertEqual(main(["install", "--rcfile", str(target)]), 0)
         text = target.read_text(encoding="utf-8")
-        self.assertEqual(text.count(_BEGIN), 1)
-        self.assertIn(main_module.HOOKS["bash"], text)
+        self.assertEqual(text.count(install.BEGIN), 1)
+        self.assertIn(install.HOOKS["bash"], text)
 
 
 class TestAFinderVisitDoesNotDisturbTheLogs(WoswoarTestCase):
@@ -470,10 +472,82 @@ class TestBothShellsRecordIntoOneHistory(WoswoarTestCase):
         self.assertIn("echo from_zsh_marker", recorded, "the zsh rc line did not record")
 
 
+class TestInstallHardensAfterItCopies(WoswoarTestCase):
+    """The order `install` does its two jobs in, which a comment claimed and
+    nothing held.
+
+    `write_bytes` creates at the ambient umask, so hardening *first* leaves the
+    files install itself just wrote as the ones its own migration missed -- and
+    on a machine with a permissive umask that is a world-readable copy of the
+    shell hook in a directory woswoar promises is owner-only. Found by mutation
+    while moving this code in #202: the invariant predates the move, the test
+    does not.
+    """
+
+    def test_a_permissive_umask_does_not_leave_the_hook_readable(self) -> None:
+        # 0 rather than a merely loose value: this is what makes `write_bytes`
+        # produce 0666, which is the state the ordering exists to clean up.
+        previous_mask = os.umask(0)
+        self.addCleanup(os.umask, previous_mask)
+
+        # `--rcfile` rather than a fifth copy of this file's redirect-`$HOME`
+        # fixture. The only reason to move `$HOME` would be to keep the block out
+        # of the real `~/.bashrc`, and naming a file does that; nothing here reads
+        # a rc file, because `--shell bash` means detection never runs.
+        rcfile = self.root / "bashrc"
+        self.assertEqual(main(["install", "--shell", "bash", "--rcfile", str(rcfile)]), 0)
+        # `support.loose_paths`, not `store.readable_by_others`: the latter and
+        # `store.harden` are both built on `store._private_paths`, so asking it
+        # would be the migration checking itself -- a path that walk stopped
+        # yielding would be skipped by `harden` and reported clean in the same
+        # breath. The helper says so in its own docstring, and the sibling test
+        # `test_a_stock_umask_cannot_loosen_what_is_written` already used it.
+        self.assertEqual(
+            support.loose_paths(),
+            [],
+            "install left something another account on this machine can read",
+        )
+
+
+class TestTheHookIsReportedBeforeTheRcFile(WoswoarTestCase):
+    """Why `install_hooks` and `wire_rcfiles` are two calls rather than one.
+
+    The rc file is the step that can fail on someone else's terms -- a read-only
+    home, a `.zshrc` owned by root, a path that is not a file at all. When it
+    does, the hook is already copied and can be sourced by hand, and that is the
+    one thing worth knowing. This is the test that holds it; `install.py` says why
+    the seam is there.
+    """
+
+    def test_an_unwritable_rcfile_still_names_the_hook_it_copied(self) -> None:
+        # A directory, because it fails the same way a read-only file does and
+        # needs no root to arrange: `write_text` on it raises OSError.
+        blocked = self.root / "not-a-file"
+        blocked.mkdir()
+
+        # `support.run_cli` cannot be used here: it returns the captured streams,
+        # and the exception means it never returns. The point of the test is what
+        # reached stdout *before* the failure, so the capture has to outlive it.
+        shown = io.StringIO()
+        with self.assertRaises(OSError), contextlib.redirect_stdout(shown):
+            main(["install", "--shell", "bash", "--rcfile", str(blocked)])
+
+        hook = store.data_dir() / install.HOOKS["bash"]
+        self.assertEqual(
+            hook.read_bytes(), install.hook_bytes("bash"), "the hook was not copied first"
+        )
+        self.assertIn(
+            f"hook    : {hook}",
+            shown.getvalue(),
+            "the install failed without saying where the hook it wrote is",
+        )
+
+
 class TestTheRefreshNeverCreates(WoswoarTestCase):
     """The hazard #159 names, and the reason this is not a tidy-up.
 
-    `_refresh_hook` runs unattended, from the background sync a prompt starts.
+    `install.refresh_hook` runs unattended, from the background sync a prompt
+    starts.
     If it ever *created* rather than refreshed, the first sync after an upgrade
     would put a `woswoar.zsh` on a bash-only machine: a file nothing sources,
     that nobody asked for, from a command nobody ran.
@@ -496,7 +570,7 @@ class TestTheRefreshNeverCreates(WoswoarTestCase):
             os.environ["HOME"] = self._home
 
     def hook(self, shell: str) -> Path:
-        return store.data_dir() / main_module.HOOKS[shell]
+        return store.data_dir() / install.HOOKS[shell]
 
     def test_a_refresh_never_creates_a_second_hook(self) -> None:
         # A `.zshrc` as well, so that *detection* would say zsh -- the refresh
@@ -506,8 +580,8 @@ class TestTheRefreshNeverCreates(WoswoarTestCase):
         (self.home / ".zshrc").write_text("# mine\n", encoding="utf-8")
         self.hook("bash").write_bytes(b"# an older woswoar\n")
 
-        self.assertTrue(main_module._refresh_hook(), "the stale bash hook was not refreshed")
-        self.assertEqual(self.hook("bash").read_bytes(), main_module._hook_bytes("bash"))
+        self.assertTrue(install.refresh_hook(), "the stale bash hook was not refreshed")
+        self.assertEqual(self.hook("bash").read_bytes(), install.hook_bytes("bash"))
         self.assertFalse(self.hook("zsh").exists(), "the refresh planted a hook nobody installed")
 
     def test_a_stale_zsh_hook_is_refreshed(self) -> None:
@@ -520,15 +594,46 @@ class TestTheRefreshNeverCreates(WoswoarTestCase):
         self.assertEqual(main(["install", "--shell", "zsh"]), 0)
         self.hook("zsh").write_bytes(b"# an older woswoar\n")
 
-        self.assertTrue(main_module._refresh_hook())
-        self.assertEqual(self.hook("zsh").read_bytes(), main_module._hook_bytes("zsh"))
+        self.assertTrue(install.refresh_hook())
+        self.assertEqual(self.hook("zsh").read_bytes(), install.hook_bytes("zsh"))
+
+    def test_the_names_of_the_refreshed_hooks_come_back(self) -> None:
+        """What #202 made load-bearing. `refresh_hook` used to print the message
+        itself; now it returns the hooks it rewrote and `cmd_sync` prints them, so
+        an empty return is the difference between a person being told their shell
+        code was replaced under them and it happening in silence. Nothing else
+        asserts that message, and the file is rewritten either way -- so a
+        `return []` would leave every other test in this class green."""
+        self.assertEqual(main(["install", "--shell", "zsh"]), 0)
+        for shell in ("bash", "zsh"):
+            self.hook(shell).write_bytes(b"# an older woswoar\n")
+        self.assertEqual(
+            sorted(install.refresh_hook()), sorted(self.hook(s) for s in install.HOOKS)
+        )
+
+    def test_a_sync_says_which_hook_it_replaced(self) -> None:
+        """The other end of the same thread: the message reaching a terminal.
+
+        Through the CLI, because what broke in the move was *which* function
+        prints -- a test that only called `refresh_hook` would pass with nobody
+        printing at all.
+        """
+        self.hook("bash").write_bytes(b"# an older woswoar\n")
+        ran = support.run_cli("sync")
+        self.assertIn("updated the shell hook", ran.out)
+        self.assertIn(str(self.hook("bash")), ran.out)
+
+    def test_a_current_hook_is_not_announced(self) -> None:
+        """Otherwise every sync would report an upgrade that did not happen."""
+        ran = support.run_cli("sync")
+        self.assertNotIn("updated the shell hook", ran.out)
 
     def test_a_stale_zsh_hook_makes_doctor_say_so(self) -> None:
         self.assertEqual(main(["install", "--shell", "zsh"]), 0)
         self.hook("zsh").write_bytes(b"# an older woswoar\n")
         ran = support.run_cli("doctor")
         self.assertIn("older than this woswoar", ran.out)
-        self.assertIn(main_module.HOOKS["zsh"], ran.out)
+        self.assertIn(install.HOOKS["zsh"], ran.out)
 
 
 if __name__ == "__main__":

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -18,7 +18,7 @@ import io
 import unittest
 from typing import ClassVar
 
-from woswoar import doctor, report, sync
+from woswoar import doctor, install, report, sync
 from woswoar.report import Check, Notice
 
 from . import support
@@ -268,29 +268,26 @@ class TestDoctorDecidesWithoutPrinting(WoswoarTestCase):
         recording and looks healthy, while whatever sync arrangement that
         version had is what it still does. It was reachable only through stdout.
         """
-        from woswoar import __main__ as main_module
         from woswoar import store
 
         support.run_cli("install")
-        hook = store.data_dir() / main_module.HOOKS["bash"]
+        hook = store.data_dir() / install.HOOKS["bash"]
         hook.write_bytes(b"# an older woswoar wrote this\n")
-        stale = [c for c in main_module._hook_checks() if c.label == "hook"]
+        stale = [c for c in install.hook_checks() if c.label == "hook"]
         self.assertTrue(stale, "no hook check was produced")
         self.assertFalse(stale[0].ok)
         self.assertIn("woswoar install", stale[0].detail)
 
     def test_a_current_hook_passes(self) -> None:
         """Without this the test above passes on a check that always fails."""
-        from woswoar import __main__ as main_module
 
         support.run_cli("install")
-        hook = [c for c in main_module._hook_checks() if c.label == "hook"]
+        hook = [c for c in install.hook_checks() if c.label == "hook"]
         self.assertTrue(hook[0].ok, hook[0].detail)
 
     def test_the_shell_check_names_the_shell_and_its_floor(self) -> None:
-        from woswoar import __main__ as main_module
 
-        checks = main_module._shell_checks()
+        checks = install.shell_checks()
         self.assertTrue(checks, "no shell was reported")
         self.assertIn("required", checks[0].detail)
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -9,12 +9,16 @@ is nobody to ask.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import os
 import unittest
 from pathlib import Path
+from typing import NamedTuple
 from unittest import mock
 
 from woswoar import __main__ as main_module
+from woswoar import importer, install, setup, store
 
 from . import support
 from .support import WoswoarTestCase
@@ -72,11 +76,34 @@ class SetupTestCase(WoswoarTestCase):
         self.rcfile = Path(self.root) / "bashrc"
         self.rcfile.write_text("# existing\n", encoding="utf-8")
 
-    def run_setup(self, *replies: str) -> Answers:
+    def run_setup(self, *replies: str, flags: tuple[str, ...] = ()) -> Answers:
         answers = Answers(*replies)
         with mock.patch("builtins.input", answers):
-            main_module.cmd_setup(argparse.Namespace(rcfile=str(self.rcfile)))
+            main_module.cmd_setup(self.setup_args(*flags))
         return answers
+
+    def setup_args(self, *extra: str) -> argparse.Namespace:
+        """`setup`'s arguments as the CLI would really parse them.
+
+        Through `build_parser`, not an `argparse.Namespace` literal. The literal
+        here was missing `shell` entirely and nothing said so, because the code
+        read it with `getattr(args, "shell", None)` and took the absence for
+        "auto" -- the same defect #202 describes in the wizard, in the test that
+        was supposed to be holding the wizard up. Parsing means a flag added to
+        `setup` arrives here with its real default, and one that is misspelled is
+        an error rather than a silent None.
+        """
+        argv = ["setup", "--rcfile", str(self.rcfile), *extra]
+        return main_module.build_parser().parse_args(argv)
+
+
+class Imported(NamedTuple):
+    """One `_import` call the wizard made, as it made it."""
+
+    kind: str
+    path: Path | None
+    dry_run: bool
+    this_host_only: bool
 
 
 def _never_asks(prompt: str = "") -> str:
@@ -138,17 +165,99 @@ class TestWhatItOffersToImport(SetupTestCase):
     def test_only_histories_that_exist_and_hold_something(self) -> None:
         (Path.home() / ".bash_history").write_text("echo hi\n", encoding="utf-8")
         (Path.home() / ".zsh_history").write_text("", encoding="utf-8")  # empty
-        kinds = [kind for kind, _, _ in main_module._importable()]
+        kinds = [kind for kind, _, _ in setup.importable()]
         self.assertEqual(kinds, ["bash"], "an empty history is not worth offering")
 
     def test_the_biggest_is_offered_first(self) -> None:
         (Path.home() / ".bash_history").write_text("x\n", encoding="utf-8")
         (Path.home() / ".zsh_history").write_text("y" * 5000, encoding="utf-8")
-        self.assertEqual([kind for kind, _, _ in main_module._importable()], ["zsh", "bash"])
+        self.assertEqual([kind for kind, _, _ in setup.importable()], ["zsh", "bash"])
 
     def test_nothing_found_is_not_a_failure(self) -> None:
         answers = self.run_setup("")  # only the repository URL is asked
         self.assertEqual(len(answers.asked), 1)
+
+
+class TestSetupAndInstallShareTheirFlags(unittest.TestCase):
+    """What `add_install_flags` is for. No fixture: this only parses argv.
+
+    `--shell` and `--rcfile` were declared twice, six identical lines each, and a
+    flag that reaches `install` but not `setup` leaves the wizard unable to pass
+    something the command accepts -- the forged-namespace defect of #202 one level
+    further down, in the parser. Asserted through parsing rather than by comparing
+    the two `add_argument` calls, so it holds however they are declared.
+    """
+
+    def parse(self, *argv: str) -> argparse.Namespace:
+        return main_module.build_parser().parse_args(list(argv))
+
+    def test_both_commands_take_the_same_shell_values(self) -> None:
+        for shell in ("auto", "bash", "zsh", "both"):
+            with self.subTest(shell=shell):
+                installed = self.parse("install", "--shell", shell, "--rcfile", "/tmp/rc")
+                wizard = self.parse("setup", "--shell", shell, "--rcfile", "/tmp/rc")
+                self.assertEqual((installed.shell, installed.rcfile), (wizard.shell, wizard.rcfile))
+
+    def test_both_default_to_auto(self) -> None:
+        """The default is what `shells_from` reads as "decide for me", so a
+        subcommand that defaulted to None instead would take a different path
+        through it without saying so."""
+        self.assertEqual(self.parse("install").shell, "auto")
+        self.assertEqual(self.parse("setup").shell, "auto")
+
+    def test_both_refuse_a_shell_they_have_no_hook_for(self) -> None:
+        """The `choices` list is the only thing standing between `--shell fish`
+        and `shells_from` quietly falling back to detection -- which installs for
+        a shell the person did not name and reports success."""
+        for command in ("install", "setup"):
+            # argparse writes usage to stderr before exiting; swallowed so a
+            # passing run does not print a fake error.
+            with (
+                self.subTest(command=command),
+                self.assertRaises(SystemExit),
+                contextlib.redirect_stderr(io.StringIO()),
+            ):
+                self.parse(command, "--shell", "fish")
+
+
+class TestWhichShellStepTwoInstalls(SetupTestCase):
+    """`setup` chooses shells through the same rule `install` does, and says which.
+
+    Untested until #202, and a mutation proved it: replacing the wizard's
+    `shells_from(args.shell, args.rcfile)` with a bare `detect_shells()` left the
+    whole suite green, because every fixture here happened to have one shell and
+    no `--shell`. The reason line matters as much as the choice -- a hook written
+    into the shell you do not use looks exactly like a hook that works.
+    """
+
+    def test_shell_zsh_installs_zsh_and_says_that_is_why(self) -> None:
+        self.run_setup("", flags=("--shell", "zsh"))
+        self.assertTrue((store.data_dir() / install.HOOKS["zsh"]).is_file())
+        self.assertFalse(
+            (store.data_dir() / install.HOOKS["bash"]).is_file(),
+            "step 2 installed a shell nobody asked for",
+        )
+
+    def test_the_reason_reaches_the_screen_with_the_flag_in_it(self) -> None:
+        """Through the CLI, so the wiring is in scope.
+
+        The two below call `why_those_shells` directly and would pass against a
+        `cmd_setup` that handed it nothing -- a mutation proved exactly that. This
+        is the one that fails when the arguments stop being threaded.
+        """
+        with (
+            mock.patch("sys.stdin.isatty", return_value=True),
+            mock.patch("builtins.input", Answers("")),
+        ):
+            ran = support.run_cli("setup", "--rcfile", str(self.rcfile), "--shell", "zsh")
+        self.assertEqual(ran.code, 0)
+        self.assertIn("zsh -- --shell zsh", ran.out)
+
+    def test_the_reason_names_the_rcfile_when_that_decided(self) -> None:
+        self.assertEqual(
+            setup.why_those_shells(None, "/somewhere/.zshrc", ["zsh"]),
+            "from the name of .zshrc",
+        )
 
 
 class TestTheAtuinQuestion(SetupTestCase):
@@ -166,13 +275,20 @@ class TestTheAtuinQuestion(SetupTestCase):
         db = Path.home() / ".local/share/atuin/history.db"
         db.parent.mkdir(parents=True, exist_ok=True)
         db.write_bytes(b"x" * 4096)
-        self.imported: list[argparse.Namespace] = []
+        self.imported: list[Imported] = []
 
-        def record(args: argparse.Namespace) -> int:
-            self.imported.append(args)
+        def record(
+            kind: importer.Kind, path: Path | None, *, dry_run: bool, this_host_only: bool
+        ) -> int:
+            self.imported.append(Imported(kind, path, dry_run, this_host_only))
             return 0
 
-        patched = mock.patch.object(main_module, "cmd_import", record)
+        # `_import`, not `cmd_import`: the wizard calls the typed half now, and
+        # the recorded arguments are the ones it really passed rather than an
+        # `argparse.Namespace` it built to look like a command line. A keyword
+        # that stops being passed is a TypeError here, where the Namespace this
+        # replaced would have silently recorded an object without the attribute.
+        patched = mock.patch.object(main_module, "_import", record)
         patched.start()
         self.addCleanup(patched.stop)
 
@@ -220,7 +336,7 @@ class TestItIsSafeToRunTwice(SetupTestCase):
         self.run_setup("")
         self.run_setup("")
         text = self.rcfile.read_text(encoding="utf-8")
-        self.assertEqual(text.count(main_module._BEGIN), 1)
+        self.assertEqual(text.count(install.BEGIN), 1)
 
 
 class TestTheBareCommandOnAFreshMachine(SetupTestCase):
@@ -236,7 +352,7 @@ class TestTheBareCommandOnAFreshMachine(SetupTestCase):
     def test_a_hook_alone_is_enough_to_be_reported_on_instead(self) -> None:
         """Someone who ran `install` and nothing else has set something up, and
         running `setup` at them would answer a question they did not ask."""
-        hook = Path(os.environ["WOSWOAR_DIR"]) / main_module.HOOKS["bash"]
+        hook = Path(os.environ["WOSWOAR_DIR"]) / install.HOOKS["bash"]
         hook.parent.mkdir(parents=True, exist_ok=True)
         hook.write_text("#", encoding="utf-8")
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -25,9 +25,10 @@ from typing import Any, ClassVar
 from unittest import mock
 
 from woswoar import archive, cache, crypto, progress, prove, search, store, sync
-from woswoar.__main__ import HOOKS, main
-from woswoar.__main__ import _hook_bytes as main_hook_bytes
+from woswoar.__main__ import main
 from woswoar.entry import Entry, format_line
+from woswoar.install import HOOKS
+from woswoar.install import hook_bytes as main_hook_bytes
 from woswoar.sync import _GRANT_REMEDY
 from woswoar.sync import COMMIT_MESSAGE as COMMIT
 

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import os
-import re
 import sys
 import textwrap
 from collections import Counter
@@ -12,7 +10,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from . import __version__, cache, importer, search, store
+from . import __version__, cache, importer, install, search, store
 from .entry import make_inert
 from .errors import WoswoarError
 from .report import Check, paragraphs
@@ -20,211 +18,50 @@ from .report import Check, paragraphs
 if TYPE_CHECKING:  # `sync` is imported lazily; only the annotations need it.
     from .sync import Failure, Reader, ReencryptReport
 
-#: The hook each shell sources, and the file each shell reads at the start of an
-#: interactive session. Two hooks rather than one that branches: the bash one is
-#: built on bash 5 builtins and the zsh one on zsh's, and the interesting half of
-#: either is what its shell does *not* offer.
-#:
-#: Ordered, because it decides the order things are printed and installed in, and
-#: a report whose lines move around between runs is harder to diff than it needs
-#: to be.
-HOOKS = {"bash": "woswoar.bash", "zsh": "woswoar.zsh"}
-RCFILES = {"bash": ".bashrc", "zsh": ".zshrc"}
 
-#: What each shell must be able to do, and how to ask it. bash 5 for
-#: $EPOCHSECONDS and $EPOCHREALTIME; zsh 5 for `zsh/datetime` and
-#: `add-zsh-hook`. Each hook enforces its own floor and switches itself off
-#: below it -- this is how `doctor` says the same thing before you find out.
-_VERSION_QUERY = {
-    "bash": "echo ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}",
-    "zsh": "echo $ZSH_VERSION",
-}
-_VERSION_FLOOR = 5
+def _install(shell: str | None, rcfile: str | None) -> int:
+    """Run the install and report it. The half `setup` shares with `install`.
 
-_BEGIN = "# >>> woswoar >>>"
-_END = "# <<< woswoar <<<"
-_BLOCK = re.compile(re.escape(_BEGIN) + r".*?" + re.escape(_END) + r"\n?", re.DOTALL)
+    The command's own two flags, which is what each of these five cores takes --
+    rather than the `argparse.Namespace` `setup` used to forge. Adding a flag to
+    `install` now means adding a parameter here, and mypy says so at the call
+    site that forgot it; a `Namespace` literal never could, because
+    `getattr(args, "shell", None)` swallowed the omission and chose a default.
 
-
-def rcfile_for(shell: str) -> Path:
-    return Path.home() / RCFILES[shell]
-
-
-def installed_shells() -> list[str]:
-    """Every shell this machine has a hook copied for.
-
-    The hooks in the data directory, not what is on PATH and not what
-    `.bashrc` says: `install` writing the file is what makes a shell one woswoar
-    is responsible for, and it is the same fact `_refresh_hook` acts on.
+    The flags raw rather than resolved, which is the second half of the same
+    point. An earlier turn of this had the caller run `shells_from` and expand
+    `~` itself, so both callers repeated two steps and either could have done
+    one of them differently -- mypy sees a `Path` from a forgotten `expanduser`
+    exactly as happily as one from a remembered one. `shells_from` is a few
+    `stat` calls, so the wizard calling it again for its own message is cheaper
+    than the chance of the two disagreeing.
     """
-    return [shell for shell in HOOKS if (store.data_dir() / HOOKS[shell]).is_file()]
+    override = Path(rcfile).expanduser() if rcfile else None
+    done = install.install_hooks(install.shells_from(shell, rcfile))
 
-
-def detect_shells() -> list[str]:
-    """The shells `install` writes to when nobody said which.
-
-    **Every shell whose rc file already exists**, which is the rule that decides
-    the two things this must not do. It must not need a flag from someone who
-    uses both shells -- `install` already edits `.bashrc` without being asked,
-    so an existing `.zshrc` is no different. And it must not *create* a
-    `~/.zshrc` for someone who has never run zsh, which is what "already exists"
-    is doing here and why this is not simply "write both".
-
-    `$SHELL` is the fallback and deliberately not the detector: it names the
-    login shell, and someone whose login shell is zsh but who works in bash
-    would get the hook in the shell they are not typing into. It only decides
-    the case where there is no rc file to go on at all -- a container, a fresh
-    account -- and there bash is the last resort, because it is the shell whose
-    hook has been shipped longest.
-    """
-    present = [shell for shell in HOOKS if rcfile_for(shell).is_file()]
-    if present:
-        return present
-    login = Path(os.environ.get("SHELL", "")).name
-    return [login] if login in HOOKS else ["bash"]
-
-
-def _hook_bytes(shell: str) -> bytes:
-    """The hook as this version ships it.
-
-    The bytes rather than a path, which is what replaced an `as_file` dance
-    here. `as_file` hands back a *temporary* path for a zipped install and
-    deletes it when its context exits, so the previous version of this returned
-    a path that no longer existed and `install` copied from it. Nothing noticed,
-    because nobody installs woswoar as a zipapp -- but `doctor` now compares
-    what is installed against what is packaged, and one function returning one
-    thing is what makes that comparison true by construction rather than by
-    hoping two readers agree.
-
-    Beside this file first, and `importlib.resources` only if that is not
-    there. `resources` costs a measured 8.7 ms to import -- a fifth of an idle
-    sync, which now runs once a minute and calls this every time -- while the
-    package layout puts the hook next to this module in every install that has
-    a filesystem at all, wheel or editable. The fallback is for a zipapp, where
-    `__file__` is a path inside the archive and nothing can open it.
-    """
-    beside = Path(__file__).resolve().parent / "shell" / HOOKS[shell]
-    if beside.is_file():
-        return beside.read_bytes()
-
-    from importlib import resources
-
-    return (resources.files("woswoar") / "shell" / HOOKS[shell]).read_bytes()
-
-
-def portable_hook_path(target: Path) -> str:
-    """The hook's location written so one ``.bashrc`` can serve every machine.
-
-    A literal ``/home/martinus/...`` in the sourced line means the same shared
-    ``.bashrc`` has to differ per machine as soon as two of them disagree about
-    the username -- which is exactly what a dotfiles repo exists to avoid. The
-    part before ``$HOME`` is the only part that varies, so that is the part
-    that becomes a variable.
-
-    Anything outside ``$HOME`` is written absolute: there is nothing portable
-    to say about it, and guessing would be worse than being explicit.
-    """
-    home = Path.home()
-    try:
-        return f"$HOME/{target.relative_to(home).as_posix()}"
-    except ValueError:
-        return str(target)
-
-
-def shells_from(args: argparse.Namespace) -> list[str]:
-    """Which shells this invocation is about.
-
-    `--shell` wins outright. Otherwise `--rcfile` decides, because a file named
-    `.zshrc` is not an ambiguous thing to be handed: taking the *detected* shell
-    there would let someone with a `.bashrc` beside it get the bash hook sourced
-    from their zsh startup file, which loads nothing and says nothing. When the
-    name settles nothing either -- `--rcfile /tmp/rc` -- detection has the only
-    other opinion available.
-    """
-    choice = getattr(args, "shell", None) or "auto"
-    rcfile = getattr(args, "rcfile", None)
-    if rcfile and choice == "both":
-        # Refused rather than resolved, because both resolutions are wrong and
-        # one of them is silent: writing two blocks into one file leaves only
-        # the second, since each replaces the marked block the last one wrote --
-        # so `--rcfile ~/.bashrc --shell both` would end with a `.bashrc`
-        # sourcing the *zsh* hook.
-        raise WoswoarError(
-            "--rcfile names one file, so it cannot be combined with --shell both.\n"
-            "Run install once per shell, or drop --rcfile to use each shell's own rc file."
-        )
-    if choice in HOOKS:
-        return [choice]
-    if choice == "both":
-        return list(HOOKS)
-    if rcfile:
-        named = [shell for shell, name in RCFILES.items() if Path(rcfile).name == name]
-        return named or detect_shells()[:1]
-    return detect_shells()
-
-
-def _write_block(rcfile: Path, target: Path) -> str:
-    """Put the sourced line into ``rcfile``, and say what that did.
-
-    Creating the file when it is absent is correct *here* and only here: a
-    caller has already decided this shell is one to install for, either by
-    detection -- which needs the file to exist -- or because it was named.
-    """
-    block = f'{_BEGIN}\nsource "{portable_hook_path(target)}"\n{_END}\n'
-    existing = rcfile.read_text(encoding="utf-8") if rcfile.is_file() else ""
-    if _BLOCK.search(existing):
-        updated = _BLOCK.sub(block, existing)
-        action = "updated"
-    else:
-        separator = "" if not existing or existing.endswith("\n") else "\n"
-        updated = f"{existing}{separator}\n{block}"
-        action = "added"
-
-    if updated == existing:
-        return "already current"
-    rcfile.write_text(updated, encoding="utf-8")
-    return action
-
-
-def cmd_install(args: argparse.Namespace) -> int:
-    """Set up machine identity, install each shell's hook, and wire up its rcfile."""
-    machine = store.machine()
-    store.private_dir(store.data_dir())
-
-    shells = shells_from(args)
-    targets = {}
-    for shell in shells:
-        target = store.data_dir() / HOOKS[shell]
-        target.write_bytes(_hook_bytes(shell))
-        targets[shell] = target
-    # After the copies, not before: `write_bytes` creates at the ambient umask,
-    # so hardening first would leave the files install itself writes as the ones
-    # its own migration missed. This is also what re-tightens a tree from a
-    # woswoar that predated owner-only directories -- `install` is the command
-    # people re-run to upgrade.
-    store.harden()
-
-    print(f"machine : {machine.name} ({machine.id})")
+    print(f"machine : {done.machine.name} ({done.machine.id})")
     print(f"logs    : {store.logs_dir()}")
-    for shell, target in targets.items():
-        print(f"hook    : {target}" + (f"  ({shell})" if len(shells) > 1 else ""))
+    # `installed` rather than `shell`: the parameter of that name is the *flag*,
+    # which may be None or "both", and rebinding it to the last shell in the loop
+    # is a trap for whoever next needs it after this point.
+    for installed, hook in done.hooks.items():
+        print(f"hook    : {hook}" + (f"  ({installed})" if len(done.hooks) > 1 else ""))
 
-    # One `--rcfile` cannot mean two files, and `shells_from` has already
-    # reduced to a single shell when it was given.
-    override = Path(args.rcfile).expanduser() if getattr(args, "rcfile", None) else None
-    for shell, target in targets.items():
-        rcfile = override if override is not None else rcfile_for(shell)
-        print(f"rcfile  : {rcfile} ({_write_block(rcfile, target)})")
+    # Reported before the rc files are touched, and that ordering is the reason
+    # `install_hooks` and `wire_rcfiles` are two calls: an unwritable `.zshrc`
+    # still leaves a person knowing the hook is there and can be sourced by hand.
+    for rc, action in install.wire_rcfiles(done.hooks, override).values():
+        print(f"rcfile  : {rc} ({action})")
 
     # One line per shell, never `source a b`: a second word there is not a
     # second file to read, it is `$1` for the first one. The pair only ever
     # differ by which shell you are standing in, so each is offered on its own.
-    if len(targets) == 1:
-        print("\nOpen a new shell, or run:  source", *targets.values())
+    if len(done.hooks) == 1:
+        print("\nOpen a new shell, or run:  source", *done.hooks.values())
     else:
         print("\nOpen a new shell. To pick it up in one already open:")
-        for shell, target in targets.items():
-            print(f"    source {target}   # in {shell}")
+        for installed, hook in done.hooks.items():
+            print(f"    source {hook}   # in {installed}")
 
     # The moment someone finds out, so the moment to say it. Recording works
     # without any of these, which is why this warns rather than fails -- but
@@ -235,6 +72,11 @@ def cmd_install(args: argparse.Namespace) -> int:
     if absent:
         print(f"\n{deps.report(absent)}", file=sys.stderr)
     return 0
+
+
+def cmd_install(args: argparse.Namespace) -> int:
+    """Set up machine identity, install each shell's hook, and wire up its rcfile."""
+    return _install(args.shell, args.rcfile)
 
 
 def cmd_list(args: argparse.Namespace) -> int:
@@ -291,17 +133,22 @@ def cmd_search(args: argparse.Namespace) -> int:
 
 
 def cmd_import(args: argparse.Namespace) -> int:
+    return _import(
+        args.kind,
+        Path(args.file).expanduser() if args.file else None,
+        dry_run=args.dry_run,
+        this_host_only=args.this_host_only,
+    )
+
+
+def _import(kind: importer.Kind, path: Path | None, *, dry_run: bool, this_host_only: bool) -> int:
+    """Import one history and report it. Shared with `setup`'s step 3."""
     try:
-        result = importer.run(
-            args.kind,
-            Path(args.file).expanduser() if args.file else None,
-            dry_run=args.dry_run,
-            this_host_only=args.this_host_only,
-        )
+        result = importer.run(kind, path, dry_run=dry_run, this_host_only=this_host_only)
     except FileNotFoundError as exc:
         print(f"woswoar: {exc}", file=sys.stderr)
         return 1
-    prefix = "would import" if args.dry_run else "imported"
+    prefix = "would import" if dry_run else "imported"
     notes = []
     if result.skipped:
         notes.append(f"{result.skipped} already present")
@@ -367,67 +214,6 @@ def cmd_stats(args: argparse.Namespace) -> int:
     return 0
 
 
-def _shell_checks() -> list[Check]:
-    """The installed shells and their versions.
-
-    The shells this machine has hooks for, or -- on one that has not run
-    `install` yet -- the ones it would get if it did. Reporting on every shell
-    woswoar *could* support instead would fail a perfectly good bash-only
-    machine for not having zsh.
-    """
-    out = []
-    for shell in installed_shells() or detect_shells():
-        version = _shell_version(shell)
-        major = int(version.split(".")[0]) if version and version[0].isdigit() else 0
-        out.append(
-            Check(
-                shell,
-                f"{version or 'not found'} ({_VERSION_FLOOR}.0+ required)",
-                ok=major >= _VERSION_FLOOR,
-            )
-        )
-    return out
-
-
-def _hook_checks() -> list[Check]:
-    """Whether each installed hook is current, and whether its rc file loads it.
-
-    `install` copies each hook into the data directory rather than sourcing it
-    out of the package, so upgrading woswoar leaves the old shell code running
-    -- and nothing said so. That was survivable while the hook only recorded;
-    syncing lives in it now, so a machine that never re-ran `install` silently
-    keeps whatever sync arrangement it had.
-    """
-    stale = _stale_hooks()
-    present = installed_shells()
-    out = []
-    if not present:
-        out.append(Check("hook", f"no hook installed in {store.data_dir()}", ok=False))
-    for shell in present:
-        hook = store.data_dir() / HOOKS[shell]
-        if shell in stale:
-            out.append(
-                Check(
-                    "hook",
-                    f"{hook} is older than this woswoar - run 'woswoar install'",
-                    ok=False,
-                )
-            )
-        else:
-            out.append(Check("hook", str(hook), ok=True))
-
-    # One line per rc file, and per *installed* shell rather than per rc file
-    # that exists: a `.zshrc` on a machine woswoar was only ever installed into
-    # bash for is not a problem, and reporting it as one would send someone
-    # looking for a block that is correctly absent.
-    for shell in present or detect_shells():
-        rcfile = rcfile_for(shell)
-        sourced = rcfile.is_file() and _BEGIN in rcfile.read_text(encoding="utf-8")
-        detail = "sources the hook" if sourced else "has no woswoar block"
-        out.append(Check(RCFILES[shell].lstrip("."), f"{rcfile} {detail}", ok=sourced))
-    return out
-
-
 def cmd_doctor(args: argparse.Namespace) -> int:
     """Render what `doctor` found. Every verdict below is decided elsewhere.
 
@@ -473,10 +259,10 @@ def cmd_doctor(args: argparse.Namespace) -> int:
             return 1
         return 0
 
-    show(_shell_checks())
+    show(install.shell_checks())
     show(doctor.fzf_check())
     show(doctor.machine_check())
-    show(_hook_checks())
+    show(install.hook_checks())
     show(doctor.age_check())
     show(doctor.identity_check())
     show(doctor.repo_checks())
@@ -489,15 +275,23 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
 
 def cmd_init(args: argparse.Namespace) -> int:
-    from . import archive, crypto, sync
-
-    known, identity, pinned = sync.initialise(
-        remote=args.remote,
+    return _init(
+        args.remote,
         new_identity=args.new_identity,
         identity=Path(args.identity).expanduser() if args.identity else None,
+        no_sync=args.no_sync,
+    )
+
+
+def _init(remote: str | None, *, new_identity: bool, identity: Path | None, no_sync: bool) -> int:
+    """Join a history repo and report it. Shared with `setup`'s step 4."""
+    from . import archive, crypto, sync
+
+    known, identity_used, pinned = sync.initialise(
+        remote=remote, new_identity=new_identity, identity=identity
     )
     print(f"machine  : {known.name} ({known.id})")
-    print(f"identity : {identity}")
+    print(f"identity : {identity_used}")
     print(f"repo     : {store.history_dir()}")
     print(f"remote   : {sync.remote_summary()}")
     print(f"\nRecipients now enrolled ({archive.recipients_file()}):")
@@ -515,7 +309,7 @@ def cmd_init(args: argparse.Namespace) -> int:
             print(f"  {crypto.fingerprint(verify_key)}")
         print("Check these against the machines themselves if the repository is shared.")
 
-    if not args.remote:
+    if not remote:
         return 0
 
     # The sync `init` used to tell you to run. Nothing about it is a separate
@@ -523,7 +317,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     # is not a state anyone wants -- and leaving it to a second command meant
     # the machine published nothing until one was run. `--no-sync` is there for
     # the case where the remote is not reachable yet.
-    if args.no_sync:
+    if no_sync:
         print("\nNext: 'woswoar sync'.")
     else:
         print()
@@ -562,12 +356,18 @@ def cmd_init(args: argparse.Namespace) -> int:
 
 
 def cmd_sync(args: argparse.Namespace) -> int:
+    return _sync(no_push=args.no_push)
+
+
+def _sync(*, no_push: bool) -> int:
+    """Sync and report it. Shared with `setup`'s step 4."""
     from . import sync
 
     # Before the sync, not after: a remote that is unreachable must not be able
     # to keep the hook out of date, and these two have nothing to do with each
     # other beyond both being things this command is well placed to do.
-    _refresh_hook()
+    for hook in install.refresh_hook():
+        print(f"updated the shell hook at {hook} to {__version__}")
 
     # The shell hook fires this detached, with its output going nowhere, so a
     # failure has to be left somewhere the bare `woswoar` can find it.
@@ -585,7 +385,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
     # by the person it was for.
     watched = sys.stderr.isatty()
     try:
-        report = sync.run(push=not args.no_push)
+        report = sync.run(push=not no_push)
     except Exception as exc:
         if not watched:
             sync.record_failure(str(exc) or exc.__class__.__name__)
@@ -701,104 +501,8 @@ def cmd_grant(args: argparse.Namespace) -> int:
     return 0
 
 
-def _shell_version(shell: str) -> str:
-    """What ``shell`` reports as its version, or "" if it cannot be asked.
-
-    Asked of the binary rather than read from a package manager, because the
-    thing that matters is the one that will source the hook. Every failure --
-    not on PATH, refuses to start, times out -- collapses to "" and is reported
-    as "not found": from `doctor`'s side those are one situation, and the
-    remedy for all of them is to install the shell.
-    """
-    import shutil
-    import subprocess
-
-    binary = shutil.which(shell)
-    if not binary:
-        return ""
-    try:
-        out = subprocess.run(
-            [binary, "-c", _VERSION_QUERY[shell]],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=5,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return ""
-    return out.stdout.strip()
-
-
-def _stale_hooks() -> list[str]:
-    """Every *installed* shell whose hook is some older woswoar's copy of it.
-
-    Installed, so a missing hook is never stale: that is a different problem
-    with a different fix, and `doctor` already has a line for it. It is also the
-    whole of what keeps `_refresh_hook` from planting a zsh hook on a machine
-    that has never asked for one.
-    """
-    return [
-        shell
-        for shell in installed_shells()
-        if (store.data_dir() / HOOKS[shell]).read_bytes() != _hook_bytes(shell)
-    ]
-
-
-def _hook_is_stale() -> bool:
-    return bool(_stale_hooks())
-
-
-def _refresh_hook() -> bool:
-    """Bring the installed hook up to this version, if it is behind.
-
-    `install` copies the hook rather than sourcing it out of the package, so
-    upgrading the program used to leave the old shell code running until
-    somebody re-ran `install`. Since the hook now starts a `woswoar sync` about
-    once a minute, that sync is the thing best placed to notice -- an upgrade
-    heals itself within a minute and the reinstall step goes away.
-
-    Deliberately *not* a symlink into the installed package, which was the first
-    idea and is worse. That path contains the Python version
-    (`.../lib/python3.14/site-packages/...`), so a distribution's Python bump or
-    a `pipx reinstall` leaves it dangling -- and a dangling `source` prints an
-    error at every shell start and switches recording off, where a merely stale
-    hook still records and still searches. It would also make `doctor` report
-    the packaged file's mode as an exposure, because its permission walk uses
-    `stat`, which follows links.
-
-    Only ever *re*-writes, and now that there are two hooks that rule is
-    load-bearing rather than tidy. This runs unattended, from a background sync
-    a prompt started. A version of it that *created* would put a `woswoar.zsh`
-    on a bash-only machine at the first sync after an upgrade -- a file nothing
-    sources, that nobody asked for, from a command nobody ran. `_stale_hooks`
-    only ever names hooks that are already there, and
-    `test_a_refresh_never_creates_a_second_hook` is what holds that.
-    """
-    refreshed = []
-    for shell in _stale_hooks():
-        hook = store.data_dir() / HOOKS[shell]
-        # The mode was set when `install` created it and `write_bytes` truncates
-        # rather than recreates, so it survives -- and the hook is public code
-        # anyway. Failure is not fatal: a read-only data directory is a real
-        # situation and it must not stop the sync this command exists for. Per
-        # hook, so one unwritable file does not stop the other being fixed.
-        try:
-            hook.write_bytes(_hook_bytes(shell))
-        except OSError:
-            continue
-        refreshed.append(hook)
-    if not refreshed:
-        return False
-    # Shells already running keep the code they sourced, exactly as they do
-    # after a hand-run `install`. New ones get this. Nothing to do about the
-    # difference, and nothing anyone needs to do.
-    for hook in refreshed:
-        print(f"updated the shell hook at {hook} to {__version__}")
-    return True
-
-
 def _report_stale_hook() -> None:
-    if not _hook_is_stale():
+    if not install.hook_is_stale():
         return
     print(
         "\nThe shell hook here was installed by an older woswoar, so this"
@@ -975,65 +679,6 @@ def cmd_trust(args: argparse.Namespace) -> int:
     return 0
 
 
-def _ask(question: str, default: str = "") -> str:
-    """Free text, with a default shown. Empty answer takes the default."""
-    shown = f" [{default}]" if default else ""
-    return input(f"{question}{shown}: ").strip() or default
-
-
-def _ask_yes(question: str, default: bool = True) -> bool:
-    """A yes/no with a default, for questions that change nothing dangerous.
-
-    Deliberately not `_confirm`: that one is a security control with an
-    `isatty` branch and a fixed refusal message about widening access. These
-    are "shall I install the shell hook" -- reusing the access gate for them
-    would blunt the thing it is for.
-    """
-    hint = "[Y/n]" if default else "[y/N]"
-    answer = input(f"{question} {hint} ").strip().lower()
-    if not answer:
-        return default
-    return answer in ("y", "yes")
-
-
-#: What `setup` offers to import, in the order it offers them. `importer` owns
-#: where each one lives; this only asks whether it is there.
-def _importable() -> list[tuple[str, Path, int]]:
-    """``(kind, path, size)`` for each history on this machine, largest first."""
-    from . import importer
-
-    found = []
-    for kind in importer.KINDS:
-        path = importer.atuin_db() if kind == "atuin" else importer.default_path(kind)
-        try:
-            size = path.stat().st_size
-        except OSError:
-            continue
-        if size:
-            found.append((kind, path, size))
-    return sorted(found, key=lambda item: item[2], reverse=True)
-
-
-def _untouched() -> bool:
-    """Is there nothing here at all yet?
-
-    Three cheap questions, and it takes any of them as a yes: the shell hook,
-    a history repo, or a single recorded line. Not "has `install` run" -- a
-    machine that imported a history without wiring the hook, or joined a repo
-    without it, is set up enough to be told where it stands, and running `setup`
-    at it would be answering a question it did not ask.
-
-    `store.machine_file` is deliberately not one of them: `store.machine()`
-    creates it, so almost any command makes it exist and it says nothing about
-    whether anyone has set anything up.
-    """
-    from . import sync
-
-    if installed_shells() or sync.is_repo():
-        return False
-    return not any(store.iter_log_files())
-
-
 def cmd_status(args: argparse.Namespace) -> int:
     """`woswoar` on its own: where you are, and the one command to run next.
 
@@ -1052,11 +697,11 @@ def cmd_status(args: argparse.Namespace) -> int:
     `setup` is the exception, and only when nothing is installed: it is all
     questions already, and there is nothing here yet to widen access to.
     """
-    from . import cache, sync
+    from . import cache, setup, sync
 
-    if _untouched():
+    if setup.untouched():
         print("Nothing installed here yet -- setting up.\n")
-        return cmd_setup(argparse.Namespace(rcfile=None, shell=None))
+        return _setup(shell=None, rcfile=None)
 
     loaded = cache.load_columns()
     stamps, _ = loaded.stamps_and_commands()
@@ -1131,8 +776,17 @@ def cmd_status(args: argparse.Namespace) -> int:
 
 
 def cmd_setup(args: argparse.Namespace) -> int:
-    """Walk a fresh machine through the whole thing, asking as it goes."""
-    from . import deps
+    return _setup(args.shell, args.rcfile)
+
+
+def _setup(shell: str | None, rcfile: str | None) -> int:
+    """Walk a fresh machine through the whole thing, asking as it goes.
+
+    The wizard's *dispatch*: which command runs, in what order, and what it is
+    handed. The questions and the prose are here too; `setup` holds what the
+    wizard works out without asking -- see that module for where the line falls.
+    """
+    from . import deps, setup
 
     if not sys.stdin.isatty():
         # It asks questions, so it cannot run unattended -- and silently
@@ -1153,7 +807,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
     absent = deps.missing()
     if absent:
         print(f"     {deps.report(absent)}")
-        if not _ask_yes("     Carry on without them?", default=False):
+        if not setup.ask_yes("     Carry on without them?", default=False):
             return 1
     else:
         print("     everything woswoar needs is installed")
@@ -1161,42 +815,28 @@ def cmd_setup(args: argparse.Namespace) -> int:
     print("\n2/4  Shell hook")
     # Named before it is written, because it is now more than one file and the
     # rule that chose them is not obvious from the output alone.
-    chosen = shells_from(args)
-    print(f"     {' and '.join(chosen)} -- {_why_those_shells(args, chosen)}")
-    cmd_install(argparse.Namespace(rcfile=args.rcfile, shell=getattr(args, "shell", None)))
+    chosen = install.shells_from(shell, rcfile)
+    print(f"     {' and '.join(chosen)} -- {setup.why_those_shells(shell, rcfile, chosen)}")
+    _install(shell, rcfile)
 
     print("\n3/4  Existing history")
     _offer_imports()
 
     print("\n4/4  Sync with your other machines")
-    return _offer_remote(args)
-
-
-def _why_those_shells(args: argparse.Namespace, chosen: list[str]) -> str:
-    """One clause saying which rule picked `chosen`, for `setup`'s step 2.
-
-    Worth a line because the answer differs per machine and the wrong one is
-    silent: a hook written into the shell you do not use looks exactly like a
-    hook that works.
-    """
-    if getattr(args, "shell", None) and args.shell != "auto":
-        return f"--shell {args.shell}"
-    if getattr(args, "rcfile", None):
-        return f"from the name of {Path(args.rcfile).name}"
-    if any(rcfile_for(shell).is_file() for shell in chosen):
-        return "found " + " and ".join(f"~/{RCFILES[shell]}" for shell in chosen)
-    return f"no rc file here, so $SHELL ({os.environ.get('SHELL', 'unset')})"
+    return _offer_remote()
 
 
 def _offer_imports() -> None:
     """Offer each history found on this machine, one at a time."""
-    found = _importable()
+    from . import setup
+
+    found = setup.importable()
     if not found:
         print("     nothing to import (no bash, zsh or atuin history found)")
         return
 
     for kind, path, size in found:
-        if not _ask_yes(f"     Import {kind} history from {path} ({size / 1e6:.1f} MB)?"):
+        if not setup.ask_yes(f"     Import {kind} history from {path} ({size / 1e6:.1f} MB)?"):
             continue
         this_host_only = False
         if kind == "atuin":
@@ -1211,21 +851,17 @@ def _offer_imports() -> None:
                 "       this one's here and let each machine import its own --\n"
                 "       otherwise every machine stores every other machine twice."
             )
-            this_host_only = _ask_yes("       Import only this machine's history?")
-        cmd_import(
-            argparse.Namespace(
-                kind=kind, file=str(path), dry_run=False, this_host_only=this_host_only
-            )
-        )
+            this_host_only = setup.ask_yes("       Import only this machine's history?")
+        _import(kind, path, dry_run=False, this_host_only=this_host_only)
 
 
-def _offer_remote(args: argparse.Namespace) -> int:
+def _offer_remote() -> int:
     """Join a history repo, or finish without one."""
-    from . import sync
+    from . import setup, sync
 
     if sync.is_repo():
         print("     already joined a history repo; syncing")
-        return cmd_sync(argparse.Namespace(no_push=False))
+        return _sync(no_push=False)
 
     print(
         "     woswoar syncs through an ordinary git repository you own -- an\n"
@@ -1233,17 +869,15 @@ def _offer_remote(args: argparse.Namespace) -> int:
         "     There is no server and no account. Leave blank to stay on this\n"
         "     machine only; you can run 'woswoar init <url>' any time later."
     )
-    remote = _ask("     Repository URL")
+    remote = setup.ask("     Repository URL")
     if not remote:
         print("\n     Staying local. Open a new shell and press Ctrl-R.")
         return 0
 
-    # Through `cmd_init`, so the sequence has one source of truth: whatever it
-    # prints as the next step is what someone following this reads, and there
-    # is no second copy here to disagree with it.
-    return cmd_init(
-        argparse.Namespace(remote=remote, new_identity=False, identity=None, no_sync=False)
-    )
+    # Through the same function `woswoar init` runs, so the sequence has one
+    # source of truth: whatever it prints as the next step is what someone
+    # following this reads, and there is no second copy here to disagree.
+    return _init(remote, new_identity=False, identity=None, no_sync=False)
 
 
 def cmd_accept(args: argparse.Namespace) -> int:
@@ -1434,6 +1068,23 @@ def build_parser() -> argparse.ArgumentParser:
             aliases=aliases or [],
         )
 
+    def add_install_flags(sub: argparse.ArgumentParser) -> None:
+        """The two flags `install` and `setup` share, declared once.
+
+        They were the same six lines twice, and #202 had to edit both copies to
+        reach `install.HOOKS` -- which is the parser-level version of the forged
+        namespaces that issue is about: a flag added to one and not the other
+        leaves the wizard unable to pass something `install` accepts.
+        """
+        sub.add_argument("--rcfile", help="file to modify (default: the rc file of each shell)")
+        sub.add_argument(
+            "--shell",
+            choices=["auto", *install.HOOKS, "both"],
+            default="auto",
+            help="which shell(s) to install for (default: auto -- every shell whose "
+            "rc file already exists, or $SHELL when there is none)",
+        )
+
     def add_scope(sub: argparse.ArgumentParser) -> None:
         sub.add_argument("--scope", choices=search.SCOPES, default="global")
         sub.add_argument(
@@ -1558,14 +1209,7 @@ def build_parser() -> argparse.ArgumentParser:
         instead rather than choosing for you.
         """,
     )
-    p_setup.add_argument("--rcfile", help="file to modify (default: the rc file of each shell)")
-    p_setup.add_argument(
-        "--shell",
-        choices=["auto", *HOOKS, "both"],
-        default="auto",
-        help="which shell(s) to install for (default: auto -- every shell whose "
-        "rc file already exists, or $SHELL when there is none)",
-    )
+    add_install_flags(p_setup)
     p_setup.set_defaults(func=cmd_setup)
 
     p_install = sub(
@@ -1584,14 +1228,7 @@ def build_parser() -> argparse.ArgumentParser:
         Reports any missing tool (fzf, age, git) and the command to install it.
         """,
     )
-    p_install.add_argument("--rcfile", help="file to modify (default: the rc file of each shell)")
-    p_install.add_argument(
-        "--shell",
-        choices=["auto", *HOOKS, "both"],
-        default="auto",
-        help="which shell(s) to install for (default: auto -- every shell whose "
-        "rc file already exists, or $SHELL when there is none)",
-    )
+    add_install_flags(p_install)
     p_install.set_defaults(func=cmd_install)
 
     p_stats = sub(

--- a/woswoar/doctor.py
+++ b/woswoar/doctor.py
@@ -12,10 +12,11 @@ here writes to a stream, and nothing here decides what a marker looks like;
 `report` owns that.
 
 The checks the *installer* owns -- which shell, whether the hook is current,
-whether the rc file sources it -- are still built in `__main__`, because the
-installer itself is. They are spliced in by `cmd_doctor`, which is where the
-order of the whole report lives. When #202 lifts the installer out, they can
-move beside these.
+whether the rc file sources it -- live in `install` rather than here, because
+they are its judgements and it owns the constants they are stated against. Both
+sets are spliced together by `cmd_doctor`, which is where the order of the whole
+report lives: the shell version leads, and the hook and rc file come between
+`machine` and `age`.
 """
 
 from __future__ import annotations

--- a/woswoar/install.py
+++ b/woswoar/install.py
@@ -1,0 +1,415 @@
+"""Installing the shell hook, and keeping it current.
+
+Everything about which shells woswoar is responsible for on this machine, what
+their hooks should contain, and how the rc files find them. It decides; the CLI
+prints. Nothing here writes to a stream.
+
+That mattered enough to be worth a module. `refresh_hook` is **policy that runs
+unattended**: the hook starts a `woswoar sync` about once a minute, and that sync
+rewrites the hook file when it is behind. Its rule -- only ever *re*-write, never
+create -- was held by one test asserting on the CLI's stdout, which is a thin
+thread for the one function here that edits a file nobody asked it to.
+
+The two `Check` producers are here for the reason `doctor` records: they are the
+installer's judgements, and they lived in `__main__` only because the installer
+did. `cmd_doctor` splices them into the middle of its report, because the shell
+version leads and the rc file comes between `machine` and `age`.
+
+`hook_bytes` is deliberately one function returning bytes, and must stay that
+way -- see its docstring for the `as_file` trap that shape exists to close.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+from . import store
+from .errors import WoswoarError
+from .report import Check
+from .store import Machine
+
+#: The hook each shell sources, and the file each shell reads at the start of an
+#: interactive session. Two hooks rather than one that branches: the bash one is
+#: built on bash 5 builtins and the zsh one on zsh's, and the interesting half of
+#: either is what its shell does *not* offer.
+#:
+#: Ordered, because it decides the order things are printed and installed in, and
+#: a report whose lines move around between runs is harder to diff than it needs
+#: to be.
+HOOKS = {"bash": "woswoar.bash", "zsh": "woswoar.zsh"}
+RCFILES = {"bash": ".bashrc", "zsh": ".zshrc"}
+
+#: What each shell must be able to do, and how to ask it. bash 5 for
+#: $EPOCHSECONDS and $EPOCHREALTIME; zsh 5 for `zsh/datetime` and
+#: `add-zsh-hook`. Each hook enforces its own floor and switches itself off
+#: below it -- this is how `doctor` says the same thing before you find out.
+_VERSION_QUERY = {
+    "bash": "echo ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}",
+    "zsh": "echo $ZSH_VERSION",
+}
+_VERSION_FLOOR = 5
+
+BEGIN = "# >>> woswoar >>>"
+_END = "# <<< woswoar <<<"
+_BLOCK = re.compile(re.escape(BEGIN) + r".*?" + re.escape(_END) + r"\n?", re.DOTALL)
+
+
+def rcfile_for(shell: str) -> Path:
+    return Path.home() / RCFILES[shell]
+
+
+def installed_shells() -> list[str]:
+    """Every shell this machine has a hook copied for.
+
+    The hooks in the data directory, not what is on PATH and not what
+    `.bashrc` says: `install` writing the file is what makes a shell one woswoar
+    is responsible for, and it is the same fact `refresh_hook` acts on.
+    """
+    return [shell for shell in HOOKS if (store.data_dir() / HOOKS[shell]).is_file()]
+
+
+def detect_shells() -> list[str]:
+    """The shells `install` writes to when nobody said which.
+
+    **Every shell whose rc file already exists**, which is the rule that decides
+    the two things this must not do. It must not need a flag from someone who
+    uses both shells -- `install` already edits `.bashrc` without being asked,
+    so an existing `.zshrc` is no different. And it must not *create* a
+    `~/.zshrc` for someone who has never run zsh, which is what "already exists"
+    is doing here and why this is not simply "write both".
+
+    `$SHELL` is the fallback and deliberately not the detector: it names the
+    login shell, and someone whose login shell is zsh but who works in bash
+    would get the hook in the shell they are not typing into. It only decides
+    the case where there is no rc file to go on at all -- a container, a fresh
+    account -- and there bash is the last resort, because it is the shell whose
+    hook has been shipped longest.
+    """
+    present = [shell for shell in HOOKS if rcfile_for(shell).is_file()]
+    if present:
+        return present
+    login = Path(os.environ.get("SHELL", "")).name
+    return [login] if login in HOOKS else ["bash"]
+
+
+def hook_bytes(shell: str) -> bytes:
+    """The hook as this version ships it.
+
+    The bytes rather than a path, which is what replaced an `as_file` dance
+    here. `as_file` hands back a *temporary* path for a zipped install and
+    deletes it when its context exits, so the previous version of this returned
+    a path that no longer existed and `install` copied from it. Nothing noticed,
+    because nobody installs woswoar as a zipapp -- but `doctor` now compares
+    what is installed against what is packaged, and one function returning one
+    thing is what makes that comparison true by construction rather than by
+    hoping two readers agree.
+
+    Beside this file first, and `importlib.resources` only if that is not
+    there. `resources` costs a measured 8.7 ms to import -- a fifth of an idle
+    sync, which now runs once a minute and calls this every time -- while the
+    package layout puts the hook next to this module in every install that has
+    a filesystem at all, wheel or editable. The fallback is for a zipapp, where
+    `__file__` is a path inside the archive and nothing can open it.
+    """
+    beside = Path(__file__).resolve().parent / "shell" / HOOKS[shell]
+    if beside.is_file():
+        return beside.read_bytes()
+
+    from importlib import resources
+
+    return (resources.files("woswoar") / "shell" / HOOKS[shell]).read_bytes()
+
+
+def portable_hook_path(target: Path) -> str:
+    """The hook's location written so one ``.bashrc`` can serve every machine.
+
+    A literal ``/home/martinus/...`` in the sourced line means the same shared
+    ``.bashrc`` has to differ per machine as soon as two of them disagree about
+    the username -- which is exactly what a dotfiles repo exists to avoid. The
+    part before ``$HOME`` is the only part that varies, so that is the part
+    that becomes a variable.
+
+    Anything outside ``$HOME`` is written absolute: there is nothing portable
+    to say about it, and guessing would be worse than being explicit.
+    """
+    home = Path.home()
+    try:
+        return f"$HOME/{target.relative_to(home).as_posix()}"
+    except ValueError:
+        return str(target)
+
+
+def shells_from(choice: str | None, rcfile: str | None) -> list[str]:
+    """Which shells this invocation is about.
+
+    `--shell` wins outright. Otherwise `--rcfile` decides, because a file named
+    `.zshrc` is not an ambiguous thing to be handed: taking the *detected* shell
+    there would let someone with a `.bashrc` beside it get the bash hook sourced
+    from their zsh startup file, which loads nothing and says nothing. When the
+    name settles nothing either -- `--rcfile /tmp/rc` -- detection has the only
+    other opinion available.
+
+    Two plain arguments rather than the `argparse.Namespace` this used to take.
+    It read them with `getattr(args, "shell", None)`, so a caller that did not
+    have the flag got a silent "auto" instead of an error -- the same thing #202
+    is about, one layer down from the forged namespaces.
+    """
+    choice = choice or "auto"
+    if rcfile and choice == "both":
+        # Refused rather than resolved, because both resolutions are wrong and
+        # one of them is silent: writing two blocks into one file leaves only
+        # the second, since each replaces the marked block the last one wrote --
+        # so `--rcfile ~/.bashrc --shell both` would end with a `.bashrc`
+        # sourcing the *zsh* hook.
+        raise WoswoarError(
+            "--rcfile names one file, so it cannot be combined with --shell both.\n"
+            "Run install once per shell, or drop --rcfile to use each shell's own rc file."
+        )
+    if choice in HOOKS:
+        return [choice]
+    if choice == "both":
+        return list(HOOKS)
+    if rcfile:
+        named = [shell for shell, name in RCFILES.items() if Path(rcfile).name == name]
+        return named or detect_shells()[:1]
+    return detect_shells()
+
+
+def write_block(rcfile: Path, target: Path) -> str:
+    """Put the sourced line into ``rcfile``, and say what that did.
+
+    Creating the file when it is absent is correct *here* and only here: a
+    caller has already decided this shell is one to install for, either by
+    detection -- which needs the file to exist -- or because it was named.
+    """
+    block = f'{BEGIN}\nsource "{portable_hook_path(target)}"\n{_END}\n'
+    existing = rcfile.read_text(encoding="utf-8") if rcfile.is_file() else ""
+    if _BLOCK.search(existing):
+        updated = _BLOCK.sub(block, existing)
+        action = "updated"
+    else:
+        separator = "" if not existing or existing.endswith("\n") else "\n"
+        updated = f"{existing}{separator}\n{block}"
+        action = "added"
+
+    if updated == existing:
+        return "already current"
+    rcfile.write_text(updated, encoding="utf-8")
+    return action
+
+
+def shell_version(shell: str) -> str:
+    """What ``shell`` reports as its version, or "" if it cannot be asked.
+
+    Asked of the binary rather than read from a package manager, because the
+    thing that matters is the one that will source the hook. Every failure --
+    not on PATH, refuses to start, times out -- collapses to "" and is reported
+    as "not found": from `doctor`'s side those are one situation, and the
+    remedy for all of them is to install the shell.
+    """
+    import shutil
+    import subprocess
+
+    binary = shutil.which(shell)
+    if not binary:
+        return ""
+    try:
+        out = subprocess.run(
+            [binary, "-c", _VERSION_QUERY[shell]],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return out.stdout.strip()
+
+
+def stale_hooks() -> list[str]:
+    """Every *installed* shell whose hook is some older woswoar's copy of it.
+
+    Installed, so a missing hook is never stale: that is a different problem
+    with a different fix, and `doctor` already has a line for it. It is also the
+    whole of what keeps `refresh_hook` from planting a zsh hook on a machine
+    that has never asked for one.
+    """
+    return [
+        shell
+        for shell in installed_shells()
+        if (store.data_dir() / HOOKS[shell]).read_bytes() != hook_bytes(shell)
+    ]
+
+
+def hook_is_stale() -> bool:
+    return bool(stale_hooks())
+
+
+def refresh_hook() -> list[Path]:
+    """Bring the installed hook up to this version, if it is behind.
+
+    Returns the hooks it rewrote, and prints nothing: this runs unattended from a
+    background sync, and what to say about it is the caller's -- `cmd_sync` is
+    the only one that has a person in front of it.
+
+    `install` copies the hook rather than sourcing it out of the package, so
+    upgrading the program used to leave the old shell code running until
+    somebody re-ran `install`. Since the hook now starts a `woswoar sync` about
+    once a minute, that sync is the thing best placed to notice -- an upgrade
+    heals itself within a minute and the reinstall step goes away.
+
+    Deliberately *not* a symlink into the installed package, which was the first
+    idea and is worse. That path contains the Python version
+    (`.../lib/python3.14/site-packages/...`), so a distribution's Python bump or
+    a `pipx reinstall` leaves it dangling -- and a dangling `source` prints an
+    error at every shell start and switches recording off, where a merely stale
+    hook still records and still searches. It would also make `doctor` report
+    the packaged file's mode as an exposure, because its permission walk uses
+    `stat`, which follows links.
+
+    Only ever *re*-writes, and now that there are two hooks that rule is
+    load-bearing rather than tidy. This runs unattended, from a background sync
+    a prompt started. A version of it that *created* would put a `woswoar.zsh`
+    on a bash-only machine at the first sync after an upgrade -- a file nothing
+    sources, that nobody asked for, from a command nobody ran. `stale_hooks`
+    only ever names hooks that are already there, and
+    `test_a_refresh_never_creates_a_second_hook` is what holds that.
+    """
+    refreshed = []
+    for shell in stale_hooks():
+        hook = store.data_dir() / HOOKS[shell]
+        # The mode was set when `install` created it and `write_bytes` truncates
+        # rather than recreates, so it survives -- and the hook is public code
+        # anyway. Failure is not fatal: a read-only data directory is a real
+        # situation and it must not stop the sync this command exists for. Per
+        # hook, so one unwritable file does not stop the other being fixed.
+        try:
+            hook.write_bytes(hook_bytes(shell))
+        except OSError:
+            continue
+        # Shells already running keep the code they sourced, exactly as they do
+        # after a hand-run `install`. New ones get this. Nothing to do about the
+        # difference, and nothing anyone needs to do.
+        refreshed.append(hook)
+    return refreshed
+
+
+def shell_checks() -> list[Check]:
+    """The installed shells and their versions.
+
+    The shells this machine has hooks for, or -- on one that has not run
+    `install` yet -- the ones it would get if it did. Reporting on every shell
+    woswoar *could* support instead would fail a perfectly good bash-only
+    machine for not having zsh.
+    """
+    out = []
+    for shell in installed_shells() or detect_shells():
+        version = shell_version(shell)
+        major = int(version.split(".")[0]) if version and version[0].isdigit() else 0
+        out.append(
+            Check(
+                shell,
+                f"{version or 'not found'} ({_VERSION_FLOOR}.0+ required)",
+                ok=major >= _VERSION_FLOOR,
+            )
+        )
+    return out
+
+
+def hook_checks() -> list[Check]:
+    """Whether each installed hook is current, and whether its rc file loads it.
+
+    `install` copies each hook into the data directory rather than sourcing it
+    out of the package, so upgrading woswoar leaves the old shell code running
+    -- and nothing said so. That was survivable while the hook only recorded;
+    syncing lives in it now, so a machine that never re-ran `install` silently
+    keeps whatever sync arrangement it had.
+    """
+    stale = stale_hooks()
+    present = installed_shells()
+    out = []
+    if not present:
+        out.append(Check("hook", f"no hook installed in {store.data_dir()}", ok=False))
+    for shell in present:
+        hook = store.data_dir() / HOOKS[shell]
+        if shell in stale:
+            out.append(
+                Check(
+                    "hook",
+                    f"{hook} is older than this woswoar - run 'woswoar install'",
+                    ok=False,
+                )
+            )
+        else:
+            out.append(Check("hook", str(hook), ok=True))
+
+    # One line per rc file, and per *installed* shell rather than per rc file
+    # that exists: a `.zshrc` on a machine woswoar was only ever installed into
+    # bash for is not a problem, and reporting it as one would send someone
+    # looking for a block that is correctly absent.
+    for shell in present or detect_shells():
+        rcfile = rcfile_for(shell)
+        sourced = rcfile.is_file() and BEGIN in rcfile.read_text(encoding="utf-8")
+        detail = "sources the hook" if sourced else "has no woswoar block"
+        out.append(Check(RCFILES[shell].lstrip("."), f"{rcfile} {detail}", ok=sourced))
+    return out
+
+
+class Installed(NamedTuple):
+    """Where this machine's hooks are, and whose machine it is.
+
+    A value rather than the prints that used to be interleaved with the work.
+    `setup` shows the same install as `woswoar install` does, and before this it
+    got there by forging an `argparse.Namespace` and calling the CLI command --
+    so the two could only ever agree by both going through argparse.
+    """
+
+    machine: Machine
+    #: shell -> the hook copied into the data directory. Ordered as installed,
+    #: which is the order it is reported in.
+    hooks: dict[str, Path]
+
+
+def install_hooks(shells: list[str]) -> Installed:
+    """Copy each shell's hook into the data directory.
+
+    Half of an install. `wire_rcfiles` is the other half and is deliberately a
+    second call: the caller reports the hooks between the two, so an rc file that
+    cannot be written still leaves a person knowing the hook itself landed. That
+    was the order the prints were in when this was one function in the CLI, and
+    it is the useful one -- the hook is what records, and sourcing it by hand is
+    a workaround someone can act on.
+    """
+    machine = store.machine()
+    store.private_dir(store.data_dir())
+
+    hooks = {}
+    for shell in shells:
+        target = store.data_dir() / HOOKS[shell]
+        target.write_bytes(hook_bytes(shell))
+        hooks[shell] = target
+    # After the copies, not before: `write_bytes` creates at the ambient umask,
+    # so hardening first would leave the files install itself writes as the ones
+    # its own migration missed. This is also what re-tightens a tree from a
+    # woswoar that predated owner-only directories -- `install` is the command
+    # people re-run to upgrade.
+    store.harden()
+    return Installed(machine, hooks)
+
+
+def wire_rcfiles(hooks: dict[str, Path], rcfile: Path | None = None) -> dict[str, tuple[Path, str]]:
+    """Make each shell's startup file load its hook. shell -> (file, what changed).
+
+    `rcfile` overrides every shell's own, and a caller that passes one has
+    already reduced `hooks` to a single entry -- `shells_from` refuses the
+    combination, because one file cannot hold two shells' blocks: each replaces
+    the marked block the last one wrote.
+    """
+    out = {}
+    for shell, target in hooks.items():
+        chosen = rcfile if rcfile is not None else rcfile_for(shell)
+        out[shell] = (chosen, write_block(chosen, target))
+    return out

--- a/woswoar/setup.py
+++ b/woswoar/setup.py
@@ -1,0 +1,115 @@
+"""What `woswoar setup` works out without asking, and the two ways it asks.
+
+Small on purpose, and worth being exact about what is here, because the obvious
+reading of the name is wrong: this is **not** the wizard. The questions' wording,
+the four numbered steps and the paragraphs that frame them are in `__main__`,
+under `_setup` and the two functions it calls. That is where #202 asked for them
+-- "leaving `cmd_install` and `cmd_setup` in the CLI as the render-and-dispatch
+half" -- and it is also forced: a dialog has to print each paragraph before the
+`input` under it, so its prose and its control flow are one thing, and separating
+them needs either a cycle back into `__main__` or the four commands passed in as
+callables.
+
+What is here is everything the wizard needs that is *not* a print:
+
+- `ask` and `ask_yes`, the two input primitives. Not `_confirm` -- see `ask_yes`.
+- `importable`, which histories exist on this machine and how big they are.
+- `untouched`, whether anything has been set up here at all. `cmd_status` asks
+  this too, to decide whether to hand over to `setup`; it is the reason this is a
+  function rather than three lines inside the wizard.
+- `why_those_shells`, one clause naming the rule that chose the shells.
+
+None of them prints, and none of them calls another, so each is testable on its
+own -- which the wizard, driven through mocked `input` and scraped stdout, is
+not. That gap is real and named in #202; closing it needs the callable-injection
+shape above, and is not what this module is.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from . import install, store
+
+if TYPE_CHECKING:  # `importer` is imported lazily; only the annotation needs it.
+    from . import importer
+
+
+def ask(question: str, default: str = "") -> str:
+    """Free text, with a default shown. Empty answer takes the default."""
+    shown = f" [{default}]" if default else ""
+    return input(f"{question}{shown}: ").strip() or default
+
+
+def ask_yes(question: str, default: bool = True) -> bool:
+    """A yes/no with a default, for questions that change nothing dangerous.
+
+    Deliberately not `_confirm`: that one is a security control with an
+    `isatty` branch and a fixed refusal message about widening access. These
+    are "shall I install the shell hook" -- reusing the access gate for them
+    would blunt the thing it is for.
+    """
+    hint = "[Y/n]" if default else "[y/N]"
+    answer = input(f"{question} {hint} ").strip().lower()
+    if not answer:
+        return default
+    return answer in ("y", "yes")
+
+
+def importable() -> list[tuple[importer.Kind, Path, int]]:
+    """``(kind, path, size)`` for each history on this machine, largest first.
+
+    The kinds are `importer.Kind` rather than plain strings, so the caller can
+    hand one straight to `importer.run` and mypy agrees. Spelling it `str` here
+    was what let the wizard's forged namespace carry anything at all.
+    """
+    from . import importer
+
+    found: list[tuple[importer.Kind, Path, int]] = []
+    for kind in importer.KINDS:
+        path = importer.atuin_db() if kind == "atuin" else importer.default_path(kind)
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        if size:
+            found.append((kind, path, size))
+    return sorted(found, key=lambda item: item[2], reverse=True)
+
+
+def untouched() -> bool:
+    """Is there nothing here at all yet?
+
+    Three cheap questions, and it takes any of them as a yes: the shell hook,
+    a history repo, or a single recorded line. Not "has `install` run" -- a
+    machine that imported a history without wiring the hook, or joined a repo
+    without it, is set up enough to be told where it stands, and running `setup`
+    at it would be answering a question it did not ask.
+
+    `store.machine_file` is deliberately not one of them: `store.machine()`
+    creates it, so almost any command makes it exist and it says nothing about
+    whether anyone has set anything up.
+    """
+    from . import sync
+
+    if install.installed_shells() or sync.is_repo():
+        return False
+    return not any(store.iter_log_files())
+
+
+def why_those_shells(choice: str | None, rcfile: str | None, chosen: list[str]) -> str:
+    """One clause saying which rule picked `chosen`, for `setup`'s step 2.
+
+    Worth a line because the answer differs per machine and the wrong one is
+    silent: a hook written into the shell you do not use looks exactly like a
+    hook that works.
+    """
+    if choice and choice != "auto":
+        return f"--shell {choice}"
+    if rcfile:
+        return f"from the name of {Path(rcfile).name}"
+    if any(install.rcfile_for(shell).is_file() for shell in chosen):
+        return "found " + " and ".join(f"~/{install.RCFILES[shell]}" for shell in chosen)
+    return f"no rc file here, so $SHELL ({os.environ.get('SHELL', 'unset')})"


### PR DESCRIPTION
Closes #202.

`__main__.py` was 1813 lines with two subsystems inverting the pattern the rest of the package follows — decide in the domain, render at the caller. Both are out; it is 1450 now.

## `woswoar/install.py` (415 lines)

Which shells this machine is responsible for, what their hooks contain, and keeping them current. Decides; never prints.

`refresh_hook` is why this was worth a module rather than a tidy-up. It is **policy that runs unattended**: the hook starts a `woswoar sync` about once a minute, and that sync rewrites the hook file when it is behind. Its rule — only ever *re*-write, never create — was held up by a single test asserting on the CLI's stdout. It returns the hooks it rewrote now, and `cmd_sync` prints them.

`shell_checks` and `hook_checks` came here too, which is what `doctor`'s own docstring said would happen once the installer had somewhere to live. `hook_bytes` stayed one function returning bytes, per the constraint in the issue.

## `woswoar/setup.py` (115 lines)

Smaller than its name, and the boundary is worth stating because the obvious reading is wrong. It holds what the wizard works out **without asking** — which histories exist, whether anything is set up here, which rule picked the shells — plus the two `input` primitives.

The questions and the four numbered steps stay in `__main__`. That is what the issue asked for — *"leaving `cmd_install` and `cmd_setup` in the CLI as the render-and-dispatch half"* — and it is also forced: a dialog prints each paragraph before the `input` under it, so its prose and its control flow are one thing. Separating them needs the four commands passed in as callables, which is a different change.

## The forged namespaces

Five, not the three the issue lists — `cmd_status`'s auto-setup and `cmd_setup`'s own were the other two. Each of the four commands now has a keyword-argument half taking **that command's own flags**, which both the command and the wizard go through, so mypy names the call site that forgot an argument.

`--shell`/`--rcfile` were also declared twice in `build_parser`, verbatim, and this change had to edit both copies to reach `install.HOOKS` — the same defect one level down in the parser. They are `add_install_flags` now, beside the existing `add_scope` precedent.

## Three defects this turned up rather than introduced

- **`tests/test_setup.py` was forging a namespace too**, and had been missing `shell` entirely since it was written — the defect #202 describes, inside the test meant to guard against it. It parses real argv now.
- **`install` hardens after it copies**, per a comment, with nothing holding it. A permissive umask leaves the shell hook world-readable inside a directory woswoar promises is owner-only.
- **Nothing held that `setup` and `install` accept the same `--shell` values**, so the wizard could silently stop being able to pass one the command takes.

## Verification

**Byte-identical to `main`** across 14 invocations — `install` twice, `--shell both`, `--rcfile`, the `--rcfile --shell both` refusal, `doctor`, `import --dry-run`, `import`, `status`, `stats`, three `--help`s, the no-tty `setup` refusal, and the resulting `.bashrc` and `zshrc` — plus the bare `woswoar` auto-setup path on an untouched machine.

**Thirteen mutations, all caught.** Four survived on the first attempt. Two were the fixture and are the reason for new tests: nothing exercised `setup --shell`, and nothing asserted step 2's reason line is derived from the real flags. The other two were **my own mutations being additive rather than a move** — the original `store.harden()` and `add_install_flags(p_setup)` were still there below the edit, so the code under test never changed and the run proved nothing. Eleven new tests, 903 → 914.

**The keypress path costs +0.30 ms** at the median of 100 interleaved runs (14.72 → 15.02 ms of a ~29 ms import, ~105 ms search). That is `install` being imported so the parser can read `install.HOOKS` for its `--shell` choices. Deferring `install` too would need the shell list spelled a second time, which is a worse trade than 0.3% of a search. `tests/test_perf.py` passes.

## What `/simplify` changed

Four review agents; the findings that survived checking:

- **`setup` was imported eagerly and the parser never needed it** — and my `LAYERS` comment claimed it did, which was simply false. Deferred to its four call sites. Worth 90 µs, which the measurement above cannot resolve; the reason to do it was the false comment.
- **`setup.py`'s docstring and `docs/architecture.md` described a split that did not ship** — they said the module owns the wizard's questions and prose. It does not; those are in `__main__`. Both rewritten. This also means my earlier framing of "I deviated from the issue" was wrong: the issue asked for exactly what shipped.
- **`_install` took pre-digested arguments**, so both callers repeated `shells_from` *and* `_rcfile_override` — reintroducing the drift #202 exists to remove, one layer up. It takes the raw flags now and `_rcfile_override` is gone.
- **The new umask test asked the code under test about itself** — `store.readable_by_others()` and `store.harden()` are both built on `store._private_paths`, so a path that walk stopped yielding would be skipped and reported clean in the same breath. `support.loose_paths()` exists precisely for this and documents why.
- **The new test's `$HOME` fixture was unnecessary** — a fifth copy of that dance in one file, when `--rcfile` keeps the write out of the real home and `--shell bash` means detection never reads a rc file. Twelve lines to none.
- **A loop variable shadowed the `shell` parameter** in `_install`. Harmless today, a trap for whoever next needs it after the loop.
- One duplicate test deleted, one stale `_hook_bytes` reference fixed, `wire_rcfiles`' unused default dropped, and this file's `install.BEGIN`/`install.HOOKS` spellings unified.

**Declined, with reasons:** compiling `_BLOCK` and building the `Installed` NamedTuple lazily (23 µs and 45 µs against a ~105 ms search — the "millisecond of fifteen" the conventions say to stop at, and `NamedTuple` is the idiom here); dropping `Installed` for a bare dict (its `machine` must be created *before* `harden` runs, so it is genuinely a product of the install, not something the caller can ask for afterwards); converting `--rcfile`/`--file`/`--identity` to `type=` callables in argparse (changes types across the CLI and touches two flags unrelated to this issue); and unifying `install._VERSION_QUERY` with `support.bash_major`/`zsh_major` (real duplication, but pre-existing and it would rewire the skip decorators every test module depends on — worth its own change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)