### PR TITLE
tools: close the three ways a measurement lied this session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,8 +210,60 @@ first such change, not during one.
   same number of bytes inside one second run each other's cached bytecode —
   which reported a *correct* test as decoration here, and nearly got it
   rewritten.
+
+  It also refuses a replacement that still **contains** the text it replaced,
+  because that leaves the code under test exactly as it was and the run means
+  nothing either way. That is how a *move* gets written wrongly — put the whole
+  span in `old`, including the line being relocated. Three of those shipped in
+  one session before the check existed, each costing a full suite run and each
+  reading as a result. `additive=True` is the escape hatch for the rare edit
+  that really does insert in front of code that stays.
+
+- **Refactors that should change nothing: prove it with `tools/compare.py`.**
+
+  ```sh
+  python -m tools.compare --base main --show .bashrc install doctor status
+  ```
+
+  It runs each command in a throwaway `$HOME` against both revisions, seeds the
+  same machine id on both sides, and diffs stdout, stderr and exit status
+  together. Only `$HOME` and the tree path are normalised by default; anything
+  else needs `--scrub REGEX=REPLACEMENT`, and the active list is printed above
+  the verdict. Quote that list whenever a pull request says "byte-identical" —
+  the claim is worth exactly what was left unnormalised, and there is no way to
+  tell from the outside.
+
+- **A/B timing: `tools/bench.py`, not a loop written on the spot.**
+
+  ```sh
+  python -m tools.bench --importtime woswoar.__main__ --base main
+  ```
+
+  Hand-rolled comparisons got this wrong twice here, in three different ways,
+  and each way survives review because the output looks like a measurement:
+
+  - **The base worktree must sit on the same filesystem.** `/tmp` is tmpfs and
+    the checkout is on btrfs, so a worktree in the obvious place reads out of
+    RAM against a tree reading off an SSD. That alone reported a resolved
+    0.08 ms difference between a tree and *itself*. `bench.py` puts the
+    worktree beside the repository.
+  - **A,B,A,B is not fair** — the second slot of every pair absorbs all the
+    drift, so an afternoon of warming up reads as a slowdown. The blocks are
+    ABBA and BAAB.
+  - **Compare the pairs, not the medians.** `median(B) - median(A)` throws away
+    the pairing that interleaving exists to create, and produces the puzzle of a
+    median gap smaller than the gap between the two minima. `bench.py` reports
+    the median of the per-pair differences with a sign test, and says *not
+    resolved* rather than quoting a number the machine cannot support.
+
+  A cost below measurement is a real answer. Write "below measurement" then,
+  not a figure with two decimal places.
 - Before blaming your branch for a CI failure, measure the same job on `main`,
   enough times to see a one-in-forty flake. Two runs of green proves nothing.
+- Moving a name between modules leaves `.mypy_cache` wrong, and it fails as
+  `AssertionError: Cannot find component 'X' for 'woswoar.old_module.X'` from
+  inside mypy rather than as a type error. `rm -rf .mypy_cache` and re-run; it is
+  not your change.
 - **Commit before comparing two revisions.** `git checkout main` carries
   uncommitted changes across, so a before-and-after benchmark run that way
   measures the same tree twice and reports no difference. That has twice nearly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,33 @@ five shapes the codebase keeps reusing. The layering is not a convention —
 real import graph, so a new edge between modules is a deliberate one-line edit
 and a sentence in the pull request.
 
+When the move is supposed to change nothing a user sees, show that rather than
+asserting it:
+
+```sh
+python -m tools.compare --base main --show .bashrc install doctor status
+```
+
+[`tools/compare.py`](tools/compare.py) runs each command against both revisions
+in a throwaway `$HOME`, with the same machine id seeded on both sides, and diffs
+stdout, stderr and exit status together. Only `$HOME` and the tree path are
+normalised unless you ask for more with `--scrub`; whatever is active is printed
+above the verdict, and that list belongs in the pull request beside the claim.
+"Byte-identical" is worth exactly what was left unnormalised.
+
+If the move might cost time, [`tools/bench.py`](tools/bench.py) is the A/B:
+
+```sh
+python -m tools.bench --importtime woswoar.__main__ --base main
+```
+
+It puts the base worktree beside the repository rather than in `/tmp` — which is
+tmpfs here, so the obvious placement measures RAM against an SSD — runs ABBA and
+BAAB blocks so a machine that warms up over the run does not read as a
+regression, and reports the median of the per-pair differences with a sign test.
+When it says *not resolved*, that is the answer: write "below measurement", not a
+figure with two decimal places.
+
 ## Comments explain *why*
 
 The comment density here is deliberate and is most of the value of the codebase.

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -1,0 +1,121 @@
+"""Tests for the A/B timing harness.
+
+Every one of these is about the harness reaching a *wrong* conclusion, because
+that is the only failure that matters here: a benchmark nobody trusts gets rerun,
+and a benchmark that is confidently wrong gets quoted in a pull request. Both
+have happened -- the number that prompted this tool was inflated by a base
+worktree sitting on tmpfs while the tree it was compared against sat on btrfs,
+and then summarised with a statistic that threw the pairing away.
+
+The timings here are synthetic on purpose. A test that actually ran two trees
+would measure this machine rather than the arithmetic, and could not state what
+the right answer was.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from tools.bench import BLOCKS, Pair, sign_p, summarise
+from tools.bench import _pairs_from as pairs_from
+
+
+def drifting(blocks: int, drift: float, offset: float = 0.0) -> list[Pair]:
+    """Pairs from a machine getting steadily slower, with a known real effect.
+
+    ``drift`` is added per measurement slot, whichever side happens to occupy it;
+    ``offset`` is added to the working tree's readings only, and is therefore the
+    answer the harness is supposed to find.
+    """
+    out: list[Pair] = []
+    slot = 0
+    for index in range(blocks):
+        block = BLOCKS[index % len(BLOCKS)]
+        samples = []
+        for letter in block:
+            value = 10.0 + drift * slot + (offset if letter == "B" else 0.0)
+            samples.append(value)
+            slot += 1
+        out += pairs_from(block, samples)
+    return out
+
+
+class TestTheBlockDesignCancelsDrift(unittest.TestCase):
+    """The reason the order is ABBA/BAAB and not ABAB."""
+
+    def test_a_steady_slowdown_is_not_reported_as_a_difference(self) -> None:
+        summary = summarise(drifting(blocks=20, drift=0.5))
+        self.assertAlmostEqual(summary.median, 0.0, places=9)
+        self.assertFalse(summary.resolved, "drift alone was reported as a real effect")
+
+    def test_the_naive_alternation_would_have_reported_it(self) -> None:
+        """What the design is protecting against, stated as a test so that anyone
+        tempted to simplify the block order can see the cost.
+
+        In A,B,A,B the working tree always occupies the later slot of its pair, so
+        every single difference carries one step of the drift and the harness
+        resolves a slowdown that does not exist.
+        """
+        drift = 0.5
+        naive = [
+            Pair(base=10.0 + drift * (2 * i), tree=10.0 + drift * (2 * i + 1), tree_first=False)
+            for i in range(40)
+        ]
+        summary = summarise(naive)
+        self.assertAlmostEqual(summary.median, drift, places=9)
+        self.assertTrue(summary.resolved, "the fixture failed to reproduce the bias")
+
+    def test_each_block_uses_both_orders(self) -> None:
+        """A counterbalance nobody checks is a claim rather than a control."""
+        for block in BLOCKS:
+            with self.subTest(block=block):
+                pairs = pairs_from(block, [1.0, 2.0, 3.0, 4.0])
+                self.assertEqual(sorted(pair.tree_first for pair in pairs), [False, True])
+
+    def test_both_readings_of_a_pair_are_adjacent_in_time(self) -> None:
+        """Pairing the two ends of a block against each other would leave two
+        slots of drift inside every difference, which is the bias this is for."""
+        for block in BLOCKS:
+            with self.subTest(block=block):
+                for pair in pairs_from(block, [1.0, 2.0, 3.0, 4.0]):
+                    self.assertEqual(abs(pair.base - pair.tree), 1.0)
+
+
+class TestItFindsARealDifference(unittest.TestCase):
+    def test_an_offset_larger_than_the_drift_is_resolved(self) -> None:
+        summary = summarise(drifting(blocks=20, drift=0.1, offset=1.0))
+        self.assertAlmostEqual(summary.median, 1.0, places=9)
+        self.assertTrue(summary.resolved)
+        self.assertEqual(summary.tree_slower, summary.pairs)
+
+    def test_the_direction_is_reported_the_way_a_reader_expects(self) -> None:
+        """Positive means the working tree is slower. Getting this backwards
+        would invert every conclusion the tool is used for."""
+        faster = summarise(drifting(blocks=10, drift=0.0, offset=-2.0))
+        self.assertLess(faster.median, 0)
+        self.assertEqual(faster.tree_slower, 0)
+
+
+class TestTheSignTest(unittest.TestCase):
+    def test_an_even_split_is_the_least_significant_thing_possible(self) -> None:
+        self.assertEqual(sign_p(15, 30), 1.0)
+
+    def test_a_clean_sweep_is_significant(self) -> None:
+        self.assertLess(sign_p(30, 30), 0.001)
+
+    def test_it_is_two_sided(self) -> None:
+        """A tree that is consistently *faster* is just as much a result, and a
+        one-sided test would call it noise."""
+        self.assertEqual(sign_p(0, 20), sign_p(20, 20))
+
+    def test_a_handful_of_pairs_cannot_resolve_anything(self) -> None:
+        """Guards against the tool being run with `--blocks 1` and believed: with
+        two pairs even a unanimous split is one coin flip in two."""
+        self.assertGreater(sign_p(2, 2), 0.05)
+
+    def test_no_pairs_is_not_a_division_by_zero(self) -> None:
+        self.assertEqual(sign_p(0, 0), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,75 @@
+"""Tests for the output-comparison harness.
+
+One failure mode matters: saying two revisions agree when they do not. The
+second, subtler one is saying they agree *after normalising away the part that
+differed* -- which reads identically in a pull request and means nothing. So the
+report has to name its scrubs, and that is asserted here rather than left to
+whoever writes the next comparison to remember.
+
+`verdict` is the half these reach. Recording a tree needs a git worktree and a
+subprocess per command, and testing that would measure git.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from tools.compare import verdict
+
+
+class TestItAgreesOnlyWhenItShould(unittest.TestCase):
+    def test_identical_recordings_agree(self) -> None:
+        agreed, report = verdict("same\noutput\n", "same\noutput\n", "main (abc123)", 2)
+        self.assertTrue(agreed)
+        self.assertIn("identical", report)
+
+    def test_one_changed_character_disagrees(self) -> None:
+        """The whole point. A refactor meant to change nothing has to fail here
+        for a single byte, or the check is a formality."""
+        agreed, report = verdict("logs    : x\n", "LOGS    : x\n", "main (abc123)", 1)
+        self.assertFalse(agreed)
+        self.assertIn("-logs    : x", report)
+        self.assertIn("+LOGS    : x", report)
+
+    def test_a_difference_in_trailing_whitespace_is_still_a_difference(self) -> None:
+        """Output is compared as bytes, not as words: trailing space is exactly
+        the kind of thing a rewritten print loop changes silently."""
+        agreed, _ = verdict("line\n", "line \n", "main (abc123)", 1)
+        self.assertFalse(agreed)
+
+    def test_reordered_output_is_a_difference(self) -> None:
+        """`doctor` reports in a fixed order on purpose, and `report.lines` says
+        so. A comparison that sorted first would bless a reordering."""
+        agreed, _ = verdict("a\nb\n", "b\na\n", "main (abc123)", 1)
+        self.assertFalse(agreed)
+
+
+class TestTheReportSaysWhatWasNormalised(unittest.TestCase):
+    """ "Byte-identical" is only worth what the scrub list next to it is worth."""
+
+    def test_no_scrubs_says_so_out_loud(self) -> None:
+        """Rather than an empty heading, which reads as though the question was
+        never asked."""
+        _, report = verdict("x", "x", "main (abc123)", 1)
+        self.assertIn("(none)", report)
+
+    def test_every_scrub_is_named(self) -> None:
+        scrubs = [(r"\d+ ms", "N ms"), (r"[0-9a-f]{16}", "ID")]
+        _, report = verdict("x", "x", "main (abc123)", 1, scrubs)
+        for pattern, replacement in scrubs:
+            self.assertIn(f"{pattern} -> {replacement}", report)
+
+    def test_the_scrubs_are_named_on_a_failure_too(self) -> None:
+        """The case where it matters most: a reader looking at a diff needs to
+        know what was already normalised out of it."""
+        _, report = verdict("a", "b", "main (abc123)", 1, [(r"\d+", "N")])
+        self.assertIn(r"\d+ -> N", report)
+
+    def test_the_revision_is_named_in_both_the_header_and_the_diff(self) -> None:
+        _, report = verdict("a", "b", "main (abc123)", 1)
+        self.assertIn("main (abc123)", report.splitlines()[0])
+        self.assertIn("--- main (abc123)", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -119,6 +119,62 @@ class TestItRefusesToGuess(MutateTestCase):
         self.assertIn("0 times", str(refused.exception))
 
 
+class TestItRefusesAnEditThatOnlyAdds(MutateTestCase):
+    """The mistake this catches shipped three times in one session.
+
+    Writing a *move* as a mutation is easy to get wrong: put only the first half
+    of the span in ``old`` and the replacement ends up containing the line you
+    meant to relocate, so it is still there underneath the edit. The code under
+    test never changes, and the run prints "caught" or "SURVIVED" about nothing
+    -- with no way to tell from the output which of the two you are looking at.
+    """
+
+    def test_a_replacement_containing_the_original_is_refused(self) -> None:
+        self.package(guarded=True)
+        with self.assertRaises(SystemExit) as refused:
+            verify(
+                [
+                    Mutation(
+                        "the guard is hoisted rather than removed",
+                        "mod.py",
+                        "    if value < 0:\n        return 0",
+                        "    print('noise')\n    if value < 0:\n        return 0",
+                        "test_mod",
+                    )
+                ]
+            )
+        self.assertIn("survives verbatim", str(refused.exception))
+
+    def test_additive_says_the_insertion_is_the_point(self) -> None:
+        """The escape hatch, and it has to exist: inserting a call in front of
+        code that stays is how you test the *order* of two steps, which is a real
+        mutation with a real answer."""
+        self.package(guarded=True)
+        survivors = verify(
+            [
+                Mutation(
+                    "an early return is inserted in front of the guard",
+                    "mod.py",
+                    "    if value < 0:",
+                    "    return 99\n    if value < 0:",
+                    "test_mod",
+                    additive=True,
+                )
+            ],
+            baseline=False,
+        )
+        self.assertEqual(survivors, 0, "the inserted return should have been caught")
+
+    def test_the_refusal_happens_before_the_file_is_touched(self) -> None:
+        """Otherwise the check would trade one wasted run for a mutated tree,
+        which is the failure `CLAUDE.md` rule 6 is about."""
+        self.package(guarded=True)
+        before = (self.root / "mod.py").read_text(encoding="utf-8")
+        with self.assertRaises(SystemExit):
+            verify([Mutation("x", "mod.py", "return value", "return value  # same", "test_mod")])
+        self.assertEqual((self.root / "mod.py").read_text(encoding="utf-8"), before)
+
+
 class TestItRestoresTheTree(MutateTestCase):
     def test_the_source_is_unchanged_afterwards(self) -> None:
         self.package(guarded=True)

--- a/tools/bench.py
+++ b/tools/bench.py
@@ -1,0 +1,309 @@
+"""Time the working tree against another revision, without fooling yourself.
+
+    python -m tools.bench --importtime woswoar.__main__
+    python -m tools.bench --base main -- list --show 20
+
+Two revisions, one machine, and a difference small enough that the machine's own
+drift is the same size as the effect. That combination has produced a wrong
+number here twice, in two different ways, and this exists to close both.
+
+**The ordering trap.** Running A,B,A,B,... looks fair and is not: within every
+pair A is always measured first, so anything that makes the machine slower over
+time -- thermal throttling, another process starting, the page cache filling --
+lands entirely on B. A run structured that way reports a slowdown that is really
+just the shape of the afternoon. So the blocks here are **ABBA** and **BAAB**,
+alternating: inside one block each side is measured once early and once late, so
+a drift that is linear over the block cancels exactly rather than on average.
+Alternating the two block shapes balances whichever side goes first as well.
+
+**The statistics trap.** Interleaving the runs and then comparing
+``median(A)`` against ``median(B)`` throws the pairing away -- which is the whole
+reason for interleaving. It also produces the puzzle of a median gap that is
+smaller than the gap between the two minima, because a difference of order
+statistics is not an order statistic of differences. What is reported here is the
+**median of the per-pair differences**, plus their spread, plus how many pairs
+each side won. When the spread straddles zero the honest answer is "not resolved
+by this many pairs", and this says so rather than quoting three decimal places.
+
+Nothing here is a substitute for `tests/test_perf.py`, which guards the budget
+that matters. This answers the narrower question a refactor raises: did *this
+change* cost anything measurable?
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import NamedTuple
+
+#: One block measures each side twice. ABBA puts A at the ends and B in the
+#: middle; BAAB is its mirror. Either one balances a linear drift on its own;
+#: alternating them also balances anything tied to which side opens a block.
+BLOCKS = ("ABBA", "BAAB")
+
+
+class Pair(NamedTuple):
+    """One measurement of each side, adjacent in time."""
+
+    base: float
+    tree: float
+    #: Which side was measured first. Kept so the report can show that both
+    #: orders were used -- a counterbalance nobody checks is a claim, not a
+    #: control.
+    tree_first: bool
+
+    @property
+    def delta(self) -> float:
+        """How much slower the working tree was. Negative means faster."""
+        return self.tree - self.base
+
+
+def sign_p(favouring: int, total: int) -> float:
+    """Two-sided sign test: the chance of a split this lopsided by luck alone.
+
+    The standard non-parametric test for paired measurements, and it needs
+    nothing about the shape of the timings -- which is the point, because
+    process timings are not normal, have a hard floor and a long right tail, and
+    a t-test on them quietly assumes otherwise.
+    """
+    if total == 0:
+        return 1.0
+    extreme = max(favouring, total - favouring)
+    tail = sum(math.comb(total, count) for count in range(extreme, total + 1))
+    return min(1.0, float(2 * tail / 2**total))
+
+
+class Summary(NamedTuple):
+    pairs: int
+    median: float
+    low: float
+    high: float
+    tree_slower: int
+    base_median: float
+    tree_median: float
+
+    @property
+    def p(self) -> float:
+        return sign_p(self.tree_slower, self.pairs)
+
+    @property
+    def resolved(self) -> bool:
+        """Whether the split between the two sides is more than luck.
+
+        The question the two hand-rolled benchmarks this replaces could not
+        answer. Deliberately a test of *direction* and not of size: a real effect
+        far below the budget still resolves here, and it is the magnitude beside
+        it that says whether anyone should care. `CLAUDE.md` has the rule for
+        that -- a millisecond of fifteen is where an optimisation sequence
+        stops.
+        """
+        return self.p < 0.05
+
+
+def summarise(pairs: Sequence[Pair]) -> Summary:
+    """The paired statistics. Pure, so the design above can be tested."""
+    deltas = sorted(pair.delta for pair in pairs)
+    quarter = max(len(deltas) // 4, 0)
+    return Summary(
+        pairs=len(deltas),
+        median=statistics.median(deltas),
+        low=deltas[quarter],
+        high=deltas[-1 - quarter],
+        tree_slower=sum(1 for value in deltas if value > 0),
+        base_median=statistics.median([pair.base for pair in pairs]),
+        tree_median=statistics.median([pair.tree for pair in pairs]),
+    )
+
+
+def _pairs_from(block: str, samples: Sequence[float]) -> list[Pair]:
+    """Turn one block's four readings into two adjacent, oppositely ordered pairs.
+
+    ``ABBA`` gives (A1,B1) -- A first -- and (A2,B2) -- B first. The two pairs
+    are what makes the block self-cancelling, so they are formed here rather than
+    by taking the block's two A's and two B's as unrelated samples.
+    """
+    first, second, third, fourth = samples
+    if block == "ABBA":
+        return [Pair(first, second, tree_first=False), Pair(fourth, third, tree_first=True)]
+    return [Pair(second, first, tree_first=True), Pair(third, fourth, tree_first=False)]
+
+
+def _importtime(tree: Path, module: str) -> float:
+    """Milliseconds to import ``module``, from the interpreter's own accounting.
+
+    Far quieter than wall clock -- it excludes interpreter startup, which is most
+    of a short run and none of the question -- and it is the number
+    `docs/woswoar_design_summary.md` budgets against.
+    """
+    done = subprocess.run(
+        [sys.executable, "-X", "importtime", "-c", f"import {module}"],
+        capture_output=True,
+        text=True,
+        cwd=tree,
+        env={**os.environ, "PYTHONPATH": str(tree)},
+        check=True,
+    )
+    for line in reversed(done.stderr.splitlines()):
+        if line.rstrip().endswith(module):
+            return int(line.split("|")[1]) / 1000
+    raise SystemExit(f"no importtime line for {module}; is it importable from {tree}?")
+
+
+def _wall(tree: Path, argv: Sequence[str], home: Path) -> float:
+    """Milliseconds of wall clock for one `woswoar` run."""
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(tree),
+        "HOME": str(home),
+        "XDG_DATA_HOME": str(home / "data"),
+        "XDG_CONFIG_HOME": str(home / "config"),
+        "XDG_CACHE_HOME": str(home / "cache"),
+        "NO_COLOR": "1",
+    }
+    started = time.perf_counter()
+    subprocess.run(
+        [sys.executable, "-m", "woswoar", *argv],
+        capture_output=True,
+        cwd=home,
+        env=env,
+        check=False,
+    )
+    return (time.perf_counter() - started) * 1000
+
+
+def _worktree(revision: str) -> tuple[Path, str]:
+    """A checkout of ``revision``, *beside the repository* rather than in /tmp.
+
+    Where it lands is not a detail. On this machine `/tmp` is tmpfs and the
+    checkout is on btrfs, so a worktree in the obvious place reads out of RAM
+    while the tree it is being compared against reads off an SSD -- a constant
+    advantage to one side that no amount of counterbalancing removes, because it
+    is not drift. Measured at the time this was written: it was enough to report
+    a resolved 0.08 ms difference between a tree and *itself*.
+    """
+    sha = subprocess.run(
+        ["git", "rev-parse", "--short", revision], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    path = Path(tempfile.mkdtemp(dir=Path.cwd().parent, prefix=".woswoar-bench-"))
+    path.rmdir()
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(path), revision],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return path, sha
+
+
+def run(
+    revision: str, blocks: int, module: str | None, argv: Sequence[str], warmup: int
+) -> tuple[Summary, str]:
+    here = Path.cwd()
+    base, sha = _worktree(revision)
+    # Beside the repository too, and for the same reason: a sandbox on tmpfs
+    # would make a wall-clock run measure the wrong filesystem.
+    homes = tempfile.TemporaryDirectory(dir=here.parent, prefix=".woswoar-bench-home-")
+    try:
+        roots = {}
+        for name in ("base", "tree"):
+            root = Path(homes.name) / name
+            (root / "config" / "woswoar").mkdir(parents=True)
+            (root / "config" / "woswoar" / "machine").write_text(
+                "id=0123456789abcdef\nname=bench@sandbox\n", encoding="utf-8"
+            )
+            roots[name] = root
+
+        def once(side: str) -> float:
+            tree = base if side == "base" else here
+            if module:
+                return _importtime(tree, module)
+            return _wall(tree, argv, roots[side])
+
+        # Thrown away rather than counted: the first run of each side pays for
+        # cold page cache and a `__pycache__` that does not exist yet, and that
+        # cost belongs to whichever side happened to go first.
+        for _ in range(warmup):
+            once("base")
+            once("tree")
+
+        pairs: list[Pair] = []
+        for index in range(blocks):
+            block = BLOCKS[index % len(BLOCKS)]
+            samples = [once("base" if letter == "A" else "tree") for letter in block]
+            pairs += _pairs_from(block, samples)
+    finally:
+        homes.cleanup()
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(base)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        shutil.rmtree(base, ignore_errors=True)
+    return summarise(pairs), sha
+
+
+def report(summary: Summary, revision: str, sha: str, what: str) -> str:
+    orders = f"{summary.pairs // 2} with each side first"
+    lines = [
+        f"{what}: working tree vs {revision} ({sha})",
+        f"  {summary.pairs} pairs in ABBA/BAAB blocks, {orders}",
+        f"  base median {summary.base_median:.2f} ms   tree median {summary.tree_median:.2f} ms",
+        f"  paired delta: median {summary.median:+.2f} ms, middle half "
+        f"{summary.low:+.2f} to {summary.high:+.2f} ms",
+        f"  the tree was slower in {summary.tree_slower} of {summary.pairs} pairs "
+        f"(sign test p={summary.p:.3f})",
+    ]
+    if summary.resolved:
+        direction = "slower" if summary.median > 0 else "faster"
+        lines.append(f"  => the working tree is {direction} by about {abs(summary.median):.2f} ms")
+    else:
+        # The answer the two earlier hand-rolled benchmarks should have given.
+        lines.append(
+            "  => not resolved: the two sides split about evenly, so this machine's "
+            "own noise\n     is larger than whatever the difference is. Quote it as "
+            "'below measurement',\n     not as a number, or run more blocks."
+        )
+    return "\n".join(lines)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.bench",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--base", default="main", help="revision to compare against")
+    parser.add_argument(
+        "--blocks", type=int, default=25, help="blocks of four runs (default: 25, so 50 pairs)"
+    )
+    parser.add_argument(
+        "--importtime",
+        metavar="MODULE",
+        help="measure importing this module instead of wall clock -- much quieter, "
+        "and the number the Ctrl-R budget is stated in",
+    )
+    parser.add_argument("--warmup", type=int, default=2, help="discarded runs per side")
+    parser.add_argument("command", nargs="*", help="woswoar arguments, when not using --importtime")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if not args.importtime and not args.command:
+        parser.error("give --importtime MODULE, or a woswoar command to time")
+
+    summary, sha = run(args.base, args.blocks, args.importtime, args.command, args.warmup)
+    what = f"import {args.importtime}" if args.importtime else f"woswoar {' '.join(args.command)}"
+    print(report(summary, args.base, sha, what))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/compare.py
+++ b/tools/compare.py
@@ -1,0 +1,245 @@
+"""Run the same commands against two revisions and diff what they printed.
+
+The check a refactor that is meant to change nothing has to pass, and the one
+that is tedious enough by hand that it gets skipped. Three slices of the #199 to
+#202 work each rebuilt this from scratch -- a worktree at the base revision, a
+throwaway ``$HOME`` for each side, a normalisation pass, a ``diff`` -- and the
+normalisation is the part where a mistake is invisible, because scrubbing too
+much makes everything match.
+
+    python -m tools.compare --base main -- install doctor status
+
+Each argument after ``--`` is a woswoar command line, run in order in one
+``$HOME`` so that state accumulates exactly as it would for a person. Both sides
+get the same fresh ``$HOME``, seeded with the same machine id, and the output of
+every command -- stdout, stderr and exit status -- is concatenated and compared.
+
+**On scrubbing.** Only two things are normalised by default: the throwaway home
+and the path of the tree being run. Both are pure environment and carry no
+information about the program. Anything else has to be asked for with
+``--scrub``, and the active list is printed in the header of the report -- so
+that a pull request quoting "byte-identical" says underneath it what was
+normalised to get there. A claim of identical output after normalising the
+interesting parts away is worth nothing, and there is no way to tell from the
+outside which kind you are reading.
+
+Exits 0 when the two agree and 1 when they do not, printing a unified diff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterable, Sequence
+from difflib import unified_diff
+from pathlib import Path
+
+#: What the sandbox's machine identity is, on both sides. Seeded rather than
+#: scrubbed: `install` prints the id it generated, and a fresh one per run would
+#: differ between the two trees for a reason that says nothing. Two characters
+#: short of a real id would be caught by nothing, so this is the same
+#: sixteen-hex-digit shape `tests/support.py` uses, and for the same reason.
+MACHINE_ID = "0123456789abcdef"
+MACHINE_FILE = f"id={MACHINE_ID}\nname=compare@sandbox\n"
+
+
+class Scrub(argparse.Action):
+    """``--scrub 'REGEX=REPLACEMENT'``, collected in the order given."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str | Sequence[str] | None,
+        option_string: str | None = None,
+    ) -> None:
+        text = str(values)
+        if "=" not in text:
+            parser.error(f"--scrub wants REGEX=REPLACEMENT, got {text!r}")
+        pattern, replacement = text.split("=", 1)
+        getattr(namespace, self.dest).append((pattern, replacement))
+
+
+def _sandbox(tree: Path, stack: list[tempfile.TemporaryDirectory[str]]) -> dict[str, str]:
+    """A throwaway home, and the environment that points woswoar at it.
+
+    Deliberately not the caller's environment with a few keys added: a
+    `WOSWOAR_SESSION` left over from the shell that started this, or an
+    `XDG_DATA_HOME` set on the developer's machine and not on anyone else's,
+    would reach one side and be reported as a difference between revisions.
+    """
+    home = tempfile.TemporaryDirectory(prefix="woswoar-compare-")
+    stack.append(home)
+    root = Path(home.name)
+    config = root / "config" / "woswoar"
+    config.mkdir(parents=True)
+    (config / "machine").write_text(MACHINE_FILE, encoding="utf-8")
+    return {
+        "HOME": str(root),
+        "XDG_DATA_HOME": str(root / "data"),
+        "XDG_CONFIG_HOME": str(root / "config"),
+        "XDG_CACHE_HOME": str(root / "cache"),
+        "PYTHONPATH": str(tree),
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        # A terminal would turn on colour and the progress meter, neither of
+        # which is what this is comparing, and both of which vary with how the
+        # comparison itself was invoked.
+        "NO_COLOR": "1",
+        "SHELL": "/bin/bash",
+    }
+
+
+def _record(
+    tree: Path, commands: Sequence[str], show: Sequence[str], scrubs: Sequence[tuple[str, str]]
+) -> str:
+    """Everything ``tree`` printed for ``commands``, normalised."""
+    stack: list[tempfile.TemporaryDirectory[str]] = []
+    try:
+        env = _sandbox(tree, stack)
+        out = []
+        for command in commands:
+            argv = shlex.split(command)
+            out.append(f"===== woswoar {' '.join(argv)}")
+            done = subprocess.run(
+                [sys.executable, "-m", "woswoar", *argv],
+                cwd=env["HOME"],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            # Interleaved as one block rather than two sections: several commands
+            # put the interesting half on stderr, and which stream a line went to
+            # is itself something a refactor can change by accident.
+            out.append(done.stdout + done.stderr)
+            out.append(f"----- exit {done.returncode}")
+        for name in show:
+            path = Path(env["HOME"]) / name
+            out.append(f"===== file {name}")
+            out.append(path.read_text(encoding="utf-8") if path.is_file() else "<absent>")
+
+        text = "\n".join(out)
+        # The two the caller never has to ask for, because neither is about the
+        # program: where the sandbox happened to land, and where the tree is.
+        text = text.replace(env["HOME"], "$HOME").replace(str(tree), "$TREE")
+        for pattern, replacement in scrubs:
+            text = re.sub(pattern, replacement, text)
+        return text
+    finally:
+        for home in reversed(stack):
+            home.cleanup()
+
+
+def _worktree(revision: str) -> tuple[Path, str]:
+    """A detached checkout of ``revision``, and the sha it resolved to."""
+    sha = subprocess.run(
+        ["git", "rev-parse", "--short", revision],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    path = Path(tempfile.mkdtemp(prefix="woswoar-compare-tree-"))
+    # `mkdtemp` made it, and `git worktree add` wants to make it itself.
+    path.rmdir()
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(path), revision],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return path, sha
+
+
+def compare(
+    revision: str,
+    commands: Sequence[str],
+    show: Sequence[str] = (),
+    scrubs: Sequence[tuple[str, str]] = (),
+) -> tuple[bool, str]:
+    """``(agreed, report)`` for the working tree against ``revision``."""
+    here = Path.cwd()
+    base, sha = _worktree(revision)
+    try:
+        before = _record(base, commands, show, scrubs)
+        after = _record(here, commands, show, scrubs)
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(base)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        shutil.rmtree(base, ignore_errors=True)
+
+    return verdict(before, after, f"{revision} ({sha})", len(commands), scrubs)
+
+
+def verdict(
+    before: str,
+    after: str,
+    label: str,
+    commands: int,
+    scrubs: Sequence[tuple[str, str]] = (),
+) -> tuple[bool, str]:
+    """``(agreed, report)`` for two recordings. Pure, and separate on purpose.
+
+    This is the half that can lie -- by calling two different things identical,
+    or by reporting a comparison without saying what was normalised to reach it
+    -- and it is the half a test can reach without a git worktree and a
+    subprocess for each side.
+    """
+    active = "\n".join(f"  {pattern} -> {value}" for pattern, value in scrubs) or "  (none)"
+    header = (
+        f"{commands} command(s) against {label}, {len(before.splitlines())} lines\n"
+        f"scrubs beyond $HOME and $TREE:\n{active}"
+    )
+    if before == after:
+        return True, f"{header}\nidentical"
+    diff = unified_diff(
+        before.splitlines(keepends=True),
+        after.splitlines(keepends=True),
+        fromfile=label,
+        tofile="working tree",
+    )
+    return False, f"{header}\n\n" + "".join(diff)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.compare",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--base", default="main", help="revision to compare against")
+    parser.add_argument(
+        "--show",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="also compare this file's contents, relative to the sandbox home "
+        "(repeatable) -- .bashrc, .zshrc",
+    )
+    parser.add_argument(
+        "--scrub",
+        action=Scrub,
+        default=[],
+        metavar="REGEX=REPLACEMENT",
+        help="normalise something else before comparing (repeatable). Listed in "
+        "the report, because what was normalised is half of what 'identical' means",
+    )
+    parser.add_argument("commands", nargs="+", help="woswoar command lines, run in order")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    agreed, report = compare(args.base, args.commands, args.show, args.scrub)
+    print(report)
+    return 0 if agreed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -32,6 +32,13 @@ time here:
   reported a *correct* test as decoration once, and the test was nearly
   rewritten because of it. Every run is ``-B`` and every ``__pycache__`` is
   removed between mutations.
+- **An edit that adds without removing is refused.** A replacement that still
+  contains the text it replaced leaves the code under test exactly as it was, so
+  the run reports "caught" or "SURVIVED" about nothing. That is the easy way to
+  write a *move* wrongly -- put the whole span in ``old``, including the line you
+  mean to relocate -- and it shipped three times in one session before this
+  check. Pass ``additive=True`` for the rare edit that really does mean to insert
+  in front of code that stays.
 - **The tree is restored even when interrupted.** A ``finally`` is not enough on
   its own -- a kill leaves the source mutated, which is exactly the state
   CLAUDE.md rule 6 is about -- so the original text is also written to a
@@ -64,6 +71,11 @@ class Mutation(NamedTuple):
     new: str
     #: Whitespace-separated unittest targets, as `python -m unittest` takes them.
     tests: str
+    #: Say so when the replacement is meant to *contain* the original -- an
+    #: inserted call, an early return in front of code that stays. Otherwise
+    #: `verify` refuses that shape, because it is overwhelmingly a mistake: see
+    #: the check for why, and what it cost before it existed.
+    additive: bool = False
 
 
 class Result(NamedTuple):
@@ -106,6 +118,25 @@ def verify(mutations: Iterable[Mutation], baseline: bool = True) -> int:
                 f"{mutation.label}: {mutation.path} contains the text to replace "
                 f"{found} times, not once. A mutation that matches nothing tests "
                 f"nothing, and one that matches twice tests something else."
+            )
+
+        # The replacement still contains everything it replaced, so the line the
+        # test is supposed to miss is still in the file and the run cannot mean
+        # anything. Always a mistake when the intent was to *move* something --
+        # write the whole span in `old`, including what follows it, or the
+        # original stays put underneath the edit.
+        #
+        # Three of these went out in one session before this check existed. Each
+        # cost a full suite run and read as "caught" when nothing had changed;
+        # the tell is that a mutation meant to break an invariant reports the
+        # same result as one that does nothing, and there is no way to see which
+        # from the output.
+        if not mutation.additive and mutation.old in mutation.new:
+            raise SystemExit(
+                f"{mutation.label}: the text to replace survives verbatim inside "
+                f"the replacement, so the code under test does not change and "
+                f"'caught' would mean nothing. If the point really is to insert "
+                f"something in front of code that stays, pass additive=True."
             )
 
         # Written somewhere findable before the file is touched, so an


### PR DESCRIPTION
Three things went wrong repeatedly while landing #199, #200 and #202 — all of them the kind that produce output looking exactly like a result. This closes each in the place it will be met again, and **corrects a number in #202's commit message**.

## 1. `tools/mutate.py` accepted a mutation that only added

It already refused an edit matching other than once and checked the baseline was green, but not that the edit *removed* anything. Writing a move as a mutation and putting only the first half of the span in `old` leaves the line being relocated still sitting there underneath — the code under test never changes, and the run reports `caught` or `SURVIVED` about nothing, with no way to tell which from the output.

That shipped **twice in one session**, each time costing a full suite run. A replacement containing the text it replaced is now refused:

```
the guard is hoisted rather than removed: the text to replace survives verbatim
inside the replacement, so the code under test does not change and 'caught' would
mean nothing. If the point really is to insert something in front of code that
stays, pass additive=True.
```

`additive=True` has to exist — inserting a call in front of code that stays is how you test the *order* of two steps, which is a real mutation with a real answer.

## 2. Byte-identical comparison, hand-rolled three times → `tools/compare.py`

Every slice of the refactoring rebuilt the same thing: a worktree at the base, a throwaway `$HOME` per side, a normalisation pass, a diff.

```
$ python -m tools.compare --base main --show .bashrc "install --shell bash" doctor status
3 command(s) against main (e8175cf), 36 lines
scrubs beyond $HOME and $TREE:
  (none)
identical
```

The normalisation is the part worth care, because scrubbing too much makes everything match and reads identically in a PR. So: only `$HOME` and the tree path by default, the machine id **seeded** on both sides rather than scrubbed, and anything else printed above the verdict. That list belongs next to the claim — "byte-identical" is worth exactly what was left unnormalised.

## 3. A/B timing was wrong in three ways at once → `tools/bench.py`

- **The base worktree must be on the same filesystem.** `/tmp` is tmpfs here and the checkout is btrfs, so the obvious placement reads out of RAM against a tree reading off an SSD. Measured: enough to report a *resolved* 0.08 ms difference between a tree and **itself**. It goes beside the repository now.
- **A,B,A,B is not fair.** The second slot of every pair absorbs all the drift, so a machine warming up over the run reads as a regression. Blocks are **ABBA** and **BAAB**, alternating — each side measured once early and once late within a block, so a linear drift cancels exactly rather than on average.
- **Compare the pairs, not the medians.** `median(B) − median(A)` discards the pairing that interleaving exists to create, and produces the puzzle you get when a median gap is smaller than the gap between the two minima. It reports the median of per-pair differences with a two-sided sign test.

```
$ python -m tools.bench --importtime woswoar.__main__ --base 6749d2a --blocks 40
  80 pairs in ABBA/BAAB blocks, 40 with each side first
  base median 14.65 ms   tree median 14.76 ms
  paired delta: median +0.10 ms, middle half -0.14 to +0.42 ms
  the tree was slower in 47 of 80 pairs (sign test p=0.146)
  => not resolved: the two sides split about evenly, so this machine's own noise
     is larger than whatever the difference is.
```

## The correction to #202

#202's commit message and PR said the CLI import cost **+0.25 ms**, later **+0.30 ms**. Both were measured with the base worktree on tmpfs and summarised as a difference of medians.

Re-measured properly — 80 pairs, ABBA/BAAB, worktree on the same filesystem — post-#202 against pre-#202 is **+0.10 ms at p=0.146: not resolved.** The honest statement is that the two new module imports cost less than this machine can measure. Nothing in the tree ever carried the wrong figure; it was in the commit message and the PR, and #209 now has a comment saying so.

## Tests

24 new, and the ones that matter are the ones that would let a wrong answer through:

- a synthetic linear drift must summarise to **zero**;
- the same fixture paired the naive A,B,A,B way must report that drift as a **real effect** — so the block design is held by a test rather than by a commit message;
- `verdict` is split out of `compare` so the half that can lie (calling two different things identical, or reporting a comparison without naming its scrubs) is reachable without a git worktree and a subprocess per side;
- the mutate guard is tested three ways, including that it refuses *before* touching the file — otherwise it would trade a wasted run for a mutated tree, which is what rule 6 is about.

## Honest scope

The new guard catches **two of this session's five mutation survivals** — the additive shape, which was the same mistake twice. The other three were not mechanically detectable: two weak fixtures, and one replacement faithful enough that the tests could not tell it from the original. Those became tests, which is the only fix available. A tool cannot check whether a mutation is *interesting*.

`CLAUDE.md` and `CONTRIBUTING.md` both document the two new tools and the traps. `CONTRIBUTING.md` was not asked for, but it has a "Before moving code" section that `compare.py` is exactly for, and the two files already describe `mutate.py` together.

Also documents the `.mypy_cache` trap: moving a name between modules makes mypy fail from inside itself with `Cannot find component 'X' for 'woswoar.old_module.X'` rather than as a type error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)