### PR TITLE
tools: mutate runs in sandboxes, and therefore in parallel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,62 +202,35 @@ first such change, not during one.
   `python -m unittest discover -s . -t . -p 'test_*.py'` runs the same tests
   serially, and takes about three times as long.
 
-- Mutation-test through `tools/mutate.py` rather than writing the loop again. It
-  runs `-B`, clears every `__pycache__` between mutations, refuses an edit that
-  matches other than exactly once, checks the baseline is green, and restores
-  the tree even when interrupted. The trap it exists for: a `.pyc` is validated
-  against `(mtime_seconds, size)`, so two mutations that change a file by the
-  same number of bytes inside one second run each other's cached bytecode —
-  which reported a *correct* test as decoration here, and nearly got it
-  rewritten.
+- Three tools in `tools/` exist because the same mistake was made more than
+  once. Each one's module docstring carries the full argument for why it is
+  shaped as it is; reach for them rather than writing the loop again.
 
-  It also refuses a replacement that still **contains** the text it replaced,
-  because that leaves the code under test exactly as it was and the run means
-  nothing either way. That is how a *move* gets written wrongly — put the whole
-  span in `old`, including the line being relocated. Three of those shipped in
-  one session before the check existed, each costing a full suite run and each
-  reading as a result. `additive=True` is the escape hatch for the rare edit
-  that really does insert in front of code that stays.
-
-- **Refactors that should change nothing: prove it with `tools/compare.py`.**
+  | when | tool |
+  |---|---|
+  | a fix needs a test that fails without it (rule 3) | [`tools/mutate.py`](tools/mutate.py) |
+  | a refactor is supposed to change no output | [`tools/compare.py`](tools/compare.py) |
+  | a change might have cost time | [`tools/bench.py`](tools/bench.py) |
 
   ```sh
+  python -m tools.mutate <spec>.py
   python -m tools.compare --base main --show .bashrc install doctor status
-  ```
-
-  It runs each command in a throwaway `$HOME` against both revisions, seeds the
-  same machine id on both sides, and diffs stdout, stderr and exit status
-  together. Only `$HOME` and the tree path are normalised by default; anything
-  else needs `--scrub REGEX=REPLACEMENT`, and the active list is printed above
-  the verdict. Quote that list whenever a pull request says "byte-identical" —
-  the claim is worth exactly what was left unnormalised, and there is no way to
-  tell from the outside.
-
-- **A/B timing: `tools/bench.py`, not a loop written on the spot.**
-
-  ```sh
   python -m tools.bench --importtime woswoar.__main__ --base main
   ```
 
-  Hand-rolled comparisons got this wrong twice here, in three different ways,
-  and each way survives review because the output looks like a measurement:
+  Three things to carry into a pull request, because they are about what you
+  write rather than what the tool does:
 
-  - **The base worktree must sit on the same filesystem.** `/tmp` is tmpfs and
-    the checkout is on btrfs, so a worktree in the obvious place reads out of
-    RAM against a tree reading off an SSD. That alone reported a resolved
-    0.08 ms difference between a tree and *itself*. `bench.py` puts the
-    worktree beside the repository.
-  - **A,B,A,B is not fair** — the second slot of every pair absorbs all the
-    drift, so an afternoon of warming up reads as a slowdown. The blocks are
-    ABBA and BAAB.
-  - **Compare the pairs, not the medians.** `median(B) - median(A)` throws away
-    the pairing that interleaving exists to create, and produces the puzzle of a
-    median gap smaller than the gap between the two minima. `bench.py` reports
-    the median of the per-pair differences with a sign test, and says *not
-    resolved* rather than quoting a number the machine cannot support.
+  - **Paste mutation output verbatim.** Retyping it is how a mutation that was
+    never run ended up quoted in a commit message here.
+  - **Quote `compare`'s scrub list beside any "byte-identical" claim.** The claim
+    is worth exactly what was left unnormalised, and nothing outside that list
+    can tell you.
+  - **"Below measurement" is a real answer.** When `bench` says *not resolved*,
+    write that, not a figure with two decimal places — and say which statistic
+    and how many blocks, because a difference of medians and a median of paired
+    differences are not the same number.
 
-  A cost below measurement is a real answer. Write "below measurement" then,
-  not a figure with two decimal places.
 - Before blaming your branch for a CI failure, measure the same job on `main`,
   enough times to see a one-in-forty flake. Two runs of green proves nothing.
 - Moving a name between modules leaves `.mypy_cache` wrong, and it fails as

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,11 +47,25 @@ and the only way to know is to try it:
 
 [`tools/mutate.py`](tools/mutate.py) is that loop, written down. Give it a table
 of edits, run `python -m tools.mutate <spec>.py`, and paste its output into the
-pull request. Use it rather than writing the loop by hand: it clears every
-`__pycache__` between mutations, because a `.pyc` is validated against
-`(mtime, size)` and two edits of the same size inside one second will run each
-other's cached bytecode — which reported a *correct* test as decoration here and
-nearly got it deleted.
+pull request — verbatim, rather than retyping it, which is how a mutation that
+was never run ended up quoted in a commit message here.
+
+Use it rather than writing the loop by hand, for three reasons it has learned:
+
+- **It never edits your working tree.** Each mutation goes into a throwaway copy,
+  so an interrupted run cannot leave mutated source behind.
+- **It runs the table in parallel**, which the copies are what make safe: 197 s
+  down to 51 s for four mutations against `tests.test_sync`.
+- **It defuses the bytecode cache.** A `.pyc` is validated against
+  `(mtime, size)`, so two edits of the same size inside one second will run each
+  other's cached bytecode — which reported a *correct* test as decoration here and
+  nearly got it deleted. The copies start with no cache and the runs are told not
+  to write one.
+
+It also refuses a replacement that still contains the text it replaced, since
+that leaves the code under test unchanged and the result means nothing either
+way. Pass `additive=True` when inserting in front of code that stays is genuinely
+the point — testing the *order* of two steps needs it.
 
 ### When a mutation survives, suspect the fixture first
 
@@ -79,18 +93,17 @@ real import graph, so a new edge between modules is a deliberate one-line edit
 and a sentence in the pull request.
 
 When the move is supposed to change nothing a user sees, show that rather than
-asserting it:
+asserting it — [`tools/compare.py`](tools/compare.py) runs the same commands
+against both revisions in a throwaway `$HOME` and diffs stdout, stderr and exit
+status together:
 
 ```sh
 python -m tools.compare --base main --show .bashrc install doctor status
 ```
 
-[`tools/compare.py`](tools/compare.py) runs each command against both revisions
-in a throwaway `$HOME`, with the same machine id seeded on both sides, and diffs
-stdout, stderr and exit status together. Only `$HOME` and the tree path are
-normalised unless you ask for more with `--scrub`; whatever is active is printed
-above the verdict, and that list belongs in the pull request beside the claim.
-"Byte-identical" is worth exactly what was left unnormalised.
+Only `$HOME` and the tree path are normalised unless you ask for more with
+`--scrub`; whatever is active is printed above the verdict, and that list belongs
+in the pull request beside the claim.
 
 If the move might cost time, [`tools/bench.py`](tools/bench.py) is the A/B:
 
@@ -98,12 +111,10 @@ If the move might cost time, [`tools/bench.py`](tools/bench.py) is the A/B:
 python -m tools.bench --importtime woswoar.__main__ --base main
 ```
 
-It puts the base worktree beside the repository rather than in `/tmp` — which is
-tmpfs here, so the obvious placement measures RAM against an SSD — runs ABBA and
-BAAB blocks so a machine that warms up over the run does not read as a
-regression, and reports the median of the per-pair differences with a sign test.
-When it says *not resolved*, that is the answer: write "below measurement", not a
-figure with two decimal places.
+Both tools' docstrings explain the traps they encode — where the two checkouts
+sit, the order readings are taken in, how they are summarised — and it is worth
+reading `bench.py`'s before quoting a number from it. When it says *not
+resolved*, that is the answer: write "below measurement".
 
 ## Comments explain *why*
 

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import unittest
 
-from tools.bench import BLOCKS, Pair, sign_p, summarise
+from tools.bench import BLOCKS, Pair, comparable, sign_p, summarise
 from tools.bench import _pairs_from as pairs_from
 
 
@@ -94,6 +94,43 @@ class TestItFindsARealDifference(unittest.TestCase):
         faster = summarise(drifting(blocks=10, drift=0.0, offset=-2.0))
         self.assertLess(faster.median, 0)
         self.assertEqual(faster.tree_slower, 0)
+
+
+class TestTheSidesMustHaveDoneTheSameWork(unittest.TestCase):
+    """The hole the three documented traps left open.
+
+    A revision where the flag did not exist yet exits in 40 ms with a usage error
+    while the working tree does 300 ms of work, and a harness that only times
+    them calls that a resolved slowdown.
+    """
+
+    def test_agreeing_statuses_are_reported_not_refused(self) -> None:
+        self.assertIn("exited 0", comparable({0}))
+
+    def test_a_consistently_failing_command_is_still_comparable(self) -> None:
+        """`doctor` exits 1 whenever it has something to report, so refusing every
+        non-zero status would make the most interesting command unbenchmarkable."""
+        self.assertIn("exited 1", comparable({1}))
+
+    def test_disagreement_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as refused:
+            comparable({0, 2})
+        self.assertIn("did not", str(refused.exception))
+
+    def test_no_readings_is_not_a_crash(self) -> None:
+        self.assertIn("exited 0", comparable(set()))
+
+
+class TestTheCounterbalanceIsCounted(unittest.TestCase):
+    def test_the_report_line_comes_from_the_pairs_and_not_arithmetic(self) -> None:
+        """It used to be derived as `pairs // 2`, which prints the same string
+        whatever the pairs contain -- so the line claiming both orders were used
+        was itself the unchecked claim its comment warned about."""
+        summary = summarise(drifting(blocks=10, drift=0.0))
+        self.assertEqual(summary.tree_first, summary.pairs // 2)
+
+        lopsided = [Pair(1.0, 2.0, tree_first=True) for _ in range(4)]
+        self.assertEqual(summarise(lopsided).tree_first, 4)
 
 
 class TestTheSignTest(unittest.TestCase):

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -21,6 +21,16 @@ from tools.mutate import Mutation, verify
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
+#: The module every fixture here mutates. One spelling: three fixtures wrote it
+#: out separately, so a change to one left the others self-consistent but no
+#: longer testing the module the rest of the file targets.
+CLAMP = """
+def clamp(value: int) -> int:
+    if value < 0:
+        return 0
+    return value
+"""
+
 
 class MutateTestCase(unittest.TestCase):
     """Each test builds a tiny package and mutates *that*, not woswoar."""
@@ -45,15 +55,7 @@ class MutateTestCase(unittest.TestCase):
 
     def package(self, guarded: bool) -> None:
         """A module with one behaviour, and a test that may or may not see it."""
-        self.write(
-            "mod.py",
-            """
-            def clamp(value: int) -> int:
-                if value < 0:
-                    return 0
-                return value
-            """,
-        )
+        self.write("mod.py", CLAMP)
         assertion = (
             "self.assertEqual(mod.clamp(-5), 0)" if guarded else "self.assertEqual(mod.clamp(5), 5)"
         )
@@ -175,6 +177,128 @@ class TestItRefusesAnEditThatOnlyAdds(MutateTestCase):
         self.assertEqual((self.root / "mod.py").read_text(encoding="utf-8"), before)
 
 
+class TestTheWorkingTreeIsNeverTouched(MutateTestCase):
+    """The stronger claim the sandbox design makes, and the one worth testing.
+
+    The two tests below it check the tree is intact *afterwards*, which was true
+    of the earlier design too -- it mutated the source and restored it in a
+    `finally`. What that could not survive was a kill in between, which is the
+    state CLAUDE.md rule 6 is about and which cost real work here. So this
+    watches from inside: the suite a mutation runs reports what it could see of
+    the original file at the moment it was running.
+    """
+
+    def witnessing(self, witness: Path) -> None:
+        """A package whose test records the state of the *original* tree.
+
+        The absolute path is baked in, so the test reads the working tree no
+        matter which directory it is running from -- which is the whole question.
+        """
+        self.write("mod.py", CLAMP)
+        original = (self.root / "mod.py").resolve()
+        self.write(
+            "test_mod.py",
+            f"""
+            import os
+            import unittest
+            from pathlib import Path
+
+            import mod
+
+
+            class T(unittest.TestCase):
+                def test_it(self) -> None:
+                    Path({str(witness)!r}).write_text(
+                        os.getcwd() + "\\n" + Path({str(original)!r}).read_text(),
+                        encoding="utf-8",
+                    )
+                    self.assertEqual(mod.clamp(-5), 0)
+            """,
+        )
+
+    def test_the_suite_runs_somewhere_else_entirely(self) -> None:
+        witness = self.root / "witness.txt"
+        self.witnessing(witness)
+        verify([Mutation("x", "mod.py", "if value < 0:", "if False:", "test_mod")], baseline=False)
+        where, _ = witness.read_text(encoding="utf-8").split("\n", 1)
+        self.assertNotEqual(
+            Path(where).resolve(),
+            self.root.resolve(),
+            "the mutation ran in the working tree rather than a copy of it",
+        )
+
+    def test_the_original_file_is_unmutated_while_the_suite_runs(self) -> None:
+        """Not just restored afterwards. A `finally` gives you the second; only a
+        copy gives you the first, and the difference is what happens when the run
+        is killed."""
+        witness = self.root / "witness.txt"
+        self.witnessing(witness)
+        verify([Mutation("x", "mod.py", "if value < 0:", "if False:", "test_mod")], baseline=False)
+        _, seen = witness.read_text(encoding="utf-8").split("\n", 1)
+        self.assertIn("if value < 0:", seen)
+        self.assertNotIn("if False:", seen)
+
+
+class TestItRunsThemInParallel(MutateTestCase):
+    """Independent by construction, and mostly waiting on a subprocess.
+
+    Asserted by occupancy rather than by wall clock: each mutation's test drops a
+    marker, counts how many markers exist at that moment, and records the count.
+    A serial run can never see more than one. A threshold on elapsed time would
+    be the same claim with a flake attached.
+    """
+
+    def test_more_than_one_mutation_is_in_flight_at_once(self) -> None:
+        markers = self.root / "markers"
+        markers.mkdir()
+        counts = self.root / "counts.txt"
+        self.write("mod.py", CLAMP)
+        self.write(
+            "test_mod.py",
+            f"""
+            import os
+            import time
+            import unittest
+            from pathlib import Path
+
+            import mod
+
+            MARKERS = Path({str(markers)!r})
+            COUNTS = Path({str(counts)!r})
+
+
+            class T(unittest.TestCase):
+                def test_it(self) -> None:
+                    mine = MARKERS / str(os.getpid())
+                    mine.write_text("here", encoding="utf-8")
+                    # Long enough that a parallel run overlaps and a serial one
+                    # cannot, without being long enough to matter to the suite.
+                    time.sleep(0.4)
+                    with COUNTS.open("a", encoding="utf-8") as log:
+                        log.write(f"{{len(list(MARKERS.iterdir()))}}\\n")
+                    mine.unlink()
+                    self.assertEqual(mod.clamp(-5), 0)
+            """,
+        )
+        verify(
+            [
+                # Not `return value + {index}`: that contains the text it
+                # replaces, so the additive guard refuses it -- which it did, to
+                # this fixture, within minutes of the guard existing.
+                Mutation(f"row {index}", "mod.py", "return value", f"return {index}", "test_mod")
+                for index in range(1, 5)
+            ],
+            baseline=False,
+            # Explicit, because the default is derived from the core count and a
+            # two-core CI runner would resolve it to a serial run -- so this test
+            # would assert the machine rather than the mechanism.
+            workers=4,
+        )
+        seen = [int(line) for line in counts.read_text(encoding="utf-8").split()]
+        self.assertTrue(seen, "no mutation reported its occupancy")
+        self.assertGreater(max(seen), 1, f"every mutation ran alone: {seen}")
+
+
 class TestItRestoresTheTree(MutateTestCase):
     def test_the_source_is_unchanged_afterwards(self) -> None:
         self.package(guarded=True)
@@ -241,6 +365,81 @@ class TestTheBytecodeTrap(MutateTestCase):
         self.assertLess(
             time.time() - started, 60, "precondition: the two runs shared a wall-clock second"
         )
+
+
+class TestAMutationThatBreaksTheSuiteIsNotCaught(MutateTestCase):
+    """The one hazard here that lies in the direction a reader believes.
+
+    `_run` used to answer "the exit status was non-zero", and a mutation that
+    makes the module unimportable exits non-zero too -- so it printed `caught`
+    while the test named in the row never ran. That is the inverse of the
+    decoration failure rule 3 is about, and it is worse, because a false `caught`
+    in a pull request is indistinguishable from a real one.
+    """
+
+    def test_a_mutation_that_breaks_the_import_is_refused(self) -> None:
+        self.package(guarded=True)
+        with self.assertRaises(SystemExit) as refused:
+            verify(
+                [Mutation("syntax", "mod.py", "def clamp", "def (", "test_mod")],
+                baseline=False,
+            )
+        self.assertIn("ran no tests", str(refused.exception))
+
+    def test_a_real_mutation_is_still_caught(self) -> None:
+        """The other half: the check must not refuse an ordinary mutation, which
+        also exits non-zero but does so after running the test."""
+        self.package(guarded=True)
+        self.assertEqual(
+            verify(
+                [Mutation("the clamp is gone", "mod.py", "if value < 0:", "if False:", "test_mod")],
+                baseline=False,
+            ),
+            0,
+        )
+
+
+class TestOneLaneIsNotADeadlock(MutateTestCase):
+    """The narrowest configuration, and the one that hung three CI jobs.
+
+    With a single lane and a baseline to check, the baseline used to take the only
+    borrowable sandbox on the main thread and never give it back, so every
+    mutation blocked forever on an empty queue. `workers` defaults to a value
+    derived from the core count, which is 16 on the machine this was written on
+    and 1 on a two-core runner -- so it passed locally and hung there.
+
+    Driven as a subprocess with a timeout because the failure is a hang. A test
+    that waits forever reports nothing, which is the same reason
+    `tests/test_setup.py` has an `input` that raises rather than blocks.
+    """
+
+    def test_a_single_lane_with_a_baseline_finishes(self) -> None:
+        self.package(guarded=True)
+        self.write(
+            "spec.py",
+            """
+            from tools.mutate import Mutation, verify
+
+            verify(
+                [Mutation("the clamp is gone", "mod.py", "if value < 0:", "if False:", "test_mod")],
+                baseline=True,
+                workers=1,
+            )
+            """,
+        )
+        try:
+            finished = subprocess.run(
+                [sys.executable, str(self.root / "spec.py")],
+                cwd=self.root,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=dict(os.environ, PYTHONPATH=str(REPO_ROOT)),
+                timeout=90,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail("one lane plus a baseline deadlocked: the run never finished")
+        self.assertIn("caught", finished.stdout, finished.stderr)
 
 
 class TestTheScriptEntryPoint(MutateTestCase):

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,241 @@
+"""Tests for the shared sandbox helpers the comparison tools are built on.
+
+One of these is a regression test for a real defect: `tools/bench.py` built its
+child environment as ``{**os.environ, ...}`` and overrode four keys, while
+`store.ENV_KEYS` has six. ``WOSWOAR_DIR`` beats ``XDG_DATA_HOME`` in
+`store.data_dir`, and the installed hook exports ``WOSWOAR_SESSION`` in every
+interactive shell -- so a benchmark run from a normal terminal measured the
+developer's own history in both trees and reported the difference as a result.
+
+That is the failure `store.ENV_KEYS`' comment was written for, and the reason the
+environment is now built from nothing rather than inherited: a key woswoar reads
+and this does not set is simply absent, so `store` falls back to its
+``$HOME``-relative default, which is inside the sandbox.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools.sandbox import (
+    MACHINE_ID,
+    same_filesystem,
+    sandbox_env,
+    seed_machine,
+    usable_cpus,
+    worktree,
+)
+from woswoar import store
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _in_a_git_repo() -> bool:
+    """Whether `worktree` has anything to check out from.
+
+    Asked rather than assumed, because two situations run this suite outside a
+    repository and both are legitimate: a copy of the tree made by
+    `tools/mutate.py`, which excludes `.git` on purpose, and an installed sdist.
+    A test that fails there would be reporting the absence of git rather than a
+    defect -- and in the mutate case it fails the *baseline*, which makes every
+    mutation result in the run meaningless.
+    """
+    return (
+        subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            cwd=REPO,
+            capture_output=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+class TestTheEnvironmentIsBuiltNotInherited(unittest.TestCase):
+    def test_no_woswoar_variable_leaks_in_from_the_caller(self) -> None:
+        """The defect, stated as the property that prevents it.
+
+        Every name in `store.ENV_KEYS` is either set by the sandbox or absent.
+        Nothing is inherited, so nothing can point at the real installation.
+        """
+        poisoned = {key: f"/somewhere/real/{key}" for key in store.ENV_KEYS}
+        with mock.patch.dict(os.environ, poisoned):
+            env = sandbox_env(REPO, Path("/tmp/sandbox-home"))
+        for key in store.ENV_KEYS:
+            with self.subTest(key=key):
+                self.assertNotEqual(
+                    env.get(key),
+                    poisoned[key],
+                    f"{key} was inherited from the caller's environment",
+                )
+
+    def test_woswoar_dir_is_absent_rather_than_pointed_somewhere(self) -> None:
+        """`WOSWOAR_DIR` wins over `XDG_DATA_HOME` in `store.data_dir`, so setting
+        the latter is not enough -- the former has to not be there at all."""
+        with mock.patch.dict(os.environ, {"WOSWOAR_DIR": "/somewhere/real"}):
+            env = sandbox_env(REPO, Path("/tmp/sandbox-home"))
+        self.assertNotIn("WOSWOAR_DIR", env)
+
+    def test_the_session_the_hook_exports_does_not_reach_the_child(self) -> None:
+        """Always inherited in practice: the hook exports it in every interactive
+        shell, so any tool run from a terminal with woswoar installed had it."""
+        with mock.patch.dict(os.environ, {"WOSWOAR_SESSION": "s-real"}):
+            env = sandbox_env(REPO, Path("/tmp/sandbox-home"))
+        self.assertNotIn("WOSWOAR_SESSION", env)
+
+    def test_a_new_key_added_to_store_needs_no_edit_here(self) -> None:
+        """Why building from nothing is the *structural* fix and not just a sweep.
+
+        A key woswoar starts reading tomorrow is absent from this environment, so
+        `store` falls back to its `$HOME`-relative default -- which is in the
+        sandbox. The inherit-and-override shape fails the other way, towards the
+        real installation, which is why it fails silently.
+        """
+        with mock.patch.dict(os.environ, {"WOSWOAR_SOMETHING_NEW": "/real"}):
+            env = sandbox_env(REPO, Path("/tmp/sandbox-home"))
+        self.assertNotIn("WOSWOAR_SOMETHING_NEW", env)
+
+    def test_path_is_carried_because_age_and_git_have_to_be_found(self) -> None:
+        env = sandbox_env(REPO, Path("/tmp/sandbox-home"))
+        self.assertEqual(env["PATH"], os.environ["PATH"])
+
+    def test_the_home_is_where_woswoar_will_look(self) -> None:
+        home = Path("/tmp/sandbox-home")
+        env = sandbox_env(REPO, home)
+        self.assertEqual(env["HOME"], str(home))
+        self.assertTrue(env["XDG_DATA_HOME"].startswith(str(home)))
+
+
+class TestBytecodeStaysOutOfTheTree(unittest.TestCase):
+    """A `.pyc` is validated against `(mtime_seconds, size)`.
+
+    So an edit that changes a file by no bytes within one second leaves a cache
+    that still looks valid for the new source. `compare` hit exactly that and
+    reported a difference between two identical trees: `logs    :` had been edited
+    to `LOGS    :` and back, and the fresh checkout it was compared against had no
+    cache while the working tree's still held the old bytecode.
+
+    `PYTHONDONTWRITEBYTECODE` does not fix it -- that stops writing, not reading.
+    Redirecting the cache does, and symmetrically for both sides.
+    """
+
+    def test_the_cache_is_redirected_into_the_sandbox(self) -> None:
+        home = Path("/tmp/sandbox-home")
+        env = sandbox_env(REPO, home)
+        self.assertTrue(env["PYTHONPYCACHEPREFIX"].startswith(str(home)))
+
+    def test_running_under_it_leaves_no_pycache_in_the_tree(self) -> None:
+        """The property rather than the variable: drives a real interpreter over a
+        throwaway module and checks where the bytecode landed."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as area:
+            root = Path(area)
+            tree, home = root / "tree", root / "home"
+            tree.mkdir()
+            home.mkdir()
+            (tree / "victim.py").write_text("VALUE = 1\n", encoding="utf-8")
+            subprocess.run(
+                [sys.executable, "-c", "import victim"],
+                env=sandbox_env(tree, home),
+                cwd=tree,
+                capture_output=True,
+                check=True,
+            )
+            self.assertEqual(
+                list(tree.rglob("__pycache__")), [], "bytecode was written into the tree"
+            )
+            self.assertTrue(
+                any((home / "pycache").rglob("*.pyc")), "bytecode did not reach the sandbox"
+            )
+
+
+class TestSeeding(unittest.TestCase):
+    def test_the_machine_file_is_where_store_reads_it(self) -> None:
+        """Written to `config/woswoar/machine` because that is what
+        `store.config_dir` resolves to under `XDG_CONFIG_HOME`."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as home:
+            root = Path(home)
+            seed_machine(root, "test@sandbox")
+            written = (root / "config" / "woswoar" / "machine").read_text(encoding="utf-8")
+        self.assertIn(f"id={MACHINE_ID}", written)
+        self.assertIn("name=test@sandbox", written)
+
+    def test_the_id_is_the_shape_a_real_one_is(self) -> None:
+        """A short id would be caught by nothing here and would then not resemble
+        what it stands in for."""
+        self.assertEqual(len(MACHINE_ID), 16)
+        self.assertTrue(all(char in "0123456789abcdef" for char in MACHINE_ID))
+
+
+class TestUsableCpus(unittest.TestCase):
+    def test_it_prefers_the_count_that_respects_an_affinity_mask(self) -> None:
+        """`os.cpu_count()` reports the host's CPUs and ignores both an affinity
+        mask and a container quota, which is exactly the CI case: on a two-core
+        runner on a sixteen-core host it answers sixteen.
+
+        The two are patched to *disagree*, because on an unrestricted machine they
+        return the same number -- so a test comparing against the real
+        `process_cpu_count` would pass just as happily against the wrong one.
+        """
+        with (
+            mock.patch.object(os, "process_cpu_count", return_value=3, create=True),
+            mock.patch.object(os, "cpu_count", return_value=99),
+        ):
+            self.assertEqual(usable_cpus(), 3)
+
+    def test_it_never_answers_zero(self) -> None:
+        """Both counters may return None, and a lane count of zero is a hang."""
+        with mock.patch.object(os, "process_cpu_count", return_value=None, create=True):
+            self.assertGreaterEqual(usable_cpus(), 1)
+
+
+class TestSameFilesystem(unittest.TestCase):
+    def test_a_path_shares_a_filesystem_with_itself(self) -> None:
+        self.assertTrue(same_filesystem(REPO, REPO))
+
+    def test_tmp_and_the_repo_are_told_apart_when_they_differ(self) -> None:
+        """The check exists because `/tmp` is tmpfs on the machine this was
+        written on while the checkout is on btrfs -- reading out of RAM against an
+        SSD, which no counterbalancing removes. Skipped where they happen to
+        match, since then there is nothing to distinguish."""
+        if Path("/tmp").stat().st_dev == REPO.stat().st_dev:
+            self.skipTest("/tmp and the repo are on one filesystem here")
+        self.assertFalse(same_filesystem(Path("/tmp"), REPO))
+
+
+@unittest.skipUnless(_in_a_git_repo(), "no git repository to check a revision out of")
+class TestWorktree(unittest.TestCase):
+    def test_it_checks_out_and_cleans_up_after_itself(self) -> None:
+        with worktree("HEAD") as (path, sha):
+            self.assertTrue((path / "woswoar" / "__init__.py").is_file())
+            self.assertTrue(sha)
+            inside = path
+        self.assertFalse(inside.exists(), "the worktree outlived its context")
+
+    def test_git_no_longer_lists_it_afterwards(self) -> None:
+        """`rmtree` alone leaves a stale entry under `.git/worktrees` that makes
+        the next `worktree add` on the same path fail, which is why the teardown
+        is both halves."""
+        with worktree("HEAD") as (path, _):
+            pass
+        listed = subprocess.run(
+            ["git", "worktree", "list"], capture_output=True, text=True, check=True, cwd=REPO
+        ).stdout
+        self.assertNotIn(str(path), listed)
+
+    def test_beside_puts_it_on_the_named_filesystem(self) -> None:
+        with worktree("HEAD", beside=REPO.parent) as (path, _):
+            self.assertEqual(path.parent, REPO.parent)
+            self.assertTrue(same_filesystem(path, REPO))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bench.py
+++ b/tools/bench.py
@@ -4,8 +4,18 @@
     python -m tools.bench --base main -- list --show 20
 
 Two revisions, one machine, and a difference small enough that the machine's own
-drift is the same size as the effect. That combination has produced a wrong
-number here twice, in two different ways, and this exists to close both.
+drift is the same size as the effect. That combination produced a wrong number
+here three times over, in three different ways, and this exists to close all
+three: where the two checkouts sat, the order they were measured in, and how the
+readings were summarised.
+
+**The filesystem trap.** ``/tmp`` is tmpfs on the machine this was written on and
+the checkout is on btrfs, so a worktree in the obvious place reads out of RAM
+against a tree reading off an SSD. That is a constant advantage to one side which
+no amount of counterbalancing removes, because it is not drift -- and it was
+enough to report a resolved 0.08 ms difference between a tree and *itself*. Both
+checkouts go on one filesystem, and `same_filesystem` *checks* rather than
+assuming, because "beside the repository" is a remedy and not the invariant.
 
 **The ordering trap.** Running A,B,A,B,... looks fair and is not: within every
 pair A is always measured first, so anything that makes the machine slower over
@@ -34,8 +44,6 @@ from __future__ import annotations
 
 import argparse
 import math
-import os
-import shutil
 import statistics
 import subprocess
 import sys
@@ -44,6 +52,8 @@ import time
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import NamedTuple
+
+from tools.sandbox import same_filesystem, sandbox_env, seed_machine, worktree
 
 #: One block measures each side twice. ABBA puts A at the ends and B in the
 #: middle; BAAB is its mirror. Either one balances a linear drift on its own;
@@ -56,9 +66,10 @@ class Pair(NamedTuple):
 
     base: float
     tree: float
-    #: Which side was measured first. Kept so the report can show that both
-    #: orders were used -- a counterbalance nobody checks is a claim, not a
-    #: control.
+    #: Which side was measured first. Counted into `Summary.tree_first` and
+    #: printed, because a counterbalance nobody checks is a claim rather than a
+    #: control -- the report used to derive that line as `pairs // 2`, which is
+    #: the same sentence with nothing behind it.
     tree_first: bool
 
     @property
@@ -90,6 +101,9 @@ class Summary(NamedTuple):
     tree_slower: int
     base_median: float
     tree_median: float
+    #: How many pairs measured the working tree first. Counted, not assumed: if
+    #: the block scheduling ever stops alternating, this is where it shows.
+    tree_first: int
 
     @property
     def p(self) -> float:
@@ -112,7 +126,7 @@ class Summary(NamedTuple):
 def summarise(pairs: Sequence[Pair]) -> Summary:
     """The paired statistics. Pure, so the design above can be tested."""
     deltas = sorted(pair.delta for pair in pairs)
-    quarter = max(len(deltas) // 4, 0)
+    quarter = len(deltas) // 4
     return Summary(
         pairs=len(deltas),
         median=statistics.median(deltas),
@@ -121,6 +135,7 @@ def summarise(pairs: Sequence[Pair]) -> Summary:
         tree_slower=sum(1 for value in deltas if value > 0),
         base_median=statistics.median([pair.base for pair in pairs]),
         tree_median=statistics.median([pair.tree for pair in pairs]),
+        tree_first=sum(1 for pair in pairs if pair.tree_first),
     )
 
 
@@ -137,8 +152,8 @@ def _pairs_from(block: str, samples: Sequence[float]) -> list[Pair]:
     return [Pair(second, first, tree_first=True), Pair(third, fourth, tree_first=False)]
 
 
-def _importtime(tree: Path, module: str) -> float:
-    """Milliseconds to import ``module``, from the interpreter's own accounting.
+def _importtime(tree: Path, module: str, env: dict[str, str]) -> tuple[float, int]:
+    """Milliseconds to import ``module``, and the exit status of asking.
 
     Far quieter than wall clock -- it excludes interpreter startup, which is most
     of a short run and none of the question -- and it is the number
@@ -149,84 +164,65 @@ def _importtime(tree: Path, module: str) -> float:
         capture_output=True,
         text=True,
         cwd=tree,
-        env={**os.environ, "PYTHONPATH": str(tree)},
-        check=True,
-    )
-    for line in reversed(done.stderr.splitlines()):
-        if line.rstrip().endswith(module):
-            return int(line.split("|")[1]) / 1000
-    raise SystemExit(f"no importtime line for {module}; is it importable from {tree}?")
-
-
-def _wall(tree: Path, argv: Sequence[str], home: Path) -> float:
-    """Milliseconds of wall clock for one `woswoar` run."""
-    env = {
-        **os.environ,
-        "PYTHONPATH": str(tree),
-        "HOME": str(home),
-        "XDG_DATA_HOME": str(home / "data"),
-        "XDG_CONFIG_HOME": str(home / "config"),
-        "XDG_CACHE_HOME": str(home / "cache"),
-        "NO_COLOR": "1",
-    }
-    started = time.perf_counter()
-    subprocess.run(
-        [sys.executable, "-m", "woswoar", *argv],
-        capture_output=True,
-        cwd=home,
         env=env,
         check=False,
     )
-    return (time.perf_counter() - started) * 1000
+    for line in reversed(done.stderr.splitlines()):
+        if line.rstrip().endswith(module):
+            return int(line.split("|")[1]) / 1000, done.returncode
+    raise SystemExit(f"no importtime line for {module}; is it importable from {tree}?")
 
 
-def _worktree(revision: str) -> tuple[Path, str]:
-    """A checkout of ``revision``, *beside the repository* rather than in /tmp.
-
-    Where it lands is not a detail. On this machine `/tmp` is tmpfs and the
-    checkout is on btrfs, so a worktree in the obvious place reads out of RAM
-    while the tree it is being compared against reads off an SSD -- a constant
-    advantage to one side that no amount of counterbalancing removes, because it
-    is not drift. Measured at the time this was written: it was enough to report
-    a resolved 0.08 ms difference between a tree and *itself*.
-    """
-    sha = subprocess.run(
-        ["git", "rev-parse", "--short", revision], capture_output=True, text=True, check=True
-    ).stdout.strip()
-    path = Path(tempfile.mkdtemp(dir=Path.cwd().parent, prefix=".woswoar-bench-"))
-    path.rmdir()
-    subprocess.run(
-        ["git", "worktree", "add", "--detach", str(path), revision],
+def _wall(tree: Path, argv: Sequence[str], env: dict[str, str]) -> tuple[float, int]:
+    """Milliseconds of wall clock for one `woswoar` run, and its exit status."""
+    started = time.perf_counter()
+    done = subprocess.run(
+        [sys.executable, "-m", "woswoar", *argv],
         capture_output=True,
-        text=True,
-        check=True,
+        cwd=env["HOME"],
+        env=env,
+        check=False,
     )
-    return path, sha
+    return (time.perf_counter() - started) * 1000, done.returncode
 
 
 def run(
     revision: str, blocks: int, module: str | None, argv: Sequence[str], warmup: int
-) -> tuple[Summary, str]:
+) -> tuple[Summary, str, str]:
+    """``(summary, sha, note)`` for the working tree against ``revision``."""
     here = Path.cwd()
-    base, sha = _worktree(revision)
-    # Beside the repository too, and for the same reason: a sandbox on tmpfs
-    # would make a wall-clock run measure the wrong filesystem.
-    homes = tempfile.TemporaryDirectory(dir=here.parent, prefix=".woswoar-bench-home-")
-    try:
-        roots = {}
-        for name in ("base", "tree"):
-            root = Path(homes.name) / name
-            (root / "config" / "woswoar").mkdir(parents=True)
-            (root / "config" / "woswoar" / "machine").write_text(
-                "id=0123456789abcdef\nname=bench@sandbox\n", encoding="utf-8"
+    # Beside the repository, so that the checkout and the tree it is compared
+    # against are on one filesystem -- and then *checked*, because "beside" is a
+    # remedy for the tmpfs trap rather than the invariant, and it fails silently
+    # wherever the parent directory is a different mount.
+    with (
+        worktree(revision, beside=here.parent) as (base, sha),
+        tempfile.TemporaryDirectory(dir=here.parent, prefix=".woswoar-bench-home-") as holder,
+    ):
+        if not same_filesystem(base, here):
+            raise SystemExit(
+                f"{base} and {here} are on different filesystems, so one side would "
+                f"be measured against faster storage than the other. That is not "
+                f"drift and no amount of counterbalancing removes it."
             )
-            roots[name] = root
+        trees = {"base": base, "tree": here}
+        envs = {}
+        for side in trees:
+            home = Path(holder) / side
+            home.mkdir()
+            seed_machine(home, "bench@sandbox")
+            # Once per side, outside every timed region.
+            envs[side] = sandbox_env(trees[side], home)
+
+        codes: set[int] = set()
 
         def once(side: str) -> float:
-            tree = base if side == "base" else here
             if module:
-                return _importtime(tree, module)
-            return _wall(tree, argv, roots[side])
+                elapsed, code = _importtime(trees[side], module, envs[side])
+            else:
+                elapsed, code = _wall(trees[side], argv, envs[side])
+            codes.add(code)
+            return elapsed
 
         # Thrown away rather than counted: the first run of each side pays for
         # cold page cache and a `__pycache__` that does not exist yet, and that
@@ -240,23 +236,37 @@ def run(
             block = BLOCKS[index % len(BLOCKS)]
             samples = [once("base" if letter == "A" else "tree") for letter in block]
             pairs += _pairs_from(block, samples)
-    finally:
-        homes.cleanup()
-        subprocess.run(
-            ["git", "worktree", "remove", "--force", str(base)],
-            capture_output=True,
-            text=True,
-            check=False,
+
+    return summarise(pairs), sha, comparable(codes)
+
+
+def comparable(codes: set[int]) -> str:
+    """One line about the exit statuses seen, or a refusal. Pure, so it is testable.
+
+    The sides have to have done the same work, or the difference is not a
+    difference in speed. Comparing against a revision where a flag did not exist
+    yet is the ordinary way in: the base exits in 40 ms having printed a usage
+    error while the tree does the job in 300 ms, and without this the report calls
+    that a resolved 260 ms slowdown -- the same class as the three traps the
+    module docstring names, and the one it left open. `compare` checks exit status
+    already; the asymmetry was the tell.
+
+    A consistently non-zero status is fine, and has to be: `doctor` exits 1
+    whenever it has anything to report. What is refused is *disagreement*.
+    """
+    if len(codes) > 1:
+        raise SystemExit(
+            f"the two revisions exited differently ({sorted(codes)}), so they did "
+            f"not do the same work and the timings are not comparable."
         )
-        shutil.rmtree(base, ignore_errors=True)
-    return summarise(pairs), sha
+    return f"both sides exited {codes.pop() if codes else 0}"
 
 
-def report(summary: Summary, revision: str, sha: str, what: str) -> str:
-    orders = f"{summary.pairs // 2} with each side first"
+def report(summary: Summary, revision: str, sha: str, what: str, note: str = "") -> str:
     lines = [
         f"{what}: working tree vs {revision} ({sha})",
-        f"  {summary.pairs} pairs in ABBA/BAAB blocks, {orders}",
+        f"  {summary.pairs} pairs in {summary.pairs // 2} ABBA/BAAB blocks, "
+        f"{summary.tree_first} measured the working tree first" + (f"; {note}" if note else ""),
         f"  base median {summary.base_median:.2f} ms   tree median {summary.tree_median:.2f} ms",
         f"  paired delta: median {summary.median:+.2f} ms, middle half "
         f"{summary.low:+.2f} to {summary.high:+.2f} ms",
@@ -299,9 +309,12 @@ def main(argv: Iterable[str] | None = None) -> int:
     if not args.importtime and not args.command:
         parser.error("give --importtime MODULE, or a woswoar command to time")
 
-    summary, sha = run(args.base, args.blocks, args.importtime, args.command, args.warmup)
+    if args.blocks < 1:
+        parser.error("--blocks must be at least 1; there is nothing to summarise from none")
+
+    summary, sha, note = run(args.base, args.blocks, args.importtime, args.command, args.warmup)
     what = f"import {args.importtime}" if args.importtime else f"woswoar {' '.join(args.command)}"
-    print(report(summary, args.base, sha, what))
+    print(report(summary, args.base, sha, what, note))
     return 0
 
 

--- a/tools/compare.py
+++ b/tools/compare.py
@@ -29,10 +29,8 @@ Exits 0 when the two agree and 1 when they do not, printing a unified diff.
 from __future__ import annotations
 
 import argparse
-import os
 import re
 import shlex
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -40,68 +38,28 @@ from collections.abc import Iterable, Sequence
 from difflib import unified_diff
 from pathlib import Path
 
-#: What the sandbox's machine identity is, on both sides. Seeded rather than
-#: scrubbed: `install` prints the id it generated, and a fresh one per run would
-#: differ between the two trees for a reason that says nothing. Two characters
-#: short of a real id would be caught by nothing, so this is the same
-#: sixteen-hex-digit shape `tests/support.py` uses, and for the same reason.
-MACHINE_ID = "0123456789abcdef"
-MACHINE_FILE = f"id={MACHINE_ID}\nname=compare@sandbox\n"
+from tools.sandbox import sandbox_env, seed_machine, worktree
 
 
-class Scrub(argparse.Action):
-    """``--scrub 'REGEX=REPLACEMENT'``, collected in the order given."""
-
-    def __call__(
-        self,
-        parser: argparse.ArgumentParser,
-        namespace: argparse.Namespace,
-        values: str | Sequence[str] | None,
-        option_string: str | None = None,
-    ) -> None:
-        text = str(values)
-        if "=" not in text:
+def _scrubs(parser: argparse.ArgumentParser, given: Sequence[str]) -> list[tuple[str, str]]:
+    """``REGEX=REPLACEMENT`` pairs, in the order given."""
+    out = []
+    for text in given:
+        pattern, sep, replacement = text.partition("=")
+        if not sep:
             parser.error(f"--scrub wants REGEX=REPLACEMENT, got {text!r}")
-        pattern, replacement = text.split("=", 1)
-        getattr(namespace, self.dest).append((pattern, replacement))
-
-
-def _sandbox(tree: Path, stack: list[tempfile.TemporaryDirectory[str]]) -> dict[str, str]:
-    """A throwaway home, and the environment that points woswoar at it.
-
-    Deliberately not the caller's environment with a few keys added: a
-    `WOSWOAR_SESSION` left over from the shell that started this, or an
-    `XDG_DATA_HOME` set on the developer's machine and not on anyone else's,
-    would reach one side and be reported as a difference between revisions.
-    """
-    home = tempfile.TemporaryDirectory(prefix="woswoar-compare-")
-    stack.append(home)
-    root = Path(home.name)
-    config = root / "config" / "woswoar"
-    config.mkdir(parents=True)
-    (config / "machine").write_text(MACHINE_FILE, encoding="utf-8")
-    return {
-        "HOME": str(root),
-        "XDG_DATA_HOME": str(root / "data"),
-        "XDG_CONFIG_HOME": str(root / "config"),
-        "XDG_CACHE_HOME": str(root / "cache"),
-        "PYTHONPATH": str(tree),
-        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
-        # A terminal would turn on colour and the progress meter, neither of
-        # which is what this is comparing, and both of which vary with how the
-        # comparison itself was invoked.
-        "NO_COLOR": "1",
-        "SHELL": "/bin/bash",
-    }
+        out.append((pattern, replacement))
+    return out
 
 
 def _record(
     tree: Path, commands: Sequence[str], show: Sequence[str], scrubs: Sequence[tuple[str, str]]
 ) -> str:
     """Everything ``tree`` printed for ``commands``, normalised."""
-    stack: list[tempfile.TemporaryDirectory[str]] = []
-    try:
-        env = _sandbox(tree, stack)
+    with tempfile.TemporaryDirectory(prefix="woswoar-compare-") as home:
+        root = Path(home)
+        seed_machine(root, "compare@sandbox")
+        env = sandbox_env(tree, root)
         out = []
         for command in commands:
             argv = shlex.split(command)
@@ -131,29 +89,6 @@ def _record(
         for pattern, replacement in scrubs:
             text = re.sub(pattern, replacement, text)
         return text
-    finally:
-        for home in reversed(stack):
-            home.cleanup()
-
-
-def _worktree(revision: str) -> tuple[Path, str]:
-    """A detached checkout of ``revision``, and the sha it resolved to."""
-    sha = subprocess.run(
-        ["git", "rev-parse", "--short", revision],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
-    path = Path(tempfile.mkdtemp(prefix="woswoar-compare-tree-"))
-    # `mkdtemp` made it, and `git worktree add` wants to make it itself.
-    path.rmdir()
-    subprocess.run(
-        ["git", "worktree", "add", "--detach", str(path), revision],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return path, sha
 
 
 def compare(
@@ -164,19 +99,9 @@ def compare(
 ) -> tuple[bool, str]:
     """``(agreed, report)`` for the working tree against ``revision``."""
     here = Path.cwd()
-    base, sha = _worktree(revision)
-    try:
+    with worktree(revision) as (base, sha):
         before = _record(base, commands, show, scrubs)
         after = _record(here, commands, show, scrubs)
-    finally:
-        subprocess.run(
-            ["git", "worktree", "remove", "--force", str(base)],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        shutil.rmtree(base, ignore_errors=True)
-
     return verdict(before, after, f"{revision} ({sha})", len(commands), scrubs)
 
 
@@ -227,7 +152,7 @@ def main(argv: Iterable[str] | None = None) -> int:
     )
     parser.add_argument(
         "--scrub",
-        action=Scrub,
+        action="append",
         default=[],
         metavar="REGEX=REPLACEMENT",
         help="normalise something else before comparing (repeatable). Listed in "
@@ -236,7 +161,7 @@ def main(argv: Iterable[str] | None = None) -> int:
     parser.add_argument("commands", nargs="+", help="woswoar command lines, run in order")
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    agreed, report = compare(args.base, args.commands, args.show, args.scrub)
+    agreed, report = compare(args.base, args.commands, args.show, _scrubs(parser, args.scrub))
     print(report)
     return 0 if agreed else 1
 

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -30,8 +30,11 @@ time here:
   ``(mtime_seconds, size)``, so two mutations that change a file by the same
   number of bytes inside one second run each other's cached bytecode. That
   reported a *correct* test as decoration once, and the test was nearly
-  rewritten because of it. Every run is ``-B`` and every ``__pycache__`` is
-  removed between mutations.
+  rewritten because of it. Three things now make it impossible rather than
+  merely unlikely: each copy of the tree starts with no ``__pycache__``, the
+  runs are ``-B`` *and* carry ``PYTHONDONTWRITEBYTECODE`` so the real ``age``
+  and ``git`` subprocesses the suite spawns cannot write one either, and a
+  reused copy is swept between mutations anyway.
 - **An edit that adds without removing is refused.** A replacement that still
   contains the text it replaced leaves the code under test exactly as it was, so
   the run reports "caught" or "SURVIVED" about nothing. That is the easy way to
@@ -39,23 +42,58 @@ time here:
   mean to relocate -- and it shipped three times in one session before this
   check. Pass ``additive=True`` for the rare edit that really does mean to insert
   in front of code that stays.
-- **The tree is restored even when interrupted.** A ``finally`` is not enough on
-  its own -- a kill leaves the source mutated, which is exactly the state
-  CLAUDE.md rule 6 is about -- so the original text is also written to a
-  recovery file, and its path is printed if anything goes wrong.
+- **Your working tree is never edited.** Each mutation is applied to a throwaway
+  copy, so a kill at the wrong moment cannot leave a mutated source behind --
+  the state CLAUDE.md rule 6 is about, and one this used to guard against with a
+  ``finally`` and a rescue file in ``/tmp``. A copy is 2 MB and takes
+  milliseconds; the earlier design paid for its cheapness with the one failure
+  mode the whole rule exists to prevent.
+
+  That is also what makes the mutations run **in parallel**. They are
+  independent by construction, each is mostly waiting on a subprocess, and the
+  suite a mutation runs is plain serial ``unittest`` rather than the sharded
+  runner -- so there is no nested pool to oversubscribe. Measured as
+  ``workers=1`` against the default, same design either way: four mutations
+  against ``tests.test_sync`` went 197.5 s to 51.5 s, and eleven against the
+  faster modules 2.4 s to 0.5 s. Both figures are serial-versus-parallel, not
+  before-and-after this module was rewritten -- the old design also ran in the
+  working tree rather than a copy, so no measurement here separates those two
+  changes and none is quoted as if it did.
+
+**What a sandbox cannot check.** ``.git`` is not copied, and the copy lands
+wherever ``$TMPDIR`` points -- tmpfs on most machines. So a test that needs a
+repository to check a revision out of, or that distinguishes two filesystems,
+skips in here and its guard cannot be mutation-verified through this module.
+`tests/test_sandbox.py` is the case that exists; those guards were verified by
+reverting them in the working tree by hand. Worth knowing before concluding that
+a surviving mutation means a weak test.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
+import queue
+import re
 import runpy
 import shutil
 import subprocess
 import sys
 import tempfile
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from pathlib import Path
 from typing import NamedTuple
+
+from tools.sandbox import usable_cpus
+
+#: Names never copied into a mutation's sandbox. ``.git`` because it is large and
+#: nothing under test reads it; the caches because a stale one is the trap this
+#: module documents, and the cheapest way to not have it is to not copy it.
+_SKIP = shutil.ignore_patterns(
+    ".git", "__pycache__", ".mypy_cache", ".ruff_cache", ".venv", "*.egg-info"
+)
 
 
 class Mutation(NamedTuple):
@@ -83,84 +121,190 @@ class Result(NamedTuple):
     caught: bool
 
 
-def _clear_bytecode() -> None:
-    for cache in Path().glob("*/__pycache__"):
+def _clear_bytecode(root: Path) -> None:
+    """The sweep the trap in the module docstring needs, for a real reason.
+
+    Not belt and braces: `tests/test_search.py`'s `picker_env` builds its own
+    environment from literals to drive the pty, so it carries no
+    ``PYTHONDONTWRITEBYTECODE``, and its ``PYTHONPATH`` points at the tree running
+    the suite -- the sandbox. Those `python -m woswoar` children do write a
+    ``__pycache__`` into a copy that a later mutation reuses, which is exactly the
+    ``(mtime, size)`` collision this module exists to avoid. Measured at 0.6 ms on
+    the full tree and 12 directories in a sandbox, against a multi-second run.
+    """
+    for cache in root.rglob("__pycache__"):
         shutil.rmtree(cache, ignore_errors=True)
 
 
-def _run(tests: Sequence[str]) -> bool:
-    """Whether the suite failed, which for a mutation is the good answer."""
-    _clear_bytecode()
+def _run(tests: Sequence[str], root: Path) -> bool:
+    """Whether the suite failed, which for a mutation is the good answer.
+
+    A non-zero exit is not enough on its own, and this is the one hazard here
+    that produces a wrong answer in the direction a reader believes. A mutation
+    that makes the module unimportable, or breaks a `setUpClass`, also exits
+    non-zero -- so it would print `caught` while the test whose name is in the row
+    never ran. So the count `unittest` prints is checked too: no "Ran N" line, or
+    "Ran 0", means the mutation broke collection rather than being noticed.
+    """
+    _clear_bytecode(root)
     finished = subprocess.run(
         [sys.executable, "-B", "-m", "unittest", *tests],
+        cwd=root,
+        # `-B` covers this process; the variable covers the real `age`, `git` and
+        # `bash` the suite spawns, which would otherwise leave a `.pyc` in a
+        # sandbox that a later mutation reuses.
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
         capture_output=True,
         text=True,
         check=False,
     )
+    ran = re.search(r"^Ran (\d+) tests? in ", finished.stderr, re.MULTILINE)
+    if ran is None or ran.group(1) == "0":
+        raise SystemExit(
+            f"{' '.join(tests)} ran no tests under this mutation, so 'caught' would "
+            f"mean 'the suite could not start' rather than 'a test noticed'. The "
+            f"mutation probably broke an import.\n{finished.stderr[-2000:]}"
+        )
     return finished.returncode != 0
 
 
-def verify(mutations: Iterable[Mutation], baseline: bool = True) -> int:
-    """Apply each mutation in turn; return how many were *not* caught.
+def _check(mutation: Mutation) -> None:
+    """Refuse a spec that cannot mean anything, reading the real file.
 
-    Prints one line per mutation, in the shape a PR body wants. With
-    ``baseline``, also confirms the untouched tree is green -- without which
-    "caught" means nothing, because a suite that is already failing catches
-    everything.
+    Every mutation is checked before any of them runs -- see `verify`. A typo in
+    the last row of a table used to be found after the first four had each cost a
+    suite run.
     """
-    survivors: list[Result] = []
-    for mutation in mutations:
-        source = Path(mutation.path)
+    original = Path(mutation.path).read_text(encoding="utf-8")
+    found = original.count(mutation.old)
+    if found != 1:
+        raise SystemExit(
+            f"{mutation.label}: {mutation.path} contains the text to replace "
+            f"{found} times, not once. A mutation that matches nothing tests "
+            f"nothing, and one that matches twice tests something else."
+        )
+
+    # The replacement still contains everything it replaced, so the line the
+    # test is supposed to miss is still in the file and the run cannot mean
+    # anything. Always a mistake when the intent was to *move* something --
+    # write the whole span in `old`, including what follows it, or the
+    # original stays put underneath the edit.
+    #
+    # Three of these went out in one session before this check existed. Each
+    # cost a full suite run and read as "caught" when nothing had changed;
+    # the tell is that a mutation meant to break an invariant reports the
+    # same result as one that does nothing, and there is no way to see which
+    # from the output.
+    if not mutation.additive and mutation.old in mutation.new:
+        raise SystemExit(
+            f"{mutation.label}: the text to replace survives verbatim inside "
+            f"the replacement, so the code under test does not change and "
+            f"'caught' would mean nothing. If the point really is to insert "
+            f"something in front of code that stays, pass additive=True."
+        )
+
+
+@contextmanager
+def _sandboxes(count: int) -> Iterator[queue.Queue[Path]]:
+    """``count`` borrowable copies of the working tree, lent out one at a time.
+
+    A queue rather than one copy per mutation: a copy is 1.9 MB of 87 files and
+    measures about a millisecond, while a test run costs seconds -- but there is
+    still no reason to make five hundred of them for a table of five hundred rows.
+    Borrow, mutate, restore, return.
+
+    **Every** borrower is a pool task, which is what keeps this deadlock-free. An
+    earlier version handed the baseline a copy taken on the *main* thread and
+    never returned it, so with a single lane the baseline held the only sandbox
+    and every mutation waited on an empty queue for ever. A task always returns
+    what it borrowed in a `finally`; the main thread must never take one.
+
+    Copied rather than ``git worktree add``, which would check out *HEAD* and so
+    quietly test committed code -- the mutation is meant to apply to the tree as
+    it stands, uncommitted changes and all, which is the whole situation this is
+    used in.
+    """
+    with tempfile.TemporaryDirectory(prefix="woswoar-mutate-") as holder:
+        available: queue.Queue[Path] = queue.Queue()
+        for index in range(count):
+            root = Path(holder) / f"tree{index}"
+            shutil.copytree(Path.cwd(), root, ignore=_SKIP, symlinks=True)
+            available.put(root)
+        yield available
+
+
+def _borrow(available: queue.Queue[Path], tests: Sequence[str]) -> bool:
+    """Run ``tests`` unmutated in a borrowed sandbox. One shard of the baseline."""
+    root = available.get()
+    try:
+        return _run(tests, root)
+    finally:
+        available.put(root)
+
+
+def _attempt(mutation: Mutation, available: queue.Queue[Path]) -> bool:
+    """Apply one mutation in a borrowed sandbox and report whether it was caught."""
+    root = available.get()
+    try:
+        source = root / mutation.path
         original = source.read_text(encoding="utf-8")
-        found = original.count(mutation.old)
-        if found != 1:
-            raise SystemExit(
-                f"{mutation.label}: {mutation.path} contains the text to replace "
-                f"{found} times, not once. A mutation that matches nothing tests "
-                f"nothing, and one that matches twice tests something else."
-            )
-
-        # The replacement still contains everything it replaced, so the line the
-        # test is supposed to miss is still in the file and the run cannot mean
-        # anything. Always a mistake when the intent was to *move* something --
-        # write the whole span in `old`, including what follows it, or the
-        # original stays put underneath the edit.
-        #
-        # Three of these went out in one session before this check existed. Each
-        # cost a full suite run and read as "caught" when nothing had changed;
-        # the tell is that a mutation meant to break an invariant reports the
-        # same result as one that does nothing, and there is no way to see which
-        # from the output.
-        if not mutation.additive and mutation.old in mutation.new:
-            raise SystemExit(
-                f"{mutation.label}: the text to replace survives verbatim inside "
-                f"the replacement, so the code under test does not change and "
-                f"'caught' would mean nothing. If the point really is to insert "
-                f"something in front of code that stays, pass additive=True."
-            )
-
-        # Written somewhere findable before the file is touched, so an
-        # interrupted run leaves a way back that does not depend on this process
-        # reaching its `finally`.
-        rescue = Path(tempfile.gettempdir()) / f"woswoar-mutate-{source.name}"
-        rescue.write_text(original, encoding="utf-8")
+        source.write_text(original.replace(mutation.old, mutation.new), encoding="utf-8")
         try:
-            source.write_text(original.replace(mutation.old, mutation.new), encoding="utf-8")
-            caught = _run(mutation.tests.split())
+            return _run(mutation.tests.split(), root)
         finally:
+            # Into the sandbox, not the working tree. Only so the next mutation
+            # to borrow this copy starts from clean source.
             source.write_text(original, encoding="utf-8")
-            _clear_bytecode()
-            rescue.unlink(missing_ok=True)
+    finally:
+        available.put(root)
 
-        print(f"  {'caught' if caught else 'SURVIVED':9} {mutation.label}")
-        if not caught:
-            survivors.append(Result(mutation, caught))
 
-    if baseline:
-        every = sorted({test for mutation in mutations for test in mutation.tests.split()})
-        if _run(every):
+def verify(mutations: Iterable[Mutation], baseline: bool = True, workers: int | None = None) -> int:
+    """Apply each mutation in its own copy of the tree; return how many survived.
+
+    Prints one line per mutation, in the order the table gives them and not the
+    order they finish, so that the output is the same every run and can be pasted
+    into a pull request as it stands.
+
+    With ``baseline``, also confirms the untouched tree is green -- without which
+    "caught" means nothing, because a suite that is already failing catches
+    everything. Its targets are sharded and queued alongside the mutations rather
+    than run as one serial pass, because a single pass over the union of every
+    target was measured at two thirds of the wall clock.
+    """
+    table = list(mutations)
+    if not table:
+        return 0
+    for mutation in table:
+        _check(mutation)
+
+    # One shard per target rather than one serial run over the union. Measured on
+    # four pinned cores with eight `tests.test_sync` classes: the mutation phase
+    # took 2.35 s across eight lanes while a single-run baseline took 6.75 s, so
+    # the check meant to cost nothing was two thirds of the wall clock and got
+    # worse as the table grew -- mutations fan out, a union sums.
+    shards = sorted({test for mutation in table for test in mutation.tests.split()})
+    # Twice the usable cores, which is what `tools/run_tests.py` measured for this
+    # same subprocess-wait-bound work (jobs=8 beat jobs=4 by ~9%, jobs=16
+    # regressed). An earlier `cpu // 2` here gave two lanes on a four-core runner
+    # and was 1.76x slower than this for eight runs. A sandbox is ~1 ms, so a lane
+    # is nearly free.
+    lanes = workers or min(len(table) + len(shards), usable_cpus() * 2, 16)
+
+    survivors: list[Result] = []
+    with _sandboxes(lanes) as available, ThreadPoolExecutor(max_workers=lanes) as pool:
+        checking = (
+            [pool.submit(_borrow, available, [shard]) for shard in shards] if baseline else []
+        )
+        futures = [pool.submit(_attempt, mutation, available) for mutation in table]
+        for mutation, future in zip(table, futures, strict=True):
+            caught = future.result()
+            print(f"  {'caught' if caught else 'SURVIVED':9} {mutation.label}")
+            if not caught:
+                survivors.append(Result(mutation, caught))
+        if any(future.result() for future in checking):
             print("  BASELINE RED -- the suite fails untouched, so nothing above means anything")
-            return len(list(mutations)) or 1
+            return len(table)
 
     if survivors:
         print(f"\n{len(survivors)} survived. A test that cannot see the fix removed is decoration:")

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -1,0 +1,146 @@
+"""What a tool comparing two revisions has to get right before it measures.
+
+`compare` and `bench` both need a checkout of some revision, a throwaway ``$HOME``
+that woswoar will treat as a fresh machine, and a count of the CPUs this process
+may actually use. Both grew their own copy of each in one commit, and the copies
+had already diverged in the way that matters:
+
+- `bench` built its environment as ``{**os.environ, ...}`` and overrode four
+  keys. `store.ENV_KEYS` has six. ``WOSWOAR_DIR`` beats ``XDG_DATA_HOME`` in
+  `store.data_dir`, and ``WOSWOAR_SESSION`` is exported by the installed hook in
+  every interactive shell -- so a benchmark run from a normal terminal measured
+  the developer's real history in both trees instead of the empty sandbox. That
+  is exactly what `store.ENV_KEYS`' own comment was written for: "a variable
+  added here but missed in a hand-kept copy would silently point a 'sandbox' at
+  the real installation, with nothing failing."
+- `bench` placed its worktree beside the repository and `compare` left it in
+  ``/tmp``. Only one of those is deliberate, and the difference is invisible.
+
+So the environment here is built from **nothing**, not from `os.environ`. That is
+what makes it correct as `store` grows: a key woswoar reads and this does not set
+is simply absent, so `store` falls back to its ``$HOME``-relative default, which
+is inside the sandbox. Inheriting and overriding is the shape that fails
+silently, and it fails towards the real installation.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+#: The identity every sandbox is given, on every side of every comparison.
+#: Seeded rather than generated: `install` prints the id it made, so a fresh one
+#: per run would differ between two trees for a reason that says nothing about
+#: either. Sixteen hex digits because that is the real shape -- a short one would
+#: be caught by nothing here and would then not resemble what it stands in for.
+MACHINE_ID = "0123456789abcdef"
+
+
+def seed_machine(home: Path, name: str) -> None:
+    """Give ``home`` a machine identity, so nothing has to generate one."""
+    config = home / "config" / "woswoar"
+    config.mkdir(parents=True, exist_ok=True)
+    (config / "machine").write_text(f"id={MACHINE_ID}\nname={name}\n", encoding="utf-8")
+
+
+def sandbox_env(tree: Path, home: Path) -> dict[str, str]:
+    """The whole environment for a woswoar run against ``tree``, inside ``home``.
+
+    Everything the child gets, and nothing else. See the module docstring for why
+    this does not start from `os.environ` -- the short version is that the failure
+    mode of inheriting is a "sandbox" pointed at the real installation.
+
+    ``PATH`` is the one thing carried across, because the suite and the CLI both
+    need to find real `age`, `git` and `bash`, and there is no sandbox-relative
+    answer to where those are.
+    """
+    return {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": str(home),
+        "XDG_DATA_HOME": str(home / "data"),
+        "XDG_CONFIG_HOME": str(home / "config"),
+        "XDG_CACHE_HOME": str(home / "cache"),
+        "PYTHONPATH": str(tree),
+        # Bytecode goes in the sandbox, so no `__pycache__` in the tree is either
+        # read or written. Both halves matter and the first one is subtle: a `.pyc`
+        # is validated against `(mtime_seconds, size)`, so an edit that changes a
+        # file by no bytes inside one second leaves a *valid-looking* cache of the
+        # previous source. That is not hypothetical -- `compare` reported a
+        # difference between two identical trees this way, because `logs    :` had
+        # been edited to `LOGS    :` and back, and the checkout it was compared
+        # against was fresh while the working tree still had the stale cache.
+        # `PYTHONDONTWRITEBYTECODE` would not have helped: it stops writing, not
+        # reading.
+        "PYTHONPYCACHEPREFIX": str(home / "pycache"),
+        # A terminal would turn on colour and the progress meter, neither of
+        # which is ever the thing being compared, and both of which vary with how
+        # the comparison itself was invoked.
+        "NO_COLOR": "1",
+        "SHELL": "/bin/bash",
+    }
+
+
+@contextmanager
+def worktree(revision: str, beside: Path | None = None) -> Iterator[tuple[Path, str]]:
+    """A detached checkout of ``revision`` and its short sha, removed afterwards.
+
+    ``beside`` puts it on a named directory's filesystem. `bench` needs that and
+    `compare` does not, which is the only difference between the two copies this
+    replaces -- so it is a parameter with a default rather than two functions.
+
+    The teardown is both halves on purpose: `git worktree remove` alone can fail
+    and leave the directory, and `rmtree` alone leaves a stale entry under
+    ``.git/worktrees`` that makes the next ``worktree add`` on the same path fail.
+    """
+    sha = subprocess.run(
+        ["git", "rev-parse", "--short", revision], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    path = Path(tempfile.mkdtemp(dir=beside, prefix=".woswoar-worktree-"))
+    # `mkdtemp` made it and `git worktree add` insists on making it itself.
+    path.rmdir()
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(path), revision],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    try:
+        yield path, sha
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def usable_cpus() -> int:
+    """How many CPUs this process may actually use.
+
+    Not ``os.cpu_count()``, which reports the host's and ignores an affinity mask
+    or a container's quota -- so on a two-core-limited runner on a sixteen-core
+    host it answers sixteen. `tools/run_tests.py` has said so since it was
+    written; this is the second caller, which is why it is here rather than
+    spelled again.
+    """
+    counter = getattr(os, "process_cpu_count", os.cpu_count)  # process_cpu_count is 3.13+
+    return counter() or 4
+
+
+def same_filesystem(one: Path, other: Path) -> bool:
+    """Whether two paths sit on the same device.
+
+    A checked precondition rather than a convention. `bench` used to say "put the
+    worktree beside the repository" and leave it there, which is a *remedy* for
+    comparing tmpfs against btrfs, not the invariant -- and it fails silently
+    wherever the parent directory is a different mount, which is any repo at a
+    mountpoint and any container bind. Asking the question costs two `stat` calls.
+    """
+    return one.stat().st_dev == other.stat().st_dev


### PR DESCRIPTION
Replaces #211, which GitHub closed when its base branch `session-tools` was deleted on merging #210 — my mistake for deleting the base before retargeting. **The review discussion is on #211 and is worth reading**, in particular the `/simplify` findings comment; nothing there is superseded, the content here is byte-identical to what passed CI on that branch, rebased onto `main`.

## The problem

`tools/mutate.py` edited the working tree in place, restored it in a `finally`, and wrote a rescue copy to `/tmp` first — an apparatus that existed to make an unsafe design survivable, and which still lost to a kill in between. That happened this session when a run hit a timeout.

## The change

Each mutation runs in a throwaway 2 MB copy. The working tree is never written, so the rescue file has nothing left to guard. That is also what lets the table run in parallel — measured as `workers=1` against the default, same design either way:

| table | serial | parallel |
|---|---|---|
| 4 mutations against `tests.test_sync` | 197.5 s | **51.5 s** |
| 11 against faster modules | 2.4 s | **0.5 s** |

Both are serial-versus-parallel, **not** before-and-after the rewrite: the old design also ran in the working tree, so no measurement here separates those two changes and none is quoted as if it did.

Beyond the move:

- **The baseline is sharded across lanes.** One serial pass over the union of every target measured 6.75 s against a 2.35 s mutation phase on four pinned cores — two thirds of the wall clock, in a check whose docstring claimed it cost nothing. Sharding also means nothing takes a sandbox outside the pool, so the dedicated spare copy from the earlier deadlock fix is gone: the simpler shape and the faster one turned out to be the same shape.
- **Lanes are twice the usable cores**, matching what `run_tests.py` measured for the same subprocess-bound work. The earlier `cpu // 2` gave two lanes on a four-core runner and was 1.76x slower for eight runs.
- **`usable_cpus` respects an affinity mask.** `os.cpu_count()` reports the host's, so a cgroup-limited runner would have started sixteen lanes.
- **`caught` no longer means only "exited non-zero".** A mutation that breaks an import exits non-zero too, so it printed `caught` while the test named in the row never ran — the one hazard here that lies in the direction a reader believes.
- **`_clear_bytecode` kept, reason corrected.** Not belt and braces: `tests/test_search.py`'s `picker_env` builds its own env for the pty with no `PYTHONDONTWRITEBYTECODE`, so its children do write into a sandbox a later mutation reuses.

## New `tools/sandbox.py`

`compare` and `bench` had each grown their own copy of the worktree, its two-part teardown, the sandbox `$HOME`, the machine seeding and the CPU count — and the copies had already diverged in the way that mattered:

**`bench.py` did not control for the environment.** `_wall` built its child env as `{**os.environ, ...}` and overrode four keys; `store.ENV_KEYS` has six. `WOSWOAR_DIR` beats `XDG_DATA_HOME` in `store.data_dir`, and the installed hook exports `WOSWOAR_SESSION` in every interactive shell — so a benchmark run from a normal terminal measured the developer's real history in both trees. Verbatim the failure `ENV_KEYS`' own comment was written for. The env is built from nothing now, which is the structural fix: an unset key falls back to a `$HOME`-relative default *inside* the sandbox, where inherit-and-override fails towards the real installation.

**`compare.py` then found a bug in itself.** It reported a difference between two identical trees (`logs    :` vs `LOGS    :`) because a stale `.pyc` from an earlier same-length edit within one second still validated — the exact `(mtime, size)` trap `CLAUDE.md` documents, hit because the fresh checkout has no cache while the working tree does. `PYTHONDONTWRITEBYTECODE` does not help (it stops writing, not reading); `PYTHONPYCACHEPREFIX` into the sandbox does.

Also from the review: `bench` ignored exit status (a base revision exiting on an unknown flag reads as a 260 ms slowdown); `same_filesystem` is a checked precondition rather than the "put it beside the repo" convention; `Pair.tree_first` was never read, so the report's "both orders were used" line was `pairs // 2` arithmetic — itself the unchecked claim its comment warned against.

## Verification

Seven mutations over the new guards, all caught, baseline green. Two further guards cannot be mutation-verified through `mutate.py` at all — its sandbox excludes `.git` and lands on tmpfs, so the tests holding them skip in there — and were verified by hand instead. That limitation is now in `mutate.py`'s docstring, so a future survivor is not misread as a weak test.

`CLAUDE.md` and `CONTRIBUTING.md` carried each tool's full rationale in triplicate and had already drifted; they are now one table of when-to-reach-for-which plus links, with the rationale in the docstrings. `CLAUDE.md` is 34 lines shorter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)