### PR TITLE
fix: doctor checks where the rc line points, and the suite stops writing to the real home

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -308,10 +308,27 @@ ENV_KEYS = store.ENV_KEYS
 
 
 class WoswoarTestCase(unittest.TestCase):
-    """Runs each test against a throwaway WOSWOAR_DIR.
+    """Runs each test against a throwaway WOSWOAR_DIR and a throwaway ``$HOME``.
 
     Every path in :mod:`woswoar.store` is resolved from the environment on each
     call rather than at import time, which is what makes this isolation work.
+
+    ``$HOME`` is redirected here rather than in each test class that happens to
+    need it, and that is not tidiness. `store.ENV_KEYS` does not contain HOME --
+    it never had to, because every path `store` resolves has an XDG variable in
+    front of it -- but `install` does not go through `store` to find a shell's
+    rc file: `rcfile_for` is `Path.home() / ".bashrc"`. So two tests here that
+    ran `install` with no `--rcfile` wrote a woswoar block into the **developer's
+    own** `~/.bashrc` and `~/.zshrc`, pointing at a `WOSWOAR_DIR` that the very
+    next line of `tearDown` deleted. That is a broken shell on the machine
+    running the suite: every interactive session printed a `No such file or
+    directory` and recorded nothing. It was found on a real machine, months
+    after the fact, by a `doctor` that said the bashrc was fine.
+
+    Four test classes had already grown their own copy of this redirect for
+    smaller versions of the same reason -- reading the developer's real shell
+    history, offering to import it. The lesson those four missed is that a test
+    must not be able to reach the real home *by forgetting to say so*.
     """
 
     def setUp(self) -> None:
@@ -328,11 +345,22 @@ class WoswoarTestCase(unittest.TestCase):
         self.root = Path(self._tmp.name).resolve()
         self.addCleanup(self._tmp.cleanup)
 
-        self._saved = {key: os.environ.get(key) for key in ENV_KEYS}
+        self._saved = {key: os.environ.get(key) for key in (*ENV_KEYS, "HOME", "SHELL")}
         self.addCleanup(self._restore_env)
 
         for key in ENV_KEYS:
             os.environ.pop(key, None)
+        # A directory of its own rather than `self.root`: `install` writes into
+        # `$HOME` and so does the importer, and a test asserting on what is in
+        # the sandbox root should not have to know which of those put it there.
+        self.home = self.root / "home"
+        self.home.mkdir()
+        os.environ["HOME"] = str(self.home)
+        # For the same reason, one variable further out: `install`'s `auto` falls
+        # back to `$SHELL` when there is no rc file to go on, so a developer
+        # whose login shell is zsh would otherwise get a different answer from
+        # CI. A test that is *about* that fallback sets it to what it needs.
+        os.environ["SHELL"] = "/bin/bash"
         os.environ["WOSWOAR_DIR"] = str(self.root / "data")
         os.environ["XDG_CONFIG_HOME"] = str(self.root / "config")
         os.environ["XDG_CACHE_HOME"] = str(self.root / "cache")

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -118,18 +118,6 @@ class TestInstallWarnsAboutMissingTools(WoswoarTestCase):
         os.environ["PATH"] = str(empty)
         self.addCleanup(lambda: os.environ.__setitem__("PATH", self._path))
 
-        self.home = self.root / "home"
-        self.home.mkdir()
-        self._home = os.environ.get("HOME")
-        os.environ["HOME"] = str(self.home)
-        self.addCleanup(self._restore_home)
-
-    def _restore_home(self) -> None:
-        if self._home is None:
-            os.environ.pop("HOME", None)
-        else:
-            os.environ["HOME"] = self._home
-
     def test_install_still_succeeds_but_says_what_is_missing(self) -> None:
         ran = support.run_cli("install", "--rcfile", str(self.home / ".bashrc"))
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -231,22 +231,6 @@ class TestDoctorReportsTheShellsThisMachineUses(WoswoarTestCase):
     nothing to fix.
     """
 
-    def setUp(self) -> None:
-        super().setUp()
-        self.home = self.root / "home"
-        self.home.mkdir()
-        self._saved = {key: os.environ.get(key) for key in ("HOME", "SHELL")}
-        self.addCleanup(self._restore)
-        os.environ["HOME"] = str(self.home)
-        os.environ["SHELL"] = "/bin/bash"
-
-    def _restore(self) -> None:
-        for key, value in self._saved.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
-
     def test_a_bash_only_machine_is_not_asked_about_zsh(self) -> None:
         (self.home / ".bashrc").write_text("", encoding="utf-8")
         support.run_cli("install")
@@ -277,6 +261,91 @@ class TestDoctorReportsTheShellsThisMachineUses(WoswoarTestCase):
         out = support.run_cli("doctor").out
         self.assertIn(f"{self.home}/.bashrc sources the hook", out)
         self.assertIn(f"{self.home}/.zshrc sources the hook", out)
+
+    def test_a_block_left_by_a_test_install_is_not_reported_as_working(self) -> None:
+        """The line pointing *somewhere*, not the marker being present.
+
+        A real `.bashrc` was found sourcing
+        `/tmp/woswoar-test-kc71_9n1/data/woswoar.bash` -- a sandbox that a test
+        run deleted on the way out. Every interactive shell printed a `No such
+        file or directory`, nothing was recorded for months, and `doctor` said
+        `bashrc ... sources the hook` the whole time, because the block was
+        there. The block being there is not the claim the line makes.
+        """
+        (self.home / ".bashrc").write_text("", encoding="utf-8")
+        support.run_cli("install")
+        gone = self.root / "gone" / "woswoar.bash"
+        install.write_block(self.home / ".bashrc", gone)
+
+        out = support.run_cli("doctor").out
+        self.assertIn("[FAIL] bashrc", out)
+        self.assertIn(str(gone), out, "the report does not say where the line points")
+        self.assertIn("woswoar install", out, "no remedy named")
+
+    def test_reinstalling_is_a_remedy_that_works(self) -> None:
+        """Without this the test above is satisfied by a check that can only
+        fail, and the command it tells people to run is untested."""
+        (self.home / ".bashrc").write_text("", encoding="utf-8")
+        support.run_cli("install")
+        install.write_block(self.home / ".bashrc", self.root / "gone" / "woswoar.bash")
+        self.assertIn("[FAIL] bashrc", support.run_cli("doctor").out)
+
+        support.run_cli("install")
+        self.assertIn("[ok] bashrc", support.run_cli("doctor").out)
+
+    def test_the_line_is_read_the_way_a_shell_reads_it(self) -> None:
+        """`$HOME/...` is what `install` writes whenever the hook is under the
+        home directory, and it is what a shared dotfiles `.bashrc` carries. A
+        check that compared the line to the hook's absolute path as text would
+        fail every one of those installs, which is a red `doctor` on a machine
+        with nothing wrong -- worse than the false green it replaced.
+
+        The sandbox puts `WOSWOAR_DIR` outside `$HOME`, where `install` writes
+        an absolute path, so this has to move it in: without that the fixture
+        cannot tell the two spellings apart.
+        """
+        os.environ["WOSWOAR_DIR"] = str(self.home / ".local/share/woswoar")
+        (self.home / ".bashrc").write_text("", encoding="utf-8")
+        support.run_cli("install")
+
+        text = (self.home / ".bashrc").read_text(encoding="utf-8")
+        self.assertIn('source "$HOME/', text, "the fixture wrote an absolute path")
+        self.assertIn("[ok] bashrc", support.run_cli("doctor").out)
+
+    def test_another_installers_source_line_is_not_mistaken_for_ours(self) -> None:
+        """An rc file is full of `source` lines and exactly one is woswoar's.
+
+        Reading the first one in the file would report nvm's path as the hook's
+        -- a red `doctor` on a healthy machine, with a remedy that changes
+        nothing. The marked block is what makes this answerable at all, and it
+        has to be the thing searched rather than merely the thing found.
+        """
+        rcfile = self.home / ".bashrc"
+        rcfile.write_text('source "$HOME/.nvm/nvm.sh"\n', encoding="utf-8")
+        support.run_cli("install")
+
+        self.assertTrue(
+            rcfile.read_text(encoding="utf-8").index("nvm.sh")
+            < rcfile.read_text(encoding="utf-8").index(install.BEGIN),
+            "the fixture's other source line has to come first to test anything",
+        )
+        self.assertIn("[ok] bashrc", support.run_cli("doctor").out)
+
+    def test_a_block_that_sources_nothing_is_not_a_missing_block(self) -> None:
+        """Three states, three lines: someone who has never installed, someone
+        whose line points at the wrong file, and someone who edited the block
+        down to a comment. Telling the third they have no woswoar block sends
+        them looking for something that is right in front of them."""
+        (self.home / ".bashrc").write_text("", encoding="utf-8")
+        support.run_cli("install")
+        (self.home / ".bashrc").write_text(
+            f"{install.BEGIN}\n# I took this out for a bit\n# <<< woswoar <<<\n",
+            encoding="utf-8",
+        )
+        out = support.run_cli("doctor").out
+        self.assertIn("[FAIL] bashrc", out)
+        self.assertIn("sources nothing", out)
+        self.assertNotIn("has no woswoar block", out)
 
     def test_a_machine_with_nothing_installed_still_reports_a_shell(self) -> None:
         """`installed_shells()` is empty before the first `install`, and a doctor

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -231,9 +231,18 @@ class TestDoctorReportsTheShellsThisMachineUses(WoswoarTestCase):
     nothing to fix.
     """
 
-    def test_a_bash_only_machine_is_not_asked_about_zsh(self) -> None:
-        (self.home / ".bashrc").write_text("", encoding="utf-8")
+    def install_bash(self, rcfile_text: str = "") -> Path:
+        """Install into the sandbox home the way a person does, and hand back
+        the `.bashrc` that names it: no `--rcfile`, so `install` finds the file
+        through `$HOME` -- which is the path the incident behind these tests
+        went down, and the one worth exercising rather than routing around."""
+        rcfile = self.home / ".bashrc"
+        rcfile.write_text(rcfile_text, encoding="utf-8")
         support.run_cli("install")
+        return rcfile
+
+    def test_a_bash_only_machine_is_not_asked_about_zsh(self) -> None:
+        self.install_bash()
         out = support.run_cli("doctor").out
         self.assertRegex(out, r"\] bash ")
         self.assertNotIn("] zsh ", out)
@@ -255,9 +264,8 @@ class TestDoctorReportsTheShellsThisMachineUses(WoswoarTestCase):
         self.assertRegex(out, r"\] zsh +.+ \(5\.0\+ required\)")
 
     def test_each_installed_shell_gets_its_own_rcfile_line(self) -> None:
-        (self.home / ".bashrc").write_text("", encoding="utf-8")
         (self.home / ".zshrc").write_text("", encoding="utf-8")
-        support.run_cli("install")
+        self.install_bash()
         out = support.run_cli("doctor").out
         self.assertIn(f"{self.home}/.bashrc sources the hook", out)
         self.assertIn(f"{self.home}/.zshrc sources the hook", out)
@@ -272,10 +280,9 @@ class TestDoctorReportsTheShellsThisMachineUses(WoswoarTestCase):
         `bashrc ... sources the hook` the whole time, because the block was
         there. The block being there is not the claim the line makes.
         """
-        (self.home / ".bashrc").write_text("", encoding="utf-8")
-        support.run_cli("install")
+        rcfile = self.install_bash()
         gone = self.root / "gone" / "woswoar.bash"
-        install.write_block(self.home / ".bashrc", gone)
+        install.write_block(rcfile, gone)
 
         out = support.run_cli("doctor").out
         self.assertIn("[FAIL] bashrc", out)
@@ -285,9 +292,7 @@ class TestDoctorReportsTheShellsThisMachineUses(WoswoarTestCase):
     def test_reinstalling_is_a_remedy_that_works(self) -> None:
         """Without this the test above is satisfied by a check that can only
         fail, and the command it tells people to run is untested."""
-        (self.home / ".bashrc").write_text("", encoding="utf-8")
-        support.run_cli("install")
-        install.write_block(self.home / ".bashrc", self.root / "gone" / "woswoar.bash")
+        install.write_block(self.install_bash(), self.root / "gone" / "woswoar.bash")
         self.assertIn("[FAIL] bashrc", support.run_cli("doctor").out)
 
         support.run_cli("install")
@@ -305,12 +310,28 @@ class TestDoctorReportsTheShellsThisMachineUses(WoswoarTestCase):
         cannot tell the two spellings apart.
         """
         os.environ["WOSWOAR_DIR"] = str(self.home / ".local/share/woswoar")
-        (self.home / ".bashrc").write_text("", encoding="utf-8")
-        support.run_cli("install")
+        text = self.install_bash().read_text(encoding="utf-8")
 
-        text = (self.home / ".bashrc").read_text(encoding="utf-8")
         self.assertIn('source "$HOME/', text, "the fixture wrote an absolute path")
         self.assertIn("[ok] bashrc", support.run_cli("doctor").out)
+
+    def test_a_block_a_person_wrote_is_read_the_way_the_shell_would(self) -> None:
+        """Every spelling here loads the hook in a real shell, so none of them
+        may be reported as broken -- the remedy is `woswoar install`, which
+        would overwrite a line its owner wrote deliberately.
+
+        This is the branch of `_expanded` and `_SOURCE_LINE` that `install`
+        never writes, and without it the tolerance they carry is untested code
+        deciding whether a green report is green.
+        """
+        os.environ["WOSWOAR_DIR"] = str(self.home / ".local/share/woswoar")
+        rcfile = self.install_bash()
+        hook = store.data_dir() / install.HOOKS["bash"]
+        under_home = hook.relative_to(self.home).as_posix()
+
+        for line in (f". ~/{under_home}", f'source "${{HOME}}/{under_home}"', f"source {hook}"):
+            rcfile.write_text(f"{install.BEGIN}\n{line}\n# <<< woswoar <<<\n", encoding="utf-8")
+            self.assertIn("[ok] bashrc", support.run_cli("doctor").out, line)
 
     def test_another_installers_source_line_is_not_mistaken_for_ours(self) -> None:
         """An rc file is full of `source` lines and exactly one is woswoar's.
@@ -320,13 +341,11 @@ class TestDoctorReportsTheShellsThisMachineUses(WoswoarTestCase):
         nothing. The marked block is what makes this answerable at all, and it
         has to be the thing searched rather than merely the thing found.
         """
-        rcfile = self.home / ".bashrc"
-        rcfile.write_text('source "$HOME/.nvm/nvm.sh"\n', encoding="utf-8")
-        support.run_cli("install")
+        text = self.install_bash('source "$HOME/.nvm/nvm.sh"\n').read_text(encoding="utf-8")
 
-        self.assertTrue(
-            rcfile.read_text(encoding="utf-8").index("nvm.sh")
-            < rcfile.read_text(encoding="utf-8").index(install.BEGIN),
+        self.assertLess(
+            text.index("nvm.sh"),
+            text.index(install.BEGIN),
             "the fixture's other source line has to come first to test anything",
         )
         self.assertIn("[ok] bashrc", support.run_cli("doctor").out)
@@ -336,9 +355,9 @@ class TestDoctorReportsTheShellsThisMachineUses(WoswoarTestCase):
         whose line points at the wrong file, and someone who edited the block
         down to a comment. Telling the third they have no woswoar block sends
         them looking for something that is right in front of them."""
-        (self.home / ".bashrc").write_text("", encoding="utf-8")
-        support.run_cli("install")
-        (self.home / ".bashrc").write_text(
+        # The install is for the hook it leaves in the data directory; the rc
+        # file it wrote is replaced on the next line.
+        self.install_bash().write_text(
             f"{install.BEGIN}\n# I took this out for a bit\n# <<< woswoar <<<\n",
             encoding="utf-8",
         )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -47,17 +47,12 @@ class TestPortableHookPath(unittest.TestCase):
 
 
 class TestTheSuiteCannotReachTheRealHome(WoswoarTestCase):
-    """The guard the incident asks for, and the reason it is in *this* file.
+    """The guard for `WoswoarTestCase`'s `$HOME` redirect -- see its docstring
+    for the incident, which is one this file's tests caused.
 
-    `install` is the one command that writes outside `store`'s directories:
-    `rcfile_for` is `Path.home() / ".bashrc"`, and no XDG variable stands in
-    front of it. Two tests here ran it with no `--rcfile` while `$HOME` was
-    still the developer's own, so the suite edited the `.bashrc` and `.zshrc` of
-    the machine running it -- pointing them at a sandbox that `tearDown` then
-    deleted. That is a broken shell, found months later on a real machine.
-
-    So this asserts the sandbox rather than any behaviour of woswoar: a test
-    must not be able to reach the real home by *forgetting* to redirect it.
+    It belongs here because `install` is the command that made it reachable:
+    `rcfile_for` is `Path.home() / ".bashrc"`, the one path in woswoar with no
+    XDG variable in front of it.
     """
 
     def test_home_is_the_sandbox(self) -> None:
@@ -65,9 +60,16 @@ class TestTheSuiteCannotReachTheRealHome(WoswoarTestCase):
         self.assertEqual(install.rcfile_for("bash").parent, self.home)
 
     def test_the_login_shell_of_the_machine_running_the_suite_does_not_leak(self) -> None:
-        """`auto` reads `$SHELL` when there is no rc file to go on, so leaving it
-        alone makes `install --shell auto` answer differently on a developer's
-        zsh box than in CI. That has cost a release before, in the fzf check."""
+        """`auto` falls back to `$SHELL` when there is no rc file to go on, so
+        an un-scrubbed one makes `install` answer differently on a developer's
+        zsh box than in CI. That has cost a release before, in the fzf check.
+
+        The behaviour first, because that is the property worth having. The
+        constant after it, because the behaviour alone cannot fail on a machine
+        whose login shell is already bash -- which is most of them, and would
+        leave this silent exactly where a guard is cheapest to lose.
+        """
+        self.assertEqual(install.detect_shells(), ["bash"])
         self.assertEqual(os.environ["SHELL"], "/bin/bash")
 
 
@@ -472,10 +474,9 @@ class TestInstallHardensAfterItCopies(WoswoarTestCase):
         previous_mask = os.umask(0)
         self.addCleanup(os.umask, previous_mask)
 
-        # `--rcfile` rather than a fifth copy of this file's redirect-`$HOME`
-        # fixture. The only reason to move `$HOME` would be to keep the block out
-        # of the real `~/.bashrc`, and naming a file does that; nothing here reads
-        # a rc file, because `--shell bash` means detection never runs.
+        # `--rcfile` because what is under test is the *hook's* mode, and naming
+        # the file keeps the rc file out of it entirely: `--shell bash` means
+        # detection never runs, so nothing here reads one.
         rcfile = self.root / "bashrc"
         self.assertEqual(main(["install", "--shell", "bash", "--rcfile", str(rcfile)]), 0)
         # `support.loose_paths`, not `store.readable_by_others`: the latter and

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -46,21 +46,35 @@ class TestPortableHookPath(unittest.TestCase):
         )
 
 
+class TestTheSuiteCannotReachTheRealHome(WoswoarTestCase):
+    """The guard the incident asks for, and the reason it is in *this* file.
+
+    `install` is the one command that writes outside `store`'s directories:
+    `rcfile_for` is `Path.home() / ".bashrc"`, and no XDG variable stands in
+    front of it. Two tests here ran it with no `--rcfile` while `$HOME` was
+    still the developer's own, so the suite edited the `.bashrc` and `.zshrc` of
+    the machine running it -- pointing them at a sandbox that `tearDown` then
+    deleted. That is a broken shell, found months later on a real machine.
+
+    So this asserts the sandbox rather than any behaviour of woswoar: a test
+    must not be able to reach the real home by *forgetting* to redirect it.
+    """
+
+    def test_home_is_the_sandbox(self) -> None:
+        self.assertEqual(Path.home(), self.home)
+        self.assertEqual(install.rcfile_for("bash").parent, self.home)
+
+    def test_the_login_shell_of_the_machine_running_the_suite_does_not_leak(self) -> None:
+        """`auto` reads `$SHELL` when there is no rc file to go on, so leaving it
+        alone makes `install --shell auto` answer differently on a developer's
+        zsh box than in CI. That has cost a release before, in the fzf check."""
+        self.assertEqual(os.environ["SHELL"], "/bin/bash")
+
+
 class TestInstall(WoswoarTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.home = self.root / "home"
-        self.home.mkdir()
-        self._home_before = os.environ.get("HOME")
-        os.environ["HOME"] = str(self.home)
-        self.addCleanup(self._restore_home)
         self.rcfile = self.home / ".bashrc"
-
-    def _restore_home(self) -> None:
-        if self._home_before is None:
-            os.environ.pop("HOME", None)
-        else:
-            os.environ["HOME"] = self._home_before
 
     def install(self) -> str:
         self.assertEqual(main(["install", "--rcfile", str(self.rcfile)]), 0)
@@ -192,25 +206,6 @@ class TestShellDetection(WoswoarTestCase):
     unconditionally puts a `~/.zshrc` on the machine of somebody who has never
     run zsh.
     """
-
-    def setUp(self) -> None:
-        super().setUp()
-        self.home = self.root / "home"
-        self.home.mkdir()
-        self._saved = {key: os.environ.get(key) for key in ("HOME", "SHELL")}
-        self.addCleanup(self._restore)
-        os.environ["HOME"] = str(self.home)
-        # Never inherited from the machine running the suite: `auto`'s fallback
-        # reads it, so a developer whose login shell is zsh would otherwise get
-        # a different answer from CI.
-        os.environ["SHELL"] = "/bin/bash"
-
-    def _restore(self) -> None:
-        for key, value in self._saved.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
 
     def rcfiles(self, *shells: str) -> None:
         for shell in shells:
@@ -418,22 +413,9 @@ class TestBothShellsRecordIntoOneHistory(WoswoarTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.home = self.root / "home"
-        self.home.mkdir()
-        self._saved = {key: os.environ.get(key) for key in ("HOME", "SHELL")}
-        self.addCleanup(self._restore)
-        os.environ["HOME"] = str(self.home)
-        os.environ["SHELL"] = "/bin/bash"
         for name in (".bashrc", ".zshrc"):
             (self.home / name).write_text("", encoding="utf-8")
         self.assertEqual(main(["install"]), 0)
-
-    def _restore(self) -> None:
-        for key, value in self._saved.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
 
     def run_shell(self, argv: list[str], rcfile: str, marker: str) -> None:
         """One command, in a shell that loads its own rc file the way a login does.
@@ -555,19 +537,8 @@ class TestTheRefreshNeverCreates(WoswoarTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.home = self.root / "home"
-        self.home.mkdir()
-        self._home = os.environ.get("HOME")
-        os.environ["HOME"] = str(self.home)
-        self.addCleanup(self._restore)
         (self.home / ".bashrc").write_text("# mine\n", encoding="utf-8")
         self.assertEqual(main(["install", "--shell", "bash"]), 0)
-
-    def _restore(self) -> None:
-        if self._home is None:
-            os.environ.pop("HOME", None)
-        else:
-            os.environ["HOME"] = self._home
 
     def hook(self, shell: str) -> Path:
         return store.data_dir() / install.HOOKS[shell]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1570,7 +1570,6 @@ class TestTheDirectoryPromptUnderARealFzf(WoswoarTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.home = self.root / "home"
         # `session-manager`, not `proj`, and that is the whole fixture: a path
         # with no scope name in it answers `global` under the old substring arms
         # too, so this test passed against them -- verified by running it with
@@ -1744,20 +1743,16 @@ class TestThePreviewUnderARealFzf(WoswoarTestCase):
 
 
 class DirScopeCase(WoswoarTestCase):
-    """A sandbox with a home of its own, and a way to stand somewhere in it.
+    """A way to stand somewhere in the sandbox home.
 
     Shared because getting the fixture right is most of what testing `dir`
-    costs: `$HOME` is not in `store.ENV_KEYS`, so the base class does not
-    isolate it, and `os.chdir` does not touch `$PWD` -- it is the *shell* that
-    maintains that. A test that only chdir'd would exercise the `getcwd`
-    fallback while believing it exercised the `$PWD` path.
+    costs: `os.chdir` does not touch `$PWD` -- it is the *shell* that maintains
+    that. A test that only chdir'd would exercise the `getcwd` fallback while
+    believing it exercised the `$PWD` path.
     """
 
     def setUp(self) -> None:
         super().setUp()
-        self.home = self.root / "home"
-        self.home.mkdir()
-        self.set_env("HOME", str(self.home))
         self.addCleanup(os.chdir, os.getcwd())
         self.ts = NOW
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -105,7 +105,7 @@ def _never_asks(prompt: str = "") -> str:
 
 
 class TestItRefusesWithNobodyToAsk(WoswoarTestCase):
-    """No HOME redirection needed: it exits before reading anything."""
+    """None of `SetupTestCase`'s fixture needed: it exits before asking."""
 
     def test_a_pipe_gets_the_commands_to_run_instead(self) -> None:
         with (
@@ -333,7 +333,7 @@ class TestTheBareCommandOnAFreshMachine(SetupTestCase):
             main_module.cmd_status(argparse.Namespace())
         self.assertTrue(answers.asked, "setup never ran")
         # `cmd_status` passes no --rcfile, so this is the default ~/.bashrc --
-        # under the redirected HOME, not the one the other tests here point at.
+        # the sandbox's, not the one the other tests here name explicitly.
         self.assertIn("woswoar", (Path.home() / ".bashrc").read_text(encoding="utf-8"))
 
     def test_a_hook_alone_is_enough_to_be_reported_on_instead(self) -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -51,19 +51,6 @@ class SetupTestCase(WoswoarTestCase):
         self._tty.start()
         self.addCleanup(self._tty.stop)
 
-        # `importer` resolves every default path from `Path.home()`, and
-        # `WoswoarTestCase` redirects the XDG variables but not HOME -- so
-        # without this these tests read the developer's own shell history and
-        # `setup` offers to import it.
-        previous = os.environ.get("HOME")
-        os.environ["HOME"] = str(self.root)
-        self.addCleanup(
-            lambda: (
-                os.environ.__setitem__("HOME", previous)
-                if previous is not None
-                else os.environ.pop("HOME", None)
-            )
-        )
         # Step 1 asks an extra question when a tool is missing, so leaving this
         # to the machine makes every scripted answer below land on a different
         # prompt depending on whether fzf happens to be installed. CI installs

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -47,7 +47,9 @@ from woswoar.sync import _GRANT_REMEDY
 from . import support
 from .support import requires_age, requires_git, requires_ssh_keygen
 
-#: One authoritative list, plus HOME which only these tests need to redirect.
+#: One authoritative list, plus the HOME these tests give each machine of its
+#: own -- `WoswoarTestCase` redirects it once for the whole suite, and here
+#: every simulated machine needs a different one.
 _ENV = (*support.ENV_KEYS, "HOME")
 
 #: `gc --auto` runs after a commit and after a push, and `gc.autoDetach` sends

--- a/woswoar/install.py
+++ b/woswoar/install.py
@@ -10,10 +10,11 @@ rewrites the hook file when it is behind. Its rule -- only ever *re*-write, neve
 create -- was held by one test asserting on the CLI's stdout, which is a thin
 thread for the one function here that edits a file nobody asked it to.
 
-The two `Check` producers are here for the reason `doctor` records: they are the
+The `Check` producers are here for the reason `doctor` records: they are the
 installer's judgements, and they lived in `__main__` only because the installer
-did. `cmd_doctor` splices them into the middle of its report, because the shell
-version leads and the rc file comes between `machine` and `age`.
+did. `cmd_doctor` splices `shell_checks` and `hook_checks` into the middle of its
+report, because the shell version leads and the rc file comes between `machine`
+and `age`.
 
 `hook_bytes` is deliberately one function returning bytes, and must stay that
 way -- see its docstring for the `as_file` trap that shape exists to close.
@@ -207,44 +208,6 @@ def write_block(rcfile: Path, target: Path) -> str:
     return action
 
 
-def sourced_path(rcfile: Path) -> str | None:
-    """What ``rcfile``'s woswoar block tells the shell to load, verbatim.
-
-    ``None`` when there is no block, and the empty string when there is one that
-    sources nothing -- three states, because `doctor` says something different
-    about each, and collapsing them into "is there a block" was how it came to
-    say nothing useful about any of them.
-
-    The search is anchored *inside* the block, which is the whole reason the
-    marked block exists: an rc file is full of `source` lines, and only ours is
-    ours to judge.
-    """
-    text = rcfile.read_text(encoding="utf-8") if rcfile.is_file() else ""
-    block = _BLOCK.search(text)
-    if not block:
-        return None
-    line = _SOURCE_LINE.search(block.group())
-    return line.group("path") if line else ""
-
-
-def _expanded(raw: str) -> Path:
-    """The file a shell would actually open for ``raw``.
-
-    `portable_hook_path` writes `$HOME/...` or an absolute path, so those are
-    what this must understand, and `~` is here because a hand-written block is
-    one of the cases this exists to catch. Anything else -- another variable, a
-    command substitution -- expands to itself, does not match the hook, and is
-    reported as a block that needs reinstalling. That is the safe direction:
-    what `doctor` can say is "I cannot see that this loads the hook", and
-    being told to re-run `install` when the line was in fact fine costs a
-    second, while the opposite cost a user a silently dead hook for months.
-    """
-    for token in ("${HOME}", "$HOME"):
-        if raw.startswith(token):
-            return Path(f"{Path.home()}{raw[len(token) :]}")
-    return Path(raw).expanduser()
-
-
 def shell_version(shell: str) -> str:
     """What ``shell`` reports as its version, or "" if it cannot be asked.
 
@@ -398,6 +361,40 @@ def hook_checks() -> list[Check]:
     return out
 
 
+def _sourced_path(rcfile: Path) -> str | None:
+    """What ``rcfile``'s woswoar block tells the shell to load, verbatim.
+
+    ``None`` when there is no block, and the empty string when there is one that
+    sources nothing -- three states, because `doctor` says something different
+    about each, and collapsing them into "is there a block" was how it came to
+    say nothing useful about any of them.
+
+    The search is anchored *inside* the block, which is the whole reason the
+    marked block exists: an rc file is full of `source` lines, and only ours is
+    ours to judge.
+    """
+    text = rcfile.read_text(encoding="utf-8") if rcfile.is_file() else ""
+    block = _BLOCK.search(text)
+    if not block:
+        return None
+    line = _SOURCE_LINE.search(block.group())
+    return line.group("path") if line else ""
+
+
+def _expanded(raw: str) -> Path:
+    """The file a shell would actually open for ``raw``.
+
+    `os.path.expandvars` rather than the `$HOME` and `${HOME}` this file's own
+    `portable_hook_path` writes, and that generality is the point: a
+    hand-written block spelling the same file through `$XDG_DATA_HOME`, or a
+    dotfiles repo that keeps its own variable, works in the shell and must not
+    be reported as broken. A name that is *not* set expands to itself, so it
+    still fails to match the hook -- which is the safe direction, since what
+    `doctor` can honestly say is "I cannot see that this loads the hook".
+    """
+    return Path(os.path.expandvars(raw)).expanduser()
+
+
 def rcfile_check(shell: str) -> Check:
     """Whether this shell's rc file loads *this machine's* hook.
 
@@ -418,7 +415,7 @@ def rcfile_check(shell: str) -> Check:
     """
     rcfile = rcfile_for(shell)
     label = RCFILES[shell].lstrip(".")
-    raw = sourced_path(rcfile)
+    raw = _sourced_path(rcfile)
     if raw is None:
         return Check(label, f"{rcfile} has no woswoar block", ok=False)
     if not raw:

--- a/woswoar/install.py
+++ b/woswoar/install.py
@@ -56,6 +56,12 @@ BEGIN = "# >>> woswoar >>>"
 _END = "# <<< woswoar <<<"
 _BLOCK = re.compile(re.escape(BEGIN) + r".*?" + re.escape(_END) + r"\n?", re.DOTALL)
 
+#: The line inside the block that loads the hook, as `write_block` writes it and
+#: as a shell would accept it -- `.` is `source`, and the quotes are optional.
+#: Only ever matched *within* a block, so it cannot pick up a `source` line
+#: someone else's installer put in the same rc file.
+_SOURCE_LINE = re.compile(r'^[ \t]*(?:source|\.)[ \t]+"?(?P<path>[^"\n]+?)"?[ \t]*$', re.M)
+
 
 def rcfile_for(shell: str) -> Path:
     return Path.home() / RCFILES[shell]
@@ -199,6 +205,44 @@ def write_block(rcfile: Path, target: Path) -> str:
         return "already current"
     rcfile.write_text(updated, encoding="utf-8")
     return action
+
+
+def sourced_path(rcfile: Path) -> str | None:
+    """What ``rcfile``'s woswoar block tells the shell to load, verbatim.
+
+    ``None`` when there is no block, and the empty string when there is one that
+    sources nothing -- three states, because `doctor` says something different
+    about each, and collapsing them into "is there a block" was how it came to
+    say nothing useful about any of them.
+
+    The search is anchored *inside* the block, which is the whole reason the
+    marked block exists: an rc file is full of `source` lines, and only ours is
+    ours to judge.
+    """
+    text = rcfile.read_text(encoding="utf-8") if rcfile.is_file() else ""
+    block = _BLOCK.search(text)
+    if not block:
+        return None
+    line = _SOURCE_LINE.search(block.group())
+    return line.group("path") if line else ""
+
+
+def _expanded(raw: str) -> Path:
+    """The file a shell would actually open for ``raw``.
+
+    `portable_hook_path` writes `$HOME/...` or an absolute path, so those are
+    what this must understand, and `~` is here because a hand-written block is
+    one of the cases this exists to catch. Anything else -- another variable, a
+    command substitution -- expands to itself, does not match the hook, and is
+    reported as a block that needs reinstalling. That is the safe direction:
+    what `doctor` can say is "I cannot see that this loads the hook", and
+    being told to re-run `install` when the line was in fact fine costs a
+    second, while the opposite cost a user a silently dead hook for months.
+    """
+    for token in ("${HOME}", "$HOME"):
+        if raw.startswith(token):
+            return Path(f"{Path.home()}{raw[len(token) :]}")
+    return Path(raw).expanduser()
 
 
 def shell_version(shell: str) -> str:
@@ -350,12 +394,47 @@ def hook_checks() -> list[Check]:
     # that exists: a `.zshrc` on a machine woswoar was only ever installed into
     # bash for is not a problem, and reporting it as one would send someone
     # looking for a block that is correctly absent.
-    for shell in present or detect_shells():
-        rcfile = rcfile_for(shell)
-        sourced = rcfile.is_file() and BEGIN in rcfile.read_text(encoding="utf-8")
-        detail = "sources the hook" if sourced else "has no woswoar block"
-        out.append(Check(RCFILES[shell].lstrip("."), f"{rcfile} {detail}", ok=sourced))
+    out += [rcfile_check(shell) for shell in present or detect_shells()]
     return out
+
+
+def rcfile_check(shell: str) -> Check:
+    """Whether this shell's rc file loads *this machine's* hook.
+
+    That the block was there used to be the whole test, and it is the wrong
+    question: the marker says somebody ran `install` once, not that what they
+    installed is still where the line points. A `.bashrc` was found here
+    sourcing `/tmp/woswoar-test-.../woswoar.bash` -- a throwaway directory from
+    a test run, deleted the moment that run ended. Every interactive shell
+    printed `No such file or directory`, nothing was recorded for months, and
+    `doctor` reported a green `bashrc ... sources the hook` throughout. It is
+    the one line of the report that a person checks *because* their history
+    stopped working.
+
+    Compared as paths rather than by reading the file, because the failure is
+    about where the line points: a hook that is missing, empty or from an older
+    woswoar is a different verdict with a different remedy, and `hook_checks`
+    prints it directly above this line.
+    """
+    rcfile = rcfile_for(shell)
+    label = RCFILES[shell].lstrip(".")
+    raw = sourced_path(rcfile)
+    if raw is None:
+        return Check(label, f"{rcfile} has no woswoar block", ok=False)
+    if not raw:
+        return Check(label, f"{rcfile} has a woswoar block that sources nothing", ok=False)
+    hook = store.data_dir() / HOOKS[shell]
+    # `realpath` on both sides, and never `samefile`: the whole point is a line
+    # pointing at something that no longer exists, and `samefile` raises there.
+    # It also settles a home directory reached through a symlink, which is every
+    # macOS sandbox and some real setups.
+    if os.path.realpath(_expanded(raw)) != os.path.realpath(hook):
+        return Check(
+            label,
+            f"{rcfile} sources {raw}, not the installed hook - run 'woswoar install'",
+            ok=False,
+        )
+    return Check(label, f"{rcfile} sources the hook", ok=True)
 
 
 class Installed(NamedTuple):


### PR DESCRIPTION
Reported from a real machine: `~/.bashrc` contained

```
# >>> woswoar >>>
source "/tmp/woswoar-test-kc71_9n1/data/woswoar.bash"
# <<< woswoar <<<
```

which is a test sandbox, deleted when that run ended. Every interactive shell
printed a `No such file or directory`, nothing was recorded, and `woswoar
doctor` said `✔ bashrc /home/martinus/.bashrc sources the hook` throughout.

Two separate defects, and they need each other to hurt: one wrote the line, the
other hid it.

## 1. The suite wrote into the developer's own home

`WoswoarTestCase` redirected `WOSWOAR_DIR` and the XDG variables, but `$HOME` is
not in `store.ENV_KEYS` -- it never had to be, because every path `store`
resolves has an XDG variable in front of it. `install` is the exception:
`install.rcfile_for` is `Path.home() / ".bashrc"`. `tests/test_report.py:273`
and `:284` ran `install` with no `--rcfile`, so they edited the real `.bashrc`
and `.zshrc` of the machine running the suite, pointing them at a `WOSWOAR_DIR`
that `tearDown` then deleted.

The sandbox now redirects `$HOME` to `<root>/home`, and pins `$SHELL` for the
same reason one variable further out (`install --shell auto` falls back to it,
so a zsh developer got a different answer from CI). Four test classes had grown
their own copy of the `$HOME` redirect for smaller versions of the same problem
-- reading the developer's real shell history -- and those are now gone; the
point is that a test must not reach the real home *by forgetting to say so*.

Note this also fixed a live env leak: three of those classes assigned
`self._saved` on top of the base class's, so the base `_restore_env` cleanup
restored `HOME`/`SHELL` and left `WOSWOAR_DIR` and the XDG variables pointing at
a deleted sandbox for whatever ran next in that process.

## 2. `doctor` only checked that the block existed

`BEGIN in rcfile.read_text()` says somebody ran `install` once, not that what
they installed is still where the line points. `rcfile_check` now pulls the
sourced line *out of the marked block* and compares it, as a path, to this
machine's hook:

- `$HOME/...` and `${HOME}/...` and `~/...` are expanded -- the first is what
  `install` writes for a hook under the home directory, and what a shared
  dotfiles `.bashrc` carries, so a textual compare against the absolute path
  would fail every one of those installs.
- `realpath` on both sides, never `samefile`: the whole point is a line pointing
  at something that no longer exists, and `samefile` raises there.
- a block that sources nothing gets its own verdict, rather than being reported
  as "has no woswoar block" to someone looking straight at one.

On the machine that reported this, the branch says:

```
[FAIL] bashrc       /home/martinus/.bashrc sources /tmp/woswoar-test-kc71_9n1/data/woswoar.bash, not the installed hook - run 'woswoar install'
```

`woswoar install` rewrites the block in place, and a test asserts that the
remedy the line names actually restores the check.

## Tests

Seven new tests. Mutation-verified per rule 3, output verbatim:

```
  caught    doctor accepts any path the block sources (the old marker-only check)
  caught    a block that sources nothing reads as a block that is fine
  caught    $HOME in the sourced line is not expanded
  caught    the marked block is no longer what the source line is looked for in
  caught    the sandbox stops redirecting $HOME
  caught    the sandbox stops pinning $SHELL
```

The fourth survived on the first run -- searching the whole rc file instead of
the block passed every fixture, because none of them had another `source` line.
Real ones are full of them, so `test_another_installers_source_line_is_not_mistaken_for_ours`
puts an nvm line before the block; that is the fixture being too weak, not the
mutation being uninteresting (rule 3).

The two harness mutations are run against the single guard test by name, never
the module: a suite whose `$HOME` is not redirected is the incident itself, and
running `tests.test_install` under that mutation would edit the `.bashrc` of the
machine doing the mutation testing.

One honest limit: `the sandbox stops pinning $SHELL` is caught here because this
machine's `$SHELL` is `/usr/bin/bash` and the guard asserts `/bin/bash`. On a
machine whose login shell is spelled exactly `/bin/bash` that mutation would
survive by construction -- the leak it guards against is environment-dependent
in both directions.

Preflight is clean: `ruff check`, `ruff format --check`, `mypy`, `shellcheck`,
and 975 tests pass (968 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)