### PR TITLE
test: a command the hook declines must not leave a log file either

### DIFF
--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -1462,6 +1462,27 @@ class RecordingIsPrivateMixin(SharedShellTestBase):
         # above cannot say on its own.
         self.assertIsNone(search.interactive("global"), "Ctrl-R would open an empty picker")
 
+    def test_a_command_the_hook_declines_leaves_no_log_file_either(self) -> None:
+        """The same invariant, reached through the other door.
+
+        The test above runs a shell that types nothing, so `__woswoar_record`
+        returns at its first guard. This one *types a command* and has the hook
+        refuse it, which walks every early return between there and the
+        once-a-day block that creates the day file -- and that ordering is the
+        whole of why the file still means "something was recorded".
+
+        It is not a contrived state. `WOSWOAR_IGNORE` rejecting the day's first
+        command is a fresh install whose owner's first act was to export a
+        credential, and `search`'s guard reads a log file's *existence*: a
+        creation hoisted above these returns would leave a rows-less file and
+        make that person's first Ctrl-R an empty picker, on the one path where
+        woswoar has nothing to show and has just told them to press the key.
+        """
+        self.run_shell("export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMIabc123\n")
+        self.assertEqual(self.commands(), [], "precondition: the hook recorded it after all")
+        self.assertEqual(sorted(self.logdir().parent.rglob("*.tsv")), [])
+        self.assertIsNone(search.interactive("global"), "Ctrl-R would open an empty picker")
+
     def test_the_hook_agrees_with_store_about_what_private_means(self) -> None:
         """The hook is copied verbatim, so it cannot import the constants.
 


### PR DESCRIPTION
Follow-up to a question about the empty-history state right after installation: *is there a bug when no command has been recorded yet?*

**Answer: no bug found.** What I checked, on a real fresh install in a sandbox (install, hook loaded, nothing recorded):

| state | behaviour |
|---|---|
| Ctrl-R with nothing recorded | no picker opens — the `iter_log_files` guard in `search.interactive` |
| Ctrl-R with a half-typed line | the line survives and still runs; the widget only redraws |
| `woswoar` / `woswoar status` | `0 commands from 0 machines`, and what to do next |
| `woswoar list` | prints nothing, exit 0 |
| `woswoar search` | exit 1, silent |
| `woswoar install`, `doctor`, `list`, `status`, `sync` | none of them creates a cache file, so none of them opens the guard |
| `woswoar import` of an empty history, or one whose only line is credential-shaped | `0 imported`, and no day file |
| first command rejected by `WOSWOAR_IGNORE` | not recorded, and **no day file** |

The empty-list hazard that does exist is reachable from an open picker rather than from an empty history — an empty scope, or a query matching nothing — and that is #218.

## What this PR adds

The guard's meaning is "a log file exists ⟹ something was recorded", and both hooks are built around it: the once-a-day block that creates the day file sits *below* every early return in `__woswoar_record`. `test_a_shell_that_records_nothing_leaves_no_log_file` holds one half of that and **cannot** hold the other — it types nothing, so recording returns at its first guard and never reaches the code the ordering is about.

This adds the other half: type a command, have the hook refuse it, assert no `.tsv` appears and that `search.interactive` still declines to open a picker. In the shared mixin, so bash and zsh both get it.

## Mutation output

The mutation is the realistic regression — the once-a-day creation hoisted above the early returns:

```
  caught    the day file is created before the hook decides to decline the command
  SURVIVED  same hoist, seen only by the test that types nothing
  caught    the zsh hook creates the day file before declining the command
```

The middle line is the point of the PR, not a failure: it is the *existing* test run against the same mutation, and it cannot see it. The first and third are the new test, against each hook.

Preflight clean; 978 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)