### PR TITLE
fix: "caught" means a test noticed, not that the run exited non-zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,9 @@ __marimo__/
 # once put a 3.7 MB shellcheck wheel in a commit. dist/ and build/ above do
 # not cover a wheel dropped in the repo root.
 *.whl
+
+# Mutation specs. Throwaway by design -- the table is written for one change and
+# is meaningless against the next, so it is deliberately not kept (see the commit
+# that removed spec_201.py). Ignored rather than merely uncommitted, because
+# `*.spec` above is PyInstaller's and matches none of these.
+spec_*.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,9 +142,12 @@ each destroyed uncommitted work here. There is no reflog for a tree that was
 never committed, so the only recovery is to write it again from memory — the
 single largest waste of a session so far, twice over.
 
-- Commit a checkpoint before anything that rewrites files in bulk. Mutation
-  testing especially: it edits sources in a loop and restores them in a
-  `finally`, and an interrupted run leaves the tree mutated.
+- Commit a checkpoint before anything that rewrites files in bulk. Not
+  `tools/mutate.py`, which since #212 edits only a throwaway copy — this bullet
+  said otherwise for months after that stopped being true, and a stale warning
+  here is worse than none: believing the tool leaves a mutated tree behind is
+  exactly what would justify reaching for `git checkout --` to tidy up, which is
+  the operation this rule exists to prevent.
 - To undo your own edit, rewrite the text you changed. Do not discard the file.
 - Tell subagents explicitly when they may not write. A review agent asked only
   to *read* a diff has reverted the tree on its own initiative; verify the tree

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,14 +21,14 @@ extra: `pip install -e '.[dev]'`. The suite also drives real `age`, real `git`,
 a real `bash` and a real `fzf`, and it will tell you which one is missing.
 
 ```bash
-python -m tools.run_tests                               # 301 tests, sharded, ~6s
+python -m tools.run_tests                               # 993 tests, sharded, ~5s
 python -m unittest discover -s . -t . -p 'test_*.py'    # the same suite, serially
 WOSWOAR_BENCH=1 python -m unittest tests.test_perf      # latency on 52k entries
 ```
 
 The suite is about 88% subprocess wait — it drives real `age`, `git` and
 `ssh-keygen` rather than mocking them — so sharding it across processes takes it
-from ~19s to ~6s. Both commands run the same tests; the runner additionally
+from ~60s to ~5s. Both commands run the same tests; the runner additionally
 fails if any test it discovered never reported back, which is a way a parallel
 run can be green that a serial one cannot.
 
@@ -50,10 +50,20 @@ of edits, run `python -m tools.mutate <spec>.py`, and paste its output into the
 pull request — verbatim, rather than retyping it, which is how a mutation that
 was never run ended up quoted in a commit message here.
 
-Use it rather than writing the loop by hand, for three reasons it has learned:
+Three verdicts, not two. `caught` means a **test method** noticed; `SURVIVED`
+means none did; `BROKE` and `TIMEOUT` mean the run never got to ask, and are
+counted apart from both. That third category exists because a mutation which
+makes a module unimportable also exits non-zero with a plausible `Ran N` — so it
+read as `caught` while the test named in the row never executed, which is a false
+pass in a pull request and indistinguishable from a real one.
+
+Use it rather than writing the loop by hand, for four reasons it has learned:
 
 - **It never edits your working tree.** Each mutation goes into a throwaway copy,
   so an interrupted run cannot leave mutated source behind.
+- **It classifies where the result objects are**, not by reading what `unittest`
+  printed. A dead `setUpClass`, an import that stopped working and a real
+  assertion failure all exit non-zero; only the last of them is an answer.
 - **It runs the table in parallel**, which the copies are what make safe: 197 s
   down to 51 s for four mutations against `tests.test_sync`.
 - **It defuses the bytecode cache.** A `.pyc` is validated against

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,9 @@ line-length = 100
 target-version = "py310"
 # Recent ruff formats fenced code blocks inside markdown; the design document
 # contains illustrative snippets that are not meant to be valid modules.
-extend-exclude = ["*.md"]
+# Mutation specs are throwaway tables of source text, and the source they quote
+# is not theirs to reformat -- a wrapped `old` string no longer matches the file.
+extend-exclude = ["*.md", "spec_*.py"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -17,7 +17,7 @@ import time
 import unittest
 from pathlib import Path
 
-from tools.mutate import Mutation, verify
+from tools.mutate import Mutation, Report, Result, Verdict, run, verify
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -377,14 +377,108 @@ class TestAMutationThatBreaksTheSuiteIsNotCaught(MutateTestCase):
     in a pull request is indistinguishable from a real one.
     """
 
-    def test_a_mutation_that_breaks_the_import_is_refused(self) -> None:
-        self.package(guarded=True)
+    def refuses(self, mutation: Mutation) -> None:
+        """Every test here asserts the same thing about a different fixture."""
         with self.assertRaises(SystemExit) as refused:
-            verify(
-                [Mutation("syntax", "mod.py", "def clamp", "def (", "test_mod")],
-                baseline=False,
-            )
-        self.assertIn("ran no tests", str(refused.exception))
+            verify([mutation], baseline=False)
+        self.assertIn("broke collection", str(refused.exception))
+
+    def test_a_mutation_that_breaks_the_import_is_refused(self) -> None:
+        """A *syntax* error, which is only one of the two ways collection breaks.
+
+        This propagates out of `unittest.loader` entirely, so there is no `Ran`
+        line to read. It is the narrow case, and for a long time it was the only
+        one here -- which is why the two below could exist unnoticed.
+        """
+        self.package(guarded=True)
+        self.refuses(Mutation("syntax", "mod.py", "def clamp", "def (", "test_mod"))
+
+    def test_an_import_error_is_not_a_catch(self) -> None:
+        """The shape the fixture above cannot reach, and it reported `caught`.
+
+        `unittest/loader.py` catches `ImportError` -- and only `ImportError` --
+        and turns it into a synthetic `unittest.loader._FailedTest`. So the run
+        prints `Ran 1 test`, `FAILED (errors=1)` and exits non-zero, which a
+        check reading the exit status and the count cannot tell apart from a test
+        noticing the mutation. A SyntaxError takes the other path and produces no
+        count at all, so the sibling fixture above passed on code that got this
+        one wrong: the two answers differ, and only one of them was ever asked.
+        """
+        self.package(guarded=True)
+        self.write("mod.py", "import json\n" + CLAMP)
+        self.refuses(
+            Mutation("the import goes bad", "mod.py", "import json", "import nope_xyz", "test_mod")
+        )
+
+    def test_a_broken_setupclass_is_not_a_catch(self) -> None:
+        """`Ran N` is greater than zero here, and still nothing asserted.
+
+        The first class runs and passes; the second's `setUpClass` dies, which
+        `unittest` reports through an `_ErrorHolder` that is not counted in
+        `testsRun`. So the count is honest, non-zero, and says nothing about
+        whether the mutation was noticed -- the reason the verdict cannot be a
+        function of the count alone.
+        """
+        self.write("mod.py", CLAMP + '\n\ndef helper() -> str:\n    return "ok"\n')
+        self.write(
+            "test_mod.py",
+            """
+            import unittest
+
+            import mod
+
+
+            class A(unittest.TestCase):
+                def test_it(self) -> None:
+                    self.assertEqual(mod.clamp(-5), 0)
+
+
+            class B(unittest.TestCase):
+                @classmethod
+                def setUpClass(cls) -> None:
+                    cls.shouted = mod.helper().upper()
+
+                def test_it(self) -> None:
+                    self.assertEqual(self.shouted, "OK")
+            """,
+        )
+        self.refuses(
+            Mutation("helper returns nothing", "mod.py", 'return "ok"', "return None", "test_mod")
+        )
+
+    def test_a_run_that_died_without_answering_is_not_a_survivor(self) -> None:
+        """The last route, and the only one the probe cannot report on itself.
+
+        `os._exit` skips every `except` and `finally` there is, so the probe is
+        gone before it can say what happened -- which is what a signal, an OOM
+        kill or a segfault in a C extension look like from outside. The parent
+        has nothing to read, and the honest reading of nothing is `broke`.
+
+        Written because the mutation that removes this branch survived: the probe
+        gained an `except BaseException` that writes `loaded: false`, and that
+        made every fixture reach the *other* branch. The code was right and the
+        fixtures could no longer tell.
+        """
+        self.package(guarded=True)
+        self.write("test_mod.py", "import os\n\nos._exit(3)\n")
+        self.refuses(
+            Mutation("the clamp is gone", "mod.py", "if value < 0:", "if False:", "test_mod")
+        )
+
+    def test_a_target_holding_no_tests_is_not_a_survivor(self) -> None:
+        """The third route to nothing having been asked, and the quietest.
+
+        The target imports, collects, and holds no test methods at all -- so the
+        run is green, exits zero, and would read as `SURVIVED`: a report that the
+        fix is unguarded, produced by a table pointed at a module that could not
+        have guarded anything. Found by mutating this file: the branch existed
+        and nothing reached it.
+        """
+        self.package(guarded=True)
+        self.write("test_empty.py", "import unittest\n")
+        self.refuses(
+            Mutation("the clamp is gone", "mod.py", "if value < 0:", "if False:", "test_empty")
+        )
 
     def test_a_real_mutation_is_still_caught(self) -> None:
         """The other half: the check must not refuse an ordinary mutation, which
@@ -397,6 +491,185 @@ class TestAMutationThatBreaksTheSuiteIsNotCaught(MutateTestCase):
             ),
             0,
         )
+
+
+class TestASubTestIsARealAnswer(MutateTestCase):
+    """The regression the first version of this classification shipped with.
+
+    Telling a real test from one of `unittest`'s synthetic carriers by asking
+    where its class is defined looks right and is not: `unittest.case._SubTest`
+    is a `TestCase` living in `unittest.case`, so a mutation whose only witness
+    was an assertion inside `with self.subTest(...)` was filed as "the suite
+    broke" -- and, the table being strict, aborted the run while blaming the
+    table. This repository uses `subTest` in more than twenty places, including
+    `tests/test_credentials.py` and `tests/test_architecture.py`.
+
+    The fix is to classify by protocol: `addSubTest` is handed the *owning* test,
+    so recording that is both correct and free of any private name.
+    """
+
+    def test_a_mutation_seen_only_inside_a_subtest_is_caught(self) -> None:
+        self.write("mod.py", CLAMP)
+        self.write(
+            "test_mod.py",
+            """
+            import unittest
+
+            import mod
+
+
+            class T(unittest.TestCase):
+                def test_it(self) -> None:
+                    # Every assertion this class makes is inside a subTest, which
+                    # is the whole point: there is no plain failure to fall back
+                    # on if the subTest route is misfiled.
+                    for value in (-5, -1):
+                        with self.subTest(value=value):
+                            self.assertEqual(mod.clamp(value), 0)
+            """,
+        )
+        survivors = verify(
+            [Mutation("the clamp is gone", "mod.py", "if value < 0:", "if False:", "test_mod")],
+            baseline=False,
+        )
+        self.assertEqual(survivors, 0, "a subTest assertion is a test noticing")
+
+
+class TestAnUnanswerableRowNeedNotEndTheRun(MutateTestCase):
+    """Strict is right for a hand table and wrong for a generated one.
+
+    A spec file is written by someone, so a row that cannot be answered is their
+    mistake and stopping is what gets it fixed. A table generated from a diff is
+    two hundred rows nobody wrote, and throwing away every answer already paid
+    for because one mutant broke an import is a different trade entirely.
+    """
+
+    def test_the_run_finishes_and_reports_all_three_outcomes(self) -> None:
+        self.package(guarded=True)
+        self.write("mod.py", "import json\n" + CLAMP)
+        report = run(
+            [
+                Mutation("the guard goes", "mod.py", "if value < 0:", "if False:", "test_mod"),
+                Mutation(
+                    "the import goes bad", "mod.py", "import json", "import nope_xyz", "test_mod"
+                ),
+                Mutation(
+                    "the pass-through changes", "mod.py", "return value", "return 99", "test_mod"
+                ),
+            ],
+            baseline=False,
+            strict=False,
+        )
+        self.assertEqual(
+            [result.verdict.outcome for result in report.results],
+            ["caught", "broke", "survived"],
+        )
+
+    def test_strict_is_still_the_default(self) -> None:
+        """Because every spec file in the repository's history relies on it."""
+        self.package(guarded=True)
+        self.write("mod.py", "import json\n" + CLAMP)
+        with self.assertRaises(SystemExit):
+            run(
+                [Mutation("bad", "mod.py", "import json", "import nope_xyz", "test_mod")],
+                baseline=False,
+            )
+
+
+class TestAMutantThatNeverFinishes(MutateTestCase):
+    """A generated mutant can turn a loop bound into one that never fires.
+
+    With no limit, that holds a lane for the rest of the table and the printout
+    stops at its row, because results are reported in table order. The answer is
+    an outcome, not an exception: the other rows still have something to say.
+    """
+
+    def test_it_times_out_instead_of_holding_the_lane(self) -> None:
+        self.package(guarded=True)
+        report = run(
+            [
+                # The *guarded* branch, because that is the one the fixture's test
+                # actually reaches: a loop behind `return 0` is never entered by
+                # `clamp(-5)`, and the row came back `survived` in milliseconds.
+                Mutation(
+                    "clamp never returns",
+                    "mod.py",
+                    "        return 0",
+                    "        while True:\n            pass",
+                    "test_mod",
+                ),
+                Mutation("the guard goes", "mod.py", "if value < 0:", "if False:", "test_mod"),
+            ],
+            baseline=False,
+            strict=False,
+            # Long enough that a healthy row is never mistaken for a hang -- the
+            # sibling row below runs in well under a second -- and short enough
+            # that this test is not the slowest in the file.
+            timeout=5.0,
+        )
+        self.assertEqual(
+            [result.verdict.outcome for result in report.results], ["timeout", "caught"]
+        )
+
+
+class TestFailfastStopsAtTheFirstTestThatNoticed(MutateTestCase):
+    """Worth having because a caught mutant is the common case.
+
+    Not asserted on wall clock, which would be the same claim with a flake
+    attached: each test records that it ran, and the count says how far the run
+    got. Note this is an average, not a bound -- `unittest` runs classes in
+    alphabetical order, so a mutant caught only by the last of them still pays
+    for nearly all of the module.
+    """
+
+    def counting(self) -> Path:
+        ledger = self.root / "ledger.txt"
+        self.write("mod.py", CLAMP)
+        self.write(
+            "test_mod.py",
+            f"""
+            import unittest
+            from pathlib import Path
+
+            import mod
+
+            LEDGER = Path({str(ledger)!r})
+
+
+            class T(unittest.TestCase):
+                def record(self) -> None:
+                    with LEDGER.open("a", encoding="utf-8") as log:
+                        log.write("ran\\n")
+
+                def test_a(self) -> None:
+                    self.record()
+                    self.assertEqual(mod.clamp(-5), 0)
+
+                def test_b(self) -> None:
+                    self.record()
+
+                def test_c(self) -> None:
+                    self.record()
+            """,
+        )
+        return ledger
+
+    def ran_under(self, failfast: bool) -> int:
+        ledger = self.counting()
+        run(
+            [Mutation("the guard goes", "mod.py", "if value < 0:", "if False:", "test_mod")],
+            baseline=False,
+            failfast=failfast,
+        )
+        return len(ledger.read_text(encoding="utf-8").split())
+
+    def test_it_stops_after_the_failure(self) -> None:
+        self.assertEqual(self.ran_under(failfast=True), 1)
+
+    def test_without_it_the_whole_class_runs(self) -> None:
+        """The other half, and the one that makes the number above mean something:
+        a ledger showing 1 proves nothing if 1 is all the class ever writes."""
+        self.assertEqual(self.ran_under(failfast=False), 3)
 
 
 class TestOneLaneIsNotADeadlock(MutateTestCase):
@@ -455,16 +728,95 @@ class TestTheScriptEntryPoint(MutateTestCase):
             ]
             """,
         )
-        finished = subprocess.run(
-            [sys.executable, "-m", "tools.mutate", str(self.root / "spec.py")],
+        finished = self.drive("spec.py")
+        self.assertEqual(finished.returncode, 0, finished.stderr)
+        self.assertIn("caught", finished.stdout)
+
+    def drive(self, name: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-m", "tools.mutate", str(self.root / name)],
             cwd=self.root,
             capture_output=True,
             text=True,
             check=False,
             env=dict(os.environ, PYTHONPATH=str(REPO_ROOT)),
         )
-        self.assertEqual(finished.returncode, 0, finished.stderr)
+
+    def test_a_script_that_calls_verify_itself_is_not_a_failure(self) -> None:
+        """#213: it ran the table, printed `caught`, and then exited 1.
+
+        The message said the file defined nothing, and because stderr is not
+        buffered against stdout it landed *above* the results it was contradicting.
+        Met while verifying #201, where the fix was to rewrite the spec into the
+        shape the docstring did not show.
+        """
+        self.package(guarded=True)
+        self.write(
+            "spec.py",
+            """
+            from tools.mutate import Mutation, verify
+
+            verify(
+                [Mutation("the clamp is gone", "mod.py", "if value < 0:", "if False:", "test_mod")]
+            )
+            """,
+        )
+        finished = self.drive("spec.py")
         self.assertIn("caught", finished.stdout)
+        self.assertEqual(finished.returncode, 0, finished.stderr)
+        self.assertNotIn("defines no MUTATIONS", finished.stderr)
+
+    def test_a_script_that_does_both_runs_the_table_once(self) -> None:
+        """The quieter half of #213: minutes of wall clock, silently doubled."""
+        self.package(guarded=True)
+        self.write(
+            "spec.py",
+            """
+            from tools.mutate import Mutation, verify
+
+            MUTATIONS = [
+                Mutation("the clamp is gone", "mod.py", "if value < 0:", "if False:", "test_mod")
+            ]
+            verify(MUTATIONS)
+            """,
+        )
+        finished = self.drive("spec.py")
+        self.assertEqual(finished.stdout.count("the clamp is gone"), 1, finished.stdout)
+        self.assertIn("Delete one of the two", finished.stderr)
+
+    def test_a_survivor_exits_nonzero(self) -> None:
+        self.package(guarded=False)
+        self.write(
+            "spec.py",
+            """
+            from tools.mutate import Mutation
+
+            MUTATIONS = [
+                Mutation("the clamp is gone", "mod.py", "if value < 0:", "if False:", "test_mod")
+            ]
+            """,
+        )
+        finished = self.drive("spec.py")
+        self.assertIn("SURVIVED", finished.stdout)
+        self.assertEqual(finished.returncode, 1)
+
+    def test_a_row_that_asked_nothing_is_not_clean(self) -> None:
+        """A `BROKE` row is not a pass. Calling it clean would report the table as
+        complete while it was quietly that much smaller than it looks."""
+        mutation = Mutation("x", "mod.py", "a", "b", "test_mod")
+        caught = Result(mutation, Verdict("caught", "test_mod.T.test_it"))
+        self.assertTrue(Report([caught]).clean)
+        self.assertFalse(Report([Result(mutation, Verdict("broke", "why"))]).clean)
+        self.assertFalse(Report([Result(mutation, Verdict("timeout", "why"))]).clean)
+        self.assertFalse(Report([Result(mutation, Verdict("survived"))]).clean)
+        self.assertFalse(Report([caught], baseline_red=True).clean)
+
+    def test_a_script_that_does_neither_still_says_so(self) -> None:
+        self.package(guarded=True)
+        self.write("spec.py", "x = 1\n")
+        finished = self.drive("spec.py")
+        self.assertNotEqual(finished.returncode, 0)
+        self.assertIn("never called verify()", finished.stderr)
 
 
 if __name__ == "__main__":

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -4,26 +4,29 @@ A test that passes whether or not the fix is present is decoration, and reading
 it will not tell you which kind you have. The only way to know is to break the
 code and watch. This does that, for a table of edits:
 
-    from tools.mutate import Mutation, verify
+    from tools.mutate import Mutation
 
-    verify(
-        [
-            Mutation(
-                "the guard is gone",
-                "woswoar/sync.py",
-                "if stamp is not None and settled:",
-                "if True:",
-                "tests.test_sync.TestSkippingAnUnchangedDay",
-            ),
-        ]
-    )
+    MUTATIONS = [
+        Mutation(
+            "the guard is gone",
+            "woswoar/sync.py",
+            "if stamp is not None and settled:",
+            "if True:",
+            "tests.test_sync.TestSkippingAnUnchangedDay",
+        ),
+    ]
 
-Run it with ``python -m tools.mutate <script>``, or import `verify` from a
-throwaway script of your own. Either way the point is that the *table* is the
-new work and everything below is not. Paths are relative to the working
-directory, so run it from the repo root, as with `tools.run_tests`.
+Run it with ``python -m tools.mutate <script>``. The *table* is the new work and
+everything below is not. Paths are relative to the working directory, so run it
+from the repo root, as with `tools.run_tests`.
 
-Two things it does that a hand-rolled loop forgets, both of which have cost real
+``MUTATIONS`` at module level is the shape, and this example used to show a
+`verify(...)` call instead -- which works, and then exited non-zero with "defines
+no MUTATIONS" printed *above* its own green results (#213). Calling `verify`
+yourself is still supported and still correct; it is simply no longer what the
+documentation teaches, because the two shapes in one file run the table twice.
+
+Four things it does that a hand-rolled loop forgets, all of which have cost real
 time here:
 
 - **The bytecode cache lies.** A ``.pyc`` is validated against
@@ -42,6 +45,16 @@ time here:
   mean to relocate -- and it shipped three times in one session before this
   check. Pass ``additive=True`` for the rare edit that really does mean to insert
   in front of code that stays.
+- **"caught" means a test method noticed, and nothing else.** A mutation that
+  turns a working import into a failing one exits non-zero and leaves ``Ran 1
+  test`` behind, exactly like a test catching it -- so a check reading the exit
+  status and the count reported ``caught`` about a test that never executed.
+  That shipped. The only fixture guarding it used a *syntax* error, which
+  ``unittest.loader`` does not wrap and which therefore takes a different path
+  entirely, so the check passed while the case it was named for went unasked --
+  the too-weak fixture CLAUDE.md rule 3 warns about, in the harness that exists
+  to find them. `_PROBE` now classifies where the result objects still are, and
+  a run that could not put the question says ``BROKE`` rather than either answer.
 - **Your working tree is never edited.** Each mutation is applied to a throwaway
   copy, so a kill at the wrong moment cannot leave a mutated source behind --
   the state CLAUDE.md rule 6 is about, and one this used to guard against with a
@@ -72,9 +85,9 @@ a surviving mutation means a weak test.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import queue
-import re
 import runpy
 import shutil
 import subprocess
@@ -84,9 +97,15 @@ from collections.abc import Iterable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from pathlib import Path
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 from tools.sandbox import usable_cpus
+
+#: Seconds one mutation may take before the run gives up on it. Generous, because
+#: `tests.test_sync` alone is tens of seconds and a loaded machine is slower
+#: still; the point is only that a mutant which never terminates cannot hold a
+#: lane for the rest of the table.
+TIMEOUT = 300.0
 
 #: Names never copied into a mutation's sandbox. ``.git`` because it is large and
 #: nothing under test reads it; the caches because a stale one is the trap this
@@ -116,9 +135,89 @@ class Mutation(NamedTuple):
     additive: bool = False
 
 
+#: What one run of the suite under one mutation is allowed to conclude.
+#:
+#: `broke` and `timeout` are not answers. They say the run could not ask the
+#: question, and they must never be folded into either real verdict -- a
+#: `broke` counted as `caught` blesses a test that never executed, which is the
+#: failure this module's own docstring calls indistinguishable from a real one.
+Outcome = Literal["caught", "survived", "broke", "timeout"]
+
+
+class Verdict(NamedTuple):
+    outcome: Outcome
+    #: The first test that noticed, or the reason nothing could. Printed for
+    #: everything except a plain `caught`, where the label already says it.
+    detail: str = ""
+
+    @property
+    def answered(self) -> bool:
+        """Was a question put at all?
+
+        One definition, because three sites need it and the run, the summary and
+        the exit status each spelled it differently -- and one of the three said
+        something subtly other than the other two.
+        """
+        return self.outcome in ("caught", "survived")
+
+
 class Result(NamedTuple):
     mutation: Mutation
-    caught: bool
+    verdict: Verdict
+
+
+class Report(NamedTuple):
+    results: list[Result]
+    #: Nothing in `results` means anything when this is set: a suite that already
+    #: fails catches every mutation, including the ones no test can see.
+    baseline_red: bool = False
+
+    @property
+    def clean(self) -> bool:
+        """Every row caught, and the baseline green. The definition of done.
+
+        Here rather than in the CLI helper that used to own it, because `verify`
+        and any generated-table driver need the same answer and only one of them
+        had a way to ask. A row that broke or timed out is not clean: it is a
+        question the run failed to put, and calling it green would report the
+        table as smaller than it was while claiming it was complete.
+        """
+        return not self.baseline_red and all(
+            result.verdict.outcome == "caught" for result in self.results
+        )
+
+
+#: Every table `run` has finished in this process, in order.
+#:
+#: Only `main` reads it, and only to tell "the script defined nothing" apart from
+#: "the script did the work itself". Before this existed, a spec written exactly
+#: as the docstring showed it ran correctly and *then* exited 1 with
+#: "defines no MUTATIONS" -- printed above its own green results, because stderr
+#: is not line-buffered against stdout (#213).
+_RUNS: list[Report] = []
+
+#: Nine wide, as before. `caught` stays lowercase and everything else shouts,
+#: because the eye scanning a pasted table is looking for the rows that are not
+#: the good news.
+_HEADLINE: dict[str, str] = {
+    "caught": "caught",
+    "survived": "SURVIVED",
+    "broke": "BROKE",
+    "timeout": "TIMEOUT",
+}
+
+
+def _probe() -> str:
+    """`tools/verdict.py`, read from *this* tree rather than the sandbox's copy.
+
+    Handed to ``python -c``, which is what puts the sandbox on ``sys.path`` so its
+    test modules import at all. Reading it from `__file__`'s directory is the
+    whole isolation property: `tools/**.py` is itself something a table may
+    mutate, and a verdict loaded out of the copy would let a mutation grade its
+    own exam. See that module's docstring for why the classification lives there
+    and not in a string constant here.
+    """
+    return (Path(__file__).resolve().with_name("verdict.py")).read_text(encoding="utf-8")
 
 
 def _clear_bytecode(root: Path) -> None:
@@ -136,36 +235,89 @@ def _clear_bytecode(root: Path) -> None:
         shutil.rmtree(cache, ignore_errors=True)
 
 
-def _run(tests: Sequence[str], root: Path) -> bool:
-    """Whether the suite failed, which for a mutation is the good answer.
+def _run(
+    tests: Sequence[str], root: Path, *, failfast: bool = False, timeout: float = TIMEOUT
+) -> Verdict:
+    """What the suite concluded about one mutation, and by which route.
 
-    A non-zero exit is not enough on its own, and this is the one hazard here
-    that produces a wrong answer in the direction a reader believes. A mutation
-    that makes the module unimportable, or breaks a `setUpClass`, also exits
-    non-zero -- so it would print `caught` while the test whose name is in the row
-    never ran. So the count `unittest` prints is checked too: no "Ran N" line, or
-    "Ran 0", means the mutation broke collection rather than being noticed.
+    The verdict used to be "the exit status was non-zero, and `Ran N` said N was
+    not zero". That is wrong in the direction a reader believes, and it shipped:
+    a mutation that turns a working import into a failing one leaves `Ran 1
+    test`, `errors=1` and a non-zero exit, exactly like a test noticing. The only
+    fixture guarding it used a *syntax* error, which takes a different path
+    through `unittest.loader` and produces no count at all -- so the check passed
+    while the case it named went unasked. `_PROBE` is the answer: classify where
+    the result objects still exist.
+
+    A timeout is its own outcome rather than an exception. A generated mutant can
+    turn a loop bound into one that never fires, and with no limit here that
+    holds a lane for the rest of the run.
     """
     _clear_bytecode(root)
-    finished = subprocess.run(
-        [sys.executable, "-B", "-m", "unittest", *tests],
-        cwd=root,
-        # `-B` covers this process; the variable covers the real `age`, `git` and
-        # `bash` the suite spawns, which would otherwise leave a `.pyc` in a
-        # sandbox that a later mutation reuses.
-        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    ran = re.search(r"^Ran (\d+) tests? in ", finished.stderr, re.MULTILINE)
-    if ran is None or ran.group(1) == "0":
-        raise SystemExit(
-            f"{' '.join(tests)} ran no tests under this mutation, so 'caught' would "
-            f"mean 'the suite could not start' rather than 'a test noticed'. The "
-            f"mutation probably broke an import.\n{finished.stderr[-2000:]}"
-        )
-    return finished.returncode != 0
+    # Both files land outside the sandbox on purpose: the copy is what the
+    # mutation edits, and a report written into it is one `open()` away from
+    # being the mutation's to write.
+    with tempfile.TemporaryDirectory(prefix="woswoar-verdict-") as box:
+        report = Path(box) / "verdict.json"
+        noise = Path(box) / "stderr.txt"
+        try:
+            with noise.open("w", encoding="utf-8") as spill:
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-B",
+                        "-c",
+                        _probe(),
+                        str(report),
+                        "1" if failfast else "0",
+                        *tests,
+                    ],
+                    cwd=root,
+                    # `-B` covers this process; the variable covers the real
+                    # `age`, `git` and `bash` the suite spawns, which would
+                    # otherwise leave a `.pyc` in a sandbox that a later mutation
+                    # reuses.
+                    env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+                    # A file rather than a pipe, and this is not a style choice.
+                    # On a timeout `subprocess.run` kills the child and then
+                    # drains the pipes with `communicate()` and *no* limit --
+                    # and the suite's `python -m woswoar` grandchildren inherit
+                    # the write end, so that drain waits for them. A hung
+                    # grandchild would hold the lane long past `timeout`, which
+                    # is the one thing this outcome exists to prevent.
+                    stdout=subprocess.DEVNULL,
+                    stderr=spill,
+                    check=False,
+                    timeout=timeout,
+                )
+        except subprocess.TimeoutExpired:
+            return Verdict("timeout", f"no answer within {timeout:g}s")
+
+        try:
+            written = json.loads(report.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            # The probe was killed before it could write anything at all. Rare
+            # and always worth the tail, because nothing else says why.
+            return Verdict("broke", _tail(noise))
+        if not written["loaded"]:
+            return Verdict("broke", _tail(noise) or str(written.get("why", "")).strip())
+
+    if written["broke"]:
+        return Verdict("broke", str(written["broke"][0]))
+    if written["noticed"]:
+        return Verdict("caught", str(written["noticed"][0]))
+    if not written["ran"]:
+        return Verdict("broke", "the targets held no tests")
+    return Verdict("survived")
+
+
+def _tail(noise: Path) -> str:
+    """The last line the run managed to say. Empty when it said nothing."""
+    try:
+        spoken = noise.read_text(encoding="utf-8", errors="replace").strip().splitlines()
+    except OSError:
+        return ""
+    return spoken[-1].strip() if spoken else ""
 
 
 def _check(mutation: Mutation) -> None:
@@ -233,24 +385,30 @@ def _sandboxes(count: int) -> Iterator[queue.Queue[Path]]:
         yield available
 
 
-def _borrow(available: queue.Queue[Path], tests: Sequence[str]) -> bool:
-    """Run ``tests`` unmutated in a borrowed sandbox. One shard of the baseline."""
+def _borrow(available: queue.Queue[Path], tests: Sequence[str], timeout: float) -> Verdict:
+    """Run ``tests`` unmutated in a borrowed sandbox. One shard of the baseline.
+
+    Never `failfast`: a red baseline is a thing you want the whole of, and a
+    green one never stops early anyway, so there is nothing to buy.
+    """
     root = available.get()
     try:
-        return _run(tests, root)
+        return _run(tests, root, timeout=timeout)
     finally:
         available.put(root)
 
 
-def _attempt(mutation: Mutation, available: queue.Queue[Path]) -> bool:
-    """Apply one mutation in a borrowed sandbox and report whether it was caught."""
+def _attempt(
+    mutation: Mutation, available: queue.Queue[Path], failfast: bool, timeout: float
+) -> Verdict:
+    """Apply one mutation in a borrowed sandbox and report what the suite said."""
     root = available.get()
     try:
         source = root / mutation.path
         original = source.read_text(encoding="utf-8")
         source.write_text(original.replace(mutation.old, mutation.new), encoding="utf-8")
         try:
-            return _run(mutation.tests.split(), root)
+            return _run(mutation.tests.split(), root, failfast=failfast, timeout=timeout)
         finally:
             # Into the sandbox, not the working tree. Only so the next mutation
             # to borrow this copy starts from clean source.
@@ -259,8 +417,16 @@ def _attempt(mutation: Mutation, available: queue.Queue[Path]) -> bool:
         available.put(root)
 
 
-def verify(mutations: Iterable[Mutation], baseline: bool = True, workers: int | None = None) -> int:
-    """Apply each mutation in its own copy of the tree; return how many survived.
+def run(
+    mutations: Iterable[Mutation],
+    baseline: bool = True,
+    workers: int | None = None,
+    *,
+    strict: bool = True,
+    failfast: bool = False,
+    timeout: float = TIMEOUT,
+) -> Report:
+    """Apply each mutation in its own copy of the tree; report what each answered.
 
     Prints one line per mutation, in the order the table gives them and not the
     order they finish, so that the output is the same every run and can be pasted
@@ -271,10 +437,16 @@ def verify(mutations: Iterable[Mutation], baseline: bool = True, workers: int | 
     everything. Its targets are sharded and queued alongside the mutations rather
     than run as one serial pass, because a single pass over the union of every
     target was measured at two thirds of the wall clock.
+
+    ``strict`` decides what an unanswerable row does. For a hand-written table it
+    should stop the run: a row that breaks collection is a mistake in the table,
+    and the other rows will still be there once it is fixed. For a generated one
+    it must not, because a single non-viable mutant out of two hundred would
+    throw away every answer already paid for.
     """
     table = list(mutations)
     if not table:
-        return 0
+        return Report([])
     for mutation in table:
         _check(mutation)
 
@@ -291,27 +463,93 @@ def verify(mutations: Iterable[Mutation], baseline: bool = True, workers: int | 
     # is nearly free.
     lanes = workers or min(len(table) + len(shards), usable_cpus() * 2, 16)
 
-    survivors: list[Result] = []
+    results: list[Result] = []
+    red = False
     with _sandboxes(lanes) as available, ThreadPoolExecutor(max_workers=lanes) as pool:
         checking = (
-            [pool.submit(_borrow, available, [shard]) for shard in shards] if baseline else []
+            [pool.submit(_borrow, available, [shard], timeout) for shard in shards]
+            if baseline
+            else []
         )
-        futures = [pool.submit(_attempt, mutation, available) for mutation in table]
+        futures = [
+            pool.submit(_attempt, mutation, available, failfast, timeout) for mutation in table
+        ]
         for mutation, future in zip(table, futures, strict=True):
-            caught = future.result()
-            print(f"  {'caught' if caught else 'SURVIVED':9} {mutation.label}")
-            if not caught:
-                survivors.append(Result(mutation, caught))
-        if any(future.result() for future in checking):
-            print("  BASELINE RED -- the suite fails untouched, so nothing above means anything")
-            return len(table)
+            verdict = future.result()
+            results.append(Result(mutation, verdict))
+            print(f"  {_HEADLINE[verdict.outcome]:9} {mutation.label}")
+            if verdict.answered:
+                continue
+            if strict:
+                # Cancel first, or the `with` block's `shutdown(wait=True)` runs
+                # every remaining row to completion and discards its verdict
+                # unprinted -- so "stopping" would cost the whole table it was
+                # meant to save. Only the rows not yet started can go; the
+                # `lanes` already in flight are paid for either way.
+                for pending in futures:
+                    pending.cancel()
+                raise SystemExit(
+                    f"{mutation.label}: this mutation broke collection rather than being "
+                    f"noticed, so neither 'caught' nor 'SURVIVED' would mean anything "
+                    f"about {mutation.tests}. {verdict.detail}"
+                )
+            # Not indented under the row by accident: an unanswered row must not
+            # be skimmable as one of the two real verdicts.
+            print(f"           -- {verdict.detail}")
+        # After the rows, not before, so a red baseline never costs the reader the
+        # results they were waiting for -- they are simply told to disbelieve them.
+        for future in checking:
+            baseline_verdict = future.result()
+            if baseline_verdict.outcome != "survived":
+                # `survived` is the untouched suite passing, which is the one
+                # place the mutation vocabulary reads backwards. A shard that
+                # broke or timed out is red too, and its reason is the only clue
+                # to why -- the old wording asserted a failure that may not have
+                # happened.
+                print(
+                    f"  BASELINE NOT GREEN ({baseline_verdict.outcome}) -- the suite does not "
+                    f"pass untouched, so nothing above means anything: {baseline_verdict.detail}"
+                )
+                red = True
+                break
 
+    if not red:
+        _summarise(results)
+    report = Report(results, red)
+    _RUNS.append(report)
+    return report
+
+
+def _summarise(results: Sequence[Result]) -> None:
+    """The part a pull request quotes when the news is bad."""
+    survivors = [result for result in results if result.verdict.outcome == "survived"]
+    unanswered = [result for result in results if not result.verdict.answered]
     if survivors:
         print(f"\n{len(survivors)} survived. A test that cannot see the fix removed is decoration:")
         for result in survivors:
             print(f"  - {result.mutation.label} ({result.mutation.tests})")
         print("Suspect the fixture before the mutation -- see CLAUDE.md rule 3.")
-    return len(survivors)
+    if unanswered:
+        # Counted separately and never as survivors: these rows asked nothing, and
+        # rolling them into either verdict is the error this module exists to
+        # avoid, one level up.
+        print(
+            f"\n{len(unanswered)} asked nothing, so the table is that much smaller than it looks:"
+        )
+        for result in unanswered:
+            print(f"  - {result.mutation.label}: {result.verdict.detail}")
+
+
+def verify(mutations: Iterable[Mutation], baseline: bool = True, workers: int | None = None) -> int:
+    """`run`, reduced to the number of survivors. The shape spec files call.
+
+    Strict, because a spec file is hand-written: a row that cannot be answered is
+    a mistake in the table, and stopping is what gets it fixed.
+    """
+    report = run(mutations, baseline, workers)
+    if report.baseline_red:
+        return len(report.results)
+    return sum(1 for result in report.results if result.verdict.outcome == "survived")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -322,12 +560,45 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("script", help="a Python file defining MUTATIONS: list[Mutation]")
     args = parser.parse_args(argv)
 
+    already = len(_RUNS)
     namespace = runpy.run_path(args.script)
+    # Every table the script ran, not just the last: a spec calling `verify`
+    # twice would otherwise have its exit status decided by the second, so a
+    # first table full of survivors followed by a clean one exits zero. That is
+    # #213's own symptom -- a run reported as the opposite of what it was --
+    # reintroduced by the fix for it.
+    mine = _RUNS[already:]
+    ran_itself = bool(mine)
     mutations = namespace.get("MUTATIONS")
-    if not mutations:
-        raise SystemExit(f"{args.script} defines no MUTATIONS")
-    return 1 if verify(mutations) else 0
+
+    if mutations and ran_itself:
+        # Both shapes in one file. Re-running the table would cost the same
+        # minutes for the same answer and print it twice with nothing to say
+        # which pass a reader is looking at, so take the one that already ran.
+        print(
+            f"{args.script} defines MUTATIONS *and* calls verify(); the results above "
+            f"are the run it did itself. Delete one of the two.",
+            file=sys.stderr,
+        )
+    if ran_itself:
+        return 0 if all(report.clean for report in mine) else 1
+    if mutations:
+        return 0 if run(mutations).clean else 1
+    raise SystemExit(
+        f"{args.script} defines no MUTATIONS and never called verify(), so there was "
+        f"nothing to run. The shape this takes is `MUTATIONS = [Mutation(...), ...]` "
+        f"at module level."
+    )
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    # Deliberately not `main()`. `python -m tools.mutate` runs this file as
+    # `__main__`, and the spec it then executes does `from tools.mutate import
+    # verify` -- which imports the file a *second* time, as a different module
+    # object with its own `_RUNS`. The local `main` would look at a list the
+    # spec's `verify` never appended to, and report a script that had just run a
+    # green table as one that defined nothing. Which is #213 again, by a
+    # different route.
+    from tools.mutate import main as _main
+
+    raise SystemExit(_main())

--- a/tools/verdict.py
+++ b/tools/verdict.py
@@ -1,0 +1,141 @@
+"""Which kind of failure a suite produced -- the question an exit status cannot answer.
+
+`tools/mutate.py` needs to know whether a *test method noticed* the mutation, or
+whether the run merely fell over. Both exit non-zero, and both leave a plausible
+``Ran N`` behind, so the distinction has to be drawn where the result objects
+still exist rather than reconstructed from what `unittest` printed. That is what
+this file is.
+
+**It is read, not imported.** `mutate` reads this source out of its *own* tree
+and hands it to ``python -c`` in the sandbox. Two properties fall out, and both
+are the point:
+
+- the sandbox's copy of ``tools/`` is never consulted, so a mutation to this file
+  cannot decide its own verdict -- which matters as soon as `tools/**.py` is
+  itself something a generated table mutates;
+- being a real module rather than a string constant, `ruff` and `mypy` see it.
+  The previous shape was a 35-line string literal that no checker could reach,
+  holding the one piece of genuinely new logic in the change.
+
+``-c`` also puts the working directory on ``sys.path`` where a script path would
+not, which is how the sandbox's own test modules are importable at all.
+
+**Classification is by protocol, never by class name.** The obvious spelling --
+"is this class defined under ``unittest.``?" -- was written first and was wrong
+in the direction that matters. `unittest.case._SubTest` is a `TestCase` whose
+module is ``unittest.case``, so an assertion failing inside ``with
+self.subTest(...)`` was filed as "the suite broke" rather than "a test noticed",
+and with a strict table that aborts the run. This repository uses `subTest` in
+more than twenty places. So instead:
+
+- ``addSubTest`` is handed the **owning** test, not the `_SubTest` carrier, so
+  overriding it records the right name;
+- a `setUpClass` or `setUpModule` failure arrives through ``addError`` as
+  `unittest.suite._ErrorHolder`, which is deliberately *not* a `TestCase` -- so
+  `isinstance` alone separates "a fixture died" from "a test failed", with no
+  private name involved;
+- a module that will not import is reported by `TestLoader.errors`, a public
+  attribute, and the suite is then not run at all. Running it would surface the
+  synthetic `unittest.loader._FailedTest` through ``addError`` -- and that one
+  *is* a `TestCase`, so it would read as a test noticing.
+
+Nothing here names a private symbol to make a decision. If a future `unittest`
+moves `_FailedTest` or `_ErrorHolder`, `loader.errors` and the `isinstance` still
+answer, and the failure mode is a name printed oddly rather than `broke`
+silently becoming `caught`.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import traceback
+import unittest
+from types import TracebackType
+from typing import Any
+
+#: What `unittest` hands a result method for a failure, spelled exactly as
+#: typeshed spells it -- `mypy --strict` checks these overrides for Liskov and a
+#: near-miss here is an error, not a warning.
+ExcInfo = tuple[type[BaseException], BaseException, TracebackType] | tuple[None, None, None]
+
+
+class Verdicts(unittest.TextTestResult):
+    """Keeps the tests that asserted apart from the carriers that did not."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        #: Real test methods that failed. This is what `caught` means.
+        self.noticed: list[str] = []
+        #: Fixtures that died before any assertion ran. Not an answer.
+        self.broke: list[str] = []
+
+    def addFailure(self, test: unittest.TestCase, err: ExcInfo) -> None:
+        super().addFailure(test, err)
+        self.noticed.append(str(test))
+
+    def addError(self, test: unittest.TestCase, err: ExcInfo) -> None:
+        super().addError(test, err)
+        # `_ErrorHolder` -- a dead `setUpClass`, `setUpModule` or `tearDown` --
+        # is not a `TestCase`, and that is the whole check. It carries a
+        # traceback for something that happened *around* the tests, so no
+        # assertion in it was ever evaluated.
+        target = self.noticed if isinstance(test, unittest.TestCase) else self.broke
+        target.append(str(test))
+
+    def addSubTest(
+        self, test: unittest.TestCase, subtest: unittest.TestCase, err: ExcInfo | None
+    ) -> None:
+        super().addSubTest(test, subtest, err)
+        if err is not None:
+            # `test` is the owning case; `subtest` is the `_SubTest` carrier that
+            # the base class files into `failures`. Recording the owner is what
+            # keeps a `subTest` assertion a real answer.
+            self.noticed.append(str(test))
+
+
+def collect(names: list[str], failfast: bool) -> dict[str, Any]:
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromNames(names)
+    if loader.errors:
+        # Public API, and checked before running: the suite `loadTestsFromNames`
+        # returns for an unimportable module holds a synthetic `_FailedTest`
+        # which *is* a `TestCase`, so running it would report a test noticing.
+        return {
+            "loaded": True,
+            "ran": 0,
+            "noticed": [],
+            # `str()` because typeshed types `errors` as exception classes while
+            # `unittest` actually appends formatted tracebacks; the first line is
+            # the "Failed to import test module: x" that says which.
+            "broke": [str(error).splitlines()[0] for error in loader.errors],
+        }
+    result = unittest.TextTestRunner(
+        stream=io.StringIO(), verbosity=0, failfast=failfast, resultclass=Verdicts
+    ).run(suite)
+    assert isinstance(result, Verdicts)
+    return {
+        "loaded": True,
+        "ran": result.testsRun,
+        "noticed": result.noticed,
+        "broke": result.broke,
+    }
+
+
+def main(argv: list[str]) -> None:
+    report, failfast, names = argv[0], argv[1] == "1", argv[2:]
+    try:
+        written = collect(names, failfast)
+    except BaseException:
+        # Said, not inferred. The caller used to conclude "the suite could not be
+        # loaded" from an absent file, which is also what a typo in this file
+        # produces -- two very different problems with byte-identical output, in
+        # a tool whose whole thesis is that those must be told apart.
+        written = {"loaded": False, "why": traceback.format_exc(limit=4)}
+    with open(report, "w", encoding="utf-8") as out:
+        json.dump(written, out)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
`tools/mutate.py` reported `caught` for mutations that broke collection.

`unittest.loader` catches `ImportError` — and only `ImportError` — and wraps it in a synthetic `_FailedTest`, so the run prints `Ran 1 test`, `FAILED (errors=1)` and exits non-zero. To a check reading the exit status and the count, that is indistinguishable from a test catching the mutation. A dead `setUpClass` does the same through `_ErrorHolder`.

The only fixture guarding this used a *syntax* error, which the loader does **not** wrap and which therefore takes a different path entirely — there is no `Ran` line at all. So the check passed while the case it was named for went unasked. That is the too-weak fixture rule 3 warns about, inside the harness built to find them.

Before the fix, the new tests print exactly what the module docstring said could never happen:

```
  caught    helper returns nothing
  caught    the import goes bad
```

Neither test asserted anything.

## The fix

`tools/verdict.py` classifies where the result objects still are, **by protocol, never by class name**:

- `addSubTest` is handed the *owning* test, not the `_SubTest` carrier;
- `_ErrorHolder` is deliberately not a `TestCase`, so `isinstance` alone separates a dead fixture from a failed test;
- `TestLoader.errors` — public — reports a module that will not import, and the suite is then not run at all. Running it would surface the synthetic `_FailedTest` through `addError`, and *that* one **is** a `TestCase`.

Nothing names a private symbol to make a decision. If a future `unittest` moves `_FailedTest`, the failure mode is a name printed oddly rather than `broke` silently becoming `caught`.

It is read from the parent's tree and fed to `python -c`, so a mutation to `tools/**.py` cannot grade its own exam — and being a real module rather than a string constant, `ruff` and `mypy` see it.

Also: `BROKE`/`TIMEOUT` outcomes counted apart from both real verdicts; a 300 s limit; `strict=False` so one non-viable row does not discard a whole generated table; `failfast`, off by default.

Closes #213.

## Found by review, and fixed here

Three findings, all in code this PR introduced:

- **`subTest` was filed as `broke`.** The first version classified by `type(test).__module__.startswith("unittest.")`. `unittest.case._SubTest` is a `TestCase` in `unittest.case`, so a mutation whose only witness was an assertion inside `with self.subTest(...)` aborted the run while blaming the table. This repository uses `subTest` in 20+ places.
- **The strict abort paid for the whole table it claimed to stop.** `raise SystemExit` inside the executor's `with` means `shutdown(wait=True)`: every remaining row ran to completion and was discarded unprinted. Now cancels pending futures first, so the cost is `lanes`, not `N`.
- **`capture_output=True` on a discarded result.** Nothing read it after the regex went away — and on a timeout `subprocess.run` kills the child then drains the pipes with `communicate()` and *no* limit, which waits for the suite's `python -m woswoar` grandchildren. A hung grandchild would have held a lane past `timeout`, the one thing the outcome exists to prevent. Now a file, not a pipe, and its tail becomes the `broke` detail.

## Mutation output, seventeen caught, verbatim

```
  caught    a module that will not import is run anyway, so its _FailedTest reads as a catch
  caught    a dead setUpClass counts as a test noticing
  caught    a target holding no tests reads as a survivor
  caught    a subTest failure stops being recorded, so it files as broken instead of caught
  caught    the probe stops reporting that it never loaded
  caught    a run that wrote no report at all reads as an answer
  caught    a mutation that never finishes is called a survivor
  caught    strict stops refusing an unanswerable row
  caught    every row is refused, strict or not
  caught    an unanswered row is treated as one of the two real verdicts
  caught    failfast is never passed to the probe
  caught    failfast is always on, whoever asked
  caught    a row that asked nothing still counts as clean
  caught    a red baseline no longer poisons the report
  caught    the CLI reads its own module's run log rather than the one the spec wrote to
  caught    a script that did the work itself is still told it defined nothing
  caught    a script that defines a table and runs it too runs it twice
```

Two rows earned themselves during the run:

- **`a target holding no tests reads as a survivor`** survived first. The branch existed and nothing reached it: a target that imports cleanly and holds no test methods would have been reported `SURVIVED` — "your fix is unguarded" — produced by a table pointed at a module that could not have guarded anything.
- **`a run that wrote no report at all reads as an answer`** survived first too, and the fixture was the culprit exactly as rule 3 predicts. The probe had just gained an `except BaseException` that writes `loaded: false`, so every fixture reached the *other* branch. `os._exit` skips every `except` and `finally` there is, which is what a signal or an OOM kill looks like from outside; that fixture reaches it.

**One mutation is deliberately absent from the table**: `timeout=timeout` → `timeout=None`. It is real and `TestAMutantThatNeverFinishes` does see it, but not *through this harness* — the inner test then hangs forever and the only thing that ends it is the harness's own 300 s limit, which is the code under mutation. It reports `TIMEOUT`, not `caught`: an unanswerable row, not a survivor. Verified by reverting it in the working tree by hand.

## Measured, because two documented figures disagreed

| | measured | `CONTRIBUTING.md` said |
|---|---|---|
| suite, serial | **60.3 s** | ~19 s |
| suite, sharded | **5.3 s** | ~6 s |
| tests | **993** | 301 |

Corrected in this PR. The serial figure is what decides PR 2's design: whole-suite-per-mutant would be ~12 minutes for a 200-row generated table, so selection plus a survivor-confirmation pass is the shape.

`CLAUDE.md` rule 6 also still said mutation testing "edits sources in a loop … and an interrupted run leaves the tree mutated" — untrue since #212, and stale in the dangerous direction: believing it is exactly what would justify reaching for `git checkout --`, the operation that rule exists to prevent.

`spec_*.py` is now git-ignored and ruff-excluded. Despite the standing "the spec stays out of the tree" policy, nothing stopped one being committed — `*.spec` in `.gitignore` is PyInstaller's and matches none of them.

## Not fixed here

`tools/run_tests.py:194` still spells `getattr(os, "process_cpu_count", os.cpu_count)` inline, which is what `sandbox.usable_cpus` was extracted to replace. One line, but in a file this diff does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)