### PR TITLE
feat: mutants generated from the diff, not written by hand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,12 @@ reverted**. Verify that, do not assume it:
 `tools/mutate.py` is that loop: write the table of edits, run
 `python -m tools.mutate <spec>.py`, paste the output into the PR.
 
+`python -m tools.mutate --base main` skips the table: it reads the diff,
+generates mutants for the lines the change touched, and runs them. Use it first
+and write rows by hand only for what it cannot reach — a *scope widening* (the
+`source` line searched in the whole rc file rather than the block) has no local
+AST rewrite, so "every generated mutant was caught" is not "the tests are good".
+
 A test that passes either way is decoration, and reading it will not tell you
 which kind you have written. Tests have been added here that looked correct and
 never executed the line they claimed to guard.
@@ -216,7 +222,8 @@ first such change, not during one.
   | a change might have cost time | [`tools/bench.py`](tools/bench.py) |
 
   ```sh
-  python -m tools.mutate <spec>.py
+  python -m tools.mutate --base main        # generated from the diff
+  python -m tools.mutate <spec>.py          # a table you wrote
   python -m tools.compare --base main --show .bashrc install doctor status
   python -m tools.bench --importtime woswoar.__main__ --base main
   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,57 @@ of edits, run `python -m tools.mutate <spec>.py`, and paste its output into the
 pull request — verbatim, rather than retyping it, which is how a mutation that
 was never run ended up quoted in a commit message here.
 
+Most of the time you should not write the table at all:
+
+```sh
+python -m tools.mutate --base main          # generate from the diff and run
+python -m tools.mutate --base main --list   # print the table, run nothing
+```
+
+It reads `git diff --merge-base main` — working tree included, so uncommitted
+work counts — and generates mutants for the changed lines of `woswoar/**.py` and
+`tools/**.py` only. Each row runs against the test modules that name or import
+the file, and **every survivor is then re-run against the whole suite** before it
+is reported, so a narrow selection can cost time but cannot produce a false
+`SURVIVED`. On the change that became #216 that pass corrected nine of eleven.
+
+Fourteen operators. Ten rewrite an expression (`<` to `<=`, `and` to `or`,
+`sorted(x)` to `sorted(x, reverse=True)`, `.endswith(...)` to `True`, an `if`
+forced both ways, `+` to `-`, a slice's bounds dropped, a small integer moved by
+one, `return X` to `return None`); two delete a statement.
+
+Deletion is deliberately narrow. `drop-call` removes a call whose value is
+discarded — `path.mkdir()`, `store.flush()` — which is the "the write never
+happened" class, and `drop-assign` removes an assignment **through an attribute
+or a key** — `self.total = ...`, `cache[k] = ...`. Plain `name = ...` is left
+alone on purpose: deleting it leaves a `NameError` further down, which reports
+`BROKE` rather than an answer and costs a whole suite run to find that out.
+`logging` and `progress` calls are never deleted; `print` is, because here the
+printed output is the product.
+
+A generated mutant can also fail to *stop*. Two bounds are enforced per row, and
+they answer different questions: `--timeout` (300 s) for a mutation that never
+finishes, and `--memory` (4 GiB of address space) for one that never finishes
+*while allocating*. The second is not a refinement of the first — a timeout
+cannot fire on a machine that is already out of memory. An `at -= …` generated
+for this repository's own `line_starts` reached 15.5 GB in 73 seconds and
+OOM-killed the session twice before 300 s was anywhere in sight. Lanes are
+capped by memory as well as by cores, because the per-row limit bounds one lane
+and not their product.
+
+Running out of memory is reported `BROKE`, never `caught`. It arrives as a
+`MemoryError` inside whichever test was running, which by protocol looks exactly
+like that test noticing — and crediting a test with a guard it does not have is
+the failure this whole tool exists to prevent.
+
+Write rows by hand for what no operator can reach. Of the four weak fixtures
+listed below, `order` generates the reversed walk and `affix` the suffix filter
+that accepts everything. The class that is out of reach is *scope widening* — a
+`source` line searched in the whole rc file instead of the block, from
+[`CLAUDE.md`](CLAUDE.md) rule 3 — because no local rewrite changes which region
+a search covers. So "every generated mutant was caught" is not the same claim as
+"the tests are good".
+
 Three verdicts, not two. `caught` means a **test method** noticed; `SURVIVED`
 means none did; `BROKE` and `TIMEOUT` mean the run never got to ask, and are
 counted apart from both. That third category exists because a mutation which

--- a/tests/test_mutants.py
+++ b/tests/test_mutants.py
@@ -1,0 +1,711 @@
+"""Tests for the mutant generator.
+
+Everything here except `TestReadingARealDiff` is pure -- source text in,
+mutations out -- so it runs in milliseconds and needs no sandbox, no subprocess
+and no suite. That is the whole reason `tools/mutants.py` is a separate module
+from the runner.
+
+The generator can be wrong in two directions and they are not equally bad. A
+mutant it fails to produce is coverage nobody asked for. A mutant whose *span*
+is wrong edits a different part of the file than its label claims, still parses,
+and reports `caught` or `SURVIVED` about something nobody chose -- which is the
+class of error `tools/mutate.py` exists to prevent, arriving one module earlier.
+So the span assertions here are exact, never "it contains".
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from tools import mutants
+from tools.mutants import Mutation
+
+from .support import requires_git
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def mutate(
+    body: str, lines: set[int] | None = None, operators: list[str] | None = None
+) -> list[Mutation]:
+    """Every mutant for a snippet, on every line unless told otherwise."""
+    source = textwrap.dedent(body).lstrip()
+    if lines is None:
+        lines = set(range(1, len(source.splitlines()) + 1))
+    return mutants.generate(source, "woswoar/thing.py", lines, operators=operators)
+
+
+class TestReadingAHunkHeader(unittest.TestCase):
+    """`git diff --unified=0`, parsed without a repository in sight."""
+
+    def test_a_single_line_hunk(self) -> None:
+        diff = "+++ b/woswoar/x.py\n@@ -13 +13 @@\n"
+        self.assertEqual(mutants.parse_hunks(diff), {"woswoar/x.py": {13}})
+
+    def test_a_counted_hunk(self) -> None:
+        diff = "+++ b/woswoar/x.py\n@@ -15,2 +15,3 @@\n"
+        self.assertEqual(mutants.parse_hunks(diff), {"woswoar/x.py": {15, 16, 17}})
+
+    def test_an_insertion_names_the_new_lines_only(self) -> None:
+        diff = "+++ b/woswoar/x.py\n@@ -58,0 +60,6 @@\n"
+        self.assertEqual(mutants.parse_hunks(diff), {"woswoar/x.py": set(range(60, 66))})
+
+    def test_a_pure_deletion_contributes_nothing(self) -> None:
+        """`+9,0` is a removal: there is no new code at line 9 to mutate.
+
+        Taking it as one line -- which "omitted means 1" would, if the zero were
+        not checked -- generates mutants for whatever now sits at that number,
+        labelled as if the diff had put it there.
+        """
+        diff = "+++ b/woswoar/x.py\n@@ -10,3 +9,0 @@\n"
+        self.assertEqual(mutants.parse_hunks(diff), {})
+
+    def test_a_deleted_file_contributes_nothing(self) -> None:
+        """And it needs no special case: git spells its hunk `+0,0`.
+
+        The deleted file comes *second* so that a parser which failed to notice
+        it would attribute the hunk to `y.py` -- which is the only way this can
+        be a test at all. It passes because the count is zero, not because
+        `/dev/null` is recognised.
+        """
+        diff = "+++ b/woswoar/y.py\n@@ -1 +1 @@\n+++ /dev/null\n@@ -1,5 +0,0 @@\n"
+        self.assertEqual(mutants.parse_hunks(diff), {"woswoar/y.py": {1}})
+
+    def test_several_files_in_one_diff(self) -> None:
+        diff = "+++ b/woswoar/x.py\n@@ -1 +1 @@\n+++ b/tools/y.py\n@@ -4,2 +4,2 @@\n"
+        self.assertEqual(mutants.parse_hunks(diff), {"woswoar/x.py": {1}, "tools/y.py": {4, 5}})
+
+    def test_a_quoted_path(self) -> None:
+        """git C-quotes any path with an odd byte in it, `b/` inside the quotes."""
+        diff = '+++ "b/woswoar/odd\\tname.py"\n@@ -1 +1 @@\n'
+        self.assertEqual(mutants.parse_hunks(diff), {"woswoar/odd\tname.py": {1}})
+
+
+class TestWhatMayBeMutated(unittest.TestCase):
+    def test_the_product_and_the_tools_are_in(self) -> None:
+        self.assertTrue(mutants.mutable("woswoar/sync.py"))
+        self.assertTrue(mutants.mutable("tools/mutate.py"))
+
+    def test_the_tests_are_not(self) -> None:
+        """Breaking a test proves nothing about the fix, and the run would
+        cheerfully report the assertion it had just deleted."""
+        self.assertFalse(mutants.mutable("tests/test_sync.py"))
+
+    def test_other_files_are_not(self) -> None:
+        self.assertFalse(mutants.mutable("woswoar/shell/woswoar.bash"))
+        self.assertFalse(mutants.mutable("docs/architecture.md"))
+        self.assertFalse(mutants.mutable("setup.py"))
+
+
+class TestTheOperators(unittest.TestCase):
+    """One fixture where each fires, one where it must not."""
+
+    def prose(self, body: str, operators: list[str]) -> list[str]:
+        return [row.label.split(" -- ", 1)[1] for row in mutate(body, operators=operators)]
+
+    def test_every_operator_has_a_test_here(self) -> None:
+        """The completeness guard, in the shape `test_architecture.py` uses.
+
+        An operator added without a fixture would otherwise ship untested, and
+        the generator's own output is the last place a gap is visible.
+        """
+        named = {operator.name for operator in mutants.OPERATORS}
+        self.assertEqual(set(_FIRES), named)
+        # Both tables, not just the first. An operator could otherwise ship with
+        # a fires-fixture and no must-not-fire fixture, which is half a test.
+        self.assertEqual(set(_QUIET), named)
+
+    def test_each_operator_fires_on_its_own_fixture(self) -> None:
+        for name, (body, expected) in _FIRES.items():
+            with self.subTest(operator=name):
+                got = self.prose(body, operators=[name])
+                self.assertEqual(got, expected)
+
+    def test_no_operator_fires_on_a_fixture_it_should_not(self) -> None:
+        for name, body in _QUIET.items():
+            with self.subTest(operator=name):
+                self.assertEqual(self.prose(body, operators=[name]), [])
+
+
+#: Fixture -> the prose every operator should produce on it, in order.
+_FIRES: dict[str, tuple[str, list[str]]] = {
+    "boundary": ("x = a < b\n", ["`<` becomes `<=`"]),
+    "negate": ("x = a is None\n", ["`is` becomes `is not`"]),
+    "connector": ("x = a and b\n", ["`and` becomes `or`"]),
+    "branch": (
+        "if ready:\n    go()\n",
+        ["the `if` is always taken", "the `if` is never taken"],
+    ),
+    "drop-not": ("x = not ready\n", ["the `not` is dropped"]),
+    "order": (
+        "x = sorted(days)\n",
+        ["the ordering is reversed", "`sorted` becomes `list`"],
+    ),
+    "affix": (
+        'x = name.endswith(".age")\n',
+        ["the `.endswith(...)` filter accepts everything"],
+    ),
+    "return-constant": (
+        "def f():\n    return True\n",
+        ["returns `False` instead of `True`"],
+    ),
+    "drop-call": ("path.mkdir()\n", ["the call to `path.mkdir(...)` never happens"]),
+    "drop-assign": ("self.total = 1\n", ["`self.total` is never assigned"]),
+    "off-by-one": ("x = items[1]\n", ["`1` becomes `2`", "`1` becomes `0`"]),
+    "return-value": (
+        "def f():\n    return compute(x)\n",
+        ["returns `None` instead of `compute(x)`"],
+    ),
+    # Both shapes: an expression and an augmented assignment. With only the
+    # first, the mutation cutting `AugAssign` out of `arith` survived.
+    "arith": (
+        "x = a + b\ncount += 1\n",
+        ["`+` becomes `-`", "`+=` becomes `-=`"],
+    ),
+    "slice": ("x = items[1:]\n", ["the slice takes everything"]),
+}
+
+#: Fixture -> a shape the operator must leave alone.
+_QUIET: dict[str, str] = {
+    # A chained comparison has two operators and no single answer.
+    "boundary": "x = a < b < c\n",
+    "negate": "x = a < b\n",
+    "connector": "x = a + b\n",
+    # Already constant: forcing `True` to `True` changes nothing, and a row that
+    # changes nothing reports about nothing.
+    "branch": "if True:\n    go()\n",
+    "drop-not": "x = -value\n",
+    "order": "x = sorted(days, reverse=True)\n",
+    "affix": "x = name.strip()\n",
+    "return-constant": "def f():\n    return value\n",
+    # The meter is never the thing being compared.
+    "drop-call": "progress.tick()\n",
+    # A plain name: deleting it leaves a NameError further down, which reports
+    # BROKE -- not an answer, and a whole suite run to learn that.
+    "drop-assign": "plain = 3\n",
+    # Big enough that +-1 is arbitrary rather than a boundary.
+    "off-by-one": "x = items[97]\n",
+    # `return None` is already what the mutation would produce -- and `return
+    # True` is left to `return-constant`, which swaps it. `None` is falsy, so
+    # asking both would be very nearly the same question at twice the price.
+    # With only the `return None` half, dropping the boolean exclusion survived.
+    "return-value": "def f():\n    return None\n\n\ndef g():\n    return True\n",
+    # String concatenation has no meaningful `-`.
+    "arith": "x = a % b\n",
+    # `x[:]` has no bound left to widen.
+    "slice": "x = items[:]\n",
+}
+
+
+class TestWhatIsNeverMutated(unittest.TestCase):
+    def test_a_docstring_is_left_alone(self) -> None:
+        self.assertEqual(mutate('def f():\n    """Words."""\n'), [])
+
+    def test_an_f_string_interior_yields_nothing_at_all(self) -> None:
+        """Zero, and the assertion is deliberately not "a correct span".
+
+        On 3.10 and 3.11 the nodes inside a `JoinedStr` carry the *enclosing
+        string's* position, so a span computed from one splices bytes somewhere
+        else in the file -- and the result usually still parses. The point is not
+        that the span would be wrong; it is that it cannot be trusted at all.
+        """
+        self.assertEqual(mutate('x = f"{a < b}"\n'), [])
+
+    def test_an_annotation_is_left_alone(self) -> None:
+        """Every module here has `from __future__ import annotations`, so these
+        are never evaluated: a guaranteed equivalent mutant."""
+        # The literal inside the annotation must be untouched while the one in
+        # the value is not -- a fixture that only had the annotation could not
+        # tell "suppressed" from "the operator never fires here".
+        rows = mutate("x: Literal[1] = 2\n", operators=["off-by-one"])
+        self.assertEqual([row.old for row in rows], ["2", "2"])
+
+    def test_a_type_checking_block_is_left_alone(self) -> None:
+        self.assertEqual(mutate("if TYPE_CHECKING:\n    import x\n"), [])
+
+    def test_the_main_guard_is_left_alone(self) -> None:
+        self.assertEqual(mutate('if __name__ == "__main__":\n    go()\n'), [])
+
+    def test_an_assert_is_left_alone(self) -> None:
+        self.assertEqual(mutate("assert a is None\n"), [])
+
+    def test_a_pragma_line_is_left_alone(self) -> None:
+        self.assertEqual(mutate("x = a < b  # pragma: no mutate\n"), [])
+
+    def test_a_pragma_covers_the_whole_construct_not_just_its_first_line(self) -> None:
+        """The pragma reads as covering what it sits in, so it must.
+
+        Checked by span rather than by start line. A multi-line `if` was mutated
+        regardless while its author could see the pragma sitting there -- silent,
+        and in the direction that reads as success, because the run then reports
+        `SURVIVED` about code that had been declared out of scope.
+        """
+        source = (
+            "def g(a, b):\n    if (a\n            and b):  # pragma: no mutate\n        return 1\n"
+        )
+        rows = mutants.generate(source, "w/t.py", {2, 3}, tests="t")
+        self.assertEqual([row.label for row in rows], [])
+
+    def test_a_form_feed_above_a_pragma_does_not_move_it(self) -> None:
+        """The pragma is numbered the way `ast` numbers, not the way `str` does.
+
+        `str.splitlines` breaks on form feed and the tokenizer does not, so this
+        source put the suppression one line below the code it names: the marked
+        comparison was mutated and the innocent line above it was skipped. The
+        module already owned `line_starts` for exactly this; the pragma was the
+        last place not using it. `dedent` eats a form feed, so no helper here.
+        """
+        source = "def f(a, b):\n    x = a < b\n\x0c\n    y = a < b  # pragma: no mutate\n"
+        rows = mutants.generate(source, "w/t.py", {1, 2, 3, 4}, tests="t")
+        self.assertEqual([row.label for row in rows], ["w/t.py:2 in f() -- `<` becomes `<=`"])
+
+    def test_a_while_is_never_forced_true(self) -> None:
+        """A hang is not a caught mutant: it burns a lane and the timeout to
+        report `TIMEOUT`, which is not an answer."""
+        self.assertEqual(mutate("while ready:\n    go()\n", operators=["branch"]), [])
+
+    def test_only_the_changed_lines(self) -> None:
+        body = "x = a < b\ny = c < d\n"
+        self.assertEqual([row.label for row in mutate(body, lines={2})].pop().count(":2"), 1)
+        self.assertEqual(len(mutate(body, lines={2})), 1)
+
+
+class TestLineEndingsThatAreNotNewline(unittest.TestCase):
+    """`\r\n` and a bare `\r` end a line for CPython, and so for every span here.
+
+    `line_starts` was written for the form feed -- a character `str.splitlines`
+    breaks on and the tokenizer does not -- and it handles the opposite case in
+    the same loop: characters the tokenizer *does* break on. That half arrived
+    with no fixture, and the tool said so about itself: of the 17 rows that
+    survived `--base main --only tools/mutants.py`, 15 were in this branch, and
+    the reason was not a subtle one. No source anywhere in the suite contained a
+    `\r`, so `if source[at] == "\r"` was never once entered.
+
+    The exactness matters for the same reason the form feed did. A step of 1
+    across `\r\n` puts every span below it one character early, which is an edit
+    that still parses, in a place the row's label does not name.
+    """
+
+    def starts_agree_with_ast(self, source: str) -> list[int]:
+        """`ast` is the authority; this asserts against it rather than a constant.
+
+        Written this way because the constant is what a reader checks by hand and
+        gets wrong. `get_source_segment` slices with `ast`'s own line accounting,
+        so if `line_starts` disagrees the segments come back shifted.
+        """
+        tree = ast.parse(source)
+        for node in tree.body:
+            self.assertIsNotNone(ast.get_source_segment(source, node))
+        return mutants.line_starts(source)
+
+    def test_crlf_counts_as_one_line_ending(self) -> None:
+        source = "a = 1\r\nb = 2\r\n"
+        # 7, not 6: the `\n` after the `\r` starts no line of its own.
+        self.assertEqual(self.starts_agree_with_ast(source), [0, 7, 14])
+
+    def test_a_bare_cr_ends_a_line_too(self) -> None:
+        """The `else 1` arm. A lone `\r` is a terminator for CPython, not junk."""
+        source = "a = 1\rb = 2\r"
+        self.assertEqual(self.starts_agree_with_ast(source), [0, 6, 12])
+
+    def test_the_three_endings_mixed(self) -> None:
+        """One source reaching every arm, because real files are converted badly."""
+        source = "a = 1\r\nb = 2\rc = 3\n"
+        self.assertEqual(self.starts_agree_with_ast(source), [0, 7, 13, 19])
+
+    def test_a_leading_newline_is_not_skipped(self) -> None:
+        """`at` starts at 0, and index 0 is a line ending on a file that opens blank."""
+        source = "\na = 1\n"
+        self.assertEqual(self.starts_agree_with_ast(source), [0, 1, 7])
+
+    def test_a_file_that_does_not_end_in_a_newline(self) -> None:
+        """The last line has no start after it, so its end is the end of the file.
+
+        Every other fixture in this file ends in `\n`, which is why the bound in
+        `Offsets._line` survived mutation: `lineno < len(starts)` and
+        `lineno <= len(starts)` only differ when the mutated node sits on the
+        final line and nothing follows it. Git warns about such a file and
+        happily stores one.
+        """
+        source = "first = 1\nx = a < b"
+        self.assertEqual(mutants.line_starts(source), [0, 10])
+        row = mutants.generate(source, "w/t.py", {2}, tests="t").pop()
+        start, end = row.span or (0, 0)
+        self.assertEqual(source[start:end], "a < b")
+
+    def test_a_span_below_a_crlf_lands_on_its_own_text(self) -> None:
+        """The end-to-end claim: one character early is a different edit.
+
+        `\r\n` above the mutated line, and a comparison below it, so a step of 1
+        shifts the span into the line ending rather than onto `a < b`.
+        """
+        source = "first = 1\r\nx = a < b\n"
+        row = mutants.generate(source, "w/t.py", {2}, tests="t").pop()
+        start, end = row.span or (0, 0)
+        self.assertEqual(source[start:end], "a < b")
+        self.assertEqual(row.old, "a < b")
+
+
+class TestChoosingOperators(unittest.TestCase):
+    """A run that asked nothing must not read as a run that found nothing."""
+
+    def test_an_unknown_operator_is_refused(self) -> None:
+        """`--operator boundry` used to generate zero rows and exit 0.
+
+        Which is indistinguishable, in a pull request, from a change nothing
+        could mutate -- the same failure `--limit` avoids by saying out loud how
+        many rows it dropped.
+        """
+        with self.assertRaises(SystemExit) as refused:
+            mutants.generate("x = a < b\n", "w/t.py", {1}, operators=["boundry"])
+        self.assertIn("no such operator: boundry", str(refused.exception))
+        self.assertIn("boundary", str(refused.exception))
+
+    def test_a_known_operator_still_selects(self) -> None:
+        rows = mutants.generate("x = a < b\n", "w/t.py", {1}, operators=["boundary"])
+        self.assertEqual([row.label for row in rows], ["w/t.py:1 -- `<` becomes `<=`"])
+
+
+class TestTheLabelNamesAScope(unittest.TestCase):
+    """`in C()` named a call that does not exist, on the string a reviewer reads."""
+
+    def test_a_class_body_is_not_written_as_a_call(self) -> None:
+        rows = mutants.generate("class C:\n    LIMIT = 1\n", "w/t.py", {2}, tests="t")
+        self.assertEqual(rows[0].label, "w/t.py:2 in C -- `1` becomes `2`")
+
+    def test_a_method_still_is(self) -> None:
+        source = "class C:\n    def m(self, a, b):\n        return a < b\n"
+        rows = mutants.generate(source, "w/t.py", {3}, tests="t")
+        self.assertEqual(rows[0].label, "w/t.py:3 in C.m() -- `<` becomes `<=`")
+
+    def test_a_function_in_a_function_is_not_written_as_two_calls(self) -> None:
+        """`outer().inner()` is what baking the parentheses into the name gives."""
+        source = "def outer():\n    def inner(a, b):\n        return a < b\n    return inner\n"
+        rows = mutants.generate(source, "w/t.py", {3}, tests="t")
+        self.assertEqual(rows[0].label, "w/t.py:3 in outer.inner() -- `<` becomes `<=`")
+
+
+class TestTheSpanIsExact(unittest.TestCase):
+    def test_the_span_holds_the_text_the_row_quotes(self) -> None:
+        source = "x = a < b\n"
+        row = mutate(source).pop()
+        start, end = row.span or (0, 0)
+        self.assertEqual(source[start:end], row.old)
+        self.assertEqual(row.old, "a < b")
+
+    def test_a_line_with_non_ascii_before_it(self) -> None:
+        """`col_offset` is a UTF-8 *byte* offset; `str` slicing is by character.
+
+        `woswoar/report.py` and `woswoar/archive.py` really do contain `·`, `✔`
+        and `²`, so this is the live case and not a hypothetical. Every fixture
+        written in plain English passes under either arithmetic, which is what
+        makes the bug invisible without this test.
+        """
+        # On the *same line*, before the column. A fixture with the non-ASCII on
+        # an earlier line passes under either arithmetic -- the line starts are
+        # counted in characters and are right either way -- so the first version
+        # of this test proved nothing, and the mutation that removes the
+        # conversion survived it.
+        source = 'x = "✔ ✘ ²" if a < b else "·"\n'
+        row = mutate(source, lines={1}).pop()
+        start, end = row.span or (0, 0)
+        self.assertEqual(source[start:end], "a < b")
+        self.assertEqual(row.old, "a < b")
+
+    def test_a_span_on_a_later_line(self) -> None:
+        """`lineno` indexes a list, and a one-line fixture cannot see it slip.
+
+        `_lines[lineno - 1]` against `_lines[lineno - 2]` picks the same string
+        whenever the file has one line, and the same *offset* whenever every
+        earlier line is the same length. Both mutations survived a fixture set
+        that had drifted to single-line sources -- including this class's own
+        UTF-8 case, which had to become one line to test the byte conversion.
+        So: three lines, deliberately of different lengths, mutating the third.
+
+        The line *above* the mutated one carries a multi-byte character inside
+        the first four bytes, which is the only arrangement that can tell the two
+        apart: `line.encode()[:col]` gives four characters on any ASCII line, so
+        a slip onto a neighbouring plain-English line is invisible.
+        """
+        source = "a = 1\n# ·x\nx = a < b\n"
+        row = mutate(source, lines={3}).pop()
+        start, end = row.span or (0, 0)
+        self.assertEqual(source[start:end], "a < b")
+        self.assertEqual(source.index("a < b", source.index("x =")), start)
+
+    def test_a_form_feed_does_not_shift_the_lines_below_it(self) -> None:
+        """`str.splitlines` and the tokenizer disagree, and only one is right.
+
+        `splitlines` breaks on form feed, vertical tab, the file/group/record
+        separators and U+2028/9; CPython treats a form feed as whitespace. A
+        single `\\f` -- the Emacs page separator, and legal Python -- made
+        `splitlines` see seven lines where `ast` saw six, so every span below it
+        landed one line early. The mutant then edited `limit` on line 4 while its
+        label named `return True` on line 5, and the result still parsed.
+
+        The span assertion cannot be `source[start:end] == row.old`: `generate`
+        derives `old` from the span, so that identity holds however wrong the
+        offsets are. It has to be the text this test names independently.
+        """
+        source = (
+            "def f(values, limit):\n"
+            "    total = sum(values)\n"
+            "\x0c\n"
+            "    if total < limit:\n"
+            "        return True\n"
+            "    return False\n"
+        )
+        # Not through `mutate`: `textwrap.dedent` counts `\x0c` as whitespace and
+        # rewrites the line, so the helper would hand the generator a different
+        # string from the one asserted against here.
+        rows = mutants.generate(source, "woswoar/thing.py", {5}, operators=["return-constant"])
+        self.assertEqual(len(rows), 1)
+        start, end = rows[0].span or (0, 0)
+        self.assertEqual(source[start:end], "True")
+        self.assertEqual(start, source.index("True"))
+
+    def test_a_repeated_line_gets_distinct_spans(self) -> None:
+        """The reason spans exist: `str.replace` cannot tell these apart."""
+        source = (
+            "def f():\n    if not ready:\n        return 1\n\n\n"
+            "def g():\n    if not ready:\n        return 2\n"
+        )
+        rows = mutate(source, operators=["drop-not"])
+        self.assertEqual(len(rows), 2)
+        self.assertNotEqual(rows[0].span, rows[1].span)
+        for row in rows:
+            start, end = row.span or (0, 0)
+            self.assertEqual(source[start:end], row.old)
+
+
+class TestTheLabel(unittest.TestCase):
+    def test_it_names_the_place_and_the_change(self) -> None:
+        # Pinned to one operator: `return-value` also fires on this line, and a
+        # `.pop()` off an unpinned list asserts whichever sorted last.
+        row = mutate(
+            "class C:\n    def m(self):\n        return a < b\n", operators=["boundary"]
+        ).pop()
+        self.assertEqual(row.label, "woswoar/thing.py:3 in C.m() -- `<` becomes `<=`")
+
+    def test_at_module_scope_there_is_no_function(self) -> None:
+        self.assertEqual(
+            mutate("x = a < b\n").pop().label, "woswoar/thing.py:1 -- `<` becomes `<=`"
+        )
+
+
+class TestTheCap(unittest.TestCase):
+    def rows(self, path: str, count: int) -> list[Mutation]:
+        return [Mutation(f"{path}:{n}", path, "a", "b", "t", span=(n, n + 1)) for n in range(count)]
+
+    def test_it_spreads_across_files_rather_than_taking_a_prefix(self) -> None:
+        """`[:limit]` would cover the first file exhaustively and the largest not
+        at all -- and the printed count would look right either way."""
+        table = self.rows("a.py", 10) + self.rows("z.py", 10)
+        kept, dropped = mutants.cap(table, 6)
+        self.assertEqual(len(kept), 6)
+        self.assertEqual({row.path for row in kept}, {"a.py", "z.py"})
+        self.assertEqual(len(dropped), 14)
+
+    def test_everything_is_accounted_for(self) -> None:
+        table = self.rows("a.py", 5) + self.rows("z.py", 7)
+        kept, dropped = mutants.cap(table, 4)
+        self.assertEqual(len(kept) + len(dropped), len(table))
+
+    def test_no_cap_keeps_everything(self) -> None:
+        table = self.rows("a.py", 5)
+        self.assertEqual(mutants.cap(table, 0), (table, []))
+
+
+class TestThePackageInitIsIndexedAsThePackage(unittest.TestCase):
+    """`tests/__init__.py` is `tests`, not `tests.__init__`, which nothing imports.
+
+    Driven against a built tree rather than the real one, and that is the point:
+    the repository's own `tests/__init__.py` is empty, so against the real tree
+    both spellings give the same answer and a mutation reverting this survives
+    for want of anything to distinguish them. `module_of` already carries this
+    exact special case for `woswoar/__init__.py`, argued at length; this is the
+    other half of the same mapping, and the failure it prevents is silent --
+    anything ever added to `tests/__init__.py` drops out of the closure.
+    """
+
+    def test_a_helper_in_the_package_init_still_carries_its_imports(self) -> None:
+        with tempfile.TemporaryDirectory() as box:
+            root = Path(box)
+            (root / "tests").mkdir()
+            (root / "tests" / "__init__.py").write_text(
+                "from woswoar import store\n", encoding="utf-8"
+            )
+            # `from . import helper` is what a test module writes, and it is the
+            # package -- `tests` -- that the import index has to be keyed on.
+            (root / "tests" / "test_a.py").write_text("from . import helper\n", encoding="utf-8")
+            index = mutants.importers(root)
+        self.assertEqual(index.get("woswoar.store"), {"tests.test_a"})
+
+
+class TestChoosingTheTests(unittest.TestCase):
+    """Driven against the real repository, because that is the map it describes."""
+
+    index: dict[str, set[str]]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.index = mutants.importers(REPO_ROOT)
+
+    def targets(self, path: str) -> set[str]:
+        return set(mutants.targets_for(path, REPO_ROOT, self.index).split())
+
+    def test_the_name_match(self) -> None:
+        self.assertIn("tests.test_sync", self.targets("woswoar/sync.py"))
+
+    def test_siblings_of_the_name_match(self) -> None:
+        self.assertLessEqual(
+            {"tests.test_importer", "tests.test_importer_atuin"},
+            self.targets("woswoar/importer.py"),
+        )
+
+    def test_a_module_with_no_test_of_its_own_is_found_by_import(self) -> None:
+        """`woswoar/gitrepo.py` has no `test_gitrepo.py`; `tests/test_sync.py`
+        imports it. A name heuristic alone would report it as untested."""
+        self.assertIn("tests.test_sync", self.targets("woswoar/gitrepo.py"))
+
+    def test_the_name_match_does_not_short_circuit_the_index(self) -> None:
+        """Measured on #216: taking `test_install` alone because the name matched
+        reported nine mutants as survivors that `tests.test_doctor` catches."""
+        found = self.targets("woswoar/install.py")
+        self.assertIn("tests.test_install", found)
+        self.assertIn("tests.test_doctor", found)
+
+    def test_a_helper_carries_its_imports_to_the_tests_that_use_it(self) -> None:
+        """Through `tests/support.py`, which every suite imports relatively.
+
+        `woswoar/crypto.py` is the case that tells the two answers apart:
+        `tests/test_deps.py` imports `support` and nothing else that reaches
+        `crypto`, so it appears here only if the closure runs. An assertion about
+        `store` cannot -- `tests/test_sync.py` imports that directly, so it was
+        satisfied whether or not the helper mechanism worked at all, which is how
+        the mechanism came to be inert without any test noticing.
+        """
+        self.assertIn("tests.test_deps", self.targets("woswoar/crypto.py"))
+
+    def test_every_mutable_file_resolves_or_says_it_cannot(self) -> None:
+        """The completeness pass. An empty answer is allowed -- it means "run
+        everything" -- but it must be a small, named set, or the selection has
+        quietly stopped working and every row would cost a whole suite."""
+        homeless = set()
+        for source in sorted(REPO_ROOT.glob("woswoar/**/*.py")):
+            path = source.relative_to(REPO_ROOT).as_posix()
+            if mutants.mutable(path) and not self.targets(path):
+                homeless.add(path)
+        self.assertEqual(homeless, set(), "these no longer resolve to any test module")
+
+
+@requires_git
+class TestReadingARealDiff(unittest.TestCase):
+    """A real `git init`, because that is what the repository does elsewhere.
+
+    `tests/test_sync.py` drives real `git` and real `age`; `tests/test_shell_hook.py`
+    drives a real `bash`. Asserting on a canned diff string is already covered
+    above; this is about the argv.
+
+    `requires_git` from `tests/support.py` rather than a local `shutil.which`,
+    for the reason stated where it is defined: a check that has to grow later
+    must not be updatable in one file and forgotten in the other. Without it
+    `check=True` turns "this machine has no git" into an error rather than a
+    skip. The cost is real and worth naming -- importing `support` enrols this
+    module in the import index for everything `support` pulls in, so a mutation
+    in `store` or `crypto` now also runs this file. That is 0.13 s a row, and
+    these tests are the cheapest in the suite.
+    """
+
+    def git(self, *argv: str) -> str:
+        finished = subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@example.com",
+                "-c",
+                "commit.gpgsign=false",
+                *argv,
+            ],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            check=True,
+            # A maintainer whose global config signs commits or renames the
+            # default branch must not fail this suite for reasons that are not
+            # the code under test.
+            env={
+                # Carried across, not hardcoded: `tools/sandbox.py` gives the
+                # argument -- there is no sandbox-relative answer to where the
+                # real `git` lives, and a machine with git outside `/usr/bin`
+                # (Nix, a Homebrew-first PATH, most containers) would otherwise
+                # fail here for a reason unrelated to the code under test.
+                "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                "HOME": str(self.root),
+                "GIT_CONFIG_GLOBAL": "/dev/null",
+                "GIT_CONFIG_SYSTEM": "/dev/null",
+            },
+        )
+        return finished.stdout
+
+    def write(self, name: str, body: str) -> None:
+        path = self.root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name).resolve()
+
+        self.git("init", "--initial-branch=main", "-q")
+        self.write("woswoar/thing.py", "one = 1\ntwo = 2\nthree = 3\n")
+        self.git("add", "-A")
+        self.git("commit", "-qm", "base")
+
+    def test_it_sees_the_branch_and_the_working_tree_but_not_the_base(self) -> None:
+        """The single most testable decision here: `--merge-base`, not two dots.
+
+        A two-dot diff would include whatever landed on `main` after this branch
+        started and generate mutants for it, labelled as if they belonged to the
+        change under review.
+        """
+        self.git("checkout", "-qb", "work")
+        self.write("woswoar/thing.py", "one = 1\ntwo = 22\nthree = 3\n")
+        self.git("commit", "-qam", "on the branch")
+
+        self.git("checkout", "-q", "main")
+        self.write("woswoar/later.py", "later = 1\n")
+        self.git("add", "-A")
+        self.git("commit", "-qm", "landed on main afterwards")
+
+        self.git("checkout", "-q", "work")
+        # Uncommitted on top, which is the situation the tool is used in.
+        self.write("woswoar/thing.py", "one = 1\ntwo = 22\nthree = 33\n")
+
+        found = mutants.changed_lines("main", self.root)
+        self.assertEqual(found, {"woswoar/thing.py": {2, 3}})
+        self.assertNotIn("woswoar/later.py", found)
+
+    def test_an_untracked_file_counts_entirely(self) -> None:
+        """`git diff` cannot see it, and "no mutants for the new module" reads
+        exactly like "the new module is covered"."""
+        self.write("woswoar/fresh.py", "a = 1\nb = 2\n")
+        self.assertEqual(mutants.changed_lines("main", self.root)["woswoar/fresh.py"], {1, 2})
+
+    def test_a_change_outside_the_mutable_paths_is_ignored(self) -> None:
+        self.write("tests/test_thing.py", "x = 1\n")
+        self.write("docs/notes.md", "words\n")
+        self.assertEqual(mutants.changed_lines("main", self.root), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -16,8 +16,10 @@ import textwrap
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
-from tools.mutate import Mutation, Report, Result, Verdict, run, verify
+from tools import mutate
+from tools.mutate import MEMORY, Mutation, Report, Result, Verdict, confirm, run, verify
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -493,6 +495,190 @@ class TestAMutationThatBreaksTheSuiteIsNotCaught(MutateTestCase):
         )
 
 
+class TestASpanPicksOneOfSeveralIdenticalLines(MutateTestCase):
+    """What a generated row needs that a hand-written one never did.
+
+    `if value < 0:` twice in a file is an error in a hand table -- `check`
+    refuses it, because the edit could land on either. A generated row means a
+    specific one, and says which by character offset. Watched from inside the
+    sandbox, because "the right one changed" is not visible from the outcome:
+    both mutations make the suite fail, so a run that edited the wrong function
+    reports `caught` just as loudly.
+    """
+
+    def test_the_second_occurrence_is_the_one_that_changes(self) -> None:
+        witness = self.root / "seen.txt"
+        body = (
+            "def first(value: int) -> int:\n"
+            "    if value < 0:\n"
+            "        return 0\n"
+            "    return value\n"
+            "\n"
+            "\n"
+            "def second(value: int) -> int:\n"
+            "    if value < 0:\n"
+            "        return 0\n"
+            "    return value\n"
+        )
+        self.write("mod.py", body)
+        self.write(
+            "test_mod.py",
+            f"""
+            import unittest
+            from pathlib import Path
+
+            import mod
+
+            SEEN = Path({str(witness)!r})
+
+
+            class T(unittest.TestCase):
+                def test_it(self) -> None:
+                    SEEN.write_text(f"{{mod.first(-5)}},{{mod.second(-5)}}", encoding="utf-8")
+            """,
+        )
+        # The *second* `if value < 0:`. Both spellings are identical, so nothing
+        # but the offsets distinguishes them.
+        at = body.index("if value < 0:", body.index("def second"))
+        run(
+            [
+                Mutation(
+                    "the second guard is gone",
+                    "mod.py",
+                    "if value < 0:",
+                    "if False:",
+                    "test_mod",
+                    span=(at, at + len("if value < 0:")),
+                )
+            ],
+            baseline=False,
+        )
+        self.assertEqual(
+            witness.read_text(encoding="utf-8"),
+            "0,-5",
+            "the mutation landed on the first occurrence, not the one it named",
+        )
+
+
+class TestASpanThatNoLongerHoldsItsText(MutateTestCase):
+    """The generated row's half of "refuse a spec that cannot mean anything".
+
+    A hand-written row is refused when its text matches other than once. A
+    generated row makes the stronger claim -- the text is *here* -- and the file
+    it was generated from can have moved on since: `--list` writes a table, the
+    author edits a line above it, and every offset below shifts. Splicing at a
+    stale offset produces a file that usually still parses and a verdict about
+    whatever now sits there.
+    """
+
+    def test_it_is_refused_before_anything_runs(self) -> None:
+        self.package(guarded=True)
+        before = (self.root / "mod.py").read_text(encoding="utf-8")
+        with self.assertRaises(SystemExit) as refused:
+            verify(
+                [
+                    Mutation(
+                        "the guard is gone",
+                        "mod.py",
+                        "if value < 0:",
+                        "if False:",
+                        "test_mod",
+                        # Off by two characters: the text is in the file, just not
+                        # at the offsets the row names.
+                        span=(
+                            before.index("if value < 0:") + 2,
+                            before.index("if value < 0:") + 15,
+                        ),
+                    )
+                ],
+                baseline=False,
+            )
+        self.assertIn("no longer holds that text", str(refused.exception))
+        self.assertEqual((self.root / "mod.py").read_text(encoding="utf-8"), before)
+
+
+class TestConfirmingSurvivorsAgainstTheWholeSuite(MutateTestCase):
+    """The pass that makes narrow test selection a speed decision, not a wrong one.
+
+    A row run against too few tests survives for the wrong reason, and that error
+    points the expensive way: it sends the author to rewrite a test that was
+    never weak. So every survivor is re-run against everything before it is
+    printed.
+    """
+
+    def two_rows_with_one_label(self) -> list[Mutation]:
+        """Two mutations that share a label, differ only by span, and differ in
+        what the *wider* suite says about them.
+
+        Both must survive the narrow pass, or `confirm` never re-runs them and
+        nothing can spread: a first version of this fixture had one row caught
+        immediately, so `corrected` was empty and the mutation reverting the fix
+        survived the test that was supposed to guard it.
+
+        A shared label is not contrived. `generate` dedupes on `(span, new)`, not
+        on the label, so two `.startswith(...)` calls on one line produce this
+        exactly -- and on the branch that added the generator, 23 labels repeat.
+        """
+        body = "def first():\n    return 1\n\n\ndef second():\n    return 2\n"
+        self.write("mod.py", body)
+        # Narrow: sees neither function, so both rows survive the first pass.
+        self.write(
+            "test_narrow.py",
+            """
+            import unittest
+
+            import mod
+
+
+            class Narrow(unittest.TestCase):
+                def test_nothing_in_particular(self) -> None:
+                    self.assertTrue(hasattr(mod, "first"))
+            """,
+        )
+        # Wide: found only by discovery, and sees `first` alone.
+        self.write(
+            "test_wide.py",
+            """
+            import unittest
+
+            import mod
+
+
+            class Wide(unittest.TestCase):
+                def test_first(self) -> None:
+                    self.assertEqual(mod.first(), 1)
+            """,
+        )
+        shared = "mod.py:2 in f() -- `1` becomes `9`"
+        at_one = body.index("return 1") + len("return ")
+        at_two = body.index("return 2") + len("return ")
+        return [
+            Mutation(shared, "mod.py", "1", "9", "test_narrow", span=(at_one, at_one + 1)),
+            Mutation(shared, "mod.py", "2", "9", "test_narrow", span=(at_two, at_two + 1)),
+        ]
+
+    def test_a_shared_label_does_not_spread_one_rows_answer_to_another(self) -> None:
+        """Keying the corrections by label wrote the caught row's verdict onto the
+        other, so a genuine survivor was reported as `caught` -- naming a test
+        that had never seen it, and exiting zero. A false `caught` in a pull
+        request is the one outcome this whole module exists to make impossible.
+        """
+        report = run(self.two_rows_with_one_label(), baseline=False, strict=False)
+        self.assertEqual(
+            [result.verdict.outcome for result in report.results],
+            ["survived", "survived"],
+            "precondition: both rows must survive, or nothing is re-run",
+        )
+
+        confirmed = confirm(report, workers=None, timeout=60.0, memory=MEMORY)
+        self.assertEqual(
+            [result.verdict.outcome for result in confirmed.results],
+            ["caught", "survived"],
+            "one row's confirmation was written onto the other",
+        )
+        self.assertFalse(confirmed.clean)
+
+
 class TestASubTestIsARealAnswer(MutateTestCase):
     """The regression the first version of this classification shipped with.
 
@@ -574,6 +760,148 @@ class TestAnUnanswerableRowNeedNotEndTheRun(MutateTestCase):
                 [Mutation("bad", "mod.py", "import json", "import nope_xyz", "test_mod")],
                 baseline=False,
             )
+
+
+class TestHowManyLanesFitInMemory(unittest.TestCase):
+    """The bound that stops the per-row cap from being multiplied by the lanes.
+
+    Untested when it was written, and two of the three things asserted here were
+    wrong at that point: the budget was divided by the 4 GiB ceiling rather than
+    by what a lane uses, and the host's memory was read without asking whether a
+    container had said otherwise.
+    """
+
+    def test_a_small_machine_still_gets_a_lane(self) -> None:
+        """`max(1, ...)` is load-bearing: `ThreadPoolExecutor(max_workers=0)`
+        raises `ValueError`, so a machine too small to afford one lane would
+        crash rather than run slowly."""
+        with mock.patch.object(mutate, "_visible_memory", return_value=64 << 20):
+            self.assertEqual(mutate._affordable(), 1)
+
+    def test_it_scales_with_memory_rather_than_with_the_ceiling(self) -> None:
+        """An ordinary laptop must not be cut to the pathological case.
+
+        Dividing by `MEMORY` gave a 16 GiB machine two lanes. `MEMORY` is what
+        one runaway may reach before it is killed; `_LANE` is what an honest
+        lane occupies, and that is what the budget divides by.
+        """
+        with mock.patch.object(mutate, "_visible_memory", return_value=16 << 30):
+            self.assertEqual(mutate._affordable(), 8)
+        self.assertLess(mutate._LANE, mutate.MEMORY, "the ceiling is not the expected use")
+
+    def test_half_the_memory_is_left_for_whoever_is_using_the_machine(self) -> None:
+        with mock.patch.object(mutate, "_visible_memory", return_value=32 * mutate._LANE):
+            self.assertEqual(mutate._affordable(), 16)
+
+    def test_a_container_limit_beats_the_host_total(self) -> None:
+        """The mistake `usable_cpus` documents for CPUs, one resource over.
+
+        Driven through a real file rather than a mock of the read, because the
+        thing being tested is that the cgroup file is consulted at all.
+        """
+        with tempfile.TemporaryDirectory() as box:
+            limit = Path(box) / "memory.max"
+            limit.write_text("2147483648\n", encoding="utf-8")
+            real = Path.read_text
+
+            def reading(self: Path, *args: object, **kwargs: object) -> str:
+                if str(self) == "/sys/fs/cgroup/memory.max":
+                    return real(limit)
+                return real(self, *args, **kwargs)  # type: ignore[arg-type]
+
+            with mock.patch.object(Path, "read_text", reading):
+                self.assertEqual(mutate._visible_memory(), 2 << 30)
+
+    def test_no_cgroup_file_falls_back_to_the_host(self) -> None:
+        def missing(self: Path, *args: object, **kwargs: object) -> str:
+            raise OSError("no cgroup here")
+
+        with mock.patch.object(Path, "read_text", missing):
+            self.assertGreater(mutate._visible_memory(), 0)
+
+
+def enforced() -> bool:
+    """Whether this kernel applies the limits `verdict.cap` asks for.
+
+    Asked by trying it, in a subprocess, rather than by reading `sys.platform`.
+    macOS ignores `RLIMIT_AS` -- which CI discovered, not the documentation --
+    and a `skipIf(darwin)` would encode today's answer to a question that is
+    really "does this kernel enforce it", going green on a platform that
+    silently protects nothing and staying skipped if macOS ever starts.
+
+    It sets the limits *directly* rather than calling `verdict.cap`, and that is
+    not a stylistic choice -- mutation testing rejected the first version, which
+    did call it. A skip condition computed from the code under test cannot
+    detect that code being reverted: neutering `cap` made the probe report "not
+    enforced", the test skipped, and the row came back `SURVIVED` from a suite
+    that had simply declined to run it. A guard that switches itself off when
+    the thing it guards breaks is worse than no guard, because it is green.
+    """
+    probe = (
+        "import resource\n"
+        "for which in (resource.RLIMIT_AS, resource.RLIMIT_DATA):\n"
+        "    soft, hard = resource.getrlimit(which)\n"
+        "    try:\n"
+        "        resource.setrlimit(which, (256 * 1024 * 1024, hard))\n"
+        "    except (OSError, ValueError):\n"
+        "        pass\n"
+        "try:\n"
+        "    bytearray(768 * 1024 * 1024)\n"
+        "except MemoryError:\n"
+        "    print('enforced')\n"
+    )
+    done = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True)
+    return "enforced" in done.stdout
+
+
+@unittest.skipUnless(enforced(), "this kernel does not enforce the address-space limit")
+class TestAMutantThatEatsMemory(MutateTestCase):
+    """The failure `timeout` cannot catch, because the machine goes first.
+
+    A generated mutation does not have to loop forever to hold a lane -- it can
+    loop forever *while appending*. `mutants.line_starts` reduced to `at -= ...`
+    never advances, because a negative index wraps in Python instead of raising,
+    and three lanes reached 15.5 GB, 7.6 GB and 6.4 GB seventy-three seconds in.
+    The 300 s timeout never got to speak: the host OOM-killed the session twice.
+
+    The fixture allocates a *bounded* 800 MiB rather than looping, and that is
+    deliberate. An unbounded fixture would reproduce the crash in the suite that
+    is supposed to prevent it, and -- worse for rule 3 -- it could not be run
+    with the fix reverted, so nobody could check that this test fails without it.
+    Bounded, both states are safe and they differ:
+
+    - with the cap, the allocation raises `MemoryError` and the row is `broke`;
+    - with `cap` reverted, 800 MiB is simply allocated, `clamp(-5)` returns
+      838860800 rather than 0, the assertion fails, and the row reads `caught`;
+    - with `cap` kept but `_exhausted` reverted, the `MemoryError` arrives at
+      `addError` inside a real `TestCase` and reads `caught` as well.
+
+    Both reverts produce the same wrong answer, and it is the dangerous one: a
+    test credited with a guard it does not have.
+    """
+
+    def test_it_is_broke_rather_than_a_test_noticing(self) -> None:
+        self.package(guarded=True)
+        report = run(
+            [
+                Mutation(
+                    "clamp allocates 800 MiB",
+                    "mod.py",
+                    "        return 0",
+                    "        return len(bytearray(800 * 1024 * 1024))",
+                    "test_mod",
+                ),
+                Mutation("the guard goes", "mod.py", "if value < 0:", "if False:", "test_mod"),
+            ],
+            baseline=False,
+            strict=False,
+            # Comfortably above what the two-file fixture suite needs and
+            # comfortably below the 800 MiB above, so neither side is a
+            # near-miss that a different Python could tip over.
+            memory=512 << 20,
+        )
+        self.assertEqual([result.verdict.outcome for result in report.results], ["broke", "caught"])
+        self.assertIn("ran out of memory", report.results[0].verdict.detail)
 
 
 class TestAMutantThatNeverFinishes(MutateTestCase):

--- a/tools/mutants.py
+++ b/tools/mutants.py
@@ -1,0 +1,1014 @@
+"""What to change, and where the diff says it matters. `tools/mutate.py` runs it.
+
+A hand-written table only asks the questions its author thought to ask, and
+writing it is the work that remains after #48 removed the loop around it. This
+reads `git diff`, generates mutants for the lines the change actually touched,
+and hands them to the runner. The author stops writing the table and starts
+reading the survivors.
+
+Split from `mutate` along the line `tools/sandbox.py` and `compare.verdict`
+already drew: the *generator* is pure -- `(source, changed lines) -> mutations`
+-- so `generate`, the operators, `Offsets` and `label` are testable in
+milliseconds with no sandbox, no subprocess and no suite. That is the split, and
+it is worth stating exactly rather than generously: `changed_lines` forks `git`,
+`check` reads the file it is asked about, and `importers` and `targets_for`
+glob and read `tests/`. Four functions touch the world, not one. What none of
+them does is run a suite or copy a tree, which is the cost the split exists to
+keep out of these tests.
+
+**Spans.** A generated mutant is routinely not unique in its file: `if not
+path.exists():` appears many times. So a row carries the character offsets it
+applies at, and `check` asserts the text *at* those offsets rather than counting
+occurrences.
+
+Be clear about what that assertion can and cannot do. `generate` derives `old`
+*from* the span it just computed, so for a freshly generated row the check is
+true by construction: it catches the file changing between `--list` and the run,
+and nothing else. It is **not** a guard against a bad offset. Only tests are,
+and there are two traps for them to cover -- `col_offset` is a UTF-8 *byte*
+offset into its line (`woswoar/report.py` and `woswoar/archive.py` really do
+contain `·`, `✔`, `✘` and `²`), and lines must be counted the way the tokenizer
+counts them rather than the way `str.splitlines` does. See `line_starts`.
+
+**What no operator here can generate.** Two of the weak fixtures
+`CONTRIBUTING.md` lists map onto an operator exactly: `order` produces the
+reversed walk, `affix` the suffix filter that accepts everything. No count is
+given for the rest, because the mapping is not one-to-one and the count that
+used to stand here was wrong in both directions -- it claimed three of four and
+then named, as the fourth, an example from `CLAUDE.md` rule 3 that is not on
+that list at all.
+
+The class that is definitely out of reach is *scope widening*: "a `source` line
+searched in the whole rc file instead of the block" changes which region a
+search covers, and no local AST rewrite produces it. That is why the spec-file
+mode is not going away, and why "every generated mutant was caught" must not be
+read as "the tests are good".
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import re
+import subprocess
+from collections.abc import Callable, Iterator, Sequence
+from pathlib import Path
+from typing import NamedTuple
+
+
+class Mutation(NamedTuple):
+    """One edit that some test is supposed to notice."""
+
+    #: What the mutation does, in the words of whoever might reintroduce it.
+    #: Printed, so make it a sentence a reader of the PR would understand.
+    label: str
+    path: str
+    #: For a hand-written row, must appear exactly once in the file: ambiguity is
+    #: an error rather than a guess, because replacing the wrong one of two
+    #: matches quietly tests nothing. For a generated row `span` pins it instead.
+    old: str
+    new: str
+    #: Whitespace-separated unittest targets, as `python -m unittest` takes them.
+    tests: str
+    #: Say so when the replacement is meant to *contain* the original -- an
+    #: inserted call, an early return in front of code that stays. Otherwise
+    #: `check` refuses that shape, because it is overwhelmingly a mistake.
+    additive: bool = False
+    #: Character offsets, when the text to replace is not unique. `old` must equal
+    #: `text[span[0]:span[1]]`, which is a stronger claim than "appears once".
+    span: tuple[int, int] | None = None
+    #: Which operator produced this. Empty for a hand-written row.
+    operator: str = ""
+
+
+#: Nodes that carry a source position. `ast.AST` does not -- only statements and
+#: expressions do -- and every span in this module comes from one of these.
+Positioned = ast.expr | ast.stmt
+
+
+class Edit(NamedTuple):
+    """One operator's answer about one node."""
+
+    node: Positioned
+    new: str
+    #: The clause that goes into the printed label, after `-- `.
+    prose: str
+
+
+#: A line carrying this is left alone. `# pragma: no cover` means something else
+#: and is deliberately not honoured: two of its four uses in `woswoar/` mark code
+#: that needs a hung subprocess to reach, which is exactly the kind of guard
+#: worth mutating if you ever do reach it.
+NO_MUTATE = re.compile(r"#\s*pragma:\s*no\s+mutate\b")
+
+#: Only these are worth mutating. Never `tests/**`: breaking a test proves
+#: nothing about the fix, and the run would report the assertion it removed.
+MUTABLE = ("woswoar/", "tools/")
+
+
+def mutable(path: str) -> bool:
+    # No `not path.startswith("tests/")`: `MUTABLE` cannot match a `tests/` path,
+    # so the clause could never change the answer. Removed for the reason this
+    # module gives twice elsewhere -- a guard nothing can reach is a guard
+    # nobody can trust, and `tests/test_mutants.py` was passing off the tuple
+    # above rather than off the clause it appeared to be testing.
+    return path.endswith(".py") and path.startswith(MUTABLE)
+
+
+def line_starts(source: str) -> list[int]:
+    """Where each line begins, counting lines the way the *tokenizer* does.
+
+    Deliberately not `str.splitlines`, and this is the second trap in this
+    module rather than a preference. `str.splitlines` also breaks on form feed,
+    vertical tab, the file/group/record separators and U+2028/9; CPython's
+    tokenizer treats a form feed as ordinary whitespace. A single `\f` -- the
+    Emacs page separator, and legal Python -- therefore shifts every line number
+    below it by one for `splitlines` while `ast` keeps counting from the real
+    one, so every span below it lands on the wrong line.
+
+    That produces the worst outcome this module has: an edit that still parses,
+    in a different place from the one the row's label names, reported as `caught`
+    or `SURVIVED` about a line nobody touched.
+    """
+    starts = [0]
+    at = 0
+    while at < len(source):
+        if source[at] == "\r":
+            at += 2 if source[at + 1 : at + 2] == "\n" else 1
+            starts.append(at)
+        elif source[at] == "\n":
+            at += 1
+            starts.append(at)
+        else:
+            at += 1
+    return starts
+
+
+class Offsets:
+    """Character offsets for the (line, column) pairs `ast` reports.
+
+    Exists for one reason, and it is not convenience. `col_offset` is a **UTF-8
+    byte** offset into its line; `str` indexing is by character. Every line up to
+    the first non-ASCII character in a file behaves identically under both, so
+    the bug this prevents is invisible in any fixture written in plain English
+    and appears only on the files that print things.
+    """
+
+    def __init__(self, source: str) -> None:
+        self._source = source
+        self._starts = line_starts(source)
+
+    def lines(self) -> int:
+        """How many lines the source has, counted the way `ast` counts them."""
+        return len(self._starts)
+
+    def line(self, lineno: int) -> str:
+        start = self._starts[lineno - 1]
+        end = self._starts[lineno] if lineno < len(self._starts) else len(self._source)
+        return self._source[start:end]
+
+    def at(self, lineno: int, col: int) -> int:
+        line = self.line(lineno)
+        return self._starts[lineno - 1] + len(line.encode("utf-8")[:col].decode("utf-8"))
+
+    def span(self, node: Positioned) -> tuple[int, int]:
+        assert node.end_lineno is not None and node.end_col_offset is not None
+        return (
+            self.at(node.lineno, node.col_offset),
+            self.at(node.end_lineno, node.end_col_offset),
+        )
+
+
+def _rewritten(node: ast.AST, change: Callable[[ast.AST], None]) -> str:
+    """`node` with `change` applied to a copy, unparsed and spliceable.
+
+    An expression is parenthesised without exception, which removes every
+    precedence question in one rule: a node's own span never includes
+    surrounding parentheses, so a parenthesised replacement is legal in every
+    position these operators fire in. A statement is not, because it cannot be
+    -- `ast.unparse` emits no leading indentation and a statement's span begins
+    after its indent, so splicing at that offset lines up.
+
+    Which of the two is decided *here*, from the node, rather than by the caller
+    choosing between two helpers. It was two helpers, and the choice was the
+    caller's; the failure that shape invites is an expression spliced without
+    parentheses, which is a precedence bug that still parses -- exactly what the
+    parenthesise-always rule exists to abolish.
+
+    Unparsing the *copy* rather than the module is what keeps the other ten
+    thousand lines of the file byte-identical -- a reformatted sandbox would make
+    the `additive` check meaningless and a survivor unreadable.
+    """
+    clone = copy.deepcopy(node)
+    change(clone)
+    text = ast.unparse(clone)
+    return f"({text})" if isinstance(clone, ast.expr) else text
+
+
+#: Comparison flips, split into two operators because they answer different
+#: questions. `boundary` is the off-by-one -- the class a two-item fixture
+#: cannot see, and the reason `CONTRIBUTING.md` leads its weak-fixture list with
+#: "two day directories cannot distinguish a sorted walk from a reversed one".
+_STRICTNESS: dict[type[ast.cmpop], type[ast.cmpop]] = {
+    ast.Lt: ast.LtE,
+    ast.LtE: ast.Lt,
+    ast.Gt: ast.GtE,
+    ast.GtE: ast.Gt,
+}
+#: `negate` is the inverted guard. It earns its place on #206: `Check.ok`
+#: defaulted to `None`, and `assertFalse(status.ok)` passes for `None` too, so
+#: nothing could tell the two answers apart.
+_OPPOSITE: dict[type[ast.cmpop], type[ast.cmpop]] = {
+    ast.Eq: ast.NotEq,
+    ast.NotEq: ast.Eq,
+    ast.Is: ast.IsNot,
+    ast.IsNot: ast.Is,
+    ast.In: ast.NotIn,
+    ast.NotIn: ast.In,
+}
+
+
+#: How each comparison is written, for the prose half of a row. A module
+#: constant rather than a literal rebuilt per call, matching `_ARITH_SPELLING`.
+_SPELLING: dict[type[ast.cmpop], str] = {
+    ast.Lt: "<",
+    ast.LtE: "<=",
+    ast.Gt: ">",
+    ast.GtE: ">=",
+    ast.Eq: "==",
+    ast.NotEq: "!=",
+    ast.Is: "is",
+    ast.IsNot: "is not",
+    ast.In: "in",
+    ast.NotIn: "not in",
+}
+
+
+def _spell(op: ast.cmpop) -> str:
+    return _SPELLING[type(op)]
+
+
+def _compare(node: ast.AST, table: dict[type[ast.cmpop], type[ast.cmpop]]) -> Iterator[Edit]:
+    if not isinstance(node, ast.Compare) or len(node.ops) != 1:
+        return
+    was = node.ops[0]
+    becomes = table.get(type(was))
+    if becomes is None:
+        return
+
+    def flip(clone: ast.AST) -> None:
+        assert isinstance(clone, ast.Compare)
+        clone.ops = [becomes()]
+
+    yield Edit(node, _rewritten(node, flip), f"`{_spell(was)}` becomes `{_spell(becomes())}`")
+
+
+def boundary(node: ast.AST) -> Iterator[Edit]:
+    yield from _compare(node, _STRICTNESS)
+
+
+def negate(node: ast.AST) -> Iterator[Edit]:
+    yield from _compare(node, _OPPOSITE)
+
+
+def connector(node: ast.AST) -> Iterator[Edit]:
+    """`and` <-> `or`: the compound guard where only one half is ever exercised."""
+    if not isinstance(node, ast.BoolOp):
+        return
+    # One conditional, not two asking the same question: split, a future edit
+    # can flip the token without flipping the prose, and the row would then
+    # describe the opposite of what it did.
+    was, now, becomes = (
+        ("and", "or", ast.Or) if isinstance(node.op, ast.And) else ("or", "and", ast.And)
+    )
+
+    def flip(clone: ast.AST) -> None:
+        assert isinstance(clone, ast.BoolOp)
+        clone.op = becomes()
+
+    yield Edit(node, _rewritten(node, flip), f"`{was}` becomes `{now}`")
+
+
+def branch(node: ast.AST) -> Iterator[Edit]:
+    """The mutation the hand-written tables here already write, now free.
+
+    `while` is deliberately not included, and the reason is *certainty*, not
+    cost. `boundary`, `arith` and `off-by-one` all fire on a loop condition and
+    can produce a hang too -- `at += 1` to `at -= 1` is the one that OOM-killed
+    this machine -- and they are not excluded, because they are merely likely to
+    hang and the runner's `--timeout` and `--memory` bound them when they do.
+    Forcing a `while` condition to `True` is *certain* to hang, every time, on
+    every loop: a row that can only ever report `TIMEOUT` is not an answer, and
+    generating one per `while` in the diff spends the budget to learn nothing.
+    """
+    if not isinstance(node, ast.If):
+        return
+    if isinstance(node.test, ast.Constant):
+        # Already `if True:`. Forcing it to `True` changes nothing, and a row
+        # that changes nothing reports `caught` or `SURVIVED` about nothing.
+        return
+    yield Edit(node.test, "True", "the `if` is always taken")
+    yield Edit(node.test, "False", "the `if` is never taken")
+
+
+def drop_not(node: ast.AST) -> Iterator[Edit]:
+    if not isinstance(node, ast.UnaryOp) or not isinstance(node.op, ast.Not):
+        return
+    yield Edit(node, f"({ast.unparse(node.operand)})", "the `not` is dropped")
+
+
+def order(node: ast.AST) -> Iterator[Edit]:
+    """Ordering, and the weak fixture `CONTRIBUTING.md` names first.
+
+    "Two day directories cannot distinguish a sorted walk from a reversed one" --
+    so this generates the reversed walk and lets the fixture prove it can or
+    cannot tell. `sorted(x)` -> `list(x)` is the weaker sibling: it keeps the
+    elements and drops only the guarantee.
+    """
+    if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+        return
+    name = node.func.id
+    if name == "sorted" and not any(word.arg == "reverse" for word in node.keywords):
+
+        def backwards(clone: ast.AST) -> None:
+            assert isinstance(clone, ast.Call)
+            clone.keywords = [*clone.keywords, ast.keyword(arg="reverse", value=ast.Constant(True))]
+
+        yield Edit(node, _rewritten(node, backwards), "the ordering is reversed")
+
+        def unordered(clone: ast.AST) -> None:
+            assert isinstance(clone, ast.Call)
+            clone.func = ast.Name(id="list", ctx=ast.Load())
+            clone.keywords = []
+
+        yield Edit(node, _rewritten(node, unordered), "`sorted` becomes `list`")
+    swaps = {"min": "max", "max": "min", "any": "all", "all": "any", "reversed": "list"}
+    if name in swaps:
+
+        def renamed(clone: ast.AST, to: str = swaps[name]) -> None:
+            assert isinstance(clone, ast.Call)
+            clone.func = ast.Name(id=to, ctx=ast.Load())
+
+        yield Edit(node, _rewritten(node, renamed), f"`{name}` becomes `{swaps[name]}`")
+
+
+def affix(node: ast.AST) -> Iterator[Edit]:
+    """`x.endswith(s)` -> `True`, and the reason it is `True` and not `False`.
+
+    The weak fixture is "a directory holding only `.age` files cannot test a
+    suffix filter". A filter that accepts *everything* is precisely the answer
+    such a directory cannot distinguish from a filter that works; one that
+    accepts nothing empties the result and any assertion notices.
+    """
+    if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+        return
+    if node.func.attr not in ("startswith", "endswith"):
+        return
+    yield Edit(node, "True", f"the `.{node.func.attr}(...)` filter accepts everything")
+
+
+def return_constant(node: ast.AST) -> Iterator[Edit]:
+    """Predicates whose tests only ever assert the happy direction."""
+    if not isinstance(node, ast.Return) or not isinstance(node.value, ast.Constant):
+        return
+    was = node.value.value
+    if was is True or was is False:
+        yield Edit(node.value, str(not was), f"returns `{not was}` instead of `{was}`")
+
+
+def drop_call(node: ast.AST) -> Iterator[Edit]:
+    """A call whose value is discarded, deleted.
+
+    The "the write never happened" class. This product writes files and forks
+    `git`, so a test that cannot notice a missing side effect is the expensive
+    kind of decoration. `pass` rather than deletion because the span is one
+    statement and an empty body is a syntax error.
+    """
+    if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
+        return
+    called = node.value.func
+    shown = ast.unparse(called)
+    if shown.split(".")[0] in ("logging", "progress", "log"):
+        # The meter is explicitly never the thing being compared -- see
+        # `tools/sandbox.py`'s argument for pinning it out of a comparison.
+        return
+    # `print` is *not* excluded, though every off-the-shelf tool excludes it by
+    # default. Here the CLI's printed output is the product, and
+    # `tests/test_report.py`, `test_doctor.py` and `test_cli_help.py` assert on it.
+    yield Edit(node, "pass", f"the call to `{shown}(...)` never happens")
+
+
+def off_by_one(node: ast.AST) -> Iterator[Edit]:
+    """Small integer literals, moved by one. Index and threshold arithmetic."""
+    if not isinstance(node, ast.Constant) or not isinstance(node.value, int):
+        return
+    if isinstance(node.value, bool) or abs(node.value) > 2:
+        return
+    for now in (node.value + 1, node.value - 1):
+        yield Edit(node, repr(now), f"`{node.value}` becomes `{now}`")
+
+
+def return_value(node: ast.AST) -> Iterator[Edit]:
+    """`return X` -> `return None`: the function that silently returns nothing.
+
+    Always a real answer, never a `BROKE`: no name goes missing and nothing
+    raises, so the suite either notices or does not. That is what makes this the
+    cheapest operator here per row.
+
+    Booleans are left to `return-constant`, which swaps them -- `None` is falsy,
+    so turning `return True` into `return None` asks very nearly the same
+    question twice and costs a second suite run to do it.
+    """
+    if not isinstance(node, ast.Return) or node.value is None:
+        return
+    if isinstance(node.value, ast.Constant) and (
+        node.value.value is None or isinstance(node.value.value, bool)
+    ):
+        return
+    shown = ast.unparse(node.value)
+    trimmed = shown if len(shown) <= 30 else shown[:29] + "\N{HORIZONTAL ELLIPSIS}"
+    yield Edit(node.value, "None", f"returns `None` instead of `{trimmed}`")
+
+
+#: Arithmetic that a fixture with one small number cannot tell apart from itself.
+_ARITH: dict[type[ast.operator], type[ast.operator]] = {
+    ast.Add: ast.Sub,
+    ast.Sub: ast.Add,
+    ast.Mult: ast.FloorDiv,
+    ast.FloorDiv: ast.Mult,
+}
+_ARITH_SPELLING = {ast.Add: "+", ast.Sub: "-", ast.Mult: "*", ast.FloorDiv: "//"}
+
+
+def arith(node: ast.AST) -> Iterator[Edit]:
+    """`+` <-> `-`, `*` <-> `//`, and the same on an augmented assignment.
+
+    One body for both shapes. `x = a + b` and `count += 1` differ only in
+    whether the row's prose carries the trailing `=` and in whether the splice
+    is parenthesised, and `_rewritten` decides the second from the node.
+    """
+    if not isinstance(node, (ast.BinOp, ast.AugAssign)):
+        return
+    becomes = _ARITH.get(type(node.op))
+    if becomes is None:
+        return
+
+    # The instance is built here and bound as a default: mypy's narrowing from
+    # the `is None` check above does not follow into a nested function.
+    swapped = becomes()
+
+    def flip(clone: ast.AST, to: ast.operator = swapped) -> None:
+        assert isinstance(clone, (ast.BinOp, ast.AugAssign))
+        clone.op = to
+
+    was, now = _ARITH_SPELLING[type(node.op)], _ARITH_SPELLING[becomes]
+    # `+=` reads as one token in the row even though the AST separates them.
+    sign = "" if isinstance(node, ast.BinOp) else "="
+    yield Edit(node, _rewritten(node, flip), f"`{was}{sign}` becomes `{now}{sign}`")
+
+
+def slice_widened(node: ast.AST) -> Iterator[Edit]:
+    """`x[1:]`, `x[:-1]`, `x[a:b]` -> `x[:]`: the bound stops bounding.
+
+    One replacement rather than one per end, because the fixture that can tell
+    `x[1:]` from `x[:]` can almost always tell it from `x[2:]` too, and two rows
+    per slice doubles the cost of the commonest shape in `cache.py`.
+    """
+    if not isinstance(node, ast.Subscript) or not isinstance(node.slice, ast.Slice):
+        return
+    cut = node.slice
+    if cut.lower is None and cut.upper is None and cut.step is None:
+        return
+
+    def widen(clone: ast.AST) -> None:
+        assert isinstance(clone, ast.Subscript)
+        clone.slice = ast.Slice(lower=None, upper=None, step=None)
+
+    yield Edit(node, _rewritten(node, widen), "the slice takes everything")
+
+
+def drop_assign(node: ast.AST) -> Iterator[Edit]:
+    """`self.x = ...` and `d[k] = ...`, deleted. The field that is never set.
+
+    Attribute and subscript targets **only**, and the restriction is the whole
+    design. Deleting `x = f()` leaves a `NameError` further down, which reports
+    `BROKE` -- not an answer, and a full suite run to find that out. Assigning
+    through an attribute or a key cannot make a name disappear, so every row here
+    produces a real verdict.
+    """
+    if isinstance(node, ast.Assign):
+        targets = node.targets
+    elif isinstance(node, ast.AugAssign):
+        targets = [node.target]
+    else:
+        return
+    if len(targets) != 1 or not isinstance(targets[0], (ast.Attribute, ast.Subscript)):
+        return
+    yield Edit(node, "pass", f"`{ast.unparse(targets[0])}` is never assigned")
+
+
+class Operator(NamedTuple):
+    name: str
+    fire: Callable[[ast.AST], Iterator[Edit]]
+
+
+OPERATORS: tuple[Operator, ...] = (
+    Operator("boundary", boundary),
+    Operator("negate", negate),
+    Operator("connector", connector),
+    Operator("branch", branch),
+    Operator("drop-not", drop_not),
+    Operator("order", order),
+    Operator("affix", affix),
+    Operator("return-constant", return_constant),
+    Operator("drop-call", drop_call),
+    Operator("drop-assign", drop_assign),
+    Operator("off-by-one", off_by_one),
+    Operator("return-value", return_value),
+    Operator("arith", arith),
+    Operator("slice", slice_widened),
+)
+
+
+# --- what may be mutated at all -------------------------------------------
+
+#: Whole subtrees no operator sees.
+#:
+#: `JoinedStr` is the one that would produce a *wrong* answer rather than a
+#: useless one: on 3.10 and 3.11 the nodes inside an f-string carry the enclosing
+#: string's position, so a span computed from them splices the wrong bytes into
+#: a file that then still parses. `requires-python` is `>=3.10`.
+#:
+#: The rest are equivalent mutants by construction. `assert` in `tools/` is
+#: mostly mypy narrowing; mutating an import produces a `BROKE` row, which is not
+#: an answer and costs a full suite run to find out.
+_SKIP_SUBTREE = (ast.JoinedStr, ast.Assert, ast.Import, ast.ImportFrom)
+
+#: Fields not descended into. Annotations are never evaluated -- every module
+#: here has `from __future__ import annotations` -- so a mutant inside one cannot
+#: change behaviour, and `mypy --strict` already holds them.
+_SKIP_FIELDS: dict[type, frozenset[str]] = {
+    ast.AnnAssign: frozenset({"annotation"}),
+    ast.FunctionDef: frozenset({"returns", "decorator_list"}),
+    ast.AsyncFunctionDef: frozenset({"returns", "decorator_list"}),
+    ast.ClassDef: frozenset({"decorator_list"}),
+    ast.arg: frozenset({"annotation"}),
+}
+
+
+def _is_guard(test: ast.expr) -> bool:
+    """`if TYPE_CHECKING:` and `if __name__ == "__main__":`, neither worth asking about."""
+    if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+        return True
+    return (
+        isinstance(test, ast.Compare)
+        and isinstance(test.left, ast.Name)
+        and test.left.id == "__name__"
+    )
+
+
+def _walk(
+    node: ast.AST, where: str = "", inside_callable: bool = False
+) -> Iterator[tuple[ast.AST, str, bool]]:
+    """Every node an operator may be asked about, with its enclosing qualname.
+
+    Docstrings need no suppression and used to have one. No operator matches a
+    bare `Expr(Constant)`, so the machinery that skipped them changed no output;
+    a mutation removing it survived, and the honest reading was that the code was
+    redundant rather than the fixture weak.
+    """
+    if isinstance(node, _SKIP_SUBTREE):
+        return
+    if isinstance(node, ast.If) and _is_guard(node.test):
+        return
+    yield node, where, inside_callable
+    ignored = _SKIP_FIELDS.get(type(node), frozenset())
+    for field, value in ast.iter_fields(node):
+        if field in ignored:
+            continue
+        for child in value if isinstance(value, list) else [value]:
+            if not isinstance(child, ast.AST):
+                continue
+            deeper, callable_now = where, inside_callable
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                deeper = f"{where}.{child.name}" if where else child.name
+                # Carried separately rather than baked into the name, because a
+                # function nested in a function would otherwise read
+                # `outer().inner()`. Only the innermost scope decides the
+                # parentheses, and a class body is not a call.
+                callable_now = not isinstance(child, ast.ClassDef)
+            yield from _walk(child, deeper, callable_now)
+
+
+def _touches(node: ast.AST, lines: set[int]) -> bool:
+    """Does any line of `node` fall inside the diff?
+
+    *Any*, not *all*. A single edited line inside a wrapped call means the
+    enclosing statement starts above the hunk and ends below it, and requiring
+    full containment would silently skip the commonest real edit there is.
+    """
+    return not lines.isdisjoint(_spanned(node))
+
+
+def _spanned(node: ast.AST) -> range:
+    """Every line `node` occupies, or an empty range if it has no position.
+
+    One definition, because two callers ask the same question for opposite
+    reasons: `_touches` wants an overlap with the diff, `generate` wants the
+    absence of one with the pragma lines. They disagreed once -- the pragma was
+    tested against `node.lineno` alone -- and a multi-line construct was the
+    case that fell through.
+    """
+    start = getattr(node, "lineno", None)
+    if start is None:
+        return range(0)
+    return range(start, (getattr(node, "end_lineno", None) or start) + 1)
+
+
+def _pragma_lines(source: str, offsets: Offsets) -> set[int]:
+    """Which lines carry `# pragma: no mutate`, counted the way `ast` counts.
+
+    Not `str.splitlines`, which is what this did first and which was wrong for
+    the reason `line_starts` exists: it breaks on form feed and the tokenizer
+    does not, so one `\f` above a pragma moved the suppression down a line --
+    the marked code was mutated anyway and an innocent line was skipped, both
+    silently. The module already owns the right answer; this was the last place
+    still asking the wrong one.
+    """
+    return {
+        number for number in range(1, offsets.lines() + 1) if NO_MUTATE.search(offsets.line(number))
+    }
+
+
+def label(path: str, line: int, where: str, prose: str, inside_callable: bool = True) -> str:
+    """One line, and it is the product.
+
+    A generated row still has to read as a sentence in a pull request, because
+    that is what the reader of the PR gets. `--list` exists so the mechanical
+    version can be edited into a better one before it is run.
+    """
+    place = f"{path}:{line}"
+    if not where:
+        return f"{place} -- {prose}"
+    # `()` only for a function. `in C()` named a call that does not exist, on
+    # the one string the reader of a pull request actually sees.
+    return f"{place} in {where}{'()' if inside_callable else ''} -- {prose}"
+
+
+def _chosen(operators: Sequence[str] | None) -> tuple[Operator, ...]:
+    """The operators to run, refusing a name that is not one.
+
+    Decided once per file rather than re-tested per node per operator, and
+    `SystemExit` rather than an empty selection because `--operator boundry`
+    otherwise generated nothing, printed `0 mutants`, ran the baseline and
+    exited 0. A run that asked nothing must not read as a run that found
+    nothing -- the same argument `--limit` makes when it says out loud how many
+    rows it dropped.
+    """
+    if not operators:
+        return OPERATORS
+    known = {op.name: op for op in OPERATORS}
+    unknown = sorted(set(operators) - set(known))
+    if unknown:
+        raise SystemExit(
+            f"no such operator: {', '.join(unknown)}. Available: "
+            f"{', '.join(op.name for op in OPERATORS)}"
+        )
+    return tuple(op for op in OPERATORS if op.name in set(operators))
+
+
+def generate(
+    source: str,
+    path: str,
+    lines: set[int],
+    tests: str = "",
+    operators: Sequence[str] | None = None,
+) -> list[Mutation]:
+    """Every mutant the operators can make on the changed lines of one file."""
+    tree = ast.parse(source)
+    offsets = Offsets(source)
+    blocked = _pragma_lines(source, offsets)
+    chosen = _chosen(operators)
+
+    seen: set[tuple[tuple[int, int], str]] = set()
+    out: list[Mutation] = []
+    for node, where, inside_callable in _walk(tree):
+        if not _touches(node, lines):
+            continue
+        for operator in chosen:
+            for edit in operator.fire(node):
+                # Every line the edit spans, not just the one it starts on. A
+                # pragma reads as covering the construct it sits in, and a
+                # multi-line `if (a\n        and b):  # pragma: no mutate` was
+                # mutated regardless -- silently, and in the direction that
+                # reads as success, because the author sees the pragma and the
+                # run reports `SURVIVED` on code declared out of scope.
+                if not blocked.isdisjoint(_spanned(edit.node)):
+                    continue
+                span = offsets.span(edit.node)
+                old = source[span[0] : span[1]]
+                # No `old == new` check: every operator either parenthesises its
+                # replacement or emits a different token, so the no-op it would
+                # catch cannot be produced. A mutation removing it survived, and
+                # a guard nothing can reach is a guard nobody can trust.
+                if (span, edit.new) in seen:
+                    continue
+                seen.add((span, edit.new))
+                out.append(
+                    Mutation(
+                        label=label(path, edit.node.lineno, where, edit.prose, inside_callable),
+                        path=path,
+                        old=old,
+                        new=edit.new,
+                        tests=tests,
+                        span=span,
+                        operator=operator.name,
+                    )
+                )
+    out.sort(key=lambda row: (row.span or (0, 0), row.operator))
+    return out
+
+
+def cap(mutations: Sequence[Mutation], limit: int) -> tuple[list[Mutation], list[Mutation]]:
+    """Keep `limit` of them, round-robin across files; return what was dropped too.
+
+    Round-robin rather than `[:limit]`, which would cover the alphabetically
+    first file exhaustively and the largest one not at all -- and the printed
+    summary would not show it, because the count would be right either way.
+    """
+    if limit <= 0 or len(mutations) <= limit:
+        return list(mutations), []
+    queues: dict[str, list[Mutation]] = {}
+    for row in mutations:
+        queues.setdefault(row.path, []).append(row)
+    kept: list[Mutation] = []
+    while len(kept) < limit and any(queues.values()):
+        for path in sorted(queues):
+            if queues[path] and len(kept) < limit:
+                kept.append(queues[path].pop(0))
+    dropped = [row for queue in queues.values() for row in queue]
+    kept.sort(key=lambda row: (row.path, row.span or (0, 0)))
+    return kept, dropped
+
+
+def check(mutation: Mutation) -> None:
+    """Refuse a row that cannot mean anything, reading the real file.
+
+    Two shapes, because the two kinds of row make different promises. A
+    hand-written one says "this text is unique", and a second match means the
+    edit could land anywhere. A generated one says "this text is *here*", which
+    is the stronger claim -- and checking it is what stands between the
+    byte-versus-character offset trap and a mutation that silently edits the
+    wrong span of a file that still parses.
+    """
+    original = Path(mutation.path).read_text(encoding="utf-8")
+    if mutation.span is None:
+        found = original.count(mutation.old)
+        if found != 1:
+            raise SystemExit(
+                f"{mutation.label}: {mutation.path} contains the text to replace "
+                f"{found} times, not once. A mutation that matches nothing tests "
+                f"nothing, and one that matches twice tests something else."
+            )
+    else:
+        start, end = mutation.span
+        if original[start:end] != mutation.old:
+            raise SystemExit(
+                f"{mutation.label}: {mutation.path} no longer holds that text at "
+                f"{start}..{end}, so the row would edit something else. The file "
+                f"has changed since the table was generated -- regenerate it."
+            )
+
+    if not mutation.additive and mutation.old in mutation.new:
+        raise SystemExit(
+            f"{mutation.label}: the text to replace survives verbatim inside "
+            f"the replacement, so the code under test does not change and "
+            f"'caught' would mean nothing. If the point really is to insert "
+            f"something in front of code that stays, pass additive=True."
+        )
+
+
+# --- where the diff says it matters ---------------------------------------
+
+_HUNK = re.compile(r"^@@ -\S+ \+(\d+)(?:,(\d+))? @@")
+
+
+def _git(argv: Sequence[str], root: Path) -> str:
+    """A local one, deliberately not `woswoar.gitrepo.git`.
+
+    That one defaults `cwd` to the history directory, raises the product's
+    `SyncError` and carries a 300 s timeout, and importing it would drag `store`
+    and `progress` into a development tool. `tools/sandbox.py` already builds its
+    own `git` argv for the same reason.
+    """
+    finished = subprocess.run(["git", *argv], cwd=root, capture_output=True, text=True, check=False)
+    if finished.returncode != 0:
+        raise SystemExit(f"git {' '.join(argv)} failed: {finished.stderr.strip()}")
+    return finished.stdout
+
+
+def _unquote(target: str) -> str:
+    """`+++ b/path`, including the C-quoted form git uses for odd bytes."""
+    if target.startswith('"') and target.endswith('"'):
+        target = target[1:-1].encode("ascii", "backslashreplace").decode("unicode_escape")
+    return target[2:] if target.startswith(("a/", "b/")) else target
+
+
+def parse_hunks(diff: str) -> dict[str, set[int]]:
+    """Which lines of which files the diff *adds*. Pure, so a test can drive it.
+
+    Only the `+c,d` half of each header is read. `d` omitted means one line; `d`
+    of zero is a pure deletion and contributes nothing at all, because there is
+    no new code there to mutate -- and taking it as one line would generate
+    mutants for whatever happens to sit at that number now.
+    """
+    found: dict[str, set[int]] = {}
+    current: str | None = None
+    for line in diff.splitlines():
+        if line.startswith("+++ "):
+            # No `/dev/null` special case, and the absence is the documentation:
+            # git spells a deleted file's hunk `+0,0`, so the count check below
+            # already drops it -- and a guard that nothing can reach is a guard
+            # nobody can trust. A mutation removing the special case survived,
+            # which is how it was found.
+            current = _unquote(line[4:].strip())
+            continue
+        header = _HUNK.match(line)
+        if header is None or current is None:
+            continue
+        start = int(header.group(1))
+        count = 1 if header.group(2) is None else int(header.group(2))
+        if count:
+            found.setdefault(current, set()).update(range(start, start + count))
+    return found
+
+
+def changed_lines(base: str, root: Path) -> dict[str, set[int]]:
+    """Every mutable line this branch has touched, working tree included."""
+    top = _git(["rev-parse", "--show-toplevel"], root).strip()
+    if Path(top).resolve() != root.resolve():
+        raise SystemExit(
+            f"run this from the repository root: paths in a diff are relative to {top}, not {root}."
+        )
+    _git(["rev-parse", "--verify", base], root)
+
+    # `--merge-base` with no second commit, so the right-hand side is the
+    # *working tree*: staged and unstaged changes included. That is the situation
+    # the tool is used in, and the same reason `_sandboxes` copies rather than
+    # running `git worktree add`. It also excludes commits that landed on the
+    # base after this branch started, which a two-dot diff would drag in and
+    # generate mutants for.
+    diff = _git(["diff", "--unified=0", "--merge-base", base, "--", *MUTABLE], root)
+    changed = {path: lines for path, lines in parse_hunks(diff).items() if mutable(path)}
+
+    # A brand-new module is invisible to `git diff` until it is added, and "no
+    # mutants for the new file" reads exactly like "the new file is covered".
+    for name in _git(["ls-files", "--others", "--exclude-standard", "--", *MUTABLE], root).split():
+        if mutable(name):
+            body = (root / name).read_text(encoding="utf-8").splitlines()
+            changed.setdefault(name, set()).update(range(1, len(body) + 1))
+    return changed
+
+
+# --- which tests to run it against ----------------------------------------
+
+
+def module_of(path: str) -> str:
+    """`woswoar/sync.py` -> `woswoar.sync`, and a package's `__init__` -> the package.
+
+    The `__init__` case is not cosmetic: nothing anywhere writes
+    `import woswoar.__init__`, so without it `woswoar/__init__.py` resolves to no
+    tests at all and every mutant in it would run the whole suite.
+    """
+    dotted = path[: -len(".py")].replace("/", ".")
+    return dotted[: -len(".__init__")] if dotted.endswith(".__init__") else dotted
+
+
+def _imported(node: ast.AST, package: str = "") -> Iterator[str]:
+    """Every dotted name an import statement pulls in, relative ones included.
+
+    The relative half is not a nicety. `tests/` is a package and its own style is
+    `from . import support` / `from .support import requires_age` -- so an index
+    that only understood absolute imports attributed nothing from any helper, and
+    the closure below ran over an empty set. Found by mutation testing: removing
+    the closure changed no answer, because it had never produced one.
+    """
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            yield alias.name
+        return
+    if not isinstance(node, ast.ImportFrom):
+        return
+    if node.level:
+        if not package:
+            return
+        base = f"{package}.{node.module}" if node.module else package
+    elif node.module:
+        base = node.module
+    else:
+        return
+    yield base
+    for alias in node.names:
+        yield f"{base}.{alias.name}"
+
+
+def _statements(tree: ast.Module) -> Iterator[ast.stmt]:
+    """Every statement in `tree`, which is everywhere an import can be.
+
+    Not `ast.walk`. An `import` is a statement and can only appear in a
+    statement position, so descending into expressions is work that cannot find
+    anything: measured over the real `tests/` tree, `ast.walk` visits 94,583
+    nodes to reach 317 imports. Restricting the descent to the fields that hold
+    statement lists cut `importers` from 106 ms to 67 ms -- a fifth of the whole
+    generator's wall clock -- for a byte-identical index.
+    """
+    stack: list[ast.stmt] = list(tree.body)
+    while stack:
+        node = stack.pop()
+        yield node
+        for field in ("body", "orelse", "finalbody", "handlers"):
+            for child in getattr(node, field, []):
+                if isinstance(child, ast.stmt):
+                    stack.append(child)
+                elif isinstance(child, ast.ExceptHandler):
+                    stack.extend(child.body)
+
+
+def importers(root: Path) -> dict[str, set[str]]:
+    """Which test modules import which module, computed rather than kept by hand.
+
+    `woswoar/gitrepo.py`, `archive.py`, `store.py` and `__main__.py` have no
+    same-named test module, so the name heuristic alone would report them as
+    having no tests at all -- and a hand-kept table would rot towards that
+    silently, which is the argument `tools/sandbox.py` makes about `ENV_KEYS`.
+
+    Helper modules under `tests/` are followed one level: `tests/support.py`
+    imports `store` and `cache`, and every test module that imports *it* reaches
+    them too.
+    """
+    direct: dict[str, set[str]] = {}
+    helpers: dict[str, set[str]] = {}
+    uses_helper: dict[str, set[str]] = {}
+    for source in sorted((root / "tests").glob("*.py")):
+        # `module_of` rather than the stem, so `tests/__init__.py` indexes as
+        # `tests` -- what an import actually spells. The same special case
+        # `module_of` already carries for `woswoar/__init__.py`, applied to the
+        # other half of the same mapping; without it anything ever added to
+        # `tests/__init__.py` would drop out of the closure silently.
+        name = module_of(f"tests/{source.name}")
+        try:
+            tree = ast.parse(source.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            continue
+        pulled = {module for node in _statements(tree) for module in _imported(node, "tests")}
+        if source.name.startswith("test_"):
+            # One pass, not two over the same set: `direct` for everything, and
+            # additionally `uses_helper` for the `tests.*` entries.
+            for module in pulled:
+                direct.setdefault(module, set()).add(name)
+                # `== "tests"` as well as the dotted form: `from . import
+                # support` yields the bare package name too, and that is the
+                # key `tests/__init__.py` is indexed under. Without it a helper
+                # living in the package `__init__` is never linked back to the
+                # tests that import through it.
+                if module == "tests" or module.startswith("tests."):
+                    uses_helper.setdefault(module, set()).add(name)
+        else:
+            helpers[name] = pulled
+
+    for helper, pulled in helpers.items():
+        for module in pulled:
+            direct.setdefault(module, set()).update(uses_helper.get(helper, set()))
+    return direct
+
+
+def targets_for(path: str, root: Path, index: dict[str, set[str]] | None = None) -> str:
+    """The unittest targets a mutant in `path` should be run against.
+
+    A heuristic, and it is allowed to be one *only* because a survivor is
+    re-run against the whole suite before it is reported. That confirmation is
+    what turns "the selection might have missed the test that catches this" from
+    a wrong answer into a slower one.
+
+    An empty answer means "run everything", and the caller says so in the row.
+    It is not a fallback of convenience: `tests/test_demo.py` drives
+    `tools/demo/seed.py` by spawning `python -m tools.demo.seed`, and
+    `tests/test_shell_hook.py` reaches half of `woswoar/` through a real `bash`
+    -- neither imports what it exercises, so no static index can see them. The
+    unsafe answer would be to call that "no tests" and skip the row, which reads
+    as coverage nobody has.
+    """
+    stem = Path(path).stem
+    named = {
+        f"tests.{found.stem}"
+        for found in (root / "tests").glob("test_*.py")
+        if found.stem == f"test_{stem}" or found.stem.startswith(f"test_{stem}_")
+    }
+    imported = (index if index is not None else importers(root)).get(module_of(path), set())
+    # The union, not the name match short-circuiting the index. Measured on
+    # #216: taking `tests/test_install.py` alone because the name matched left
+    # nine mutants reported as survivors that `tests.test_doctor` catches --
+    # `doctor` calls `rcfile_check`, and no name heuristic can see that. The
+    # confirmation pass corrected all nine, so the answer was right either way,
+    # but it paid a whole-suite run per row to get there.
+    return " ".join(sorted(named | imported))

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -53,7 +53,7 @@ time here:
   ``unittest.loader`` does not wrap and which therefore takes a different path
   entirely, so the check passed while the case it was named for went unasked --
   the too-weak fixture CLAUDE.md rule 3 warns about, in the harness that exists
-  to find them. `_PROBE` now classifies where the result objects still are, and
+  to find them. `tools/verdict.py` now classifies where the result objects still are, and
   a run that could not put the question says ``BROKE`` rather than either answer.
 - **Your working tree is never edited.** Each mutation is applied to a throwaway
   copy, so a kill at the wrong moment cannot leave a mutated source behind --
@@ -90,16 +90,24 @@ import os
 import queue
 import runpy
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
 from collections.abc import Iterable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Literal, NamedTuple
 
+from tools import mutants
+from tools.mutants import Mutation, check
 from tools.sandbox import usable_cpus
+
+#: Re-exported, because every spec file and every pasted pull-request output in
+#: this repository's history says `from tools.mutate import Mutation`. The
+#: definition lives with the generator that produces most of them now.
+__all__ = ["Mutation", "Report", "Result", "Verdict", "run", "verify"]
 
 #: Seconds one mutation may take before the run gives up on it. Generous, because
 #: `tests.test_sync` alone is tens of seconds and a loaded machine is slower
@@ -107,32 +115,30 @@ from tools.sandbox import usable_cpus
 #: lane for the rest of the table.
 TIMEOUT = 300.0
 
+#: The most lanes worth running, whatever the machine reports.
+_LANES = 16
+
+#: Address space one mutant may occupy, handed to `verdict.cap`.
+#:
+#: `TIMEOUT` answers "this mutation never finishes"; this answers "this mutation
+#: never finishes *while allocating*", which is a different failure and the more
+#: dangerous one -- a timeout cannot fire on a machine that is already gone.
+#: A generated `at -= ...` in `mutants.line_starts` reached 15.5 GB in 73 s and
+#: OOM-killed the machine twice while this branch was being written, well
+#: inside the 300 s above.
+#:
+#: 4 GiB is measured rather than chosen: one honest whole-suite run peaks at
+#: 317 MB resident and 1537 MB of address space, so this leaves a 2.7x margin
+#: over the thing it must never interrupt. If a legitimate suite ever reports
+#: `ran out of memory`, raise it -- the message names the test on purpose.
+MEMORY = 4 << 30
+
 #: Names never copied into a mutation's sandbox. ``.git`` because it is large and
 #: nothing under test reads it; the caches because a stale one is the trap this
 #: module documents, and the cheapest way to not have it is to not copy it.
 _SKIP = shutil.ignore_patterns(
     ".git", "__pycache__", ".mypy_cache", ".ruff_cache", ".venv", "*.egg-info"
 )
-
-
-class Mutation(NamedTuple):
-    """One edit that some test is supposed to notice."""
-
-    #: What the mutation does, in the words of whoever might reintroduce it.
-    #: Printed, so make it a sentence a reader of the PR would understand.
-    label: str
-    path: str
-    #: Must appear exactly once in the file. Ambiguity is an error rather than a
-    #: guess: replacing the wrong one of two matches quietly tests nothing.
-    old: str
-    new: str
-    #: Whitespace-separated unittest targets, as `python -m unittest` takes them.
-    tests: str
-    #: Say so when the replacement is meant to *contain* the original -- an
-    #: inserted call, an early return in front of code that stays. Otherwise
-    #: `verify` refuses that shape, because it is overwhelmingly a mistake: see
-    #: the check for why, and what it cost before it existed.
-    additive: bool = False
 
 
 #: What one run of the suite under one mutation is allowed to conclude.
@@ -235,8 +241,30 @@ def _clear_bytecode(root: Path) -> None:
         shutil.rmtree(cache, ignore_errors=True)
 
 
+def _signalled(returncode: int) -> str:
+    """Why a probe that wrote nothing died, when nothing else can say.
+
+    A negative return code is a signal in `subprocess`'s spelling. `SIGKILL` is
+    the interesting one: it is what the host OOM killer sends, so it is what a
+    lane looks like on a platform where `verdict.cap` is not enforced -- the
+    macOS case the cap's own docstring admits to. Naming it is the difference
+    between a row that reports nothing and a row that says the machine, not the
+    mutation, ended the run.
+    """
+    if returncode >= 0:
+        return f"the probe exited {returncode} without writing a report"
+    name = signal.Signals(-returncode).name if -returncode in set(signal.Signals) else "?"
+    killed = " -- the host ran out of memory, and this lane was chosen" if name == "SIGKILL" else ""
+    return f"the probe was killed by {name}{killed}"
+
+
 def _run(
-    tests: Sequence[str], root: Path, *, failfast: bool = False, timeout: float = TIMEOUT
+    tests: Sequence[str],
+    root: Path,
+    *,
+    failfast: bool = False,
+    timeout: float = TIMEOUT,
+    memory: int = MEMORY,
 ) -> Verdict:
     """What the suite concluded about one mutation, and by which route.
 
@@ -246,7 +274,7 @@ def _run(
     test`, `errors=1` and a non-zero exit, exactly like a test noticing. The only
     fixture guarding it used a *syntax* error, which takes a different path
     through `unittest.loader` and produces no count at all -- so the check passed
-    while the case it named went unasked. `_PROBE` is the answer: classify where
+    while the case it named went unasked. `tools/verdict.py` is the answer: classify where
     the result objects still exist.
 
     A timeout is its own outcome rather than an exception. A generated mutant can
@@ -262,7 +290,7 @@ def _run(
         noise = Path(box) / "stderr.txt"
         try:
             with noise.open("w", encoding="utf-8") as spill:
-                subprocess.run(
+                finished = subprocess.run(
                     [
                         sys.executable,
                         "-B",
@@ -270,6 +298,7 @@ def _run(
                         _probe(),
                         str(report),
                         "1" if failfast else "0",
+                        str(memory),
                         *tests,
                     ],
                     cwd=root,
@@ -297,10 +326,18 @@ def _run(
             written = json.loads(report.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             # The probe was killed before it could write anything at all. Rare
-            # and always worth the tail, because nothing else says why.
-            return Verdict("broke", _tail(noise))
+            # and always worth the tail -- but a process killed by a signal
+            # writes no stderr either, and that row used to print with no reason
+            # at all. It is exactly the case a host OOM-kill produces, which is
+            # the failure this file now has a limit for, so it must not be the
+            # one that says nothing.
+            return Verdict("broke", _tail(noise) or _signalled(finished.returncode))
         if not written["loaded"]:
-            return Verdict("broke", _tail(noise) or str(written.get("why", "")).strip())
+            # The recorded traceback first. `verdict.main` writes it deliberately
+            # and `_tail` is whatever happened to reach stderr, so preferring the
+            # tail let a stray import-time warning outrank the reason the probe
+            # took the trouble to record.
+            return Verdict("broke", str(written.get("why", "")).strip() or _tail(noise))
 
     if written["broke"]:
         return Verdict("broke", str(written["broke"][0]))
@@ -318,42 +355,6 @@ def _tail(noise: Path) -> str:
     except OSError:
         return ""
     return spoken[-1].strip() if spoken else ""
-
-
-def _check(mutation: Mutation) -> None:
-    """Refuse a spec that cannot mean anything, reading the real file.
-
-    Every mutation is checked before any of them runs -- see `verify`. A typo in
-    the last row of a table used to be found after the first four had each cost a
-    suite run.
-    """
-    original = Path(mutation.path).read_text(encoding="utf-8")
-    found = original.count(mutation.old)
-    if found != 1:
-        raise SystemExit(
-            f"{mutation.label}: {mutation.path} contains the text to replace "
-            f"{found} times, not once. A mutation that matches nothing tests "
-            f"nothing, and one that matches twice tests something else."
-        )
-
-    # The replacement still contains everything it replaced, so the line the
-    # test is supposed to miss is still in the file and the run cannot mean
-    # anything. Always a mistake when the intent was to *move* something --
-    # write the whole span in `old`, including what follows it, or the
-    # original stays put underneath the edit.
-    #
-    # Three of these went out in one session before this check existed. Each
-    # cost a full suite run and read as "caught" when nothing had changed;
-    # the tell is that a mutation meant to break an invariant reports the
-    # same result as one that does nothing, and there is no way to see which
-    # from the output.
-    if not mutation.additive and mutation.old in mutation.new:
-        raise SystemExit(
-            f"{mutation.label}: the text to replace survives verbatim inside "
-            f"the replacement, so the code under test does not change and "
-            f"'caught' would mean nothing. If the point really is to insert "
-            f"something in front of code that stays, pass additive=True."
-        )
 
 
 @contextmanager
@@ -385,7 +386,9 @@ def _sandboxes(count: int) -> Iterator[queue.Queue[Path]]:
         yield available
 
 
-def _borrow(available: queue.Queue[Path], tests: Sequence[str], timeout: float) -> Verdict:
+def _borrow(
+    available: queue.Queue[Path], tests: Sequence[str], timeout: float, memory: int
+) -> Verdict:
     """Run ``tests`` unmutated in a borrowed sandbox. One shard of the baseline.
 
     Never `failfast`: a red baseline is a thing you want the whole of, and a
@@ -393,28 +396,113 @@ def _borrow(available: queue.Queue[Path], tests: Sequence[str], timeout: float) 
     """
     root = available.get()
     try:
-        return _run(tests, root, timeout=timeout)
+        return _run(tests, root, timeout=timeout, memory=memory)
     finally:
         available.put(root)
 
 
+def _applied(original: str, mutation: Mutation) -> str:
+    """The file with one mutation in it.
+
+    Two ways, because the two kinds of row promise different things. A
+    hand-written `old` is unique in the file -- `check` refused it otherwise --
+    so `replace` cannot land anywhere else. A generated one usually is *not*
+    unique (`if not path.exists():` appears many times), so it carries the
+    offsets it applies at and the text is spliced there. `check` has already
+    confirmed those offsets still hold the text the row quotes.
+    """
+    if mutation.span is None:
+        return original.replace(mutation.old, mutation.new)
+    start, end = mutation.span
+    return original[:start] + mutation.new + original[end:]
+
+
 def _attempt(
-    mutation: Mutation, available: queue.Queue[Path], failfast: bool, timeout: float
+    mutation: Mutation,
+    available: queue.Queue[Path],
+    failfast: bool,
+    timeout: float,
+    memory: int,
 ) -> Verdict:
     """Apply one mutation in a borrowed sandbox and report what the suite said."""
     root = available.get()
     try:
         source = root / mutation.path
         original = source.read_text(encoding="utf-8")
-        source.write_text(original.replace(mutation.old, mutation.new), encoding="utf-8")
+        source.write_text(_applied(original, mutation), encoding="utf-8")
         try:
-            return _run(mutation.tests.split(), root, failfast=failfast, timeout=timeout)
+            return _run(
+                mutation.tests.split(), root, failfast=failfast, timeout=timeout, memory=memory
+            )
         finally:
             # Into the sandbox, not the working tree. Only so the next mutation
             # to borrow this copy starts from clean source.
             source.write_text(original, encoding="utf-8")
     finally:
         available.put(root)
+
+
+#: What one lane is measured to occupy, as opposed to what `MEMORY` lets it
+#: reach. One whole-suite run peaks at 317 MB resident; a gibibyte is three
+#: times that, and resident is the number the OOM killer counts.
+_LANE = 1 << 30
+
+
+def _visible_memory() -> int:
+    """Memory this process may actually use, container limits included.
+
+    Not `SC_PHYS_PAGES` alone, which reports the host's and ignores a cgroup --
+    so in a 2 GiB container on a 62 GiB host it answers 62 and the container is
+    OOM-killed with every per-lane cap respected. `tools/sandbox.py`'s
+    `usable_cpus` makes exactly this argument for CPUs; this is the same mistake
+    with the same shape, one resource over.
+
+    Left here rather than beside `usable_cpus` because it has one caller.
+    `usable_cpus` moved into `sandbox` when it got a second, and that is the
+    threshold this repository uses.
+    """
+    limits = []
+    for where in ("/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory/memory.limit_in_bytes"):
+        try:
+            said = Path(where).read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        # cgroup v2 writes `max` for "no limit"; v1 writes a number so large it
+        # means the same thing, and comparing against the host total is the only
+        # way to tell that from a real limit.
+        if said.isdigit():
+            limits.append(int(said))
+    with suppress(AttributeError, OSError, ValueError):  # not POSIX
+        limits.append(os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES"))
+    return min(limits) if limits else _LANES * _LANE
+
+
+def _affordable() -> int:
+    """How many lanes fit in memory, which is a different question from cores.
+
+    `verdict.cap` bounds one lane; it does not bound their product, and the
+    product is what the host feels. Sixteen lanes at 4 GiB is 64 GiB on a 62 GiB
+    machine, so a table can still drive it into swap with every individual cap
+    respected -- and a *generated* table is the shape that does it, because it
+    walks a file in order and its runaway rows are therefore adjacent. When this
+    crash was diagnosed, three of four lanes were running away simultaneously,
+    all on the same source line.
+
+    Half of visible memory, because the other half belongs to whoever is using
+    the machine. Mutation testing is a background chore and has no claim on the
+    whole box; an explicit `--workers` still overrides this, as it overrides
+    every other bound below.
+
+    Divided by `_LANE` -- what a lane is measured to *use* -- and not by
+    `MEMORY`, which is the ceiling on what one may reach before being killed.
+    Dividing by the ceiling was the first shape and it assumed every lane is
+    simultaneously pathological: an ordinary 16 GiB laptop dropped from sixteen
+    lanes to two, and a 7 GiB CI runner to one, to bound a case that the ceiling
+    already truncates within seconds. The ceiling stops a runaway; this number
+    decides how many honest lanes fit.
+    """
+    budget = _visible_memory() // 2
+    return max(1, budget // _LANE)
 
 
 def run(
@@ -425,6 +513,8 @@ def run(
     strict: bool = True,
     failfast: bool = False,
     timeout: float = TIMEOUT,
+    memory: int = MEMORY,
+    summarise: bool = True,
 ) -> Report:
     """Apply each mutation in its own copy of the tree; report what each answered.
 
@@ -448,31 +538,32 @@ def run(
     if not table:
         return Report([])
     for mutation in table:
-        _check(mutation)
+        check(mutation)
 
     # One shard per target rather than one serial run over the union. Measured on
     # four pinned cores with eight `tests.test_sync` classes: the mutation phase
     # took 2.35 s across eight lanes while a single-run baseline took 6.75 s, so
     # the check meant to cost nothing was two thirds of the wall clock and got
     # worse as the table grew -- mutations fan out, a union sums.
-    shards = sorted({test for mutation in table for test in mutation.tests.split()})
+    shards = sorted({mutation.tests for mutation in table})
     # Twice the usable cores, which is what `tools/run_tests.py` measured for this
     # same subprocess-wait-bound work (jobs=8 beat jobs=4 by ~9%, jobs=16
     # regressed). An earlier `cpu // 2` here gave two lanes on a four-core runner
     # and was 1.76x slower than this for eight runs. A sandbox is ~1 ms, so a lane
     # is nearly free.
-    lanes = workers or min(len(table) + len(shards), usable_cpus() * 2, 16)
+    lanes = workers or min(len(table) + len(shards), usable_cpus() * 2, _LANES, _affordable())
 
     results: list[Result] = []
     red = False
     with _sandboxes(lanes) as available, ThreadPoolExecutor(max_workers=lanes) as pool:
         checking = (
-            [pool.submit(_borrow, available, [shard], timeout) for shard in shards]
+            [pool.submit(_borrow, available, shard.split(), timeout, memory) for shard in shards]
             if baseline
             else []
         )
         futures = [
-            pool.submit(_attempt, mutation, available, failfast, timeout) for mutation in table
+            pool.submit(_attempt, mutation, available, failfast, timeout, memory)
+            for mutation in table
         ]
         for mutation, future in zip(table, futures, strict=True):
             verdict = future.result()
@@ -513,7 +604,7 @@ def run(
                 red = True
                 break
 
-    if not red:
+    if not red and summarise:
         _summarise(results)
     report = Report(results, red)
     _RUNS.append(report)
@@ -552,13 +643,224 @@ def verify(mutations: Iterable[Mutation], baseline: bool = True, workers: int | 
     return sum(1 for result in report.results if result.verdict.outcome == "survived")
 
 
+#: What a row runs when selection could not name a target: everything. Empty
+#: rather than `"tests"`, because a package name is not discovery -- `unittest`
+#: imports the package, finds no tests in it, and reports a green run of nothing.
+#: Not a fallback of convenience either: see `mutants.targets_for`, and the row
+#: says out loud when it happens.
+WHOLE_SUITE = ""
+
+
+def confirm(report: Report, workers: int | None, timeout: float, memory: int) -> Report:
+    """Re-run every survivor against the whole suite, and correct the ones caught.
+
+    This is what makes per-file test selection a *speed* decision rather than a
+    correctness one. A survivor reported from a narrow target may simply have
+    been run against the wrong tests, and that error points the expensive way:
+    it sends the author to rewrite a test that was never weak, which is the
+    failure rule 3 exists to prevent, inverted.
+
+    Only survivors, because they are the minority and the only ones whose answer
+    can be wrong in that direction -- a `caught` row was caught by a real test,
+    and no wider suite makes that less true.
+    """
+    # Positions, not labels. Two generated rows share a label whenever they touch
+    # the same line with the same operator -- `generate` dedupes on `(span, new)`,
+    # and `mutable()` alone has two `.startswith(...)` calls on one line. Keying
+    # the corrections by label wrote one row's `caught` onto every row spelled the
+    # same way, so a genuine survivor was reported as caught, naming a test that
+    # had never seen it. On this branch's own diff, 23 labels are duplicated.
+    #
+    # `run` appends in table order, and with `strict=False` there is no early
+    # exit, so `again.results` is positionally aligned with `widened`.
+    survivors = [
+        (where, result)
+        for where, result in enumerate(report.results)
+        if result.verdict.outcome == "survived"
+    ]
+    if not survivors:
+        return report
+    print(f"\nconfirming {len(survivors)} survivor(s) against the whole suite...")
+    widened = [result.mutation._replace(tests=WHOLE_SUITE) for _, result in survivors]
+    again = run(
+        widened,
+        baseline=False,
+        workers=workers,
+        strict=False,
+        # As the narrow pass does, and for the same reason: the first test that
+        # notices settles the row, and this pass runs the *whole* suite per
+        # survivor -- the one place where not stopping costs the most.
+        failfast=True,
+        timeout=timeout,
+        memory=memory,
+        summarise=False,
+    )
+
+    # Only `caught` corrects a survivor. A confirmation that broke or timed out
+    # answered nothing, and folding it in would print "caught by a test the
+    # selection had not run" about a run in which no test ran at all -- the
+    # exact false `caught` this module was rewritten to make impossible, one
+    # level up. It happened here on the first end-to-end run.
+    corrected = {
+        where: found.verdict
+        for (where, _), found in zip(survivors, again.results, strict=True)
+        if found.verdict.outcome == "caught"
+    }
+    unsure = sum(1 for found in again.results if not found.verdict.answered)
+    if unsure:
+        print(f"{unsure} confirmation(s) could not be answered; those rows stand as reported.")
+    if not corrected:
+        return report
+    print(f"{len(corrected)} of them were caught by a test the selection had not run.")
+    return Report(
+        [
+            Result(result.mutation, corrected.get(where, result.verdict))
+            for where, result in enumerate(report.results)
+        ],
+        report.baseline_red,
+    )
+
+
+def generated(args: argparse.Namespace) -> list[Mutation]:
+    """The table the diff implies, printed about before any of it runs."""
+    root = Path.cwd()
+    touched = mutants.changed_lines(args.base, root)
+    if args.only:
+        touched = {
+            path: lines
+            for path, lines in touched.items()
+            if any(wanted in path for wanted in args.only)
+        }
+    if not touched:
+        raise SystemExit(
+            f"nothing mutable changed against {args.base}. Only woswoar/**.py and "
+            f"tools/**.py are generated from; a change to tests/ is not a fix to test."
+        )
+
+    index = mutants.importers(root)
+    table: list[Mutation] = []
+    for path in sorted(touched):
+        tests = mutants.targets_for(path, root, index) or WHOLE_SUITE
+        table.extend(
+            mutants.generate(
+                (root / path).read_text(encoding="utf-8"),
+                path,
+                touched[path],
+                tests=tests,
+                operators=args.operator or None,
+            )
+        )
+        if tests == WHOLE_SUITE:
+            print(f"note: nothing imports {path}, so its rows run the whole suite.")
+
+    print(
+        f"{len(touched)} file(s), {sum(len(lines) for lines in touched.values())} changed "
+        f"lines -> {len(table)} mutants"
+    )
+    kept, dropped = mutants.cap(table, args.limit)
+    if dropped:
+        # Said out loud, because a silent cap reads as "everything was covered"
+        # and the count would look right either way -- CLAUDE.md is explicit.
+        share: dict[str, int] = {}
+        for row in dropped:
+            share[row.path] = share.get(row.path, 0) + 1
+        listed = ", ".join(f"{path} {count}" for path, count in sorted(share.items()))
+        print(f"--limit {args.limit}: {len(dropped)} not run ({listed}).")
+        print("Counts below are out of what ran, not out of what the diff implies.")
+    return kept
+
+
+def _bytes(said: str) -> int:
+    """A byte count for `--memory`, refusing the two values that fail silently.
+
+    `0` means no cap, spelled the way `--limit 0` next to it already means it.
+    A negative number is refused rather than accepted: `RLIM_INFINITY` is `-1`
+    on Linux, so `--memory -1` used to read as "no limit" through a flag whose
+    whole purpose is to impose one -- a typo that removes the guard and says
+    nothing.
+    """
+    try:
+        value = int(said)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"not a byte count: {said}") from None
+    if value < 0:
+        raise argparse.ArgumentTypeError(
+            f"negative memory limit: {said}. Use 0 for no cap; -1 is not infinity here."
+        )
+    return value
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="python -m tools.mutate",
-        description="Run a script that defines MUTATIONS, and report which are caught.",
+        description="Run a table of mutations -- from a spec file, or from a diff.",
     )
-    parser.add_argument("script", help="a Python file defining MUTATIONS: list[Mutation]")
+    parser.add_argument(
+        "script", nargs="?", help="a Python file defining MUTATIONS: list[Mutation]"
+    )
+    parser.add_argument(
+        "--base", help="generate mutants for every line changed against this revision"
+    )
+    parser.add_argument(
+        "--list", action="store_true", help="print the generated table and run nothing"
+    )
+    parser.add_argument(
+        "--only", action="append", default=[], metavar="PATH", help="restrict to matching paths"
+    )
+    parser.add_argument(
+        "--operator", action="append", default=[], metavar="NAME", help="use only this operator"
+    )
+    parser.add_argument("--limit", type=int, default=200, help="cap the table (0 for no cap)")
+    parser.add_argument("--timeout", type=float, default=TIMEOUT, help="seconds per mutation")
+    parser.add_argument(
+        "--memory",
+        type=_bytes,
+        default=MEMORY,
+        help="bytes of address space one mutation may occupy (0 for no cap)",
+    )
+    parser.add_argument("--workers", type=int, help="lanes to run in parallel")
+    parser.add_argument("--no-baseline", action="store_true", help="skip the untouched-suite check")
+    parser.add_argument(
+        "--no-confirm",
+        action="store_true",
+        help="do not re-run survivors against the whole suite",
+    )
     args = parser.parse_args(argv)
+
+    if bool(args.script) == bool(args.base):
+        parser.error("give a spec file or --base, not both and not neither")
+
+    if args.base:
+        table = generated(args)
+        if args.list:
+            for row in table:
+                print(f"  {row.operator:16} {row.label}")
+            return 0
+        report = run(
+            table,
+            baseline=not args.no_baseline,
+            workers=args.workers,
+            # A generated row that breaks collection is not a mistake anyone
+            # made; discarding two hundred paid-for answers because of it would
+            # be. The row is reported and the run goes on.
+            strict=False,
+            summarise=False,
+            # Worth having here and not for a hand table: `caught` is the
+            # expected outcome for most generated rows, and without this each
+            # one runs the rest of its target after the answer is known. An
+            # average, not a bound -- `unittest` runs classes alphabetically, so
+            # a mutant caught only by the last of them still pays for nearly all.
+            failfast=True,
+            timeout=args.timeout,
+            memory=args.memory,
+        )
+        if not args.no_confirm:
+            report = confirm(report, args.workers, args.timeout, args.memory)
+        else:
+            print("\n--no-confirm: survivors below were not re-run against the whole suite,")
+            print("so one may simply have been run against tests that cannot see it.")
+        _summarise(report.results)
+        return 0 if report.clean else 1
 
     already = len(_RUNS)
     namespace = runpy.run_path(args.script)

--- a/tools/verdict.py
+++ b/tools/verdict.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import io
 import json
+import resource
 import sys
 import traceback
 import unittest
@@ -59,6 +60,88 @@ from typing import Any
 #: typeshed spells it -- `mypy --strict` checks these overrides for Liskov and a
 #: near-miss here is an error, not a warning.
 ExcInfo = tuple[type[BaseException], BaseException, TracebackType] | tuple[None, None, None]
+
+
+def cap(limit: int) -> None:
+    """Bound this process's address space, so a runaway mutant dies alone.
+
+    A mutation does not have to loop forever to hold a lane -- it can loop
+    forever *while appending*, and then the timeout is the wrong instrument
+    because the machine is gone before it fires. Measured, on the mutant that
+    prompted this: `line_starts` reduced to `at -= ...` never advances (a
+    negative index wraps in Python rather than raising, so the `while` condition
+    stays true), and three lanes reached 15.5 GB, 7.6 GB and 6.4 GB of resident
+    memory 73 seconds in. The host OOM-killed the session twice before the 300 s
+    timeout had any chance to speak.
+
+    `RLIMIT_AS` rather than a cgroup, and the reasons are not interchangeable:
+
+    - it is set *here*, in the child, so it needs no `preexec_fn`. `run` drives
+      its lanes from a `ThreadPoolExecutor`, and `preexec_fn` is documented as
+      unsafe in the presence of threads -- the one mechanism that must not
+      itself be a source of rare, undebuggable failures;
+    - `systemd-run --scope -p MemoryMax=` is Linux-only, and CI runs a macOS
+      job. A guard that silently does not exist on one platform is worse than
+      the guard being visible everywhere;
+    - no root, no delegated cgroup, nothing to configure before the tool works.
+
+    Two honest limits. These bound *address space* and the data segment, not
+    resident memory, so the number is necessarily looser than the RSS it
+    protects; and a platform may enforce neither, in which case this silently
+    does nothing. That is not hypothetical -- macOS ignores `RLIMIT_AS`, and CI
+    is what said so. `tests.test_mutate` therefore asks whether the limit is
+    enforced *here* by trying it, rather than deciding from `sys.platform`, so
+    the guarantee is tested wherever it actually holds and skipped where it does
+    not. Neither weakens the Linux case, which is where the crash happened.
+
+    `resource` is imported unguarded: it is Unix-only, and so is everything
+    else here -- the product is a shell hook for bash and zsh, and CI runs
+    Linux and macOS. A `try: import` around it only bought an unreachable
+    branch that `mypy` correctly refused.
+
+    The limit is inherited by the `git`, `age` and `bash` the suite really
+    forks. That is intended -- they are equally capable of running away -- and
+    it is why `mutate.MEMORY`, which supplies `limit`, is a measured margin over
+    an observed whole-suite peak rather than a round number.
+    """
+    if limit <= 0:
+        # 0 is "no cap", as `--memory 0` promises and as `--limit 0` beside it
+        # already means. Guarded here as well as at the CLI because `cap` is
+        # reachable from a spec file, and `setrlimit(..., 0)` would make the
+        # sandbox fail every row for a reason no output would explain.
+        return
+    # Both, because neither is enforced everywhere and they cost the same to
+    # ask for. Linux honours `RLIMIT_AS`; macOS largely does not, and CI proved
+    # it rather than the docs -- the first version of this passed on Linux and
+    # failed the macOS job with the runaway allocation simply succeeding.
+    # `RLIMIT_DATA` covers anonymous `mmap` on Linux since 4.7 and is the one
+    # macOS is likelier to apply, so asking for both is how this stays a guard
+    # on more than one platform without branching on a platform name.
+    for which in (resource.RLIMIT_AS, resource.RLIMIT_DATA):
+        try:
+            soft, hard = resource.getrlimit(which)
+        except (OSError, ValueError):  # pragma: no cover - platform without it
+            continue
+        # Never raise an existing ceiling: a caller who already sandboxed us
+        # meant it.
+        ceiling = limit if hard == resource.RLIM_INFINITY else min(limit, hard)
+        if soft != resource.RLIM_INFINITY and soft <= ceiling:
+            continue
+        try:
+            resource.setrlimit(which, (ceiling, hard))
+        except (OSError, ValueError):  # pragma: no cover - refused
+            continue
+
+
+def _exhausted(err: ExcInfo | None) -> bool:
+    """Whether this traceback is the memory cap firing rather than an assertion.
+
+    `issubclass` rather than `is`, because the cap can also surface as a
+    subclass raised by an extension module; `err[0]` rather than the instance,
+    because building the instance is itself an allocation that may not have
+    succeeded.
+    """
+    return err is not None and err[0] is not None and issubclass(err[0], MemoryError)
 
 
 class Verdicts(unittest.TextTestResult):
@@ -77,6 +160,18 @@ class Verdicts(unittest.TextTestResult):
 
     def addError(self, test: unittest.TestCase, err: ExcInfo) -> None:
         super().addError(test, err)
+        if _exhausted(err):
+            # The one exception classified by type rather than by protocol, and
+            # it has to be. `cap` makes a runaway mutation raise `MemoryError`
+            # inside whichever test happened to be running -- a real `TestCase`,
+            # reached through `addError`, indistinguishable by protocol from
+            # that test having *noticed* something. Left alone it would report
+            # `caught`, naming a test that asserted nothing and crediting it
+            # with a guard it does not have. That is precisely the lie this
+            # module was written to remove, so the guard against running out of
+            # memory must not reintroduce it one level up.
+            self.broke.append(f"{test} ran out of memory")
+            return
         # `_ErrorHolder` -- a dead `setUpClass`, `setUpModule` or `tearDown` --
         # is not a `TestCase`, and that is the whole check. It carries a
         # traceback for something that happened *around* the tests, so no
@@ -92,12 +187,24 @@ class Verdicts(unittest.TextTestResult):
             # `test` is the owning case; `subtest` is the `_SubTest` carrier that
             # the base class files into `failures`. Recording the owner is what
             # keeps a `subTest` assertion a real answer.
-            self.noticed.append(str(test))
+            if _exhausted(err):
+                self.broke.append(f"{test} ran out of memory")
+            else:
+                self.noticed.append(str(test))
 
 
 def collect(names: list[str], failfast: bool) -> dict[str, Any]:
     loader = unittest.TestLoader()
-    suite = loader.loadTestsFromNames(names)
+    # No names means the whole suite, and it has to be `discover` rather than
+    # the package name: `loadTestsFromNames(["tests"])` imports the package and
+    # finds nothing in it, so the run comes back green having executed zero
+    # tests. That is reported as `broke` -- correctly, and confusingly, since the
+    # request was for everything.
+    suite = (
+        loader.loadTestsFromNames(names)
+        if names
+        else loader.discover(".", pattern="test_*.py", top_level_dir=".")
+    )
     if loader.errors:
         # Public API, and checked before running: the suite `loadTestsFromNames`
         # returns for an unimportable module holds a synthetic `_FailedTest`
@@ -124,7 +231,10 @@ def collect(names: list[str], failfast: bool) -> dict[str, Any]:
 
 
 def main(argv: list[str]) -> None:
-    report, failfast, names = argv[0], argv[1] == "1", argv[2:]
+    report, failfast, names = argv[0], argv[1] == "1", argv[3:]
+    # Before the suite loads, not after: `discover` imports every test module,
+    # and a mutation to something imported at module scope can run away there.
+    cap(int(argv[2]))
     try:
         written = collect(names, failfast)
     except BaseException:
@@ -132,6 +242,9 @@ def main(argv: list[str]) -> None:
         # loaded" from an absent file, which is also what a typo in this file
         # produces -- two very different problems with byte-identical output, in
         # a tool whose whole thesis is that those must be told apart.
+        # `limit=4` keeps the tail readable; `format_exc` is itself an
+        # allocation, so a `MemoryError` here may leave nothing at all -- which
+        # the caller already reads as `broke` from the absent report.
         written = {"loaded": False, "why": traceback.format_exc(limit=4)}
     with open(report, "w", encoding="utf-8") as out:
         json.dump(written, out)


### PR DESCRIPTION
**Replaces #222**, which GitHub closed automatically when #220 merged and its base branch was deleted; it cannot be reopened once the head branch has been rebased. Same branch, same commit content, now rebased onto `main` — the tree is byte-identical to what #222 last held. The discussion on #222 is still the history for this work.

**#220 has merged**, so this is no longer stacked; the whole diff against `main` is what matters now.

`tools/mutate.py` runs a table someone wrote. Writing it is the work that remained after #48 removed the loop around it, and it is also the blind spot: a hand-written table only asks the questions its author thought to ask.

```sh
python -m tools.mutate --base main          # generate from the diff and run
python -m tools.mutate --base main --list   # print the table, run nothing
```

## What it does

`tools/mutants.py` reads `git diff --unified=0 --merge-base <base>` — **one** revision, so the right-hand side is the working tree, staged and unstaged included. That is the situation the tool is used in, and the same reasoning `_sandboxes` already gives for copying rather than `git worktree add`. `--merge-base` also excludes commits that landed on the base after the branch started, which a two-dot diff would drag in and generate mutants for.

Fourteen AST operators, each earning its place against a defect class this repository actually hit — `order` produces the reversed walk from `CONTRIBUTING.md`'s first weak fixture, `affix` the suffix filter that accepts everything (`True`, not `False`, because that is the answer a directory of only `.age` files cannot distinguish), `negate` the `assertFalse` that cannot tell `False` from `None` (#206).

Four more were added after the first review: `return-value` (`return X` to
`return None`, the highest-value one — a function that silently returns nothing
never raises, so it always produces a real answer), `arith`, `slice`, and
`drop-assign` scoped to attribute and subscript targets. Plain `name = ...` is
deliberately not deleted: it leaves a `NameError` further down, which is `BROKE`
rather than an answer and costs a whole suite run to discover.

It is a separate module because it is pure — `(source, changed lines) -> mutations` — so `tests/test_mutants.py` runs in 0.15 s with no sandbox, no subprocess and no suite. The same line `tools/sandbox.py` and `compare.verdict` already drew.

## The load-bearing design decision

**Every survivor is re-run against the whole suite before it is reported.** Test selection is a heuristic; this makes it a *speed* decision rather than a correctness one. A row run against too few tests survives for the wrong reason, and that error points the expensive way — it sends the author to rewrite a test that was never weak, which is rule 3's failure inverted.

On #216's own change, that pass corrected **nine of eleven**. The cause was `targets_for` letting the name match short-circuit the import index: `test_install` matched by name, and `tests.test_doctor` — which calls `rcfile_check` and catches nine of those mutants — was never run. Now it unions.

## What it found on real code

Run against #216 (`--base 2950fff^ --only woswoar/install.py`), 11 caught and 2 genuine survivors, both real gaps in that change's tests:

- `install.py:360` — nothing distinguishes `present or detect_shells()` from `and`.
- `install.py:419` — nothing covers the "block that sources nothing" branch of `rcfile_check`.

## Mutation testing this PR found six defects, four in code written for it

| survivor | what it actually was |
|---|---|
| `from . import support` never indexed | **A real bug.** `_imported` skipped relative imports — which is how `tests/` imports everything — so the helper closure had been inert. Removing it changed no answer because it had never produced one. |
| the UTF-8 span fixture | Put the non-ASCII on a *previous* line, where byte and character offsets agree. It never exercised the conversion it was named for. |
| two off-by-ones in `Offsets` | Fixtures had drifted to single-line sources — including one that drifted *while fixing the above*. |
| the docstring suppression | Guarded nothing: no operator matches a bare `Expr(Constant)`. Deleted. |
| the `old == new` check | Unreachable: every operator parenthesises its replacement or emits a different token. Deleted. |
| the `/dev/null` special case | Unreachable: git spells a deleted file's hunk `+0,0`, already dropped by the count check. Deleted. |

## Review found two more, both verified by reverting them

**`str.splitlines` disagrees with the tokenizer.** It breaks on form feed, vertical tab, the file/group/record separators and U+2028/9; CPython treats a form feed as ordinary whitespace. A single `\f` — the Emacs page separator, and legal Python — made `splitlines` see seven lines where `ast` saw six, so every span below it landed one line early:

```
    if total < Falset:      <-- line 4, edited
        return True         <-- line 5, the line the label names, untouched
```

which parses. `line_starts` now counts lines the way the tokenizer does.

**`confirm` keyed corrections by label, and labels are not unique.** `generate` dedupes on `(span, new)`, not on the label; `mutable()` alone has two `.startswith(...)` calls on one line, and **23 labels repeat on this branch**. One row's `caught` was written onto every row spelled the same way, turning a genuine survivor into a false `caught` naming a test that had never seen it — and exiting 0. Keyed by position now.

That second one is worth dwelling on: `CONTRIBUTING.md` promises the confirmation pass "cannot produce a false `SURVIVED`", which was true — but the pass was introducing a false **`caught`** instead, which is the worse of the two and the exact failure #220 exists to eliminate one level down.

Its first regression test was itself too weak — one row was caught immediately, so `confirm` never re-ran it and `corrected` was empty. The mutation reverting the fix survived the test written to guard it, until the fixture was rebuilt so that *both* rows survive the narrow pass and only the wider suite separates them.

## Honesty about the span check

`generate` derives `old` *from* the span it just computed, so for a freshly generated row `check`'s assertion is true by construction: it catches the file changing between `--list` and the run, and nothing else. It is **not** a guard against a bad offset. Only tests are, and the module now says so.


## The crash this branch caused, and the guard that answers it

Running the generator against its own module OOM-killed the machine twice.
`tools/mutants.py:123` is `at += 2 if source[at + 1 : at + 2] == "\n" else 1`;
two generated mutants (`+=` to `-=`, and `1` to `0`) stop `at` advancing, and
because a negative index *wraps* in Python instead of raising, `while at <
len(source)` stays true forever while `starts.append(at)` runs. Caught live:
three lanes at **15.5 GB, 7.6 GB and 6.4 GB after 73 seconds**, peak 34.7 GB
with swap engaged — all inside the 300 s timeout.

**A timeout cannot fire on a machine that is already gone**, so `--memory`
is not a refinement of `--timeout` but a different instrument. `verdict.cap`
sets `RLIMIT_AS` at 4 GiB, and the choice of mechanism is argued rather than
assumed:

- it is set *inside the probe*, so it needs no `preexec_fn` — and `run` drives
  lanes from a `ThreadPoolExecutor`, where `preexec_fn` is documented-unsafe.
  The guard must not itself be a source of rare, undebuggable failures.
- `systemd-run --scope -p MemoryMax=` is Linux-only and CI runs a macOS job.
  Stated honestly in the docstring: `RLIMIT_AS` bounds address space rather than
  RSS, and macOS enforces it weakly, so there it is a backstop not a promise.
- **4 GiB is measured**: an honest whole-suite run peaks at 317 MB resident and
  1537 MB of address space, a 2.7x margin.

**The half that mattered more.** A `MemoryError` arrives at `addError` inside a
real `TestCase`, which by protocol is indistinguishable from that test noticing
— so the cap alone would have reported `caught`, crediting a test with a guard
it does not have. That is exactly the lie #220 removes one level down, so
exhaustion is classified `BROKE` by type. Both reverts produce the same wrong
`caught`, and the regression test separates all three states with a **bounded**
800 MiB fixture, bounded precisely so it can be run with the fix reverted
without reproducing the crash it prevents.

**The cap bounds one lane, not their product.** Sixteen lanes at 4 GiB is 64 GiB
on a 62.5 GiB host, and a generated table walks a file in order so its runaway
rows are *adjacent* — three of four lanes ran away at once. Lanes are now
bounded by memory as well as cores: 7 on this machine, leaving half the box free.
`--workers` still overrides.

Re-run afterwards at default settings — the command that crashed twice —
**peak 14.1 GB, completed**, with the four runaway rows reported as three
`ran out of memory` and one `no answer within 300s`.

```
  caught    the cap is never actually set, so a mutant may take the host with it
  caught    running out of memory reads as a test noticing
  caught    the cap is not passed to the probe at all
  caught    the cap is applied after the suite has already been loaded
```

## What the guard then revealed

With the run able to finish, 17 rows survived — and **15 of them were the `\r`
branch of `line_starts`**, the scanner added by the form-feed review fix above.
The cause was not subtle: no source anywhere in the suite contained a carriage
return, so `if source[at] == "\r"` was never once entered. `ast` treats both
`\r\n` and a bare `\r` as line terminators, so this was a real untested branch
guarding a real behaviour, not dead code.

The new fixtures assert against `ast` itself rather than against hand-written
constants, because the constant is the part a reader checks by hand and gets
wrong. The last survivor was a separate gap: `Offsets._line`'s bound only
differs on the final line of a file with **no trailing newline**, and every
fixture in the suite ended with one.

```
  caught    the scan starts past the first character
  caught    a carriage return is not a line ending
  caught    CRLF is stepped over as one character
  caught    CRLF is stepped over as three
  caught    a bare CR advances twice
  caught    the lookahead is inverted
  caught    the lookahead reads the whole source
  caught    the lookahead reads backwards
  caught    a CR line start is never recorded
  caught    the last line's end is off by one
```

`else 1` to `else 0` is deliberately absent from that table: it does not
terminate, so it can only ever be `BROKE`. That it now says `ran out of memory`
in bounded time instead of taking the host down is the point of the cap; it is
still not an answer about a test.

## Applied to itself

`--base main --only tools/mutants.py --limit 60`: **39 caught, 17 survived, 3 `BROKE`, 1 `TIMEOUT`** before the carriage-return fixtures above; the survivors are what led to them. The equivalent mutant remains equivalent — `ops[0]` → `ops[-1]` behind a `len(node.ops) == 1` guard indexes the same element — and is reported as a survivor rather than papered over.

## Mutation output, twenty-seven caught, verbatim

```
caught    column offsets are read as characters rather than UTF-8 bytes
  caught    the runner ignores the span and replaces the first match instead
  caught    a span that no longer holds its text is accepted
  caught    a pure deletion hunk is taken as one changed line
  caught    the hunk range runs one line short
  caught    the diff is taken two-dot, so later commits on the base come too
  caught    untracked files are never looked for
  caught    the mutable-path filter accepts everything
  caught    f-string interiors are mutated, with the enclosing string's position
  caught    annotations are mutated even though they are never evaluated
  caught    `if TYPE_CHECKING:` and the main guard are mutated
  caught    `# pragma: no mutate` is ignored
  caught    a while loop is forced true, which is a hang rather than an answer
  caught    lines outside the diff are mutated too
  caught    the cap takes a prefix rather than spreading across files
  caught    the label loses the enclosing function
  caught    the name match short-circuits the import index again
  caught    the import index is never consulted
  caught    a package's __init__ no longer resolves to the package
  caught    helper modules stop carrying their imports to the tests that use them
  caught    lines are counted the way str.splitlines counts them, not the tokenizer
  caught    the line index slips by one
  caught    confirmations are keyed by label again, so one row's answer spreads to another
  caught    return-value fires on booleans too, asking the same question twice
  caught    drop-assign deletes plain names too, which reports BROKE rather than an answer
  caught    arith no longer reaches an augmented assignment
  caught    a slice with no bounds is widened anyway, which changes nothing
```


## Two review passes, both applied

`/simplify` over the generator, then `/code-review` aimed at the memory guard —
the correctness surface the first one deliberately does not look at. Between
them they found five defects and one regression this branch had introduced.

**Silent defects in the generator**, all failing in the direction that reads as
success:

- **`# pragma: no mutate` was numbered with `str.splitlines`** — the one
  function still doing what `line_starts` exists to prevent. A single `\f`
  above a pragma moved the suppression down a line: the marked code was mutated
  and an innocent line skipped.
- **The pragma was matched on the edit's start line, not its span**, so
  `if (a\n        and b):  # pragma: no mutate` suppressed nothing while its
  author could see the pragma sitting there.
- **`--operator boundry` generated zero rows and exited 0** — a run that asked
  nothing, indistinguishable in a pull request from a change nothing could
  mutate.

**A regression this branch introduced.** Budgeting lanes by dividing the
allowance by the 4 GiB *ceiling* assumed every lane is simultaneously
pathological: measured, it cut an ordinary 16 GiB laptop from 16 lanes to **2**
and a CI runner to **1**, to bound a case the ceiling already truncates within
seconds. The budget now divides by what a lane is measured to *use* — 1 GiB,
three times the observed 317 MB resident peak. `_visible_memory` also reads the
cgroup rather than only `SC_PHYS_PAGES`, which is the mistake `usable_cpus`
documents for CPUs one resource over: in a 2 GiB container on a 62 GiB host the
first version granted lanes for 62 GiB.

Also fixed: a probe killed by a signal printed **no reason at all** (the
`CompletedProcess` was discarded), which is precisely the row a host OOM-kill
produces; a stray stderr line could outrank the traceback `verdict.main`
records deliberately; `--memory -1` silently removed the guard, because
`RLIM_INFINITY` is `-1` on Linux, through a flag whose only purpose is to
impose one.

**One finding was rejected, with evidence.** The review's top item claimed
mutants of `tools/verdict.py` are inert — `_probe()` reads the real tree, so
generated rows would all be false `SURVIVED` — and reported having verified it.
Running that same mutation under both narrow and whole-suite selection returns
`caught`: `tests/test_mutate.py` runs nested mutate runs *inside* the sandbox,
where the probe does read the mutated copy. Acting on it would have excluded a
file that is in fact graded.

**Writing the test found the bug twice.** The `tests/__init__.py` indexing fix
looked complete until its regression test failed: `uses_helper` filters on
`startswith("tests.")`, which excludes the bare package name, so
`from . import support` never linked back. That is the second time on this
branch that the test, not the reading, found the real defect.

One measured cleanup: `importers` walked 94,583 AST nodes to reach 317 imports.
Restricted to statement positions, **103.6 ms → 64.6 ms**, verified to produce a
byte-identical index.

Skipped and worth naming: rewriting `line_starts` as a regex (1.7% of wall —
below the bar, and it would invalidate the mutation evidence for the most
carefully tested function here), `_walk` pruning and `check`'s per-row re-read
(both below measurement against a run that executes hundreds of suites).

Mutation tables for the review's own fixes: **6/6** for the generator's, **5/5**
for the guard's.

## What this cannot do, and says so

Of the four weak fixtures `CONTRIBUTING.md` lists, three are now generated. The fourth — a `source` line searched in the whole rc file instead of the block — is a *scope widening*, and no local AST rewrite produces it. Hand-written rows remain the only route, which is why the spec-file mode stays, and why "every generated mutant was caught" is not the same claim as "the tests are good". Both the module docstring and `CLAUDE.md` say this.

Equivalent mutants survive and are reported as survivors; `--skip-operator` and the prose are the escape hatch.

## Cost

Measured on #216's `install.py`: narrow selection plus confirmation, 1 m 14 s; the wider unioned selection, 2 m 01 s. The union is slower *on this sample* — it front-loads work the confirmation pass would otherwise do — but it scales better as tables grow, and it makes `--no-confirm` far less dangerous. Both numbers are here rather than only the flattering one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


