### PR TITLE
test: guard the three claims the whole-package mutation run found unguarded

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import os
 import pathlib
 import pickle
+import tempfile
 import unittest
+from pathlib import Path
 
 from woswoar import cache, store
 from woswoar.entry import Entry, format_line
@@ -369,6 +371,55 @@ class TestEntriesLeaveTheCacheInert(WoswoarTestCase):
         warm = self.loaded(self.HOSTILE).cmd
         store.cache_file().unlink()
         self.assertEqual(cache.load_entries()[0].cmd, warm)
+
+
+class TestReadTailReturnsWholeLinesOnly(unittest.TestCase):
+    """The incremental reader every export and cache rebuild sits on.
+
+    8 of its 17 mutants survived the whole-package run, and the interesting one
+    is `cut < 0` becoming `cut <= 0`: with a tail whose *first* byte is a
+    newline, `rfind` can legitimately return 0, and the mutant then reports "no
+    complete line here" and leaves the offset where it was. That line is read
+    again next time or never, depending on what follows -- which is a history
+    file silently losing or repeating a command.
+
+    No fixture in the suite started a tail with a newline, so nothing could see
+    it. Driven against real files, since the whole function is file offsets.
+    """
+
+    def tail(self, body: bytes, offset: int = 0) -> tuple[bytes, int]:
+        with tempfile.TemporaryDirectory() as box:
+            path = Path(box) / "log"
+            path.write_bytes(body)
+            return store.read_tail(path, offset)
+
+    def test_a_tail_that_begins_with_a_newline(self) -> None:
+        """`rfind` returns 0 here, which is a real cut, not "not found"."""
+        data, offset = self.tail(b"\n")
+        self.assertEqual(data, b"\n")
+        self.assertEqual(offset, 1)
+
+    def test_a_partial_final_line_is_left_for_next_time(self) -> None:
+        data, offset = self.tail(b"one\ntwo\nthre")
+        self.assertEqual(data, b"one\ntwo\n")
+        self.assertEqual(offset, 8, "the partial line must not be consumed")
+
+    def test_no_newline_at_all_consumes_nothing(self) -> None:
+        data, offset = self.tail(b"incomplete")
+        self.assertEqual((data, offset), (b"", 0))
+
+    def test_it_resumes_from_the_offset_it_returned(self) -> None:
+        """The contract the caller relies on: reading twice yields each line
+        once. A fixture that only ever reads from 0 cannot check it."""
+        body = b"one\ntwo\n"
+        first, offset = self.tail(body)
+        second, final = self.tail(body, offset)
+        self.assertEqual(first, body)
+        self.assertEqual((second, final), (b"", len(body)))
+
+    def test_a_missing_file_is_not_an_error(self) -> None:
+        with tempfile.TemporaryDirectory() as box:
+            self.assertEqual(store.read_tail(Path(box) / "absent", 0), (b"", 0))
 
 
 if __name__ == "__main__":

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from woswoar import cache, install, store
 from woswoar.__main__ import main
@@ -191,6 +192,27 @@ class TestPrivateByDefault(WoswoarTestCase):
         store.write_atomic(borrowed / "note", b"hello")
         self.assertEqual(borrowed.stat().st_mode & 0o777, 0o755)
         self.assertEqual((borrowed / "note").stat().st_mode & 0o777, 0o600)
+
+    def test_a_failed_write_leaves_no_scratch_file(self) -> None:
+        """The branch whose comment says "Never leave the scratch file next to
+        the real one" -- and which nothing executed.
+
+        It matters because the scratch name is `.<name>-<random>.tmp` in the
+        *same* directory as the real file, so a leaked one sits inside `logs/`
+        or `history/` looking like data. `iter_log_files` and `chunk_names`
+        filter by suffix and would ignore it, but `doctor`'s private-mode walk
+        and any human reading the directory would not.
+
+        The write is made to fail rather than mocked away: a real `OSError` out
+        of `handle.write` is what a full disk gives.
+        """
+        target = store.data_dir() / "atomic" / "note"
+        boom = OSError("no space left on device")
+        with mock.patch("os.fdopen", side_effect=boom), self.assertRaises(OSError):
+            store.write_atomic(target, b"hello")
+        self.assertFalse(target.exists(), "the real file must not appear")
+        leftovers = [p.name for p in target.parent.iterdir()]
+        self.assertEqual(leftovers, [], f"scratch file left behind: {leftovers}")
 
     def test_doctor_reports_an_exposed_history(self) -> None:
         self.first_run()

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -55,5 +55,60 @@ class TestTheSigningSelfTest(unittest.TestCase):
             self.assertFalse(manifest.signs_and_verifies(mine, other_public))
 
 
+class TestTheSignedBytesAreDeterministic(unittest.TestCase):
+    """The claim `_body` makes about itself, which nothing was checking.
+
+    Its docstring says "Sorted, so the same set of chunks always produces
+    byte-identical output and a sync that adds nothing rewrites nothing." That
+    sort survived mutation to both `list(...)` and `reversed(...)` against the
+    whole suite, because until now no test built a manifest at all -- the two
+    tests above cover signing and never reach `_body`.
+
+    Why it matters more than tidiness: these bytes are what `crypto.sign`
+    covers. Lose the order and the same chunk set signs differently on each
+    run, so a sync with nothing to say rewrites and re-signs every manifest it
+    touches, and every peer sees churn it must re-verify.
+
+    This is the first entry on `CLAUDE.md`'s weak-fixture list -- "two day
+    directories cannot distinguish a sorted walk from a reversed one" -- which
+    is why the fixture below uses three names whose insertion order is neither
+    sorted nor its reverse. Two would pass against `reversed()` half the time.
+    """
+
+    def entries(self, names: list[str]) -> dict[str, manifest.ManifestEntry]:
+        return {name: manifest.ManifestEntry(digest=f"d-{name}") for name in names}
+
+    def test_insertion_order_does_not_change_the_bytes(self) -> None:
+        scrambled = self.entries(["b.age", "c.age", "a.age"])
+        ordered = self.entries(["a.age", "b.age", "c.age"])
+        self.assertNotEqual(list(scrambled), list(ordered), "precondition: the dicts differ")
+        self.assertEqual(
+            manifest._body("host", "2026-08-18", scrambled),
+            manifest._body("host", "2026-08-18", ordered),
+        )
+
+    def test_the_order_is_sorted_and_not_merely_stable(self) -> None:
+        """`list(...)` would satisfy the test above whenever both dicts agree.
+
+        So this one pins the actual sequence: a fixture inserted in reverse must
+        still come out ascending.
+        """
+        body = manifest._body("host", "2026-08-18", self.entries(["c.age", "b.age", "a.age"]))
+        names = [line.split(" ", 1)[0] for line in body.splitlines()[1:]]
+        self.assertEqual(names, ["a.age", "b.age", "c.age"])
+
+    def test_subsumes_is_ordered_too(self) -> None:
+        """`sync.compact` builds this tuple, and `_body` writes it into the
+        signed line. Unsorted there moves the churn one level in, where the
+        entry looks identical but its bytes are not."""
+        one = manifest.ManifestEntry(digest="d", subsumes=("b.age", "a.age"))
+        other = manifest.ManifestEntry(digest="d", subsumes=("a.age", "b.age"))
+        self.assertNotEqual(
+            manifest._body("host", "2026-08-18", {"merged.age": one}),
+            manifest._body("host", "2026-08-18", {"merged.age": other}),
+            "if this ever passes, _body sorts subsumes itself and compact need not",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -589,6 +589,28 @@ class TestThePickerAppearsBeforeTheHistoryIsBuilt(WoswoarTestCase):
         with redirect_stdout(io.StringIO()):
             self.assertIsNone(search.interactive("global"))
 
+    def test_the_cli_exit_code_says_whether_anything_was_chosen(self) -> None:
+        """`cmd_search` is five lines and every one of its 11 mutants survived.
+
+        It is the only place the picker's outcome becomes an exit status, and
+        that status is a shell contract: the hook and any script wrapping
+        `woswoar search` branch on it. Both directions are asserted here because
+        a test of one alone passes against `return 0` unconditionally.
+        """
+        # History first, for both halves: with none, `interactive` declines to
+        # open a picker at all and returns 1 without the branch under test ever
+        # being reached -- the cancel half would pass for the wrong reason.
+        self.some_history()
+        self.fake_fzf("import sys\nsys.exit(130)\n")
+        with redirect_stdout(io.StringIO()) as cancelled:
+            self.assertEqual(main(["search"]), 1, "cancelling must not read as success")
+        self.assertEqual(cancelled.getvalue(), "", "nothing was chosen, so nothing is printed")
+
+        self.fake_fzf("import sys\nprint(sys.stdin.readline().rstrip('\\n'))\n")
+        with redirect_stdout(io.StringIO()) as chosen:
+            self.assertEqual(main(["search"]), 0)
+        self.assertNotEqual(chosen.getvalue().strip(), "", "a choice must reach stdout")
+
     def test_a_machine_with_no_history_opens_no_picker(self) -> None:
         """Ctrl-R on a fresh install did nothing, and must keep doing nothing
         rather than opening an empty picker to escape out of.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -984,6 +984,34 @@ class TestGrantConfirmation(SyncTestCase):
         self.assertEqual(marked, [mine])
 
 
+class TestRevokeSaysWhatItDid(SyncTestCase):
+    """The CLI half of revoke, which nothing drove.
+
+    `sync.revoke` is well covered below; `cmd_revoke` was not reached by any
+    test at all, so the mutation deleting its confirmation line survived. That
+    line is the only signal a user gets that a *security* operation happened --
+    the command otherwise succeeds in silence, and "did that work?" is the
+    question someone answers by revoking a second time.
+    """
+
+    def test_it_reports_the_revocation_and_the_resealing(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            gone = alpha.append_recipient(name="old-laptop")
+            fingerprint = crypto.fingerprint(gone)
+
+        ran = self.run_cli(alpha, "revoke", fingerprint, "--yes")
+        self.assertEqual(ran.code, 0, ran.out + ran.err)
+        self.assertIn("revoked", ran.out)
+        self.assertIn("re-sealed", ran.out)
+        # Not merely "it printed something": the count is the part that says
+        # whether the day keys were actually rewritten for the remaining readers.
+        self.assertRegex(ran.out, r"re-sealed \d+ key file\(s\)")
+
+        with alpha.active():
+            self.assertNotIn(gone, sync.recipients())
+
+
 class TestRevokeSubtraction(SyncTestCase):
     """A withdrawal has to survive `merge=union`, which never deletes a line."""
 
@@ -1953,6 +1981,74 @@ class TestCompact(SyncTestCase):
         with beta.active():
             sync.run()
             self.assertEqual(beta.commands(), {"command 0", "command 1", "command 2"})
+
+
+class TestSigningStatus(SyncTestCase):
+    """The other half of what `doctor` says about this machine's keys.
+
+    `TestIdentityStatus` below has covered its neighbour since #201; this had
+    nothing. A whole-package mutation run put 13 survivors in this one function
+    -- every failure branch could `return None` and the suite stayed green --
+    which is the same shape `tests/test_manifest.py` was written for: a `doctor`
+    verdict a user reads, on a path where the machine keeps recording, looks
+    healthy, and publishes history no peer will ever accept.
+    """
+
+    def test_a_healthy_signing_key_is_reported(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            status = sync.signing_status(store.machine())
+            self.assertTrue(status.ok, status.detail)
+            self.assertIn(str(store.signing_key_file()), status.detail)
+
+    def test_a_missing_signing_key_is_reported(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            store.signing_key_file().unlink()
+            status = sync.signing_status(store.machine())
+            self.assertIs(status.ok, False)
+            self.assertIn("missing", status.detail)
+            self.assertIn("woswoar init", status.detail)
+
+    def test_a_key_that_signs_but_does_not_verify_is_reported(self) -> None:
+        """The failure the round trip exists for.
+
+        Not "the file is absent" and not "signing raised" -- a key that produces
+        a signature this machine then refuses. Forced by making the round trip
+        answer False, because manufacturing a real one means corrupting
+        ssh-keygen's own output in a way it would reject earlier.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            with mock.patch.object(manifest, "signs_and_verifies", return_value=False):
+                status = sync.signing_status(store.machine())
+            self.assertIs(status.ok, False)
+            self.assertIn("does not verify", status.detail)
+
+    def test_a_key_that_cannot_sign_at_all_is_reported(self) -> None:
+        """`WoswoarError` out of the round trip, not an escape."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            boom = errors.WoswoarError("ssh-keygen said no")
+            with mock.patch.object(crypto, "signing_public", side_effect=boom):
+                status = sync.signing_status(store.machine())
+            self.assertIs(status.ok, False)
+            self.assertIn("cannot sign", status.detail)
+            self.assertIn("ssh-keygen said no", status.detail)
+
+    def test_no_ssh_keygen_at_all_is_reported(self) -> None:
+        """The branch a machine without ssh-keygen takes.
+
+        Patched rather than skipped: every machine that runs this suite has
+        ssh-keygen (`requires_ssh_keygen`), so the branch is unreachable here by
+        construction and would otherwise never be executed anywhere.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            with mock.patch.object(crypto, "signing_available", return_value=False):
+                status = sync.signing_status(store.machine())
+            self.assertIs(status.ok, False)
+            self.assertIn("ssh-keygen is not installed", status.detail)
 
 
 class TestIdentityStatus(SyncTestCase):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1983,6 +1983,59 @@ class TestCompact(SyncTestCase):
             self.assertEqual(beta.commands(), {"command 0", "command 1", "command 2"})
 
 
+class TestTrustStatus(SyncTestCase):
+    """`doctor`'s third key verdict, and the one nothing reached.
+
+    Found the same way as `TestSigningStatus` next to it -- and found *late*,
+    because the first triage pass fixed `signing_status` and walked past its
+    neighbour in the same file with the same caller. 10 of its 11 mutants
+    survived: `!=` becoming `==` puts this machine in its own "other machines"
+    list, and `not in` becoming `in` swaps accepted for waiting. Either way
+    `doctor` reports a trust state that is not the one the repository is in,
+    which is the whole of what this line is for.
+    """
+
+    def test_no_repository_yet_is_not_a_failure(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            with mock.patch.object(gitrepo, "is_repo", return_value=False):
+                status = sync.trust_status(store.machine())
+            self.assertTrue(status.ok, status.detail)
+            self.assertIn("no history repo", status.detail)
+
+    def test_a_lone_machine_does_not_count_itself_as_an_other(self) -> None:
+        """`host != known.id` -- flip it and the only machine present becomes an
+        unaccepted stranger, so a healthy single-machine install reports FAIL."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+            status = sync.trust_status(store.machine())
+            self.assertTrue(status.ok, status.detail)
+            self.assertIn("0 of 0", status.detail)
+
+    def test_an_unaccepted_peer_is_reported_as_waiting(self) -> None:
+        alpha, _beta = self.history_across_days(days=1, per_day=1)
+        with alpha.active():
+            sync.run()
+            status = sync.trust_status(store.machine())
+            self.assertIs(status.ok, False)
+            self.assertIn("0 of 1", status.detail)
+            self.assertIn("woswoar trust", status.detail)
+
+    def test_an_accepted_peer_stops_being_waiting(self) -> None:
+        """The counting half. `0 of 1` and `1 of 1` are the two answers, and a
+        fixture with no peer at all cannot tell them apart."""
+        alpha, _beta = self.history_across_days(days=1, per_day=1)
+        with alpha.active():
+            sync.run()
+        self.run_cli(alpha, "trust", "--yes")
+        with alpha.active():
+            status = sync.trust_status(store.machine())
+            self.assertTrue(status.ok, status.detail)
+            self.assertIn("1 of 1", status.detail)
+            self.assertNotIn("woswoar trust", status.detail)
+
+
 class TestSigningStatus(SyncTestCase):
     """The other half of what `doctor` says about this machine's keys.
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1983,6 +1983,80 @@ class TestCompact(SyncTestCase):
             self.assertEqual(beta.commands(), {"command 0", "command 1", "command 2"})
 
 
+class TestPushRetriesWhenAPeerGotThereFirst(SyncTestCase):
+    """`gitrepo.push`'s `except SyncError:` branch, which nothing executed.
+
+    Found by crossing coverage with the mutation run: dropping either the
+    `fetch_and_rebase` or the second `git push` survived the whole suite,
+    because no test ever made the first push fail. Every other test fetches and
+    rebases before pushing, so the remote has never moved underneath one.
+
+    That is the normal multi-machine case, not an exotic error -- two machines
+    syncing on a timer race exactly here, in the window between this machine's
+    fetch and its push, and without the retry the loser reports a failed sync
+    and publishes nothing until the next run.
+
+    The *race* is injected, not the failure: a real peer really pushes into that
+    window, so `git` really rejects a non-fast-forward and the recovery path
+    runs for real. Patching `git` to raise would assert that the code handles an
+    exception it was written next to, which is the restatement rule 3 warns of.
+    """
+
+    def peer_publishes(self) -> str:
+        """A second clone commits and pushes, as another machine would."""
+
+        def run(*argv: str) -> None:
+            subprocess.run(list(argv), check=True, timeout=60, capture_output=True)
+
+        work = self.root / "peer-clone"
+        if not work.exists():
+            run("git", "clone", "--quiet", str(self.origin), str(work))
+            run("git", "-C", str(work), "config", "user.name", "peer")
+            run("git", "-C", str(work), "config", "user.email", "peer@example.com")
+        marker = f"peer-{secrets.token_hex(4)}.txt"
+        (work / marker).write_text("published by someone else\n", encoding="utf-8")
+        run("git", "-C", str(work), "add", marker)
+        run("git", "-C", str(work), "commit", "--quiet", "-m", f"peer adds {marker}")
+        run("git", "-C", str(work), "push", "--quiet", "origin", "HEAD")
+        return marker
+
+    def test_a_push_that_loses_the_race_still_publishes(self) -> None:
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()  # establishes the branch on the origin
+
+            alpha.record("2023-11-14", 1_700_000_002, "git commit")
+            real = gitrepo.git
+            pushes: list[int] = []
+            marker: list[str] = []
+
+            def racing(*argv: str, **kwargs: object) -> str:
+                if argv[:1] == ("push",):
+                    pushes.append(1)
+                    if len(pushes) == 1:
+                        # The window: a peer publishes between our fetch and our
+                        # push, so this very call is rejected non-fast-forward.
+                        marker.append(self.peer_publishes())
+                return real(*argv, **kwargs)  # type: ignore[arg-type]
+
+            with mock.patch.object(gitrepo, "git", racing):
+                report = sync.run()
+
+        self.assertTrue(report.pushed, "the retry did not publish")
+        self.assertEqual(len(pushes), 2, "the first push must fail and the second succeed")
+
+        published = subprocess.run(
+            ["git", "-C", str(self.origin), "ls-tree", "-r", "--name-only", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=60,
+        ).stdout
+        self.assertIn(marker[0], published, "the peer's commit was discarded by our retry")
+        self.assertIn("hosts/", published, "our own history never reached the remote")
+
+
 class TestTrustStatus(SyncTestCase):
     """`doctor`'s third key verdict, and the one nothing reached.
 

--- a/woswoar/crypto.py
+++ b/woswoar/crypto.py
@@ -343,7 +343,7 @@ def generate_signing_key(path: Path) -> str:
     # whatever the umask, so removing this line changes nothing observable and
     # no test can catch it. Kept anyway, because the mode of a file woswoar
     # creates should not depend on another tool's habits.
-    path.chmod(0o600)
+    path.chmod(0o600)  # pragma: no mutate - see above: ssh-keygen already writes 0600
     public_half(path).chmod(0o600)
     return signing_public(path)
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -2177,7 +2177,11 @@ def choose_identity(new_identity: bool = False, explicit: Path | None = None) ->
 
     identity = crypto.generate_identity()
     store.write_atomic(dedicated, identity.secret.encode("utf-8"))
-    dedicated.chmod(0o600)
+    # Belt and braces, and unobservable: `write_atomic` creates through
+    # `tempfile.mkstemp`, which is 0600 before the `os.replace`, so removing this
+    # changes no mode any test could read. Kept because the mode of a file woswoar
+    # creates should not depend on another module's implementation of "atomic".
+    dedicated.chmod(0o600)  # pragma: no mutate
     return dedicated
 
 
@@ -3114,7 +3118,13 @@ def compact(before: str | None = None) -> tuple[int, int, int]:
             # any of those must not merge this as if it were new history, and it
             # cannot work that out from the bytes -- the lines are the same ones.
             listed[merged.name] = manifest.ManifestEntry(
-                manifest.digest_of(sealed), tuple(sorted(chunk.name for chunk in chunks))
+                # `sorted` is defensive and no test can see it: `chunks` arrives
+                # from `archive.iter_chunks`, which lists via `chunk_names` --
+                # already sorted. It stays because these bytes are *signed*, and
+                # manifest determinism must not depend on the iteration order of
+                # another module.
+                manifest.digest_of(sealed),
+                tuple(sorted(chunk.name for chunk in chunks)),  # pragma: no mutate
             )
             manifest.write(known, day, listed)
             days += 1


### PR DESCRIPTION
Triage and plan are in #225; this is steps 1–6 of it.

The generator ran over all of `woswoar/` for the first time — 3124 mutants,
748 survivors (23%). Almost all of those are equivalent mutants or output
nobody should assert on. **Three** were claims the code makes about itself with
nothing holding them, and this PR guards those and closes the file on the
rest.

## 1. Manifest determinism — the signed bytes

`manifest._body`'s docstring: *"Sorted, so the same set of chunks always
produces byte-identical output and a sync that adds nothing rewrites nothing."*
`tests/test_manifest.py` held two tests, both about key signing, and neither
built a manifest — so both `sorted` → `list` and `sorted` → `reversed` survived
the whole suite.

These bytes are what `crypto.sign` covers. Lose the order and a sync with
nothing to say re-signs and rewrites every manifest it touches, and every peer
re-verifies churn.

The fixture uses **three** names in an order that is neither sorted nor its
reverse. Two would pass against `reversed()` half the time — this is the first
entry on `CLAUDE.md`'s weak-fixture list ("two day directories cannot
distinguish a sorted walk from a reversed one"), so it seemed worth not
repeating it in the fix for it.

## 2. `sync.signing_status` had no test at all

13 survivors in one function; every failure branch could `return None` and the
suite stayed green:

```
if not crypto.signing_available():        -> "ssh-keygen is not installed"
if not path.is_file():                    -> "is missing - created by 'woswoar init'"
if not manifest.signs_and_verifies(...):  -> "signs, but the signature does not verify"
except (WoswoarError, OSError) as exc:    -> "cannot sign: {exc}"
```

Its only caller is `doctor.py:168`, and no test in `tests/test_doctor.py`
mentions signing. So `doctor` could stop reporting a broken signing setup and
nothing would notice — on a path where the machine keeps recording, looks
healthy, and publishes history no peer will ever accept.

`identity_status` right beside it has been covered since #201. That asymmetry
is what made the gap visible at all.

The no-ssh-keygen branch is patched rather than skipped: every machine running
this suite has ssh-keygen (`requires_ssh_keygen`), so that branch is
unreachable here by construction and would otherwise never execute anywhere.

## 3. `write_atomic`'s cleanup branch

`os.unlink(tmp)` never ran in any test, though its comment says "Never leave
the scratch file next to the real one". The scratch name is
`.<name>-<random>.tmp` in the *same* directory as the real file, so a leaked
one sits inside `logs/` or `history/` looking like data. Driven with a real
`OSError` out of `handle.write`, which is what a full disk gives.

## 4. `cmd_revoke` said nothing

No test drove it. The confirmation line is the only signal that a **security**
operation happened; without it the command succeeds in silence and "did that
work?" gets answered by revoking a second time.

## Three survivors that are equivalent, and now say so

Rather than leave these on the list for the next person to re-investigate:

| survivor | why no test can catch it |
|---|---|
| `crypto.py` `path.chmod(0o600)` | ssh-keygen writes a private key 0600 whatever the umask — the comment there already argued this, years before the tool existed |
| `sync.py` `dedicated.chmod(0o600)` | `write_atomic` creates through `tempfile.mkstemp`, which is 0600 before the `os.replace`. Verified: `mkstemp` + `replace` leaves `-rw-------` |
| `sync.py` `tuple(sorted(chunk.name ...))` | `chunks` arrives from `archive.iter_chunks`, which lists via `chunk_names` — already sorted |

Each gets `# pragma: no mutate` **with the argument in the comment**, not a
bare suppression.

**Correction to #225:** that issue claimed the third one was a real gap "one
level up" from the manifest. It is not — I traced `by_day` back to
`archive.iter_chunks` and the input is already sorted. The issue has been
corrected; the `sorted` stays because manifest determinism should not depend on
another module's iteration order, but it is defensive, not load-bearing.

## What is deliberately not here

`__main__.py`'s 274 survivors (46%, the highest rate in the package) are the
rendering layer — 98 of them are a dropped `print` or `show`. The domain
functions beneath them are tested: `sync.revoke`, `sync.compact`, `stats`. That
is `docs/architecture.md`'s "the domain decides, the CLI renders" working as
designed. `progress.py` (18) is the meter, which `CLAUDE.md` says is never the
thing being compared, and `prove.py` (18) is its own test scaffolding.

No attempt is made on the 23%. There is no target rate, and writing tests to
kill the remaining survivors would be decoration — the failure `tools/mutate.py`
exists to detect, not to cause.

## Mutations, nine of nine caught

```
  caught    the manifest body is not sorted, so the signed bytes depend on dict order
  caught    the manifest body is sorted backwards
  caught    a missing ssh-keygen is not reported
  caught    a missing signing key is reported as healthy
  caught    a key that signs but does not verify is reported as healthy
  caught    the round trip is never run, so a broken key reads as healthy
  caught    a key that cannot sign at all raises instead of reporting
  caught    a failed write leaves its scratch file next to the real one
  caught    revoke succeeds in silence
```

Refs #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second round: the triage method was wrong, and this is what it missed

The first pass filtered survivors by grepping the mutated **line** for
disk/crypto/ordering words. That is the wrong signal — it finds lines that
*mention* `mkdir` or `sorted`, and misses a function where everything survives
because its lines happen to be unremarkable. Nine rows of action out of 748
survivors should have been a warning about the filter rather than a conclusion.

Ranking instead by **what fraction of each function's mutants survived**:

| ratio | surv/tot | function |
|---|---|---|
| 100% | 12/12 | `__main__.cmd_compact` |
| 100% | 11/11 | `__main__.cmd_search` |
| 93% | 13/14 | `sync.signing_status` *(first round)* |
| 91% | 10/11 | **`sync.trust_status`** |
| 85% | 23/27 | `__main__.cmd_stats` |
| 77% | 30/39 | `__main__.cmd_trust` |
| 75% | 6/8 | `store.append_entries` |
| 47% | 8/17 | **`store.read_tail`** |

**`sync.trust_status` is the plain miss.** `doctor` runs three key checks —
`repo_format_status`, `signing_status`, `trust_status` — and the first round
fixed the middle one and walked past its neighbour, same file, same caller.
`!=` → `==` puts this machine in its own list of *other* machines; `not in` →
`in` swaps accepted for waiting. Either way `doctor` reports a trust state the
repository is not in. Now covered, including the counting half — `0 of 1` and
`1 of 1` are the two answers, and a fixture with no peer cannot tell them apart.

**`store.read_tail`** is the incremental reader under every export and cache
rebuild. `cut < 0` → `cut <= 0` bites when a tail *begins* with a newline,
where `rfind` legitimately returns 0: the mutant calls that "no complete line"
and leaves the offset where it was, so a recorded command is read twice or
never. No fixture in the suite began a tail with a newline.

**`cmd_search`** is the only place the picker's outcome becomes an exit status,
which the shell hook branches on. Its fixture calls `some_history()` first —
with no history `interactive` declines to open a picker at all and returns 1
without the branch under test being reached, so the cancel half would have
passed for the wrong reason.

### One alarm that was false, on inspection

`store.append_entries` (75%) looked like the worst finding in the package: its
largest survivor drops `private_dir(host_dir(...))`, i.e. the plaintext history
directory might not be created owner-only. It is not a regression —
`private_append` calls `private_dir` on the parent itself, and the hoisted call
is purely the optimisation its own comment describes ("Once, not once per day
… measured 17% of a two-year import"). Behaviourally equivalent, and left
alone.

`cmd_compact`, `cmd_stats` and `cmd_trust` remain uncovered. They are argparse
wrappers over domain functions that *are* tested, so the surviving mutants are
mostly dropped `print`s — the same write-off as the rest of `__main__`, and now
made with the ratio in view rather than instead of it.

### Mutations, ten of ten caught

```
  caught    this machine counts as one of the other machines
  caught    accepted and waiting are swapped
  caught    the accepted count is the waiting count
  caught    a repository that is waiting on nobody still says run 'woswoar trust'
  caught    trust is reported ok whatever is waiting
  caught    a tail starting with a newline reads as no complete line
  caught    the newline is dropped from the returned tail
  caught    the offset does not advance past the newline, so a line repeats
  caught    cancelling the picker exits zero
  caught    a chosen line never reaches stdout
```
