### PR TITLE
tools: coverage-crossed survivor analysis, and the rest of #224

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,12 +218,14 @@ first such change, not during one.
   | when | tool |
   |---|---|
   | a fix needs a test that fails without it (rule 3) | [`tools/mutate.py`](tools/mutate.py) |
+  | a mutation run left more survivors than you can read | [`tools/reached.py`](tools/reached.py) |
   | a refactor is supposed to change no output | [`tools/compare.py`](tools/compare.py) |
   | a change might have cost time | [`tools/bench.py`](tools/bench.py) |
 
   ```sh
   python -m tools.mutate --base main        # generated from the diff
   python -m tools.mutate <spec>.py          # a table you wrote
+  python -m tools.reached r.json c.json     # which survivors are missing tests
   python -m tools.compare --base main --show .bashrc install doctor status
   python -m tools.bench --importtime woswoar.__main__ --base main
   ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,7 @@ first such change, not during one.
   `python -m unittest discover -s . -t . -p 'test_*.py'` runs the same tests
   serially, and takes about three times as long.
 
-- Three tools in `tools/` exist because the same mistake was made more than
+- Four tools in `tools/` exist because the same mistake was made more than
   once. Each one's module docstring carries the full argument for why it is
   shaped as it is; reach for them rather than writing the loop again.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,28 @@ OOM-killed the session twice before 300 s was anywhere in sight. Lanes are
 capped by memory as well as by cores, because the per-row limit bounds one lane
 and not their product.
 
+A survivor list is not a finding, and reading one unaided is how two confident
+wrong triages happened here. Cross it with coverage:
+
+```sh
+python -m tools.mutate --base main --json results.json
+coverage run --source=woswoar -m unittest discover -s . -t . -p 'test_*.py'
+coverage json -o coverage.json
+python -m tools.reached results.json coverage.json --list
+```
+
+That splits survivors in two, and the halves mean opposite things. A survivor on
+a line **no test executes** is a missing test. A survivor on a line the suite
+**does** execute is a weak fixture or an equivalent mutant — rule 3's "suspect
+the fixture", and much the larger half: 590 of 751 on the run this was built
+for. Conflating them is what makes a survivor list read as hundreds of bugs.
+
+Both inputs must come from the same tree; a fix that shifts line numbers
+silently unmatches them. `coverage` is not a dependency and is not imported —
+`tools/reached.py` only reads the JSON. It also folds *caught* mutants back into
+the map, because a caught mutation proves its line ran and in-process coverage
+cannot see the lines this suite reaches by running a real `bash`.
+
 Running out of memory is reported `BROKE`, never `caught`. It arrives as a
 `MemoryError` inside whichever test was running, which by protocol looks exactly
 like that test noticing — and crediting a test with a guard it does not have is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,19 @@ Most of the time you should not write the table at all:
 ```sh
 python -m tools.mutate --base main          # generate from the diff and run
 python -m tools.mutate --base main --list   # print the table, run nothing
+python -m tools.mutate --all --json out.json  # every line of every mutable file
 ```
+
+`--all` is the whole package rather than a diff — several thousand mutants and
+hours — so it batches by file and writes `--json` as each one lands: a crash
+costs one file, and re-running with the same `--json` skips what is already
+recorded. There is no `--resume` flag; the report *is* the resume state.
+`--batch` asks for the same behaviour on a large `--base` diff. `--all` also
+drops the default `--limit`, which is sized for a diff and would otherwise run
+a twentieth of the table.
+
+Confirmation is pooled to the end rather than run per batch, because per batch
+a file with one survivor pays a whole suite run with fifteen lanes idle.
 
 It reads `git diff --merge-base main` — working tree included, so uncommitted
 work counts — and generates mutants for the changed lines of `woswoar/**.py` and
@@ -64,10 +76,13 @@ the file, and **every survivor is then re-run against the whole suite** before i
 is reported, so a narrow selection can cost time but cannot produce a false
 `SURVIVED`. On the change that became #216 that pass corrected nine of eleven.
 
-Fourteen operators. Ten rewrite an expression (`<` to `<=`, `and` to `or`,
-`sorted(x)` to `sorted(x, reverse=True)`, `.endswith(...)` to `True`, an `if`
-forced both ways, `+` to `-`, a slice's bounds dropped, a small integer moved by
-one, `return X` to `return None`); two delete a statement.
+Fifteen operators, and `--skip-operator NAME` drops one — the escape hatch for
+an equivalent mutant a whole operator keeps producing, where `# pragma: no
+mutate` only suppresses a line. Twelve rewrite an expression (`<` to `<=`, `and`
+to `or`, `sorted(x)` to `sorted(x, reverse=True)`, `.endswith(...)` to `True`, an
+`if` forced both ways, `+` to `-`, a slice's bounds dropped, a small integer
+moved by one, `return X` to `return None`); two delete a statement, and one
+drops a keyword argument.
 
 Deletion is deliberately narrow. `drop-call` removes a call whose value is
 discarded — `path.mkdir()`, `store.flush()` — which is the "the write never
@@ -77,6 +92,15 @@ alone on purpose: deleting it leaves a `NameError` further down, which reports
 `BROKE` rather than an answer and costs a whole suite run to find that out.
 `logging` and `progress` calls are never deleted; `print` is, because here the
 printed output is the product.
+
+`drop-kwarg` removes a keyword argument, and only from a named list —
+`mode`, `check=True`, `encoding`, `exist_ok`, `follow_symlinks`. Blanket
+dropping was measured first and is mostly noise: of 281 keyword arguments in
+`woswoar/`, the commonest are *required* parameters passed by name, where
+dropping one is a `TypeError` and so `BROKE` rather than an answer. The list
+holds the ones whose absence silently weakens a guarantee instead — it is the
+only way to generate `mkdir(..., mode=0o700)` without its mode, which is what
+`docs/security.md` rests on.
 
 A generated mutant can also fail to *stop*. Two bounds are enforced per row, and
 they answer different questions: `--timeout` (300 s) for a mutation that never

--- a/tests/test_mutants.py
+++ b/tests/test_mutants.py
@@ -157,6 +157,7 @@ _FIRES: dict[str, tuple[str, list[str]]] = {
     ),
     "drop-call": ("path.mkdir()\n", ["the call to `path.mkdir(...)` never happens"]),
     "drop-assign": ("self.total = 1\n", ["`self.total` is never assigned"]),
+    "drop-kwarg": ("path.mkdir(mode=0o700)\n", ["`mode=448` is dropped"]),
     "off-by-one": ("x = items[1]\n", ["`1` becomes `2`", "`1` becomes `0`"]),
     "return-value": (
         "def f():\n    return compute(x)\n",
@@ -189,6 +190,9 @@ _QUIET: dict[str, str] = {
     # A plain name: deleting it leaves a NameError further down, which reports
     # BROKE -- not an answer, and a whole suite run to learn that.
     "drop-assign": "plain = 3\n",
+    # `ok=` is a required field, not an optional guarantee: dropping it is a
+    # `TypeError`, which is BROKE rather than an answer.
+    "drop-kwarg": 'Check(label="x", ok=True)\n',
     # Big enough that +-1 is arbitrary rather than a boundary.
     "off-by-one": "x = items[97]\n",
     # `return None` is already what the mutation would produce -- and `return
@@ -350,6 +354,107 @@ class TestLineEndingsThatAreNotNewline(unittest.TestCase):
         start, end = row.span or (0, 0)
         self.assertEqual(source[start:end], "a < b")
         self.assertEqual(row.old, "a < b")
+
+
+class TestDroppingAKeywordArgument(unittest.TestCase):
+    """The operator written for `mkdir(..., mode=0o700)`.
+
+    Deliberately narrow. A blanket "drop any keyword" was measured first: of 281
+    keyword arguments in `woswoar/`, the commonest are *required* parameters
+    passed by name, and dropping one raises `TypeError` -- `BROKE` rather than
+    an answer, at the price of a whole suite run. `_DROPPABLE` inverts the rule
+    so that a keyword nobody argued for is never dropped.
+    """
+
+    def dropped(self, body: str) -> list[str]:
+        rows = mutants.generate(body, "w/t.py", {1}, tests="t", operators=["drop-kwarg"])
+        return [row.label.split(" -- ")[-1] for row in rows]
+
+    def test_a_mode_is_droppable(self) -> None:
+        """The case it exists for: the directory is still made, still returns,
+        and every test that only asks whether the path exists still passes."""
+        self.assertEqual(
+            self.dropped("path.mkdir(parents=True, mode=0o700)\n"), ["`mode=448` is dropped"]
+        )
+
+    def test_check_true_is_droppable(self) -> None:
+        self.assertEqual(
+            self.dropped("subprocess.run(argv, check=True)\n"), ["`check=True` is dropped"]
+        )
+
+    def test_check_false_is_not(self) -> None:
+        """It is `subprocess.run`'s own default, so removing it changes nothing
+        and the row could only ever be an unkillable survivor."""
+        self.assertEqual(self.dropped("subprocess.run(argv, check=False)\n"), [])
+
+    def test_a_keyword_nobody_argued_for_is_left_alone(self) -> None:
+        """`ok=` is a required `Check` field: dropping it is a `TypeError`."""
+        self.assertEqual(self.dropped('Check(label="x", ok=True)\n'), [])
+
+    def test_a_star_star_spread_is_not_a_keyword_to_drop(self) -> None:
+        self.assertEqual(self.dropped("f(**options)\n"), [])
+
+    def test_the_replacement_actually_omits_it(self) -> None:
+        """The prose could be right while the edit is not."""
+        rows = mutants.generate(
+            'p.read_text(encoding="utf-8")\n', "w/t.py", {1}, tests="t", operators=["drop-kwarg"]
+        )
+        self.assertNotIn("encoding", rows[0].new)
+
+    def test_each_droppable_keyword_is_reachable(self) -> None:
+        """Otherwise a name can sit in `_DROPPABLE` spelled wrongly for ever."""
+        for name in sorted(mutants._DROPPABLE):
+            with self.subTest(keyword=name):
+                value = "True" if name in ("check", "exist_ok", "follow_symlinks") else "0"
+                self.assertEqual(len(self.dropped(f"f(a, {name}={value})\n")), 1)
+
+
+class TestSkippingAnOperator(unittest.TestCase):
+    """`--skip-operator`, the escape hatch a pragma cannot serve.
+
+    A pragma suppresses a *line*; this suppresses a *kind*, which is what an
+    equivalent mutant produced by one operator over and over needs.
+    """
+
+    def test_it_subtracts_from_the_default_set(self) -> None:
+        every = mutants.generate("x = a < b\n", "w/t.py", {1}, tests="t")
+        fewer = mutants.generate("x = a < b\n", "w/t.py", {1}, tests="t", skip=["boundary"])
+        self.assertTrue(any(row.operator == "boundary" for row in every))
+        self.assertFalse(any(row.operator == "boundary" for row in fewer))
+        self.assertLess(len(fewer), len(every))
+
+    def test_an_unknown_name_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as refused:
+            mutants.generate("x = a < b\n", "w/t.py", {1}, skip=["boundry"])
+        self.assertIn("no such operator: boundry", str(refused.exception))
+
+    def test_skipping_everything_is_refused_rather_than_silent(self) -> None:
+        """An empty selection generates nothing and would exit 0 -- a run that
+        asked nothing reading as a run that found nothing."""
+        with self.assertRaises(SystemExit) as refused:
+            mutants.generate(
+                "x = a < b\n", "w/t.py", {1}, operators=["boundary"], skip=["boundary"]
+            )
+        self.assertIn("every operator was skipped", str(refused.exception))
+
+
+class TestEveryLine(unittest.TestCase):
+    """What `--all` means, enumerated rather than diffed against the first commit."""
+
+    def test_it_finds_the_mutable_files_and_all_their_lines(self) -> None:
+        found = mutants.every_line(REPO_ROOT)
+        self.assertIn("tools/mutants.py", found)
+        self.assertIn("woswoar/sync.py", found)
+        body = (REPO_ROOT / "woswoar/sync.py").read_text(encoding="utf-8").splitlines()
+        self.assertEqual(max(found["woswoar/sync.py"]), len(body))
+        self.assertEqual(min(found["woswoar/sync.py"]), 1)
+
+    def test_it_holds_nothing_that_is_not_mutable(self) -> None:
+        for path in mutants.every_line(REPO_ROOT):
+            self.assertTrue(mutants.mutable(path), path)
+
+    def test_tests_are_not_swept(self) -> None:
+        self.assertFalse(any(p.startswith("tests/") for p in mutants.every_line(REPO_ROOT)))
 
 
 class TestChoosingOperators(unittest.TestCase):

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -8,6 +8,9 @@ which is what happened before there was a harness to share.
 
 from __future__ import annotations
 
+import contextlib
+import io
+import json
 import os
 import subprocess
 import sys
@@ -16,9 +19,10 @@ import textwrap
 import time
 import unittest
 from pathlib import Path
+from typing import Any
 from unittest import mock
 
-from tools import mutate
+from tools import mutate, reached
 from tools.mutate import MEMORY, Mutation, Report, Result, Verdict, confirm, run, verify
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -760,6 +764,66 @@ class TestAnUnanswerableRowNeedNotEndTheRun(MutateTestCase):
                 [Mutation("bad", "mod.py", "import json", "import nope_xyz", "test_mod")],
                 baseline=False,
             )
+
+
+class TestTheJsonReport(unittest.TestCase):
+    """The contract `tools/reached.py` reads, tested from this side of it.
+
+    Both tools would otherwise agree only by coincidence: `reached` parses a
+    shape nothing here promises, and a renamed key would break the analysis
+    with a `KeyError` in a different file at the end of a run measured in
+    hours.
+    """
+
+    def report(self) -> Report:
+        rows = [
+            Mutation(
+                "mod.py:7 in f() -- `<` becomes `<=`",
+                "mod.py",
+                "a",
+                "b",
+                "test_mod",
+                operator="boundary",
+            ),
+            Mutation("written by hand", "mod.py", "c", "d", "test_mod"),
+        ]
+        return Report(
+            [
+                Result(rows[0], Verdict("survived")),
+                Result(rows[1], Verdict("broke", "it fell over")),
+            ]
+        )
+
+    def written(self) -> dict[str, Any]:
+        with tempfile.TemporaryDirectory() as box:
+            where = Path(box) / "out.json"
+            with contextlib.redirect_stdout(io.StringIO()):
+                mutate._persist(self.report(), where)
+            loaded: dict[str, Any] = json.loads(where.read_text(encoding="utf-8"))
+        return loaded
+
+    def test_every_key_reached_needs_is_present(self) -> None:
+        first = self.written()["results"][0]
+        self.assertEqual(first["path"], "mod.py")
+        self.assertEqual(first["line"], 7, "the line is parsed out of the label")
+        self.assertEqual(first["outcome"], "survived")
+        self.assertEqual(first["operator"], "boundary")
+
+    def test_a_hand_written_row_has_no_line_rather_than_a_wrong_one(self) -> None:
+        """`reached` skips these. Inventing a line would file a spec row under
+        whichever source line happened to be first."""
+        self.assertIsNone(self.written()["results"][1]["line"])
+
+    def test_outcomes_that_asked_nothing_are_kept(self) -> None:
+        """`broke` is not a survivor and not a catch, and `reached` needs to see
+        it to leave it out of the partition rather than guess."""
+        self.assertEqual(self.written()["results"][1]["outcome"], "broke")
+
+    def test_it_round_trips_through_reached(self) -> None:
+        """The actual contract: what one writes, the other reads."""
+        rows = reached.rows_from(self.written())
+        self.assertEqual([r.line for r in rows], [7], "only positioned rows survive the read")
+        self.assertTrue(rows[0].survived)
 
 
 class TestHowManyLanesFitInMemory(unittest.TestCase):

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -8,10 +8,12 @@ which is what happened before there was a harness to share.
 
 from __future__ import annotations
 
+import argparse
 import contextlib
 import io
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -824,6 +826,148 @@ class TestTheJsonReport(unittest.TestCase):
         rows = reached.rows_from(self.written())
         self.assertEqual([r.line for r in rows], [7], "only positioned rows survive the read")
         self.assertTrue(rows[0].survived)
+
+
+class TestAllDropsTheDiffSizedCap(unittest.TestCase):
+    """`--limit`'s default is sized for one change's table.
+
+    Left in place it turned the documented `--all` into 200 rows of several
+    thousand -- and, because the cap spreads across files, into batches of about
+    seven, so batching, incremental `--json` and resume all did nothing on the
+    one command line anybody would type. Driven through `main` rather than the
+    parser, because the reset happens after parsing and `--list` runs nothing.
+    """
+
+    def listed(self, *argv: str) -> str:
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            mutate.main([*argv, "--list"])
+        return out.getvalue()
+
+    def test_all_runs_the_whole_table(self) -> None:
+        self.assertNotIn("not run", self.listed("--all"))
+
+    def test_an_explicit_limit_is_still_honoured(self) -> None:
+        """Reset, not ignored: someone who says `--limit 50` means it."""
+        self.assertIn("--limit 50:", self.listed("--all", "--limit", "50"))
+
+    def test_a_diff_run_keeps_the_default(self) -> None:
+        """The default exists for this shape and must not be collateral."""
+        self.assertEqual(mutate.LIMIT, 200)
+
+
+class TestResumingASweep(unittest.TestCase):
+    """What a resumed sweep must keep, not just what it may skip.
+
+    `sweep` had no test at all, and that is exactly why it shipped losing data:
+    a resume rewrote `--json` with only the batches it had run, deleting the
+    answers it had decided to skip. Recovery eating the thing it recovers is
+    invisible unless something drives the round trip.
+    """
+
+    def rows(self, *labels: str) -> list[Result]:
+        return [
+            Result(
+                Mutation(label, label.split(":")[0], "a", "b", "test_mod", operator="boundary"),
+                Verdict("survived"),
+            )
+            for label in labels
+        ]
+
+    def persisted(self, results: list[Result]) -> Path:
+        box = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, box, True)
+        where = Path(box) / "out.json"
+        with contextlib.redirect_stdout(io.StringIO()):
+            mutate._persist(Report(results), where)
+        return where
+
+    def test_a_recorded_row_comes_back_whole(self) -> None:
+        """Not just its label: `confirm` needs `old` and `new` to re-run it."""
+        back = mutate._recorded(self.persisted(self.rows("mod.py:1 -- x")))
+        self.assertEqual(len(back), 1)
+        self.assertEqual(back[0].mutation.old, "a")
+        self.assertEqual(back[0].mutation.new, "b")
+        self.assertEqual(back[0].verdict.outcome, "survived")
+
+    def test_a_resumed_sweep_keeps_what_it_skipped(self) -> None:
+        """The bug this class exists for. Sweep a second file against a report
+        that already holds the first, and the first must still be there."""
+        where = self.persisted(self.rows("a.py:1 -- one", "a.py:2 -- two"))
+        # `a.py` is in the table too, or there would be nothing to skip and the
+        # test would pass against a sweep that simply never saw it.
+        table = [
+            Mutation("a.py:1 -- one", "a.py", "a", "b", "test_mod"),
+            Mutation("b.py:1 -- three", "b.py", "c", "d", "test_mod"),
+        ]
+        args = argparse.Namespace(
+            json=where,
+            no_baseline=True,
+            workers=1,
+            timeout=30.0,
+            memory=mutate.MEMORY,
+            all=True,
+            batch=True,
+        )
+        # `run` is stubbed: `sweep`'s job is the bookkeeping around it -- which
+        # files to skip, what to keep, what to write -- and running a real
+        # mutation would test `run`, which has its own tests above.
+        answered = Report([Result(table[1], Verdict("caught"))])
+        with (
+            contextlib.redirect_stdout(io.StringIO()) as said,
+            mock.patch.object(mutate, "run", return_value=answered),
+        ):
+            report = mutate.sweep(table, args)
+
+        self.assertIn("a.py: already recorded, skipping", said.getvalue())
+        paths = sorted({result.mutation.path for result in report.results})
+        self.assertEqual(paths, ["a.py", "b.py"], "the skipped file left the report")
+        on_disk = json.loads(where.read_text(encoding="utf-8"))
+        self.assertEqual(len(on_disk["results"]), 3, "a resume must not shorten the report")
+
+    def test_the_skipped_rows_still_reach_the_summary(self) -> None:
+        """A resume whose new batches are all caught would otherwise print a
+        clean summary and exit 0 while recorded survivors went unmentioned."""
+        where = self.persisted(self.rows("a.py:1 -- survivor"))
+        args = argparse.Namespace(
+            json=where,
+            no_baseline=True,
+            workers=1,
+            timeout=30.0,
+            memory=mutate.MEMORY,
+            all=True,
+            batch=True,
+        )
+        with contextlib.redirect_stdout(io.StringIO()):
+            report = mutate.sweep([], args)
+        self.assertFalse(report.clean, "a recorded survivor still counts against the run")
+
+    def test_a_missing_file_is_not_an_error(self) -> None:
+        """The first run of a sweep has nothing to resume from."""
+        with tempfile.TemporaryDirectory() as box:
+            self.assertEqual(mutate._recorded(Path(box) / "absent.json"), [])
+
+    def test_no_file_asked_for_at_all(self) -> None:
+        self.assertEqual(mutate._recorded(None), [])
+
+    def test_a_corrupt_report_resumes_from_nothing_rather_than_dying(self) -> None:
+        """A half-written file is what a crash mid-write leaves, and re-running
+        everything is the safe reading of it."""
+        with tempfile.TemporaryDirectory() as box:
+            where = Path(box) / "half.json"
+            where.write_text('{"results": [{"label": "one",', encoding="utf-8")
+            self.assertEqual(mutate._recorded(where), [])
+
+    def test_a_report_missing_the_rebuild_fields_resumes_from_nothing(self) -> None:
+        """An older report has no `old`/`new`. Re-running is right: a row that
+        cannot be rebuilt cannot be confirmed either."""
+        with tempfile.TemporaryDirectory() as box:
+            where = Path(box) / "old.json"
+            where.write_text(
+                json.dumps({"results": [{"label": "x", "path": "a.py", "outcome": "caught"}]}),
+                encoding="utf-8",
+            )
+            self.assertEqual(mutate._recorded(where), [])
 
 
 class TestHowManyLanesFitInMemory(unittest.TestCase):

--- a/tests/test_reached.py
+++ b/tests/test_reached.py
@@ -1,0 +1,278 @@
+"""Tests for the survivor partition.
+
+Pure -- JSON in, buckets out -- so this runs in milliseconds with no sandbox
+and no suite, the same line `tools/mutants.py` is split along.
+
+The case worth reading is `TestCaughtMutantsRepairTheMap`. Coverage measured
+in-process cannot see a line executed by a subprocess, and this repository
+tests its shell hook by running a real `bash`; on the run this module was
+written for, 111 mutants were *caught* on lines coverage called unexecuted.
+Without folding that back in, those lines read as "no test reaches this" and a
+third of the missing-test list is noise.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from tools import reached
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def results(*rows: tuple[str, int, str]) -> dict[str, Any]:
+    """A `--json` report holding `(path, line, outcome)` rows."""
+    return {
+        "baseline_red": False,
+        "results": [
+            {
+                "label": f"{path}:{line} in f() -- something",
+                "path": path,
+                "line": line,
+                "tests": "t",
+                "operator": "boundary",
+                "outcome": outcome,
+            }
+            for path, line, outcome in rows
+        ],
+    }
+
+
+def coverage(**files: list[int]) -> dict[str, Any]:
+    """A `coverage json` report. `a__b=[3]` means `a/b.py` ran line 3.
+
+    The `.py` matters and this helper forgot it at first: the paths then matched
+    nothing, every survivor read as unreached, and two of the assertions below
+    failed for a reason that had nothing to do with the code. A fixture whose
+    keys silently miss is the failure this module exists to find.
+    """
+    return {
+        "files": {
+            path.replace("__", "/") + ".py": {"executed_lines": lines}
+            for path, lines in files.items()
+        }
+    }
+
+
+class TestPartition(unittest.TestCase):
+    def test_a_survivor_on_an_executed_line_is_a_weak_fixture(self) -> None:
+        rows = reached.rows_from(results(("a/b.py", 10, "survived")))
+        split = reached.partition(rows, {"a/b.py": {10}})
+        self.assertEqual((len(split.unreached), len(split.weak)), (0, 1))
+
+    def test_a_survivor_on_an_unexecuted_line_is_a_missing_test(self) -> None:
+        rows = reached.rows_from(results(("a/b.py", 10, "survived")))
+        split = reached.partition(rows, {"a/b.py": {99}})
+        self.assertEqual((len(split.unreached), len(split.weak)), (1, 0))
+
+    def test_caught_rows_are_not_survivors(self) -> None:
+        """The partition is of survivors only; a caught row is already an answer."""
+        rows = reached.rows_from(results(("a/b.py", 10, "caught"), ("a/b.py", 11, "survived")))
+        split = reached.partition(rows, {})
+        self.assertEqual(split.total, 1)
+
+    def test_a_file_absent_from_the_map_is_not_executed(self) -> None:
+        rows = reached.rows_from(results(("never/seen.py", 3, "survived")))
+        self.assertEqual(len(reached.partition(rows, {"other.py": {3}}).unreached), 1)
+
+
+class TestCaughtMutantsRepairTheMap(unittest.TestCase):
+    """A caught mutation is proof its line ran, whatever coverage says."""
+
+    def test_a_caught_row_adds_its_line(self) -> None:
+        rows = reached.rows_from(results(("a/b.py", 10, "caught")))
+        self.assertEqual(reached.repair({}, rows), {"a/b.py": {10}})
+
+    def test_a_survivor_does_not_add_its_line(self) -> None:
+        """The whole question. A survivor on an unexecuted line is the finding;
+        letting it mark its own line executed would erase every one of them."""
+        rows = reached.rows_from(results(("a/b.py", 10, "survived")))
+        self.assertEqual(reached.repair({}, rows), {})
+
+    def test_broke_and_timeout_prove_nothing(self) -> None:
+        """They never got to ask, so they are not evidence the line ran."""
+        rows = reached.rows_from(results(("a/b.py", 10, "broke"), ("a/b.py", 11, "timeout")))
+        self.assertEqual(reached.repair({}, rows), {})
+
+    def test_repair_changes_the_answer(self) -> None:
+        """End to end: the same survivor lands in a different bucket once a
+        sibling row proves the line is reachable by a subprocess-driven test."""
+        rows = reached.rows_from(results(("a/b.py", 10, "survived"), ("a/b.py", 10, "caught")))
+        naive = reached.partition(rows, {})
+        fixed = reached.partition(rows, reached.repair({}, rows))
+        self.assertEqual(len(naive.unreached), 1, "without the repair it reads as unreached")
+        self.assertEqual(len(fixed.weak), 1, "with it, the line is known to run")
+
+    def test_it_does_not_discard_what_coverage_already_knew(self) -> None:
+        rows = reached.rows_from(results(("a/b.py", 10, "caught")))
+        self.assertEqual(reached.repair({"a/b.py": {7}}, rows), {"a/b.py": {7, 10}})
+
+
+class TestReadingTheInputs(unittest.TestCase):
+    def test_a_row_without_a_position_is_skipped(self) -> None:
+        """A hand-written spec row has no line, and cannot be classified."""
+        report = results(("a/b.py", 10, "survived"))
+        report["results"].append(
+            {
+                "label": "by hand",
+                "path": "a/b.py",
+                "line": None,
+                "tests": "t",
+                "operator": "",
+                "outcome": "survived",
+            }
+        )
+        self.assertEqual(len(reached.rows_from(report)), 1)
+
+    def test_coverage_paths_are_normalised(self) -> None:
+        got = reached.executed_lines({"files": {"a\\b.py": {"executed_lines": [1, 2]}}})
+        self.assertEqual(got, {"a/b.py": {1, 2}})
+
+    def test_a_file_with_no_executed_lines_is_empty_not_missing(self) -> None:
+        self.assertEqual(reached.executed_lines({"files": {"a.py": {}}}), {"a.py": set()})
+
+
+class TestTheCommandLine(unittest.TestCase):
+    """Driven as a subprocess, because the exit status and the printed
+    partition are what a person actually uses."""
+
+    def run_it(
+        self, report: dict[str, Any], cov: dict[str, Any], *extra: str
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as box:
+            r, c = Path(box) / "r.json", Path(box) / "c.json"
+            r.write_text(json.dumps(report), encoding="utf-8")
+            c.write_text(json.dumps(cov), encoding="utf-8")
+            return subprocess.run(
+                [sys.executable, "-m", "tools.reached", str(r), str(c), *extra],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+
+    def counts(self, out: str) -> dict[str, int]:
+        """The numbers, not the labels.
+
+        Asserting that the words "missing test" appear is what the first version
+        of this test did, and every count mutation survived it -- the partition
+        could report 0 and 0 and still pass. The numbers are the output.
+        """
+        found = {}
+        for line in out.splitlines():
+            hit = re.match(
+                r"(ALL|caught|broke.*?|timeout.*?|SURVIVED|on a line.*?)\s{2,}(\d+)$", line.strip()
+            )
+            if hit:
+                found[hit.group(1).strip()] = int(hit.group(2))
+        return found
+
+    def test_it_counts_both_buckets(self) -> None:
+        done = self.run_it(
+            results(
+                ("a/b.py", 10, "survived"), ("a/b.py", 20, "survived"), ("a/b.py", 30, "caught")
+            ),
+            coverage(a__b=[10]),
+        )
+        self.assertEqual(done.returncode, 0, done.stderr)
+        got = self.counts(done.stdout)
+        self.assertEqual(got["ALL"], 3, done.stdout)
+        self.assertEqual(got["caught"], 1, done.stdout)
+        self.assertEqual(got["SURVIVED"], 2, done.stdout)
+        self.assertEqual(got["on a line NO test executes  (missing test)"], 1, done.stdout)
+        self.assertEqual(got["on a line tests DO execute  (weak/equiv)"], 1, done.stdout)
+
+    def test_rows_that_asked_nothing_are_counted_apart(self) -> None:
+        """`broke` and `timeout` are neither caught nor survived, and folding
+        them into either would misstate the partition they sit outside."""
+        done = self.run_it(
+            results(("a/b.py", 10, "broke"), ("a/b.py", 11, "timeout"), ("a/b.py", 12, "survived")),
+            coverage(a__b=[]),
+        )
+        got = self.counts(done.stdout)
+        self.assertEqual(got["ALL"], 3, done.stdout)
+        self.assertEqual(got["SURVIVED"], 1, done.stdout)
+        self.assertEqual(got.get("broke (asked nothing)"), 1, done.stdout)
+        self.assertEqual(got.get("timeout (asked nothing)"), 1, done.stdout)
+
+    def test_the_repair_is_reported_when_it_changes_something(self) -> None:
+        """Silent repair would make the partition unauditable: a reader could
+        not tell a clean map from one this had to correct 111 times."""
+        loud = self.run_it(results(("a/b.py", 10, "caught")), coverage(a__b=[]))
+        self.assertIn("1 line(s) had a caught mutation", loud.stdout)
+        quiet = self.run_it(results(("a/b.py", 10, "caught")), coverage(a__b=[10]))
+        self.assertNotIn("had a caught mutation", quiet.stdout)
+
+    def test_the_unreached_tally_names_each_file(self) -> None:
+        done = self.run_it(
+            results(
+                ("a/one.py", 1, "survived"),
+                ("a/one.py", 2, "survived"),
+                ("b/two.py", 1, "survived"),
+            ),
+            coverage(),
+        )
+        self.assertRegex(done.stdout, r"2\s+a/one\.py")
+        self.assertRegex(done.stdout, r"1\s+b/two\.py")
+
+    def test_a_run_where_nothing_was_answered_says_so(self) -> None:
+        """All broke: there is no partition, and printing 0 and 0 would read as
+        a clean bill of health."""
+        done = self.run_it(results(("a/b.py", 10, "broke")), coverage(a__b=[]))
+        self.assertIn("nothing was answered", done.stdout)
+
+    def test_the_unreached_list_is_optional_and_ordered(self) -> None:
+        """Ordered by file then line, so two runs of the same state produce the
+        same text and a diff between them is a change rather than a shuffle.
+        The fixture lists them backwards for that reason."""
+        report = results(
+            ("b/z.py", 9, "survived"), ("a/b.py", 20, "survived"), ("a/b.py", 3, "survived")
+        )
+        quiet = self.run_it(report, coverage())
+        loud = self.run_it(report, coverage(), "--list")
+        self.assertNotIn("a/b.py:20", quiet.stdout)
+        self.assertIn("unreached survivors by file:", quiet.stdout)
+
+        listed = [
+            line.strip().split(" ")[0]
+            for line in loud.stdout.splitlines()
+            if line.strip().startswith(("a/", "b/")) and ":" in line
+        ]
+        self.assertEqual(listed, ["a/b.py:3", "a/b.py:20", "b/z.py:9"], loud.stdout)
+        self.assertIn("unreached survivors:", loud.stdout)
+
+    def test_a_report_with_nothing_to_classify_is_refused(self) -> None:
+        """Silence would read as "no gaps" -- the failure mode this whole
+        module exists to prevent one level up."""
+        done = self.run_it({"results": []}, coverage(a__b=[1]))
+        self.assertNotEqual(done.returncode, 0)
+        self.assertIn("no positioned rows", done.stderr + done.stdout)
+
+    def test_unreadable_inputs_say_so(self) -> None:
+        with tempfile.TemporaryDirectory() as box:
+            done = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "tools.reached",
+                    str(Path(box) / "absent.json"),
+                    str(Path(box) / "gone.json"),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        self.assertNotEqual(done.returncode, 0)
+        self.assertIn("cannot read the inputs", done.stderr + done.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/mutants.py
+++ b/tools/mutants.py
@@ -179,6 +179,11 @@ class Offsets:
         )
 
 
+def _trimmed(text: str, width: int) -> str:
+    """`text` cut to `width` with an ellipsis. Prose for a label, never a rewrite."""
+    return text if len(text) <= width else text[: width - 1] + "\N{HORIZONTAL ELLIPSIS}"
+
+
 def _rewritten(node: ast.AST, change: Callable[[ast.AST], None]) -> str:
     """`node` with `change` applied to a copy, unparsed and spliceable.
 
@@ -398,6 +403,69 @@ def drop_call(node: ast.AST) -> Iterator[Edit]:
     yield Edit(node, "pass", f"the call to `{shown}(...)` never happens")
 
 
+#: Keywords `drop-kwarg` may remove, and what each one is holding up.
+#:
+#: A table rather than "drop any keyword", because a blanket version is mostly
+#: noise and this was measured before it was written. Of 281 keyword arguments
+#: in `woswoar/`, the commonest are *required* parameters passed by name --
+#: `ok=` is a `Check` field, `cwd=` and `ts=` are `Entry` fields -- and dropping
+#: one raises `TypeError`, which is `BROKE` rather than an answer and costs a
+#: whole suite run to discover. That is the argument `drop_assign` already makes
+#: for leaving plain `name = ...` alone. Nine more pass `check=False`, which is
+#: `subprocess.run`'s own default, so removing it changes nothing and the row is
+#: an unkillable equivalent mutant.
+#:
+#: Optional-versus-required is not decidable from the AST; it needs the callee's
+#: signature. So the rule is inverted: a keyword not named here is never
+#: dropped, and the list holds the ones whose absence *silently weakens a
+#: guarantee* rather than breaking anything.
+_DROPPABLE = {
+    #: `mkdir(mode=0o700)`, `chmod` -- the mode is the guarantee. `docs/security.md`
+    #: claims are meant to be backed by tests, and nothing could generate this.
+    "mode",
+    #: `subprocess.run(check=True)` -- dropped, a failing command reads as success.
+    #: Only when it is `True`; `check=False` is the default and unkillable.
+    "check",
+    #: `open(encoding="utf-8")` -- dropped, the locale decides, and it differs
+    #: between a developer's shell and a systemd timer.
+    "encoding",
+    #: The symlink and permission flags, same class as `mode`.
+    "follow_symlinks",
+    "exist_ok",
+}
+
+
+def drop_kwarg(node: ast.AST) -> Iterator[Edit]:
+    """One keyword argument removed, where its absence weakens a guarantee.
+
+    Narrow on purpose -- see `_DROPPABLE`. The failure this reaches is the one
+    that leaves no trace: `mkdir(..., mode=0o700)` without its mode still makes
+    the directory, still returns, and still passes every test that only asks
+    whether the path exists.
+    """
+    if not isinstance(node, ast.Call) or not node.keywords:
+        return
+    for at, keyword in enumerate(node.keywords):
+        # No `arg is None` guard: `_DROPPABLE` holds strings, so a `**spread`
+        # (whose `arg` is `None`) already fails the membership test. A guard
+        # nothing can reach is one nobody can trust -- as `every_line` says.
+        if keyword.arg not in _DROPPABLE:
+            continue
+        if keyword.arg == "check" and not (
+            isinstance(keyword.value, ast.Constant) and keyword.value.value is True
+        ):
+            # `check=False` is `subprocess.run`'s default: dropping it changes
+            # nothing, and a row that changes nothing can only ever survive.
+            continue
+
+        def without(clone: ast.AST, index: int = at) -> None:
+            assert isinstance(clone, ast.Call)
+            del clone.keywords[index]
+
+        trimmed = _trimmed(ast.unparse(keyword.value), 20)
+        yield Edit(node, _rewritten(node, without), f"`{keyword.arg}={trimmed}` is dropped")
+
+
 def off_by_one(node: ast.AST) -> Iterator[Edit]:
     """Small integer literals, moved by one. Index and threshold arithmetic."""
     if not isinstance(node, ast.Constant) or not isinstance(node.value, int):
@@ -425,8 +493,7 @@ def return_value(node: ast.AST) -> Iterator[Edit]:
         node.value.value is None or isinstance(node.value.value, bool)
     ):
         return
-    shown = ast.unparse(node.value)
-    trimmed = shown if len(shown) <= 30 else shown[:29] + "\N{HORIZONTAL ELLIPSIS}"
+    trimmed = _trimmed(ast.unparse(node.value), 30)
     yield Edit(node.value, "None", f"returns `None` instead of `{trimmed}`")
 
 
@@ -523,6 +590,7 @@ OPERATORS: tuple[Operator, ...] = (
     Operator("return-constant", return_constant),
     Operator("drop-call", drop_call),
     Operator("drop-assign", drop_assign),
+    Operator("drop-kwarg", drop_kwarg),
     Operator("off-by-one", off_by_one),
     Operator("return-value", return_value),
     Operator("arith", arith),
@@ -655,7 +723,9 @@ def label(path: str, line: int, where: str, prose: str, inside_callable: bool = 
     return f"{place} in {where}{'()' if inside_callable else ''} -- {prose}"
 
 
-def _chosen(operators: Sequence[str] | None) -> tuple[Operator, ...]:
+def _chosen(
+    operators: Sequence[str] | None, skip: Sequence[str] | None = None
+) -> tuple[Operator, ...]:
     """The operators to run, refusing a name that is not one.
 
     Decided once per file rather than re-tested per node per operator, and
@@ -664,17 +734,28 @@ def _chosen(operators: Sequence[str] | None) -> tuple[Operator, ...]:
     exited 0. A run that asked nothing must not read as a run that found
     nothing -- the same argument `--limit` makes when it says out loud how many
     rows it dropped.
+
+    `skip` is the escape hatch for an equivalent mutant whose operator is
+    otherwise worth running -- the one `# pragma: no mutate` cannot serve,
+    because a pragma suppresses a *line* and this suppresses a *kind*. It
+    subtracts after `operators` selects, so naming a name in both is an empty
+    selection, which is refused for the reason above.
     """
-    if not operators:
-        return OPERATORS
-    known = {op.name: op for op in OPERATORS}
-    unknown = sorted(set(operators) - set(known))
+    known = {op.name for op in OPERATORS}
+    asked, skipped = set(operators or ()), set(skip or ())
+    unknown = sorted((asked | skipped) - known)
     if unknown:
         raise SystemExit(
             f"no such operator: {', '.join(unknown)}. Available: "
             f"{', '.join(op.name for op in OPERATORS)}"
         )
-    return tuple(op for op in OPERATORS if op.name in set(operators))
+    wanted = (asked or known) - skipped
+    if not wanted:
+        raise SystemExit(
+            "every operator was skipped, so nothing would be generated. "
+            "Drop a --skip-operator, or say what you did want with --operator."
+        )
+    return tuple(op for op in OPERATORS if op.name in wanted)
 
 
 def generate(
@@ -683,12 +764,13 @@ def generate(
     lines: set[int],
     tests: str = "",
     operators: Sequence[str] | None = None,
+    skip: Sequence[str] | None = None,
 ) -> list[Mutation]:
     """Every mutant the operators can make on the changed lines of one file."""
     tree = ast.parse(source)
     offsets = Offsets(source)
     blocked = _pragma_lines(source, offsets)
-    chosen = _chosen(operators)
+    chosen = _chosen(operators, skip)
 
     seen: set[tuple[tuple[int, int], str]] = set()
     out: list[Mutation] = []
@@ -868,6 +950,36 @@ def changed_lines(base: str, root: Path) -> dict[str, set[int]]:
             body = (root / name).read_text(encoding="utf-8").splitlines()
             changed.setdefault(name, set()).update(range(1, len(body) + 1))
     return changed
+
+
+def every_line(root: Path) -> dict[str, set[int]]:
+    """Every line of every mutable file. What `--all` means.
+
+    Enumerated rather than diffed against the repository's first commit. Those
+    two agreed exactly when it was checked, but only because this repository's
+    root commit happens to be near-empty -- a fact about its history rather than
+    about what "everything" means. No absolute count is quoted here on purpose:
+    it moves with every commit, and a stale one reads as a promise.
+
+    `git` is not consulted at all, so an unstaged or untracked file counts the
+    same as a committed one. That matches `changed_lines`, which folds untracked
+    files in for the same reason: a brand-new module with no mutants reads
+    exactly like a covered one.
+    """
+    found: dict[str, set[int]] = {}
+    for prefix in MUTABLE:
+        # No `mutable(name)` filter: walking `MUTABLE` for `*.py` already
+        # satisfies both halves of it, so the check could never be false. A
+        # mutation removing it survived, and this module deletes a guard nothing
+        # can reach rather than keeping one nobody can trust -- as it does for
+        # the `tests/` conjunct in `mutable` and the `/dev/null` case in
+        # `parse_hunks`.
+        for path in sorted((root / prefix).rglob("*.py")):
+            name = path.relative_to(root).as_posix()
+            body = path.read_text(encoding="utf-8").splitlines()
+            if body:
+                found[name] = set(range(1, len(body) + 1))
+    return found
 
 
 # --- which tests to run it against ----------------------------------------

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -119,6 +119,11 @@ TIMEOUT = 300.0
 #: The most lanes worth running, whatever the machine reports.
 _LANES = 16
 
+#: Rows a generated table runs before it stops, when nobody said otherwise.
+#: Sized for a diff; `--all` resets it, because a cap meant to keep one
+#: change's table readable turns a whole-package sweep into 4% of itself.
+LIMIT = 200
+
 #: Address space one mutant may occupy, handed to `verdict.cap`.
 #:
 #: `TIMEOUT` answers "this mutation never finishes"; this answers "this mutation
@@ -725,7 +730,7 @@ def confirm(report: Report, workers: int | None, timeout: float, memory: int) ->
 def generated(args: argparse.Namespace) -> list[Mutation]:
     """The table the diff implies, printed about before any of it runs."""
     root = Path.cwd()
-    touched = mutants.changed_lines(args.base, root)
+    touched = mutants.every_line(root) if args.all else mutants.changed_lines(args.base, root)
     if args.only:
         touched = {
             path: lines
@@ -734,7 +739,9 @@ def generated(args: argparse.Namespace) -> list[Mutation]:
         }
     if not touched:
         raise SystemExit(
-            f"nothing mutable changed against {args.base}. Only woswoar/**.py and "
+            "no mutable files at all under woswoar/ or tools/."
+            if args.all
+            else f"nothing mutable changed against {args.base}. Only woswoar/**.py and "
             f"tools/**.py are generated from; a change to tests/ is not a fix to test."
         )
 
@@ -749,14 +756,16 @@ def generated(args: argparse.Namespace) -> list[Mutation]:
                 touched[path],
                 tests=tests,
                 operators=args.operator or None,
+                skip=args.skip_operator or None,
             )
         )
         if tests == WHOLE_SUITE:
             print(f"note: nothing imports {path}, so its rows run the whole suite.")
 
+    counted = sum(len(lines) for lines in touched.values())
     print(
-        f"{len(touched)} file(s), {sum(len(lines) for lines in touched.values())} changed "
-        f"lines -> {len(table)} mutants"
+        f"{len(touched)} file(s), {counted} {'' if args.all else 'changed '}lines "
+        f"-> {len(table)} mutants"
     )
     kept, dropped = mutants.cap(table, args.limit)
     if dropped:
@@ -815,6 +824,14 @@ def _persist(report: Report, where: Path) -> None:
                 "operator": result.mutation.operator,
                 "outcome": result.verdict.outcome,
                 "detail": result.verdict.detail,
+                # Enough to rebuild the row, not just to read about it. Without
+                # `old`/`new` a resumed sweep could skip a file but never
+                # re-confirm its survivors, and `CONTRIBUTING.md` promises every
+                # survivor is re-run against the whole suite before it is
+                # reported. A resume must not quietly drop that guarantee.
+                "old": result.mutation.old,
+                "new": result.mutation.new,
+                "span": list(result.mutation.span) if result.mutation.span else None,
             }
         )
     where.write_text(
@@ -822,6 +839,111 @@ def _persist(report: Report, where: Path) -> None:
         encoding="utf-8",
     )
     print(f"\nwrote {len(rows)} row(s) to {where}")
+
+
+def _run_generated(rows: Sequence[Mutation], args: argparse.Namespace) -> Report:
+    """One batch of generated rows. Both the whole table and `sweep` use this.
+
+    `strict=False`: a generated row that breaks collection is not a mistake
+    anyone made, and discarding two hundred paid-for answers because of it would
+    be. The row is reported and the run goes on.
+
+    `failfast=True`: worth having for a generated table and not for a hand
+    table, because `caught` is the expected outcome for most generated rows and
+    without it each one runs the rest of its target after the answer is known.
+    An average, not a bound -- `unittest` runs classes alphabetically, so a
+    mutant caught only by the last of them still pays for nearly all.
+    """
+    return run(
+        rows,
+        baseline=not args.no_baseline,
+        workers=args.workers,
+        strict=False,
+        summarise=False,
+        failfast=True,
+        timeout=args.timeout,
+        memory=args.memory,
+    )
+
+
+def _recorded(where: Path | None) -> list[Result]:
+    """Every row a previous `--json` report holds, rebuilt.
+
+    Rebuilt rather than merely counted, because `sweep` has to do three things
+    with them and only one is "skip". They must stay in the file it rewrites --
+    the first version returned labels only, so a resumed run persisted just the
+    batches it had run and *deleted* the answers it had decided to skip, which
+    is the recovery mechanism eating the thing it recovers. They must reach
+    `confirm`, or a resumed sweep reports a survivor that was never re-run
+    against the whole suite. And they must reach `_summarise` and the exit
+    status, or a resume whose new batches are all caught exits 0 while recorded
+    survivors go unmentioned.
+
+    A half-written file resumes as nothing: re-running everything is the safe
+    reading of a crash mid-write.
+    """
+    if where is None or not where.is_file():
+        return []
+    try:
+        saved = json.loads(where.read_text(encoding="utf-8"))
+        return [
+            Result(
+                Mutation(
+                    row["label"],
+                    row["path"],
+                    row["old"],
+                    row["new"],
+                    row["tests"],
+                    span=(row["span"][0], row["span"][1]) if row.get("span") else None,
+                    operator=row.get("operator", ""),
+                ),
+                Verdict(row["outcome"], row.get("detail", "")),
+            )
+            for row in saved.get("results", [])
+        ]
+    except (OSError, ValueError, KeyError, TypeError):
+        return []
+
+
+def sweep(table: Sequence[Mutation], args: argparse.Namespace) -> Report:
+    """Run a large table a file at a time, writing answers out as they land.
+
+    One table of three thousand rows reports nothing until it ends, and the run
+    it was written for took 151 minutes and was killed twice by an out-of-memory
+    machine before the guard in #223 existed. A crash then cost the afternoon.
+    Batched by file, a crash costs one file, and re-running with the same
+    `--json` skips what is already recorded -- there is no separate flag.
+
+    Confirmation is pooled to the end rather than run per batch, and that is not
+    an optimisation detail: per batch, a file with a single survivor pays a whole
+    suite run with fifteen lanes idle. Measured on the first sweep here,
+    `credentials.py` spent 68 s on 13 mutants, almost all of it confirming one
+    row.
+    """
+    collected = _recorded(args.json)
+    # Keyed by file, not by row: `_persist` writes after a whole batch, so a
+    # file is recorded entirely or not at all, and a label is not unique anyway
+    # -- 7 are duplicated in the `--all` table, for the reason `confirm`'s
+    # docstring gives.
+    done = {result.mutation.path for result in collected}
+    by_file: dict[str, list[Mutation]] = {}
+    for row in table:
+        by_file.setdefault(row.path, []).append(row)
+
+    red = False
+    order = sorted(by_file, key=lambda path: len(by_file[path]))
+    for at, path in enumerate(order, start=1):
+        if path in done:
+            print(f"[{at}/{len(order)}] {path}: already recorded, skipping")
+            continue
+        rows = by_file[path]
+        print(f"\n[{at}/{len(order)}] {path}: {len(rows)} mutant(s)")
+        batch = _run_generated(rows, args)
+        red |= batch.baseline_red
+        collected.extend(batch.results)
+        if args.json:
+            _persist(Report(collected, red), args.json)
+    return Report(collected, red)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -844,7 +966,24 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--operator", action="append", default=[], metavar="NAME", help="use only this operator"
     )
-    parser.add_argument("--limit", type=int, default=200, help="cap the table (0 for no cap)")
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="every line of every mutable file, rather than a diff",
+    )
+    parser.add_argument(
+        "--batch",
+        action="store_true",
+        help="run a file at a time, writing --json as each lands (implied by --all)",
+    )
+    parser.add_argument(
+        "--skip-operator",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="run every operator but this one",
+    )
+    parser.add_argument("--limit", type=int, default=LIMIT, help="cap the table (0 for no cap)")
     parser.add_argument("--timeout", type=float, default=TIMEOUT, help="seconds per mutation")
     parser.add_argument(
         "--memory",
@@ -867,8 +1006,21 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if args.all and args.base:
+        parser.error("--all is every line; --base is what changed. Not both.")
+    if args.all:
+        # Downstream only asks "generated or a spec file?", and `--all` is the
+        # generated path with a wider net rather than a third kind of run.
+        args.base = "--all"
+        if args.limit == LIMIT:
+            # The default cap is sized for a diff. Left alone it turned the
+            # documented `--all` into 200 of 4451 rows -- and, because the cap
+            # spreads across files, into batches of seven, so batching,
+            # incremental `--json` and resume all did nothing on the one command
+            # line anybody would type. An explicit `--limit` is still honoured.
+            args.limit = 0
     if bool(args.script) == bool(args.base):
-        parser.error("give a spec file or --base, not both and not neither")
+        parser.error("give a spec file, --base or --all")
 
     if args.base:
         table = generated(args)
@@ -876,24 +1028,7 @@ def main(argv: list[str] | None = None) -> int:
             for row in table:
                 print(f"  {row.operator:16} {row.label}")
             return 0
-        report = run(
-            table,
-            baseline=not args.no_baseline,
-            workers=args.workers,
-            # A generated row that breaks collection is not a mistake anyone
-            # made; discarding two hundred paid-for answers because of it would
-            # be. The row is reported and the run goes on.
-            strict=False,
-            summarise=False,
-            # Worth having here and not for a hand table: `caught` is the
-            # expected outcome for most generated rows, and without this each
-            # one runs the rest of its target after the answer is known. An
-            # average, not a bound -- `unittest` runs classes alphabetically, so
-            # a mutant caught only by the last of them still pays for nearly all.
-            failfast=True,
-            timeout=args.timeout,
-            memory=args.memory,
-        )
+        report = sweep(table, args) if args.all or args.batch else _run_generated(table, args)
         if not args.no_confirm:
             report = confirm(report, args.workers, args.timeout, args.memory)
         else:

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -88,6 +88,7 @@ import argparse
 import json
 import os
 import queue
+import re
 import runpy
 import shutil
 import signal
@@ -790,6 +791,39 @@ def _bytes(said: str) -> int:
     return value
 
 
+def _persist(report: Report, where: Path) -> None:
+    """The run's answers, as `tools/reached.py` reads them.
+
+    Written because a survivor list is not the end of the analysis. Crossing
+    these outcomes with a coverage map is what separates "no test reaches this"
+    from "a test reaches it and asserts nothing", and that cannot be done from
+    the printed table -- which is prose, in table order, with no line numbers.
+
+    `line` is parsed back out of the label rather than carried on `Mutation`,
+    because a hand-written row has no position at all, and the label is the one
+    place both kinds already agree on how to say where they are.
+    """
+    rows = []
+    for result in report.results:
+        found = re.match(r"\S+?:(\d+) ", result.mutation.label)
+        rows.append(
+            {
+                "label": result.mutation.label,
+                "path": result.mutation.path,
+                "line": int(found.group(1)) if found else None,
+                "tests": result.mutation.tests,
+                "operator": result.mutation.operator,
+                "outcome": result.verdict.outcome,
+                "detail": result.verdict.detail,
+            }
+        )
+    where.write_text(
+        json.dumps({"baseline_red": report.baseline_red, "results": rows}, indent=1),
+        encoding="utf-8",
+    )
+    print(f"\nwrote {len(rows)} row(s) to {where}")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="python -m tools.mutate",
@@ -824,6 +858,12 @@ def main(argv: list[str] | None = None) -> int:
         "--no-confirm",
         action="store_true",
         help="do not re-run survivors against the whole suite",
+    )
+    parser.add_argument(
+        "--json",
+        type=Path,
+        metavar="PATH",
+        help="write the outcomes here, for `python -m tools.reached`",
     )
     args = parser.parse_args(argv)
 
@@ -860,6 +900,8 @@ def main(argv: list[str] | None = None) -> int:
             print("\n--no-confirm: survivors below were not re-run against the whole suite,")
             print("so one may simply have been run against tests that cannot see it.")
         _summarise(report.results)
+        if args.json:
+            _persist(report, args.json)
         return 0 if report.clean else 1
 
     already = len(_RUNS)

--- a/tools/reached.py
+++ b/tools/reached.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from collections import defaultdict
+from collections import Counter
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -125,13 +125,11 @@ def partition(rows: list[Row], executed: dict[str, set[int]]) -> Split:
 
 
 def _summarise(rows: list[Row], split: Split, corrected: int) -> None:
-    answered = [r for r in rows if r.answered]
-    caught = sum(1 for r in rows if r.outcome == "caught")
+    counts = Counter(row.outcome for row in rows)
     print(f"{'ALL':<46}{len(rows):>6}")
-    print(f"{'  caught':<46}{caught:>6}")
+    print(f"{'  caught':<46}{counts['caught']:>6}")
     for outcome in ("broke", "timeout"):
-        count = sum(1 for r in rows if r.outcome == outcome)
-        if count:
+        if count := counts[outcome]:
             print(f"{'  ' + outcome + ' (asked nothing)':<46}{count:>6}")
     print(f"{'  SURVIVED':<46}{split.total:>6}")
     print(f"{'    on a line NO test executes  (missing test)':<46}{len(split.unreached):>6}")
@@ -144,15 +142,16 @@ def _summarise(rows: list[Row], split: Split, corrected: int) -> None:
             f"\n{corrected} line(s) had a caught mutation but were absent from the "
             "coverage map,\nso the suite reaches them through a subprocess. Folded in."
         )
-    if not answered:
+    if not any(row.answered for row in rows):
         print("\nnothing was answered: no partition is possible.")
 
 
 def _by_file(rows: list[Row]) -> None:
-    counts: dict[str, int] = defaultdict(int)
-    for row in rows:
-        counts[row.path] += 1
-    for path, n in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+    # `sorted` rather than `most_common`, which does not tie-break by path and
+    # would make two runs of the same state print in different orders.
+    for path, n in sorted(
+        Counter(row.path for row in rows).items(), key=lambda kv: (-kv[1], kv[0])
+    ):
         print(f"  {n:5d}  {path}")
 
 

--- a/tools/reached.py
+++ b/tools/reached.py
@@ -1,0 +1,201 @@
+"""Why a mutation survived: nothing ran the line, or nothing asserted on it.
+
+A survivor list is not a finding. Run the generator over a whole package and it
+answers with hundreds of rows, and the shape of that pile is not visible from
+the pile: `progress.py` and `store.py` survive at the same rate and mean
+opposite things. Reading it unaided produced two confident, wrong triages here
+before this module existed -- first by grepping the mutated *line* for words
+like `mkdir`, then by ranking functions by survival ratio. Each found real gaps
+and each presented a sample as an accounting.
+
+The partition that does hold is against **coverage**:
+
+- a survivor on a line no test executes is a **missing test**. Nothing reaches
+  the code, so no fixture could have caught anything;
+- a survivor on a line the suite *does* execute is a **weak fixture or an
+  equivalent mutant**. The test got there and said nothing about that effect,
+  which is `CLAUDE.md` rule 3's "suspect the fixture before the mutation".
+
+Those are different problems with different answers, and the second is much
+larger -- 590 of 751 on the run this was written for. Conflating them is what
+makes a survivor list read as several hundred bugs.
+
+**Coverage is wrong here, and the mutation data corrects it.** In-process
+coverage cannot see a line executed by a real subprocess, and this repository
+tests its shell hook by running a real `bash` that runs `python -m woswoar`. On
+the run above, 111 mutants were *caught* on lines coverage called unexecuted --
+impossible unless the line ran. A caught mutant is proof of execution, so
+`repair` folds that evidence back in before anything is partitioned. Without it
+those lines read as "no test reaches this" and the missing-test list is a third
+noise.
+
+**No dependency on `coverage`.** `pyproject.toml` declares none and this is not
+the module to start, so the map arrives as the JSON `coverage json` already
+emits. Produce it however you like; this only reads `files.*.executed_lines`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, NamedTuple
+
+
+class Row(NamedTuple):
+    """One mutation and what became of it, as `tools/mutate.py --json` writes it."""
+
+    label: str
+    path: str
+    line: int
+    outcome: str
+
+    @property
+    def survived(self) -> bool:
+        return self.outcome == "survived"
+
+    @property
+    def answered(self) -> bool:
+        """Caught or survived. `broke` and `timeout` say nothing about a line.
+
+        They are excluded from `repair` for that reason: a row that never got to
+        ask is not evidence its line ran.
+        """
+        return self.outcome in ("caught", "survived")
+
+
+def rows_from(results: dict[str, Any]) -> list[Row]:
+    """The rows of a `--json` report, ignoring anything without a position."""
+    out = []
+    for item in results.get("results", []):
+        line = item.get("line")
+        if line is None:
+            continue
+        out.append(Row(item["label"], item["path"], int(line), item["outcome"]))
+    return out
+
+
+def executed_lines(coverage: dict[str, Any]) -> dict[str, set[int]]:
+    """`{path: {line, ...}}` from a `coverage json` report.
+
+    Paths are taken as the report spells them; `coverage` writes them relative
+    to the run's root, which is what a mutation label carries too.
+    """
+    return {
+        path.replace("\\", "/"): set(info.get("executed_lines", []))
+        for path, info in coverage.get("files", {}).items()
+    }
+
+
+def repair(executed: dict[str, set[int]], rows: list[Row]) -> dict[str, set[int]]:
+    """`executed`, plus every line a mutation proves ran by being caught.
+
+    The correction the docstring above argues for. Only `caught` counts: a
+    survivor is exactly the case in doubt, and `broke`/`timeout` never reached
+    the question.
+    """
+    fixed = {path: set(lines) for path, lines in executed.items()}
+    for row in rows:
+        if row.outcome == "caught":
+            fixed.setdefault(row.path, set()).add(row.line)
+    return fixed
+
+
+class Split(NamedTuple):
+    """Survivors, partitioned by whether anything runs the line."""
+
+    unreached: list[Row]
+    weak: list[Row]
+
+    @property
+    def total(self) -> int:
+        return len(self.unreached) + len(self.weak)
+
+
+def partition(rows: list[Row], executed: dict[str, set[int]]) -> Split:
+    unreached: list[Row] = []
+    weak: list[Row] = []
+    for row in rows:
+        if not row.survived:
+            continue
+        (weak if row.line in executed.get(row.path, set()) else unreached).append(row)
+    return Split(unreached, weak)
+
+
+def _summarise(rows: list[Row], split: Split, corrected: int) -> None:
+    answered = [r for r in rows if r.answered]
+    caught = sum(1 for r in rows if r.outcome == "caught")
+    print(f"{'ALL':<46}{len(rows):>6}")
+    print(f"{'  caught':<46}{caught:>6}")
+    for outcome in ("broke", "timeout"):
+        count = sum(1 for r in rows if r.outcome == outcome)
+        if count:
+            print(f"{'  ' + outcome + ' (asked nothing)':<46}{count:>6}")
+    print(f"{'  SURVIVED':<46}{split.total:>6}")
+    print(f"{'    on a line NO test executes  (missing test)':<46}{len(split.unreached):>6}")
+    print(f"{'    on a line tests DO execute  (weak/equiv)':<46}{len(split.weak):>6}")
+    if corrected:
+        # Said out loud, because it is the difference between this partition and
+        # a naive one, and because a large number here means the coverage map
+        # was taken from a different tree than the run.
+        print(
+            f"\n{corrected} line(s) had a caught mutation but were absent from the "
+            "coverage map,\nso the suite reaches them through a subprocess. Folded in."
+        )
+    if not answered:
+        print("\nnothing was answered: no partition is possible.")
+
+
+def _by_file(rows: list[Row]) -> None:
+    counts: dict[str, int] = defaultdict(int)
+    for row in rows:
+        counts[row.path] += 1
+    for path, n in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+        print(f"  {n:5d}  {path}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.reached",
+        description="Split mutation survivors into missing tests and weak fixtures.",
+        epilog=(
+            "Produce the coverage map with:\n"
+            "  coverage run --source=woswoar -m unittest discover -s . -t . -p 'test_*.py'\n"
+            "  coverage json -o coverage.json\n"
+            "and the results with `python -m tools.mutate --base main --json results.json`.\n"
+            "Both must come from the same tree: a fix that shifts line numbers "
+            "silently unmatches them."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("results", type=Path, help="a --json report from tools.mutate")
+    parser.add_argument("coverage", type=Path, help="a `coverage json` report")
+    parser.add_argument("--list", action="store_true", help="print the unreached survivors")
+    args = parser.parse_args(argv)
+
+    try:
+        rows = rows_from(json.loads(args.results.read_text(encoding="utf-8")))
+        raw = executed_lines(json.loads(args.coverage.read_text(encoding="utf-8")))
+    except (OSError, ValueError) as exc:
+        raise SystemExit(f"cannot read the inputs: {exc}") from None
+    if not rows:
+        raise SystemExit(f"{args.results} holds no positioned rows to classify.")
+
+    fixed = repair(raw, rows)
+    corrected = sum(len(fixed[p] - raw.get(p, set())) for p in fixed)
+    split = partition(rows, fixed)
+    _summarise(rows, split, corrected)
+    if split.unreached:
+        print("\nunreached survivors by file:")
+        _by_file(split.unreached)
+    if args.list:
+        print("\nunreached survivors:")
+        for row in sorted(split.unreached, key=lambda r: (r.path, r.line)):
+            print(f"  {row.label}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part of #224 — the analysis half. Grew out of #225, where reading 751 survivors
unaided produced two confident, wrong triages before the right method turned up.

## The problem

A survivor list is not a finding. `progress.py` and `store.py` survived the
whole-package run at the same rate and mean opposite things, and nothing in the
list says which is which. My first triage grepped the mutated *line* for words
like `mkdir`; my second ranked functions by survival ratio. Both found real
gaps. Both were samples presented as an accounting.

## The partition that holds

- a survivor on a line **no test executes** → a **missing test**; nothing
  reaches the code, so no fixture could have caught anything
- a survivor on a line the suite **does** execute → a **weak fixture or an
  equivalent mutant** — rule 3's "suspect the fixture before the mutation"

Different problems, different answers, and the second is much the larger:
**590 of 751**. Conflating them is what makes a survivor list read as several
hundred bugs.

```sh
python -m tools.mutate --base main --json results.json
coverage run --source=woswoar -m unittest discover -s . -t . -p 'test_*.py'
coverage json -o coverage.json
python -m tools.reached results.json coverage.json --list
```

## Two things that are why this is code, not a recipe

**Coverage is wrong here, and the mutation data corrects it.** In-process
coverage cannot see a line executed by a subprocess, and this suite tests its
shell hook by running a real `bash` that runs `python -m woswoar`. On the
reference run, **111 mutants were *caught* on lines coverage called
unexecuted** — impossible unless the line ran. `repair` folds that evidence
back in before anything is partitioned; without it a third of the missing-test
list is noise. Only `caught` counts: a survivor is exactly the case in doubt,
and `broke`/`timeout` never reached the question.

**No dependency on `coverage`.** `pyproject.toml` declares none and this is not
the module to start one. The map arrives as the JSON `coverage json` already
emits and is only read.

## Applied to itself

The first version of this reported **33 unreached survivors in its own module**.
The cause was a weak fixture in the tests for the tool that detects weak
fixtures: the CLI tests asserted that the words `missing test` appeared in the
output and never the numbers, so every count mutation survived them. The
partition could have printed 0 and 0 and passed.

Asserting the counts instead:

```
ALL                                               76
  caught                                          66
  SURVIVED                                        10
    on a line NO test executes  (missing test)     0
    on a line tests DO execute  (weak/equiv)      10

43 line(s) had a caught mutation but were absent from the coverage map,
so the suite reaches them through a subprocess. Folded in.
```

Zero unreached: every line is executed by its tests. The 10 remaining are
executed-but-unasserted, which is the honest residue rather than a target to
drive to zero.

Also found while writing it: the `coverage()` test helper built paths without
`.py`, so its keys matched nothing and two assertions failed for a reason that
had nothing to do with the code. A fixture whose keys silently miss is exactly
what this module exists to surface.

## Mutations

The `--json` schema is the contract between the two tools, so it is tested from
the writing side as well as the reading side — a renamed key would otherwise
break the analysis with a `KeyError` in a different file at the end of a run
measured in hours.

```
  caught    a hand-written row is given a line number anyway
  caught    the outcome is dropped from the report
  caught    the path is taken from the label rather than the mutation
```

20 tests for `tools/reached.py`, pure and running in 0.3 s — no sandbox, no
subprocess for the logic, the same split `tools/mutants.py` is drawn along.

## Not in this PR

The other two items of #224 — the `drop-kwarg` operator and `--skip-operator` —
and the batching/resume half of the whole-codebase mode. This is the piece that
would otherwise have been lost: it existed only as shell history.

Refs #224, #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## The rest of #224, and what `/simplify` found in it

`drop-kwarg` (the 15th operator), `--skip-operator`, and `--all` — a whole-package
sweep, batched by file, resumable.

`drop-kwarg` is the only operator that can generate `mkdir(..., mode=0o700)`
without its mode — the mutation `docs/security.md`'s claims rest on, which had
to be hand-written in #226. It drops only from a named list, because blanket
dropping was measured first: of 281 keyword arguments in `woswoar/`, the
commonest are *required* parameters passed by name, where dropping one is a
`TypeError` and so `BROKE` rather than an answer.

### Three defects the review found in that work

Two of them made the feature worse than not having it, and both were invisible
because `sweep` had no test:

- **A resumed sweep deleted the answers it skipped.** `collected` started empty
  and `_persist` rewrites the whole file, so run 2 wrote only its own batches.
  The recovery mechanism ate the thing it recovers. Measured before the fix:
  **78 rows became 58**.
- **Resumed rows never reached `confirm`** — so the one mode built for
  hours-long runs quietly dropped the guarantee `CONTRIBUTING.md` states without
  qualification, that a survivor is always re-run against the whole suite.
  Fixed by persisting enough to *rebuild* a row rather than only to read about
  it.
- **`--all` inherited `--limit`'s default of 200**, sized for a diff. The
  documented command ran 200 of 4459 rows, in batches of about seven, so
  batching, incremental `--json` and resume all did nothing on the one command
  line anybody would type.

`sweep` now has seven tests, and the round trip is one of them.

### Smaller things from the same pass

Resume keys on the **file**, not the label — 7 labels are duplicated in the
`--all` table, for the reason `confirm`'s docstring already gives. The
unreachable `keyword.arg is None` guard is gone, as its neighbour `every_line`
argues. `_run_generated` holds the seven-argument call and its justification
once instead of twice. `reached` counts with `Counter`. The docs stop naming a
`--resume` flag that does not exist, stop saying "three tools", and stop quoting
an absolute mutant count that moves with every commit.

**The efficiency agent found nothing worth doing** and said so with numbers: the
new operator is 5.8 ms of a 197 ms generation, `_persist`'s re-serialisation is
35 ms against a run of hours, and batching costs about 5% in partial waves —
bought deliberately, and the only term a stopwatch would ever see.

### Mutations, twelve of twelve

```
  caught    check=False is dropped too, which is an unkillable equivalent mutant
  caught    every keyword is droppable, not only the ones argued for
  caught    the keyword is not actually removed from the call
  caught    skip does not subtract, so --skip-operator does nothing
  caught    an unknown --skip-operator name is accepted silently
  caught    skipping every operator generates nothing and exits green
  caught    --all stops at the first line of each file
  caught    a corrupt resume file raises instead of resuming from nothing
  caught    a resumed sweep starts from nothing, so it rewrites the report without them
  caught    a recorded file is swept again rather than skipped
  caught    a row is recorded without the text needed to re-run it
  caught    --all keeps the cap sized for a diff, so it runs a twentieth of the table
```

Closes #224.
