### PR TITLE
perf(ci): shard the sync suite so macOS stops being the critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,10 +356,11 @@ jobs:
 
   macos:
     # macOS arrives through zsh: it ships bash 3.2, which is below the hook's
-    # floor and refused, and zsh 5.9, which is not. So this job runs the suite,
-    # the sync ceremony and a real first-run install on a Mac -- everything
-    # except the two things that platform cannot answer, each excluded by name
-    # rather than by dropping a guard.
+    # floor and refused, and zsh 5.9, which is not. So this job runs the suite
+    # and a real first-run install on a Mac -- everything except the two things
+    # that platform cannot answer, each excluded by name rather than by dropping
+    # a guard. The sync ceremony is the `macos-sync` job below; it left this one
+    # because it was 115 s of its 145 s.
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
@@ -386,12 +387,13 @@ jobs:
           floor = search.TRANSFORM_SINCE
           assert got is not None and got >= floor, f'fzf {got} is below {floor}'
           "
-      # The four modules below are re-run immediately afterwards under
-      # `--no-skips`, so running them here as well is 79% of this job's work
-      # done twice -- `test_sync` alone is 75 s of the suite's 95 s. Measured:
-      # 11.8 s to 8.3 s wall, 174 s to 96 s of CPU, on a runner with three cores
-      # to absorb it. Nothing is lost; every exclusion here reappears below
-      # under a strictly stronger flag.
+      # The four modules below are re-run under `--no-skips` -- three in the
+      # steps just after this one, and `test_sync` in the `macos-sync` job --
+      # so running them here as well is 79% of this job's work done twice.
+      # Measured when all four were re-run in this job: 11.8 s to 8.3 s wall,
+      # 174 s to 96 s of CPU, on a runner with three cores to absorb it.
+      # Nothing is lost; every exclusion here reappears under a strictly
+      # stronger flag, `test_sync`'s on another machine.
       - run: |
           python -m tools.run_tests \
             --exclude tests.test_shell_hook_zsh \
@@ -423,7 +425,8 @@ jobs:
             --exclude tests.test_shell_hook_zsh.TestForkFree \
             --exclude tests.test_shell_hook_zsh.TestAZshAndABashShellShareOneHistory
       - run: python -m tools.run_tests --only tests.test_search --no-skips
-      - run: python -m tools.run_tests --only tests.test_sync --no-skips
+      # `tests.test_sync` is not here: it is the `macos-sync` job below, which
+      # runs it in shards. It stays excluded from the whole-suite step above.
       # Same reason as the zsh suite above: the both-shells class needs a bash 5.
       - run: |
           python -m tools.run_tests --only tests.test_install --no-skips \
@@ -455,3 +458,65 @@ jobs:
           # exit is a regression on the platform this job exists to cover, and
           # masking it would leave the line asserting nothing.
           woswoar doctor
+
+  macos-sync:
+    # `tests.test_sync` was 115 s of the macOS job's 145 s, against 38 s for the
+    # same suite in the Linux `sync` job. Almost none of that gap is the suite:
+    # it is one serial run of 17,651 process spawns -- 11,696 `git`, 3,612
+    # `age`, 1,544 `ssh-keygen`, 799 `age-keygen` -- and every one of them costs
+    # about four times as much on this runner. Measured on both, 30 iterations
+    # of the shapes this suite actually runs, ms per call, macOS against Linux:
+    #
+    #     add 8.96/2.27   commit 19.10/5.15   push 63.56/16.45
+    #     fetch 34.62/8.77   clone 60.09/14.61
+    #
+    # Uniformly ~3.9x, which is what says it is the spawning and not any one
+    # operation. Three cores rather than four accounts for part of the rest.
+    #
+    # Two things it is not, both measured rather than assumed. It is not fsync
+    # on APFS: `core.fsync=none` changed nothing on either platform. And it is
+    # not the worker count -- a sweep of `--jobs` over 6, 10, 16 and 24 on the
+    # macOS runner spanned 155.4 s to 130.9 s with the default at 139.6 s, which
+    # is noise around a flat line, so there is nothing there to tune.
+    #
+    # What is left is to stop one machine carrying all of it. Each shard runs a
+    # disjoint share of the classes and together they run every one:
+    # `tools/run_tests.py` packs them with the same rule it uses for the
+    # processes inside a shard, and `--no-skips` still applies per shard.
+    #
+    # Three, not more. The macOS job is the whole workflow's critical path only
+    # until it drops under the Linux `test` matrix at ~63 s, and on Linux -- the
+    # only place the curve could be measured per shard -- the suite goes 43 s
+    # whole, 26.7 s at two shards, 19.7 s at three, 16.9 s at four. The fourth
+    # shard buys a number nothing waits on, and GitHub allows five concurrent
+    # macOS jobs on this plan, which `macos` above already spends one of.
+    #
+    # Linux is deliberately left alone. Its `sync` job is 49 s inside a workflow
+    # that finishes in about 65 s, so sharding it would spend runners to move a
+    # number nothing waits on.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          # Same reason as the `macos` job: the system python3 is 3.9.
+          python-version: "3.12"
+      - name: install age
+        # No fzf, unlike the `macos` job: nothing in `tests.test_sync` reaches
+        # for it. git, ssh-keygen and zsh are already on the runner.
+        run: |
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install age
+          age --version && git --version && command -v ssh-keygen
+      # `strategy.job-total` rather than a repeated literal: the shard count is
+      # then the length of the matrix above and nowhere else, so raising it
+      # cannot leave a shard of the suite that no job runs. Out-of-range and
+      # more-shards-than-classes are both fatal in the runner rather than a
+      # green run of nothing, which is the failure this whole file guards.
+      - name: sync suite, shard ${{ matrix.shard }} of ${{ strategy.job-total }}
+        run: |
+          python -m tools.run_tests --only tests.test_sync --no-skips \
+            --shard ${{ matrix.shard }}/${{ strategy.job-total }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,12 +484,22 @@ jobs:
     # `tools/run_tests.py` packs them with the same rule it uses for the
     # processes inside a shard, and `--no-skips` still applies per shard.
     #
-    # Three, not more. The macOS job is the whole workflow's critical path only
-    # until it drops under the Linux `test` matrix at ~63 s, and on Linux -- the
-    # only place the curve could be measured per shard -- the suite goes 43 s
-    # whole, 26.7 s at two shards, 19.7 s at three, 16.9 s at four. The fourth
-    # shard buys a number nothing waits on, and GitHub allows five concurrent
-    # macOS jobs on this plan, which `macos` above already spends one of.
+    # Three, not more, and the honest version of why. Measured on the runners
+    # after this change: the shards' suite steps are 58 s, 42 s and 62 s, their
+    # jobs 71 s, 57 s and 73 s once ~11 s of checkout and brew are counted, and
+    # the whole workflow 80 s against 151 s before. So macOS is still the
+    # critical path, by about ten seconds over the Linux `test` matrix -- the
+    # prediction that three shards would take it *under* that line was wrong.
+    #
+    # A fourth would recover most of those ten seconds: on Linux, where the
+    # curve could be measured per shard, the suite goes 43 s whole, 26.7 s at
+    # two, 19.7 s at three, 16.9 s at four. It is not taken because GitHub
+    # allows five concurrent macOS jobs on this plan and `macos` above already
+    # spends one, so four shards sits exactly on the cap -- and a shard that
+    # queues costs a whole job's wait to save eight seconds. The remaining
+    # imbalance (42 s against 62 s) is a better place to look first: `pack`
+    # weighs classes by test count, and these classes differ by ~7x in seconds
+    # per test.
     #
     # Linux is deliberately left alone. Its `sync` job is 49 s inside a workflow
     # that finishes in about 65 s, so sharding it would spend runners to move a

--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -102,11 +102,11 @@ def tampering(mutate: Callable[[list[str]], list[str]]) -> Iterator[None]:
 
 
 class TestDiscovery(unittest.TestCase):
-    def test_every_test_is_assigned_to_exactly_one_shard(self) -> None:
-        """The sharding must partition the real suite -- no gaps, no double runs."""
+    def test_every_test_is_assigned_to_exactly_one_batch(self) -> None:
+        """The batching must partition the real suite -- no gaps, no double runs."""
         classes = run_tests.discover()
         ids = [tid for group in classes.values() for tid in group]
-        self.assertEqual(len(ids), len(set(ids)), "a test landed in two shards")
+        self.assertEqual(len(ids), len(set(ids)), "a test landed in two batches")
 
         serial = unittest.defaultTestLoader.discover(
             str(ROOT), pattern="test_*.py", top_level_dir=str(ROOT)
@@ -142,6 +142,77 @@ class TestPacking(unittest.TestCase):
         self.assertTrue(run_tests.selects("tests.test_sync", "tests.test_sync"))
         self.assertTrue(run_tests.selects("tests.test_sync.TestX", "tests.test_sync"))
         self.assertFalse(run_tests.selects("tests.test_sync_chunks.TestX", "tests.test_sync"))
+
+
+class TestShardingSplitsOneSuiteOverSeveralMachines(unittest.TestCase):
+    """`--shard I/N` is what stops one slow suite from being a job's whole cost.
+
+    The property to hold is coverage, not speed: run every shard of a split and
+    each test must have run exactly once. A test that only checked "a shard runs
+    fewer tests" would pass against a partition that dropped a class on the
+    floor -- and that failure is green, which is the one this file exists for.
+
+    Driven through classes that *fail* on purpose, because the summary names the
+    ids it failed and so says which tests actually ran. Counting them would not:
+    two shards running the same four tests and two shards splitting eight both
+    add up to eight.
+    """
+
+    def failures(self, text: str) -> list[str]:
+        return [line.split("FAIL: ")[1] for line in text.splitlines() if "FAIL: " in line]
+
+    def test_the_shards_together_run_every_test_exactly_once(self) -> None:
+        seen: list[str] = []
+        with fixture(FAILS, FAILS, FAILS, FAILS) as classes:
+            for index in (1, 2, 3):
+                code, text = run_main("--jobs", "2", "--shard", f"{index}/3")
+                self.assertEqual(code, 1, text)
+                # No shard may be empty either: one that ran nothing is the
+                # partial run that passes, and here it would hide in the union.
+                self.assertTrue(self.failures(text), f"shard {index}/3 ran nothing:\n{text}")
+                seen.extend(self.failures(text))
+        self.assertEqual(len(seen), len(set(seen)), f"a test ran in two shards: {seen}")
+        self.assertEqual({tid.rsplit(".", 1)[0] for tid in seen}, set(classes))
+
+    def test_one_shard_runs_less_than_the_whole(self) -> None:
+        """Otherwise the union above is satisfied by a --shard that does nothing."""
+        with fixture(PASSES, PASSES, PASSES, PASSES):
+            code, whole = run_main("--jobs", "2")
+            _, part = run_main("--jobs", "2", "--shard", "1/4")
+        self.assertEqual(code, 0, whole)
+        self.assertIn("Ran 4 tests", whole)
+        self.assertIn("Ran 1 tests in", part)
+        # Named in the summary: four green jobs that each ran a quarter of the
+        # suite read exactly like four that each ran all of it.
+        self.assertIn("(shard 1/4)", part)
+
+    def test_more_shards_than_classes_is_fatal_rather_than_an_empty_green_run(self) -> None:
+        """A matrix that outgrew the suite must be red, not quietly idle."""
+        with fixture(PASSES, PASSES):
+            code, text = run_main("--jobs", "2", "--shard", "3/3")
+        self.assertEqual(code, 1, text)
+        self.assertIn("more shards than there are classes", text)
+
+    def test_a_malformed_or_out_of_range_shard_is_fatal(self) -> None:
+        for spec in ("1", "0/2", "3/2", "1/0", "one/two", "/2", "2/"):
+            with self.subTest(spec=spec), fixture(PASSES, PASSES):
+                code, text = run_main("--jobs", "2", "--shard", spec)
+            self.assertEqual(code, 1, text)
+            self.assertIn("--shard", text)
+
+    def test_sharding_composes_with_only_and_no_skips(self) -> None:
+        """The macOS job passes all three at once, so the combination is the case.
+
+        The skipping class is selected *into* the shard being run, so --no-skips
+        still has something to catch -- a shard that quietly dropped it would
+        otherwise turn this green.
+        """
+        with fixture(SKIPS, SKIPS) as classes:
+            code, text = run_main(
+                "--jobs", "2", "--no-skips", "--only", classes[0], "--shard", "1/1"
+            )
+        self.assertEqual(code, 1, text)
+        self.assertIn("tests were skipped", text)
 
 
 class TestExclusionKeepsTheRestUnderNoSkips(unittest.TestCase):
@@ -202,7 +273,7 @@ class TestABatchThatDies(unittest.TestCase):
 
         self.assertEqual(code, 1, "a run whose batches all died reported success")
         self.assertIn("never ran", text)
-        self.assertIn("shard died without reporting", text)
+        self.assertIn("batch died without reporting", text)
 
     def test_a_worker_that_reports_fewer_tests_than_it_was_given_fails_the_run(self) -> None:
         """The count is not enough: the ids must match by name.

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -2,17 +2,17 @@
 
 The suite is dominated by `tests.test_sync`, which spends about 88% of its wall
 clock waiting on real `git`, `age` and `ssh-keygen` -- 5400 git invocations for
-one serial run. That is latency, not CPU, so it shards across processes almost
+one serial run. That is latency, not CPU, so it splits across processes almost
 linearly: 21s serially, 6.7s on a four-core runner.
 
-Sharding is by test *class*: classes are the unit that shares `setUpClass`, so
+Splitting is by test *class*: classes are the unit that shares `setUpClass`, so
 splitting one would run its fixture twice. Classes are then packed into batches,
 a few per worker rather than one process per class -- 71 interpreter starts cost
 about 5.6s of import CPU between them, which is most of what parallelism had
 just bought.
 
 What this adds over `python -m unittest discover` is an accounting check. A
-parallel runner has a failure mode a serial one does not: a shard that dies
+parallel runner has a failure mode a serial one does not: a batch that dies
 before it reports, leaving a run that is green because nothing ran. So every id
 handed to a batch must come back in that batch's report, by name:
 
@@ -23,6 +23,19 @@ Two honest limits on that. It is a closed loop -- both sides come from the same
 stays green, exactly as it would under plain unittest. And when a batch dies the
 ids come back as never-run, which is the point, but the diagnosis of *why* is in
 that batch's own stderr rather than in the summary.
+
+There are two splits, and they compose. Batches divide a suite over the
+processes of one machine, which is what the paragraphs above are about.
+`--shard I/N` divides it over N machines, each of which then batches its own
+share. The second exists for macOS: `tests.test_sync` is 17,651 process spawns,
+and each costs about four times there what it costs on Linux -- uniformly so
+across `git add`, `commit`, `push`, `fetch` and `clone`, which is what says it is
+the spawning rather than any one operation. That one suite was 115s of the macOS
+job's 145s while taking 38s on Linux. The measurements, and why neither `--jobs`
+nor `core.fsync` was the answer, are in `.github/workflows/ci.yml` beside the
+job that spends them. Nothing about the accounting changes -- each shard checks
+that the ids *it* was given all reported -- and `pack` does both splits, so the
+machines are balanced by the rule that already balanced the processes.
 
 `pytest -n auto --dist loadscope` would cover most of this in two dev
 dependencies. It is not used because the project carries no runtime dependencies
@@ -106,6 +119,21 @@ def pack(classes: dict[str, list[str]], bins: int) -> list[list[str]]:
     return batches
 
 
+def shard_of(spec: str) -> tuple[int, int]:
+    """Parse ``I/N`` into a zero-based index and a count.
+
+    Raises `ValueError` with the text a caller should print. Separate from
+    `main` so the parsing has a test that does not need a suite to run.
+    """
+    index, sep, total = spec.partition("/")
+    if not sep or not index.strip().isdigit() or not total.strip().isdigit():
+        raise ValueError(f"--shard wants I/N, got {spec!r}")
+    got, count = int(index), int(total)
+    if count < 1 or not 1 <= got <= count:
+        raise ValueError(f"--shard {spec} is out of range: I must be 1..N and N at least 1")
+    return got - 1, count
+
+
 class _Recorder(unittest.TextTestResult):
     """A result that remembers which ids ran, not just how many."""
 
@@ -161,6 +189,14 @@ def main(argv: list[str] | None = None) -> int:
         help="skip this module or class entirely; repeatable, and each pattern must "
         "match. For a suite that cannot run somewhere, so the rest keeps --no-skips",
     )
+    parser.add_argument(
+        "--shard",
+        default="",
+        metavar="I/N",
+        help="run only shard I of N, for splitting one suite over N machines. "
+        "The batches below split a suite over the processes of one machine; this "
+        "splits it over the machines, and the two compose",
+    )
     parser.add_argument("--worker", nargs="+", help=argparse.SUPPRESS)
     parser.add_argument("--out", help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
@@ -187,6 +223,27 @@ def main(argv: list[str] | None = None) -> int:
             print(f"::error::no test class matches --exclude {pattern!r}")
             return 1
         classes = kept
+    if args.shard:
+        try:
+            index, count = shard_of(args.shard)
+        except ValueError as exc:
+            print(f"::error::{exc}")
+            return 1
+        # `pack` is reused rather than a slice of the sorted names, so the
+        # machines get comparable amounts of work for the same reason the
+        # processes do -- and so that one balancing rule is tested once.
+        #
+        # More shards than classes is fatal rather than an empty green run. An
+        # empty shard reports "Ran 0 tests" and exits 0, which is precisely the
+        # partial run that is green because nothing happened -- the thing this
+        # script exists to refuse. It can only come from a matrix that outgrew
+        # the suite, so it is the CI config that is wrong, and silence there
+        # would spread to every shard as classes were removed.
+        if count > len(classes):
+            print(f"::error::--shard {args.shard} wants more shards than there are classes")
+            return 1
+        chosen = pack(classes, count)[index]
+        classes = {name: classes[name] for name in chosen}
     expected = {tid for ids in classes.values() for tid in ids}
 
     # Twice the CPUs, because the work is subprocess wait rather than CPU:
@@ -197,7 +254,7 @@ def main(argv: list[str] | None = None) -> int:
     # others rather than deciding the wall clock on its own.
     batches = pack(classes, jobs * 2)
 
-    with tempfile.TemporaryDirectory(prefix="woswoar-shards-") as tmp:
+    with tempfile.TemporaryDirectory(prefix="woswoar-batches-") as tmp:
 
         def run(indexed: tuple[int, list[str]]) -> dict[str, Any]:
             index, names = indexed
@@ -210,7 +267,7 @@ def main(argv: list[str] | None = None) -> int:
                 # Killed by the OOM killer, a segfault in a C extension, a crash
                 # in setUpClass: no report, so nothing it would have said can be
                 # believed. Its ids come out below as never-run.
-                print(f"::error::shard died without reporting, exit {proc.returncode}: {names}")
+                print(f"::error::batch died without reporting, exit {proc.returncode}: {names}")
                 return {"ran": [], "failures": [], "errors": list(names), "skipped": []}
             loaded: dict[str, Any] = json.loads(out.read_text(encoding="utf-8"))
             return loaded
@@ -223,7 +280,8 @@ def main(argv: list[str] | None = None) -> int:
     errors = [tid for report in reports for tid in report["errors"]]
     skipped = [pair for report in reports for pair in report["skipped"]]
 
-    print(f"\nRan {len(ran)} tests in {len(batches)} batches on {jobs} workers")
+    where = f" (shard {args.shard})" if args.shard else ""
+    print(f"\nRan {len(ran)} tests in {len(batches)} batches on {jobs} workers{where}")
     for label, ids in (("FAIL", failures), ("ERROR", errors)):
         for tid in ids:
             print(f"  {label}: {tid}")  # the traceback is already above, from the batch


### PR DESCRIPTION
## Why the macOS job was slow

Three things compounding. Measured, not guessed:

1. **One step was 79% of the job.** `tests.test_sync` was 115 s of the macOS job's 145 s, against 38 s for the same suite in the Linux `sync` job. Everything else on macOS totals ~30 s.
2. **That suite is 17,651 process spawns** — 11,696 `git`, 3,612 `age`, 1,544 `ssh-keygen`, 799 `age-keygen` — and each costs ~4x more on the macOS runner. Benchmarked on both runners, 30 iterations of the operations the suite actually runs, ms per call:

   | | add | commit | push | fetch | clone |
   |---|---|---|---|---|---|
   | macOS | 8.96 | 19.10 | 63.56 | 34.62 | 60.09 |
   | Linux | 2.27 | 5.15 | 16.45 | 8.77 | 14.61 |

   Uniformly ~3.9x. That uniformity is what says it is the spawning rather than any one operation. Three cores instead of four accounts for part of the rest.
3. **macOS ran in one sequential job what Linux spreads over four parallel ones** (`test`, `sync`, `hook`, `install`).

Two plausible culprits ruled out by measurement rather than argument:

- **Not fsync on APFS.** `core.fsync=none` changed nothing on either platform.
- **Not the worker count.** A `--jobs` sweep of 6/10/16/24 on the macOS runner spanned 155.4 s to 130.9 s with the default (6) at 139.6 s — noise around a flat line. There is nothing there to tune.

## The change

`tools/run_tests.py` grows `--shard I/N`, splitting one suite over N machines the way batches already split it over one machine's processes. `pack` does both splits, so the machines are balanced by the rule that already balanced the processes, and the accounting check is unchanged: each shard verifies that the ids *it* was given all reported.

Two ways to lose coverage silently are fatal rather than green:

- a shard index out of range, or a malformed `I/N`
- a matrix with more shards than the suite has classes — an empty shard would otherwise report `Ran 0 tests` and exit 0, which is exactly the partial run this script exists to refuse

`tests.test_sync` moves to a `macos-sync` matrix of three shards. The count is `strategy.job-total`, so the matrix list is the only place it is written and raising it cannot leave a share of the suite that no job runs.

Linux is deliberately left alone: its `sync` job is 49 s inside a workflow that finished in ~65 s, so sharding it would spend runners to move a number nothing waits on.

## Result, measured on CI

Run [356](https://github.com/martinus/woswoar/actions/runs/32137130293), all 12 jobs green:

| | before | after |
|---|---|---|
| whole workflow | 151 s | **80 s** |
| macOS critical path | 145 s | **73 s** |
| `macos` job | 145 s | 50 s |

Coverage confirmed on the real runners rather than only locally — the three shards reported `Ran 90`, `Ran 90`, `Ran 89` = **269 tests**, the whole suite, no overlap, `0 skipped` in each.

Since that run, main gained #226 and #227 and has been merged in. They add four classes to `tests.test_sync`, so the suite is now 62 classes / 280 tests and the shards repartition to 94/93/93 — checked, still a partition with no gap and no overlap. The numbers above are from before that merge; the CI run on this PR is the current one.

## Regression tests (rule 3)

`python -m tools.mutate --base main`, verbatim:

```
1 file(s), 64 changed lines -> 37 mutants
  caught    tools/run_tests.py:129 in shard_of() -- the `not` is dropped
  caught    tools/run_tests.py:129 in shard_of() -- the `if` is always taken
  caught    tools/run_tests.py:129 in shard_of() -- the `if` is never taken
  caught    tools/run_tests.py:129 in shard_of() -- `or` becomes `and`
  caught    tools/run_tests.py:129 in shard_of() -- the `not` is dropped
  caught    tools/run_tests.py:129 in shard_of() -- the `not` is dropped
  caught    tools/run_tests.py:132 in shard_of() -- `<` becomes `<=`
  caught    tools/run_tests.py:132 in shard_of() -- the `if` is always taken
  caught    tools/run_tests.py:132 in shard_of() -- the `if` is never taken
  caught    tools/run_tests.py:132 in shard_of() -- `or` becomes `and`
  caught    tools/run_tests.py:132 in shard_of() -- `1` becomes `2`
  SURVIVED  tools/run_tests.py:132 in shard_of() -- `1` becomes `0`
  caught    tools/run_tests.py:132 in shard_of() -- the `not` is dropped
  caught    tools/run_tests.py:132 in shard_of() -- `1` becomes `2`
  caught    tools/run_tests.py:132 in shard_of() -- `1` becomes `0`
  caught    tools/run_tests.py:134 in shard_of() -- `-` becomes `+`
  caught    tools/run_tests.py:134 in shard_of() -- returns `None` instead of `(got - 1, count)`
  SURVIVED  tools/run_tests.py:134 in shard_of() -- `1` becomes `2`
  caught    tools/run_tests.py:134 in shard_of() -- `1` becomes `0`
  caught    tools/run_tests.py:192 in main() -- the call to `parser.add_argument(...)` never happens
  caught    tools/run_tests.py:226 in main() -- the `if` is always taken
  caught    tools/run_tests.py:226 in main() -- the `if` is never taken
  caught    tools/run_tests.py:230 in main() -- the call to `print(...)` never happens
  caught    tools/run_tests.py:231 in main() -- `1` becomes `2`
  caught    tools/run_tests.py:231 in main() -- `1` becomes `0`
  caught    tools/run_tests.py:231 in main() -- returns `None` instead of `1`
  caught    tools/run_tests.py:242 in main() -- `>` becomes `>=`
  caught    tools/run_tests.py:242 in main() -- the `if` is always taken
  caught    tools/run_tests.py:242 in main() -- the `if` is never taken
  caught    tools/run_tests.py:243 in main() -- the call to `print(...)` never happens
  caught    tools/run_tests.py:244 in main() -- `1` becomes `2`
  caught    tools/run_tests.py:244 in main() -- `1` becomes `0`
  caught    tools/run_tests.py:244 in main() -- returns `None` instead of `1`
  caught    tools/run_tests.py:266 in main.run() -- the `if` is always taken
  caught    tools/run_tests.py:266 in main.run() -- the `if` is never taken
  caught    tools/run_tests.py:270 in main.run() -- the call to `print(...)` never happens
  caught    tools/run_tests.py:284 in main() -- the call to `print(...)` never happens

confirming 2 survivor(s) against the whole suite...
  caught    tools/run_tests.py:132 in shard_of() -- `1` becomes `0`
  caught    tools/run_tests.py:134 in shard_of() -- `1` becomes `2`
2 of them were caught by a test the selection had not run.
```

All 37 caught. But the generated mutants only reach `shard_of`, which is the *parsing* — none of them can express "the shards no longer partition the suite", which is the failure that matters here because it is green. So four were written by hand for the partition itself:

```
  caught    every shard runs the first bin, so two thirds of the suite never runs
  caught    the shard selection is dropped entirely, so every shard runs everything
  caught    a shard beyond the class count is allowed to run nothing, and passes
  SURVIVED  shards are cut by name order rather than balanced, but still partition
```

**The survivor is deliberate and I am not "fixing" it.** Cutting the classes by name order instead of by `pack` is still a correct partition — no test is dropped and none runs twice — it is only worse balanced. The tests assert coverage and disjointness, which are correctness; balance is a performance property that `TestPacking` already covers for the same function. A test that failed on that mutant would be pinning an implementation detail.

## Notes

- The second commit corrects a claim in the first. I had predicted three shards would take macOS *under* the Linux `test` matrix; it landed ~10 s above, so macOS is still the critical path, just much shorter. The comment now says that, says what a fourth shard would buy (~8 s), and says why it is not taken: `macos` plus four shards sits exactly on GitHub's five-concurrent-macOS-job cap, and a queued shard costs a whole job's wait to save eight seconds.
- **Branch protection:** `macos-sync (1|2|3)` are new check names. If `macos` is a required check, the new ones likely want adding.
- Not filed as an issue, per rule 4, but worth saying: the remaining shard imbalance is 42 s against 62 s, because `pack` weighs classes by test count while these classes differ ~7x in seconds per test. That is a real ~20 s. By the convergence rule at the end of CLAUDE.md it is close to the point where this should stop, so it is recorded here rather than turned into a card — happy to file it if you would rather track it.