### PR TITLE
test: a subTest that runs out of memory is not a test noticing

### DIFF
--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -1112,6 +1112,7 @@ class TestAMutantThatEatsMemory(MutateTestCase):
         self.assertIn("ran out of memory", report.results[0].verdict.detail)
 
 
+@unittest.skipUnless(enforced(), "this kernel does not enforce the address-space limit")
 class TestASubTestThatRunsOutOfMemory(MutateTestCase):
     """The intersection of the two cases above, which neither of them covers.
 
@@ -1125,6 +1126,12 @@ class TestASubTestThatRunsOutOfMemory(MutateTestCase):
     `caught`: a test credited with a guard it does not have, which is the exact
     lie #220 removed one level down. This repository uses `subTest` in more than
     twenty places, so the intersection is reachable rather than theoretical.
+
+    Gated on `enforced()` for the same reason as its sibling, which CI taught
+    twice: macOS does not apply `RLIMIT_AS`, so the 800 MiB simply succeeds
+    there, `clamp` returns a large number, the subtest notices it and the row
+    reads `caught`. The first version of this test copied the fixture and not
+    the gate.
     """
 
     def subtesting_package(self) -> None:

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -1112,6 +1112,63 @@ class TestAMutantThatEatsMemory(MutateTestCase):
         self.assertIn("ran out of memory", report.results[0].verdict.detail)
 
 
+class TestASubTestThatRunsOutOfMemory(MutateTestCase):
+    """The intersection of the two cases above, which neither of them covers.
+
+    `TestASubTestIsARealAnswer` drives an assertion inside `with
+    self.subTest(...)`; `TestAMutantThatEatsMemory` drives a `MemoryError` in a
+    plain test. `Verdicts.addSubTest` has a branch for both at once, and the
+    whole-package sweep of `tools/` found it unreached -- the only real gap that
+    sweep turned up, and it is in the code that decides what `caught` means.
+
+    Reverted, a memory-exhausted subtest is filed as `noticed` and the row reads
+    `caught`: a test credited with a guard it does not have, which is the exact
+    lie #220 removed one level down. This repository uses `subTest` in more than
+    twenty places, so the intersection is reachable rather than theoretical.
+    """
+
+    def subtesting_package(self) -> None:
+        """`CLAMP`, and a test whose every assertion is inside a `subTest`."""
+        self.write("mod.py", CLAMP)
+        self.write(
+            "test_mod.py",
+            """
+            import unittest
+
+            import mod
+
+
+            class T(unittest.TestCase):
+                def test_it(self) -> None:
+                    for value in (-5, -1):
+                        with self.subTest(value=value):
+                            self.assertEqual(mod.clamp(value), 0)
+            """,
+        )
+
+    def test_it_is_broke_rather_than_the_subtest_noticing(self) -> None:
+        self.subtesting_package()
+        report = run(
+            [
+                Mutation(
+                    "clamp allocates 800 MiB inside a subTest",
+                    "mod.py",
+                    "        return 0",
+                    "        return len(bytearray(800 * 1024 * 1024))",
+                    "test_mod",
+                ),
+                # The sibling row proves the fixture's subTest route really does
+                # report a catch, so "broke" above is not simply a broken fixture.
+                Mutation("the guard goes", "mod.py", "if value < 0:", "if False:", "test_mod"),
+            ],
+            baseline=False,
+            strict=False,
+            memory=512 << 20,
+        )
+        self.assertEqual([result.verdict.outcome for result in report.results], ["broke", "caught"])
+        self.assertIn("ran out of memory", report.results[0].verdict.detail)
+
+
 class TestAMutantThatNeverFinishes(MutateTestCase):
     """A generated mutant can turn a loop bound into one that never fires.
 


### PR DESCRIPTION
The one real gap the `tools/` sweep found, and it is in the code that decides
what `caught` means.

`Verdicts.addSubTest` has a branch for a `MemoryError` arriving inside `with
self.subTest(...)`. Two existing tests bracket it without covering it:

- `TestASubTestIsARealAnswer` — an assertion inside a `subTest`
- `TestAMutantThatEatsMemory` — a `MemoryError` in a plain test

The intersection was unreached. Reverted, a memory-exhausted subtest is filed as
`noticed` and the row reads **`caught`** — a test credited with a guard it does
not have, which is the exact lie #220 removed one level down. This repository
uses `subTest` in more than twenty places, so it is reachable rather than
theoretical.

The fixture's sibling row is deliberate: it proves the same `subTest` route does
report a real catch, so `broke` on the first row is not simply a broken fixture.

```
  caught    a memory-exhausted subTest is filed as a test noticing
  caught    the subTest exhaustion branch records nothing at all
```

## Where it came from, and what else that sweep found

`--all --only tools/` crossed with coverage via `tools/reached.py`. 417 of 1306
rows completed before the sweep was abandoned (see below):

```
ALL       417
  caught  163
  broke    31
  timeout   1
  SURVIVED 222
    on a line NO test executes  165
    on a line tests DO execute   57
```

Everything else in the unreached 165 was either an **equivalent mutant** or dev
tooling nobody asserts on:

| | rows | |
|---|---|---|
| `demo/seed.py` | 68 | demo seeding |
| `bench.py` | 60 | the benchmark tool |
| `compare.py` | 26 | the comparison tool |
| **`verdict.py`** | **9** | **1 real gap, this PR; 8 equivalent** |
| `reached.py` | 2 | `sorted` on a printed tally |

The `verdict.py` equivalents are worth naming so nobody re-investigates them:
`verbosity=0 → 1` writes more to a `StringIO` that is discarded, and `"ran": 0`
in the loader-error path is unobservable because `_run` returns on a non-empty
`broke` before it ever checks `ran`.

## The sweep was abandoned, and why

It OOM-killed the machine three times and I stopped it. Two causes, one of them
a regression I introduced:

1. **The lane × cap product exceeds RAM.** 16 lanes × 4 GiB = 64 GiB on a 63 GiB
   box. The guard originally bounded lanes by dividing the budget by the 4 GiB
   ceiling, giving 7. #227's review correctly showed that over-restricted
   ordinary machines (a 16 GiB laptop got 2 lanes), so I divided by *measured*
   use instead — which restored 16 lanes and with them the over-commitment the
   original divisor prevented. That was a trade, and I did not notice I was
   making one.

2. **Sweeping `tools/` is recursive.** `tests/test_mutate.py` invokes the
   harness 22 times and `tools/run_tests.py` has its own `ThreadPoolExecutor`
   and subprocesses, so each outer lane hosts an inner mutation run with its own
   lanes and its own 4 GiB caps. `verdict.cap` bounds one probe; it cannot bound
   a probe that spawns a fleet of probes.

The three files still unswept — `mutants.py` (450), `mutate.py` (298),
`run_tests.py` (141) — are exactly the recursive ones. Filed separately; this PR
is only the finding.

The resume did its job through all three crashes: 417 rows survived on disk and
the second attempt skipped the six completed files rather than redoing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)