### PR TITLE
fix: mutate bounds the process tree, not one process at a time (#232)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,15 +103,25 @@ without its mode, which is what `docs/security.md` rests on. `encoding` fails
 the second half and was removed: dropping it is a real defect under a non-UTF-8
 locale, and unkillable in a suite that never runs under one.
 
-A generated mutant can also fail to *stop*. Two bounds are enforced per row, and
-they answer different questions: `--timeout` (300 s) for a mutation that never
-finishes, and `--memory` (4 GiB of address space) for one that never finishes
-*while allocating*. The second is not a refinement of the first — a timeout
-cannot fire on a machine that is already out of memory. An `at -= …` generated
-for this repository's own `line_starts` reached 15.5 GB in 73 seconds and
-OOM-killed the session twice before 300 s was anywhere in sight. Lanes are
-capped by memory as well as by cores, because the per-row limit bounds one lane
-and not their product.
+A generated mutant can also fail to *stop*, and there are three ways rather than
+one. `--timeout` (300 s) answers a mutation that never finishes. `--memory`
+(4 GiB of address space, per process) answers one that never finishes *while
+allocating* — not a refinement of the first, because a timeout cannot fire on a
+machine that is already out of memory: an `at -= …` generated for this
+repository's own `line_starts` reached 15.5 GB in 73 seconds and OOM-killed the
+session twice before 300 s was anywhere in sight.
+
+The third is a mutation that spawns *processes*, which neither of the others can
+see. `tools/mutate.py` and `tools/run_tests.py` are themselves things a sweep
+mutates, and a mutant in either decides how many processes its lane starts. The
+sweep that found this had 4,340 alive at once holding 26 GB between them, six
+megabytes each and none within two orders of magnitude of its own ceiling, and
+it took the machine down three times (#232). So each probe now runs in its own
+session, its whole process group is counted once a second against the share
+`_share` gave it, and a group over that share is killed whole and reported
+`BROKE`. Lanes and the ceiling are chosen together for the same reason: what the
+machine feels is their product, and sixteen lanes promised 4 GiB each is 64 GiB
+of promises on a 63 GiB box.
 
 A survivor list is not a finding, and reading one unaided is how two confident
 wrong triages happened here. Cross it with coverage:

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -1222,6 +1222,167 @@ def outliving(pids: Sequence[int], seconds: float) -> list[int]:
         time.sleep(0.1)
 
 
+class TestNoCapMeansNoWatcher(MutateTestCase):
+    """`--memory 0` promises no cap, and a ceiling of zero is the opposite of one.
+
+    Registered rather than skipped, a lane at zero is over its share the moment
+    it has a page, so every row of a `--memory 0` run would be killed and
+    reported unanswered -- the flag doing precisely what it says it does not.
+    """
+
+    def test_a_lane_with_no_ceiling_is_not_killed(self) -> None:
+        self.write("mod.py", CLAMP)
+        self.write(
+            "test_mod.py",
+            """
+            import time
+            import unittest
+
+            import mod
+
+
+            class T(unittest.TestCase):
+                def test_it(self) -> None:
+                    # Longer than one sample, or a lane that finishes before the
+                    # watcher has looked once proves nothing about being watched.
+                    time.sleep(2)
+                    self.assertEqual(mod.clamp(-5), 0)
+            """,
+        )
+        verdict = mutate._run(["test_mod"], self.root, memory=0, timeout=60.0)
+        self.assertEqual(verdict.outcome, "survived", verdict.detail)
+
+
+class TestItSaysWhatItGaveTheLanes(MutateTestCase):
+    """A share lowered in silence reads as a slow tool rather than a bounded one,
+    and it is what makes a later `ran out of memory` row inexplicable. Same
+    argument as `--limit` printing what it dropped."""
+
+    def running(self, visible: int, workers: int | None = None) -> str:
+        self.package(guarded=True)
+        said = io.StringIO()
+        with (
+            mock.patch.object(mutate, "_visible_memory", return_value=visible),
+            contextlib.redirect_stdout(said),
+        ):
+            run(
+                [Mutation("the clamp is gone", "mod.py", "if value < 0:", "if False:", "test_mod")],
+                baseline=False,
+                workers=workers,
+            )
+        return said.getvalue()
+
+    def test_a_machine_that_cannot_afford_what_was_asked_is_told_so(self) -> None:
+        said = self.running(2 << 30)
+        self.assertIn("lane(s) at", said)
+        self.assertIn("_share", said)
+
+    def test_a_machine_with_room_is_not_lectured(self) -> None:
+        self.assertNotIn("lane(s) at", self.running(512 << 30))
+
+    def test_a_pinned_run_hears_about_its_ceiling(self) -> None:
+        """The half that only a pinned run reaches: the lane count is exactly
+        what was asked for and the *ceiling* is what gave way, so a condition
+        that wants both to have changed says nothing at all."""
+        self.assertIn("lane(s) at", self.running(2 << 30, workers=1))
+
+
+class TestTheSamplerAndTheLanesItHasLeft(unittest.TestCase):
+    """What a mutation table found unguarded: `_Lanes`' own bookkeeping.
+
+    The storm test above drives one lane from beginning to end, and a sweep of
+    this file showed what that cannot see -- a `release` that forgets to
+    unregister, or that stops the sampler while other lanes are still running,
+    leaves every assertion in that test passing on a harness that has silently
+    stopped guarding anything after the first row.
+    """
+
+    def holding(self, bytes_held: int) -> subprocess.Popen[bytes]:
+        """A process in a session of its own, holding `bytes_held`, for 30s.
+
+        Its own session because that is what a lane is: `_Lanes` counts by
+        process group, so a fixture sharing this one's group would be asking a
+        different question -- and would put this suite's own pid in the table.
+        """
+        held = subprocess.Popen(
+            [sys.executable, "-c", f"import time; held = bytearray({bytes_held}); time.sleep(30)"],
+            start_new_session=True,
+        )
+        self.addCleanup(reap, held.pid)
+        self.addCleanup(mutate._WATCHED.release, held.pid)
+        return held
+
+    def test_releasing_one_lane_leaves_the_others_watched(self) -> None:
+        over = self.holding(64 << 20)
+        under = self.holding(1 << 20)
+        mutate._WATCHED.watch(under.pid, 512 << 20)
+        mutate._WATCHED.watch(over.pid, 8 << 20)
+        mutate._WATCHED.release(under.pid)
+        self.assertKilled(over, "the sampler stopped when the first lane was released")
+        self.assertGreater(mutate._WATCHED.release(over.pid), 8 << 20)
+
+    def test_the_sampler_comes_back_after_the_last_lane_goes(self) -> None:
+        """It is stopped when nothing is left to watch, so the next lane has to
+        start it again -- and a run is many lanes, one after another."""
+        first = self.holding(1 << 20)
+        mutate._WATCHED.watch(first.pid, 512 << 20)
+        mutate._WATCHED.release(first.pid)
+
+        later = self.holding(64 << 20)
+        mutate._WATCHED.watch(later.pid, 8 << 20)
+        self.assertKilled(later, "no lane was watched after the sampler had stopped")
+        self.assertGreater(mutate._WATCHED.release(later.pid), 8 << 20)
+
+    def assertKilled(self, held: subprocess.Popen[bytes], why: str) -> None:
+        """Waited on rather than polled with `os.kill(pid, 0)`.
+
+        These children have this process as their parent, so a killed one is a
+        zombie until it is reaped -- and a zombie answers signal 0 exactly like
+        a running process. `outliving` is right for the tests above it, whose
+        children are orphaned by the kill and reaped by init; here it would
+        report a killed child as alive for ever.
+        """
+        try:
+            held.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.fail(why)
+        self.assertEqual(held.returncode, -signal.SIGKILL, why)
+
+
+class TestReadingPsOutputThatIsNotWhatItExpects(unittest.TestCase):
+    """`ps` is the reader macOS depends on, and the only one with a parser.
+
+    Every line real `ps` prints here is two numbers, so nothing in the suite
+    distinguishes the check from no check at all -- a sweep of this file
+    reported five surviving mutants on that one line. Junk is what it is for:
+    a header, a truncated line, a `?` where a number was expected.
+    """
+
+    def reading(self, said: str) -> dict[int, int]:
+        listed = subprocess.CompletedProcess([""], 0, stdout=said, stderr="")
+        with mock.patch.object(subprocess, "run", return_value=listed):
+            return mutate._from_ps()
+
+    def test_only_lines_of_two_numbers_are_counted(self) -> None:
+        self.assertEqual(
+            self.reading(
+                "  PGID   RSS\n"  # a header, if the `=` suffixes ever stop working
+                "   501  1024\n"
+                "     ?    12\n"  # a field `ps` could not answer
+                "   502\n"  # truncated
+                "   503  4096 stray\n"  # more than was asked for
+                "\n"
+                "   501  2048\n"  # a second process in a group already seen
+            ),
+            {501: 3072 * 1024},
+        )
+
+    def test_kibibytes_are_not_bytes(self) -> None:
+        """The unit `ps` answers in, which is the difference between killing a
+        lane at its share and killing it at a thousandth of it."""
+        self.assertEqual(self.reading("  700  2048\n"), {700: 2 << 20})
+
+
 class TestALaneThatSpawnsProcesses(MutateTestCase):
     """The failure a per-process ceiling cannot see, at the scale that killed it.
 

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -1100,6 +1100,22 @@ class TestTheShareOneLaneGets(unittest.TestCase):
         lanes, memory = self.share(8 << 30, wanted=64)
         self.assertLessEqual(lanes * memory, (8 << 30) // 2)
 
+    def test_a_pinned_lane_count_is_kept_and_the_ceiling_gives_way(self) -> None:
+        """`--workers` is a count a caller has reasons to fix, and this cannot
+        see them. It is also what the class above uses to assert that mutations
+        overlap at all -- lowering it there would have turned a test of the pool
+        into a test of the machine, which is the failure its own comment names.
+
+        A pinned run is not unbounded: `_Lanes` measures what the lanes hold
+        rather than predicting it, and that is the guard a wrong prediction
+        leaves standing.
+        """
+        with mock.patch.object(mutate, "_visible_memory", return_value=2 << 30):
+            pinned = mutate._share(4, MEMORY, pinned=True)
+            asked = mutate._share(4, MEMORY)
+        self.assertEqual(pinned, mutate.Share(4, mutate._FLOOR))
+        self.assertEqual(asked.lanes, 1, "unpinned, the machine decides")
+
 
 class TestAHarnessRunningInsideALane(unittest.TestCase):
     """`tests/test_mutate.py` starts this module, so a lane mutating `tools/`
@@ -1119,6 +1135,35 @@ class TestAHarnessRunningInsideALane(unittest.TestCase):
         for said in ("", "lots", "-1", "0"):
             with self.subTest(said=said), mock.patch.dict(os.environ, {mutate._BUDGET: said}):
                 self.assertGreater(mutate._visible_memory(), 0)
+
+
+class TestALaneCarriesItsShareIntoTheProbe(MutateTestCase):
+    """The wire between the two halves: `_share` decides, and the probe has to
+    be *told*, or an inner harness reads the host's memory and sizes itself for
+    a machine it does not have.
+
+    The variable is spelled out here rather than taken from `mutate._BUDGET`
+    on purpose. It is a name two processes agree on, so a test that reads it
+    from the same constant the code does would pass through any rename --
+    including one that changed only the half that writes it.
+    """
+
+    def test_the_probe_is_told_what_it_may_spend(self) -> None:
+        share = 1 << 30
+        self.write(
+            "test_budget.py",
+            f"""
+            import os
+            import unittest
+
+
+            class T(unittest.TestCase):
+                def test_the_lane_said_so(self) -> None:
+                    self.assertEqual(os.environ.get("WOSWOAR_MUTATE_BUDGET"), "{share}")
+            """,
+        )
+        verdict = mutate._run(["test_budget"], self.root, memory=share)
+        self.assertEqual(verdict.outcome, "survived", verdict.detail)
 
 
 class TestCountingWhatALaneHolds(unittest.TestCase):

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -1028,6 +1028,226 @@ class TestHowManyLanesFitInMemory(unittest.TestCase):
             self.assertGreater(mutate._visible_memory(), 0)
 
 
+class TestTheShareOneLaneGets(unittest.TestCase):
+    """Lanes and ceiling are one decision, because the machine feels the product.
+
+    #232: sixteen lanes at a 4 GiB ceiling is 64 GiB of promises on a 63 GiB
+    machine, and the kernel collected on them three times. Each half was
+    defensible alone -- which is why what is asserted here is the product, and
+    why the class above it, asserting the lane count on its own, was green
+    throughout.
+    """
+
+    def share(self, visible: int, wanted: int = 16, memory: int = MEMORY) -> mutate.Share:
+        with mock.patch.object(mutate, "_visible_memory", return_value=visible):
+            return mutate._share(wanted, memory)
+
+    def test_the_product_stays_inside_the_budget(self) -> None:
+        # From a small CI runner to a large server. Every size below has room
+        # for at least one lane at the floor, so the budget is a real bound
+        # here; the machine that has not is the test after this one.
+        for gib in (8, 16, 32, 63, 128, 512):
+            with self.subTest(gib=gib):
+                lanes, memory = self.share(gib << 30)
+                self.assertLessEqual(lanes * memory, (gib << 30) // 2)
+
+    def test_a_machine_too_small_for_one_honest_lane_still_gets_one(self) -> None:
+        """And gets the floor, over budget, on purpose.
+
+        The alternative is a ceiling under what an honest suite needs, which
+        does not fail as "too small to run": it fails as `ran out of memory`
+        against whichever test was running, which reads as a finding.
+        """
+        lanes, memory = self.share(2 << 30)
+        self.assertEqual(lanes, 1)
+        self.assertEqual(memory, mutate._FLOOR)
+
+    def test_the_ceiling_gives_way_before_the_lanes_do(self) -> None:
+        """A big machine keeps its parallelism and stops over-promising.
+
+        Sixteen lanes is what this box ran before #232 and what it runs after;
+        the difference is the ceiling each was told it could reach.
+        """
+        lanes, memory = self.share(63 << 30)
+        self.assertGreaterEqual(lanes, 8)
+        self.assertLess(memory, MEMORY)
+
+    def test_a_laptop_is_not_cut_to_the_pathological_case(self) -> None:
+        """#227's complaint, which the first fix for this would have brought back.
+
+        Dividing the budget by `MEMORY` gave a 16 GiB machine two lanes, to
+        bound a case the ceiling already truncates within seconds.
+        """
+        lanes, _ = self.share(16 << 30)
+        self.assertGreater(lanes, 2)
+
+    def test_the_ceiling_never_falls_under_the_floor(self) -> None:
+        for gib in (2, 8, 16, 63, 512):
+            with self.subTest(gib=gib):
+                self.assertGreaterEqual(self.share(gib << 30).memory, mutate._FLOOR)
+
+    def test_no_cap_is_left_uncapped(self) -> None:
+        """`--memory 0` is a promise the flag makes; there is no product to bound."""
+        self.assertEqual(self.share(63 << 30, memory=0).memory, 0)
+
+    def test_an_explicit_ceiling_under_the_floor_is_the_callers_own(self) -> None:
+        """Reproducing a small machine on purpose is a real reason to ask."""
+        lanes, memory = self.share(63 << 30, memory=256 << 20)
+        self.assertEqual(memory, 256 << 20)
+        self.assertLessEqual(lanes * memory, (63 << 30) // 2)
+
+    def test_asking_for_more_lanes_does_not_conjure_memory(self) -> None:
+        lanes, memory = self.share(8 << 30, wanted=64)
+        self.assertLessEqual(lanes * memory, (8 << 30) // 2)
+
+
+class TestAHarnessRunningInsideALane(unittest.TestCase):
+    """`tests/test_mutate.py` starts this module, so a lane mutating `tools/`
+    hosts a second harness -- which sized itself for the whole host, sixteen
+    lanes deep, until the budget was passed down."""
+
+    def test_an_inherited_budget_is_a_limit_like_the_cgroup(self) -> None:
+        with mock.patch.dict(os.environ, {mutate._BUDGET: str(3 << 30)}):
+            self.assertEqual(mutate._visible_memory(), 3 << 30)
+
+    def test_it_can_only_lower(self) -> None:
+        """A lane cannot be given more memory than the machine has by saying so."""
+        with mock.patch.dict(os.environ, {mutate._BUDGET: str(1 << 60)}):
+            self.assertLess(mutate._visible_memory(), 1 << 60)
+
+    def test_nonsense_is_ignored_rather_than_raised(self) -> None:
+        for said in ("", "lots", "-1", "0"):
+            with self.subTest(said=said), mock.patch.dict(os.environ, {mutate._BUDGET: said}):
+                self.assertGreater(mutate._visible_memory(), 0)
+
+
+class TestCountingWhatALaneHolds(unittest.TestCase):
+    """Both readers, on every platform, because one of them is macOS's only guard."""
+
+    def test_ps_sees_this_process_group(self) -> None:
+        self.assertGreater(mutate._from_ps().get(os.getpgrp(), 0), 1 << 20)
+
+    @unittest.skipUnless(Path("/proc/self/stat").exists(), "no /proc on this platform")
+    def test_proc_sees_this_process_group(self) -> None:
+        self.assertGreater(mutate._from_proc().get(os.getpgrp(), 0), 1 << 20)
+
+    @unittest.skipUnless(Path("/proc/self/stat").exists(), "no /proc on this platform")
+    def test_the_two_readers_agree_about_this_group(self) -> None:
+        """Not to the byte -- `ps` and `/proc` count shared pages differently and
+        the suite allocates between the two calls -- but within a factor, which
+        is what a ceiling comparison actually needs."""
+        ours = os.getpgrp()
+        from_proc, from_ps = mutate._from_proc()[ours], mutate._from_ps()[ours]
+        self.assertLess(max(from_proc, from_ps) / min(from_proc, from_ps), 4)
+
+
+class TestALaneThatSpawnsProcesses(MutateTestCase):
+    """The failure a per-process ceiling cannot see, at the scale that killed it.
+
+    Sixteen children holding 64 MiB each is a gibibyte between them, and every
+    one of them is far inside the ceiling the lane is given -- exactly the
+    kernel log of #232's last crash, where 4,340 processes held 26 GB and none
+    was within two orders of magnitude of its own limit. So `verdict.cap` cannot
+    fire here by construction: if the lane is not killed, nothing is guarding.
+    """
+
+    def storm(self, children: int, held: int) -> None:
+        self.write(
+            "test_storm.py",
+            f"""
+            import subprocess
+            import sys
+            import unittest
+
+
+            class T(unittest.TestCase):
+                def test_it_spawns(self) -> None:
+                    # Each child leaves on its own after twenty seconds, so a
+                    # guard that is not working costs this test its assertion
+                    # and the machine a gibibyte briefly -- not the session.
+                    kids = [
+                        subprocess.Popen(
+                            [sys.executable, "-c",
+                             "import time; held = bytearray({held}); time.sleep(20)"]
+                        )
+                        for _ in range({children})
+                    ]
+                    for kid in kids:
+                        kid.wait()
+            """,
+        )
+
+    def test_the_lane_is_killed_whole_and_says_why(self) -> None:
+        self.storm(children=16, held=64 << 20)
+        verdict = mutate._run(["test_storm"], self.root, memory=512 << 20, timeout=90.0)
+        self.assertEqual(verdict.outcome, "broke", verdict.detail)
+        self.assertIn("held", verdict.detail)
+        self.assertIn("share", verdict.detail)
+
+    def test_a_lane_that_stays_inside_its_share_is_left_alone(self) -> None:
+        """The other half, and the one that fails if the ceiling is read as a
+        threshold to kill at rather than a ceiling to stay under."""
+        self.storm(children=2, held=8 << 20)
+        verdict = mutate._run(["test_storm"], self.root, memory=512 << 20, timeout=90.0)
+        self.assertEqual(verdict.outcome, "survived", verdict.detail)
+
+
+class TestATimeoutEndsTheWholeSession(MutateTestCase):
+    """A killed lane must not leave its children behind.
+
+    `subprocess.run(timeout=...)` kills the process it holds a handle to, and
+    the suite forks `git`, `age`, `bash` and `python -m woswoar`. Those are
+    reparented to init, hold what they held, and are invisible to the run that
+    started them -- the slow half of #232, where a sweep with enough timeouts
+    accumulates them until the machine is gone.
+    """
+
+    def test_a_child_does_not_outlive_the_lane(self) -> None:
+        ledger = self.root / "child.pid"
+        self.write(
+            "test_hang.py",
+            f"""
+            import subprocess
+            import sys
+            import time
+            import unittest
+            from pathlib import Path
+
+
+            class T(unittest.TestCase):
+                def test_it_hangs(self) -> None:
+                    kid = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"])
+                    Path({str(ledger)!r}).write_text(str(kid.pid), encoding="utf-8")
+                    time.sleep(120)
+            """,
+        )
+        verdict = mutate._run(["test_hang"], self.root, timeout=5.0)
+        self.assertEqual(verdict.outcome, "timeout", verdict.detail)
+        orphan = int(ledger.read_text(encoding="utf-8"))
+        # Whatever this test concludes, it leaves no sleeping process behind --
+        # including when it fails, which is the case where there is one.
+        self.addCleanup(self.reap, orphan)
+        self.assertFalse(self.waits_out(orphan), "the child outlived the lane that started it")
+
+    def reap(self, pid: int) -> None:
+        with contextlib.suppress(OSError):
+            os.kill(pid, 9)
+
+    def waits_out(self, pid: int, seconds: float = 10.0) -> bool:
+        """Whether `pid` is still there after up to `seconds`. Polled, because a
+        `killpg` and the kernel reaping what it killed are not the same instant."""
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return False
+            except PermissionError:  # pragma: no cover - not ours any more
+                return True
+            time.sleep(0.1)
+        return True
+
+
 def enforced() -> bool:
     """Whether this kernel applies the limits `verdict.cap` asks for.
 

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -14,12 +14,14 @@ import io
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
 import textwrap
 import time
 import unittest
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 from unittest import mock
@@ -1186,6 +1188,40 @@ class TestCountingWhatALaneHolds(unittest.TestCase):
         self.assertLess(max(from_proc, from_ps) / min(from_proc, from_ps), 4)
 
 
+def reap(pid: int) -> None:
+    """Kill `pid` if it is still there.
+
+    For cleanups: a test whose complaint is that a process survived must not
+    leave that process behind when it makes it.
+    """
+    with contextlib.suppress(OSError):
+        os.kill(pid, signal.SIGKILL)
+
+
+def outliving(pids: Sequence[int], seconds: float) -> list[int]:
+    """Which of `pids` are still there after up to `seconds`.
+
+    Polled rather than slept, and the polling is the point: a `killpg` and the
+    kernel reaping what it killed are not the same instant, so a fixed sleep
+    guesses at a race in both directions -- too short and it reports survivors
+    that are already gone, too long and every green run pays for it.
+    """
+    deadline = time.monotonic() + seconds
+    while True:
+        left = []
+        for pid in pids:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                continue
+            except PermissionError:  # pragma: no cover - the id belongs elsewhere now
+                pass
+            left.append(pid)
+        if not left or time.monotonic() > deadline:
+            return left
+        time.sleep(0.1)
+
+
 class TestALaneThatSpawnsProcesses(MutateTestCase):
     """The failure a per-process ceiling cannot see, at the scale that killed it.
 
@@ -1196,43 +1232,67 @@ class TestALaneThatSpawnsProcesses(MutateTestCase):
     fire here by construction: if the lane is not killed, nothing is guarding.
     """
 
-    def storm(self, children: int, held: int) -> None:
+    def storm(self, children: int, held: int, sleeps: int) -> Path:
+        """A lane spawning `children`, each holding `held` bytes for `sleeps`
+        seconds. Returns the file they list themselves in, because whether they
+        *died* is a question the verdict alone cannot answer."""
+        pids = self.root / "pids.txt"
         self.write(
             "test_storm.py",
             f"""
             import subprocess
             import sys
             import unittest
+            from pathlib import Path
+
+            PIDS = Path({str(pids)!r})
 
 
             class T(unittest.TestCase):
                 def test_it_spawns(self) -> None:
-                    # Each child leaves on its own after twenty seconds, so a
-                    # guard that is not working costs this test its assertion
-                    # and the machine a gibibyte briefly -- not the session.
+                    # `sleeps` is what makes the guard the only thing that can
+                    # end this early, and it is load-bearing. At twenty seconds
+                    # the children outlived the sample and exited on their own,
+                    # so the row came back `broke` from the bookkeeping alone:
+                    # deleting the `killpg` survived a table with every
+                    # assertion below still passing.
                     kids = [
                         subprocess.Popen(
                             [sys.executable, "-c",
-                             "import time; held = bytearray({held}); time.sleep(20)"]
+                             "import time; held = bytearray({held}); time.sleep({sleeps})"]
                         )
                         for _ in range({children})
                     ]
+                    PIDS.write_text("\\n".join(str(kid.pid) for kid in kids), encoding="utf-8")
                     for kid in kids:
                         kid.wait()
             """,
         )
+        return pids
 
     def test_the_lane_is_killed_whole_and_says_why(self) -> None:
-        self.storm(children=16, held=64 << 20)
-        verdict = mutate._run(["test_storm"], self.root, memory=512 << 20, timeout=90.0)
+        pids = self.storm(children=16, held=64 << 20, sleeps=120)
+        # The timeout is the fail-safe here, not the mechanism: a working guard
+        # ends this in about a second, and a broken one reports `timeout` rather
+        # than holding a gibibyte for two minutes.
+        verdict = mutate._run(["test_storm"], self.root, memory=512 << 20, timeout=20.0)
         self.assertEqual(verdict.outcome, "broke", verdict.detail)
         self.assertIn("held", verdict.detail)
         self.assertIn("share", verdict.detail)
 
+        # And they are *gone*, which the verdict above cannot tell you. Deleting
+        # the `killpg` and keeping the bookkeeping leaves every assertion before
+        # this one passing on a run that still takes the machine -- a mutation
+        # table said exactly that, and this block is what it bought.
+        children = [int(said) for said in pids.read_text(encoding="utf-8").split()]
+        for child in children:
+            self.addCleanup(reap, child)
+        self.assertEqual(outliving(children, 5.0), [], "children outlived the killed lane")
+
     def test_a_lane_that_stays_inside_its_share_is_left_alone(self) -> None:
         """The other half, and the one that fails if the ceiling is read as a
         threshold to kill at rather than a ceiling to stay under."""
-        self.storm(children=2, held=8 << 20)
+        self.storm(children=2, held=8 << 20, sleeps=1)
         verdict = mutate._run(["test_storm"], self.root, memory=512 << 20, timeout=90.0)
         self.assertEqual(verdict.outcome, "survived", verdict.detail)
 
@@ -1271,26 +1331,10 @@ class TestATimeoutEndsTheWholeSession(MutateTestCase):
         orphan = int(ledger.read_text(encoding="utf-8"))
         # Whatever this test concludes, it leaves no sleeping process behind --
         # including when it fails, which is the case where there is one.
-        self.addCleanup(self.reap, orphan)
-        self.assertFalse(self.waits_out(orphan), "the child outlived the lane that started it")
-
-    def reap(self, pid: int) -> None:
-        with contextlib.suppress(OSError):
-            os.kill(pid, 9)
-
-    def waits_out(self, pid: int, seconds: float = 10.0) -> bool:
-        """Whether `pid` is still there after up to `seconds`. Polled, because a
-        `killpg` and the kernel reaping what it killed are not the same instant."""
-        deadline = time.monotonic() + seconds
-        while time.monotonic() < deadline:
-            try:
-                os.kill(pid, 0)
-            except ProcessLookupError:
-                return False
-            except PermissionError:  # pragma: no cover - not ours any more
-                return True
-            time.sleep(0.1)
-        return True
+        self.addCleanup(reap, orphan)
+        self.assertEqual(
+            outliving([orphan], 10.0), [], "the child outlived the lane that started it"
+        )
 
 
 def enforced() -> bool:

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -784,7 +784,7 @@ class Share(NamedTuple):
     memory: int
 
 
-def _share(wanted: int, memory: int) -> Share:
+def _share(wanted: int, memory: int, pinned: bool = False) -> Share:
     """Pick both together, so that their product is something the machine has.
 
     `verdict.cap` bounds one lane and `_affordable` counts lanes, and for one
@@ -805,9 +805,17 @@ def _share(wanted: int, memory: int) -> Share:
 
     So a big machine keeps its sixteen lanes and simply stops promising each of
     them four gigabytes it cannot deliver, and a small one loses lanes rather
-    than reliability. An explicit `--workers` is still the caller's to set, and
-    it enters as `wanted`: it can ask for fewer lanes than the machine affords,
-    and asking for more still cannot conjure memory that is not there.
+    than reliability.
+
+    ``pinned`` is an explicit `--workers`, and it keeps the lane count it asked
+    for. The ceiling still shrinks around it, which is the part worth having; it
+    is the *count* that a caller has reasons to fix that this cannot see.
+    `tests.test_mutate.TestItRunsThemInParallel` is the case that made this
+    concrete -- it pins four lanes to assert that mutations overlap at all, and
+    on a machine with too little memory to afford four it would otherwise assert
+    the machine rather than the mechanism, which is what its own comment says it
+    is pinned to avoid. The bound that still holds for a pinned run is `_Lanes`,
+    which measures rather than predicts.
 
     ``memory <= 0`` is `--memory 0`, "no cap", and it passes straight through.
     There is no product to bound once one factor is infinite, and quietly
@@ -820,7 +828,7 @@ def _share(wanted: int, memory: int) -> Share:
     # to correct: they may be reproducing a small machine on purpose. It still
     # sets how many lanes fit.
     floor = min(memory, _FLOOR)
-    lanes = max(1, min(wanted, _affordable(), budget // floor))
+    lanes = max(1, wanted if pinned else min(wanted, _affordable(), budget // floor))
     return Share(lanes, min(memory, max(floor, budget // lanes)))
 
 
@@ -872,7 +880,7 @@ def run(
     # and was 1.76x slower than this for eight runs. A sandbox is ~1 ms, so a lane
     # is nearly free.
     wanted = workers or min(len(table) + len(shards), usable_cpus() * 2, _LANES)
-    lanes, memory = _share(wanted, memory)
+    lanes, memory = _share(wanted, memory, pinned=workers is not None)
     if lanes != wanted or memory != asked:
         # Said out loud, for the reason `--limit` says what it dropped: a run
         # that quietly took fewer lanes than the machine has cores reads as a

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -563,9 +563,12 @@ def _run(
             probe.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
             _end(probe)
-            _WATCHED.release(probe.pid)
             return Verdict("timeout", f"no answer within {timeout:g}s")
-        held = _WATCHED.release(probe.pid)
+        finally:
+            # In a `finally` so that no path leaves a group registered: a
+            # `KeyboardInterrupt` here would otherwise leave the sampler holding
+            # a pid the kernel is free to hand to something else.
+            held = _WATCHED.release(probe.pid)
         if held:
             # Before the report is read, not after. A killed lane may well have
             # written one -- the kill lands on whichever process is running, and

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -65,7 +65,15 @@ time here:
   That is also what makes the mutations run **in parallel**. They are
   independent by construction, each is mostly waiting on a subprocess, and the
   suite a mutation runs is plain serial ``unittest`` rather than the sharded
-  runner -- so there is no nested pool to oversubscribe. Measured as
+  runner. That last clause used to end "so there is no nested pool to
+  oversubscribe", which is true of every file in ``woswoar/`` and false of three
+  in ``tools/``: `tests/test_mutate.py` starts this harness twenty-two times and
+  `tests/test_run_tests.py` starts the sharded runner, so a lane mutating those
+  hosts a pool of its own -- sixteen lanes each hosting sixteen, which is how
+  4,340 processes came to be alive at once and how a 63 GiB machine was
+  OOM-killed three times (#232). `_share`, `_BUDGET` and `_Lanes` are what that
+  cost; the sentence is left here rather than deleted because a comment that
+  reassures is worse than none. Measured as
   ``workers=1`` against the default, same design either way: four mutations
   against ``tests.test_sync`` went 197.5 s to 51.5 s, and eleven against the
   faster modules 2.4 s to 0.5 s. Both figures are serial-versus-parallel, not
@@ -95,6 +103,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 from collections.abc import Iterable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager, suppress
@@ -137,7 +146,36 @@ LIMIT = 200
 #: 317 MB resident and 1537 MB of address space, so this leaves a 2.7x margin
 #: over the thing it must never interrupt. If a legitimate suite ever reports
 #: `ran out of memory`, raise it -- the message names the test on purpose.
+#:
+#: What a lane is actually given is `_share`'s answer rather than this, because
+#: sixteen lanes promised four gigabytes each is 64 GiB of promises on a 63 GiB
+#: machine. This stays the ceiling a lane may *ask* for; `_FLOOR` is the point
+#: below which the answer stops being safe to give.
 MEMORY = 4 << 30
+
+#: The smallest ceiling `_share` hands a lane before it takes a *lane* away
+#: instead. `MEMORY` is what one runaway may reach; this is what an honest run
+#: needs, and keeping them as two numbers is the whole fix for #232. Dividing a
+#: small machine's budget by the ceiling was the over-restriction #227 removed
+#: (a 16 GiB laptop dropped to two lanes); multiplying the lane count back up
+#: without lowering the ceiling was the over-commitment that replaced it, at 16
+#: lanes x 4 GiB = 64 GiB on a 63 GiB machine. One number cannot answer both.
+#:
+#: Measured, and by running the thing rather than reasoning about it: one
+#: whole-suite probe peaks at 838 MiB of address space here, and survives a cap
+#: of 1 GiB but not 768 MiB. Twice the smallest cap that works, so the margin is
+#: a stated factor rather than a number that happens to be round.
+_FLOOR = 2 << 30
+
+#: How a lane tells a harness it starts itself what it may spend.
+#: `tests/test_mutate.py` starts this module 22 times and `tests/test_run_tests.py`
+#: starts the sharded runner, so a lane mutating `tools/` hosts a second harness --
+#: which, reading the host's memory as its own, sizes itself for a machine it does
+#: not have. Sixteen lanes each hosting sixteen is how 4,340 processes came to be
+#: alive at once. Carried in the environment because that is what survives
+#: ``python -c``, and read back by `_visible_memory` as one limit among the
+#: cgroup's.
+_BUDGET = "WOSWOAR_MUTATE_BUDGET"
 
 #: Names never copied into a mutation's sandbox. ``.git`` because it is large and
 #: nothing under test reads it; the caches because a stale one is the trap this
@@ -264,6 +302,186 @@ def _signalled(returncode: int) -> str:
     return f"the probe was killed by {name}{killed}"
 
 
+#: How often `_Lanes` counts what the lanes are holding. Seconds rather than
+#: minutes: the storm that prompted this reached 26 GB inside a single 20-second
+#: gap between two `free` readings. One pass over `/proc` and no fork, so the
+#: sample is cheap enough to take at this rate for the length of a sweep.
+_SAMPLE = 1.0
+
+
+def _resident_by_group() -> dict[int, int]:
+    """Resident bytes held by each process group, for everything this user can see.
+
+    Resident rather than address space, because resident is what the OOM killer
+    counts and what a fork storm actually spends. The one that took this machine
+    down was 4,340 processes holding 26 GB of RSS between them and 961 GB of
+    address space, and only one of those two numbers is a reason to intervene.
+
+    Two readers rather than one, and `/proc` first: reading it forks nothing,
+    while `ps` is a fork that can fail at exactly the moment its answer matters.
+    macOS has no `/proc`, so there it is `ps` or nothing -- and there it is also
+    the *only* one of this module's two guards that works at all, since that
+    kernel ignores the `RLIMIT_AS` `verdict.cap` asks for. Both are exercised by
+    the tests on every platform for that reason: the fallback must not be
+    discovered to be broken on the machine that has nothing else.
+    """
+    return _from_proc() if Path("/proc/self/stat").exists() else _from_ps()
+
+
+def _from_proc() -> dict[int, int]:
+    """`_resident_by_group` where there is a `/proc`. Reads, never forks."""
+    total: dict[int, int] = {}
+    page = os.sysconf("SC_PAGE_SIZE")
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            said = (entry / "stat").read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            # Exited between the listing and the read, or belongs to another
+            # user. Both are ordinary, and both are why this is a loop with a
+            # `try` in it rather than a comprehension.
+            continue
+        # Everything after the comm field, which is the one that may itself
+        # contain spaces and brackets -- so the split starts past its closing
+        # one rather than at the beginning of the line. Counting from `pid`,
+        # `pgrp` is the fifth field and `rss` the twenty-fourth, which is why
+        # the indices below are those minus the three that come first.
+        fields = said.rpartition(") ")[2].split()
+        if len(fields) < 22:
+            continue
+        with suppress(ValueError):
+            group = int(fields[2])
+            total[group] = total.get(group, 0) + int(fields[21]) * page
+    return total
+
+
+def _from_ps() -> dict[int, int]:
+    """`_resident_by_group` where there is no `/proc`, which is macOS."""
+    total: dict[int, int] = {}
+    listed = subprocess.run(
+        ["ps", "-eo", "pgid=,rss="], capture_output=True, text=True, check=False
+    )
+    for line in listed.stdout.splitlines():
+        fields = line.split()
+        if len(fields) == 2 and fields[0].isdigit() and fields[1].isdigit():
+            # Kibibytes, which POSIX does not promise and both platforms do.
+            total[int(fields[0])] = total.get(int(fields[0]), 0) + int(fields[1]) * 1024
+    return total
+
+
+class _Lanes:
+    """Kills a lane whose process *tree* outgrows its share, which no rlimit can.
+
+    `verdict.cap` bounds one process's address space, and that is the wrong
+    shape for the failure that actually took this machine down. From the kernel
+    log of the last one: 4,340 python processes alive at once, six megabytes of
+    resident memory each, 26 GB between them -- and not one of them within two
+    orders of magnitude of its own 4 GiB ceiling. Nothing ran away. There were
+    simply thousands of them, because a lane mutating `tools/` hosts a harness
+    that starts lanes of its own.
+
+    A per-process limit cannot see that, and cannot be made to: the mutation
+    under test is what decides how many processes the lane starts, so a limit it
+    inherits is beside the point. `_BUDGET` shrinks an honest nested harness;
+    this is what answers a mutant that ignores it.
+
+    Counted by process group, which is why `_run` gives each probe its own
+    session. Everything the suite forks -- `git`, `age`, `bash`, a nested
+    harness and its probes -- inherits the group, so one number covers the
+    subtree and one `killpg` ends all of it. A grandchild that calls `setsid`
+    leaves the group and is no longer counted; that is a real hole and a small
+    one, since the thing that does it is a nested `_run`, which arrives already
+    bounded by the share it inherited.
+
+    Sampling rather than a cgroup, for the reasons `verdict.cap` gives for
+    `RLIMIT_AS` over `systemd-run --scope -p MemoryMax=`: no root, no delegated
+    controller, nothing to configure, and it exists on macOS. What sampling buys
+    over both is that it needs no cooperation from the code under test.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        #: What each watched group may hold.
+        self._ceilings: dict[int, int] = {}
+        #: What a group was holding when this killed it, until `release` says it.
+        self._killed: dict[int, int] = {}
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    def watch(self, group: int, ceiling: int) -> None:
+        """Count `group` against `ceiling` from now on. ``0`` is no cap."""
+        if ceiling <= 0:
+            return
+        with self._lock:
+            self._ceilings[group] = ceiling
+            if self._thread is None:
+                # One sampler for every lane, started with the first and stopped
+                # with the last. Per-lane threads would each walk the whole
+                # process table, and the table is longest exactly when a storm
+                # makes the walk expensive.
+                self._stop = threading.Event()
+                self._thread = threading.Thread(
+                    target=self._sample, args=(self._stop,), name="mutate-lanes", daemon=True
+                )
+                self._thread.start()
+
+    def release(self, group: int) -> int:
+        """Stop counting, and say what it held if this is what killed it."""
+        with self._lock:
+            self._ceilings.pop(group, None)
+            held = self._killed.pop(group, 0)
+            if not self._ceilings and self._thread is not None:
+                self._stop.set()
+                self._thread = None
+        return held
+
+    def _sample(self, stop: threading.Event) -> None:
+        """Every `_SAMPLE` seconds until the last lane is released."""
+        while not stop.wait(_SAMPLE):
+            with self._lock:
+                watched = dict(self._ceilings)
+            if not watched:
+                continue
+            held = _resident_by_group()
+            for group, ceiling in watched.items():
+                if held.get(group, 0) <= ceiling:
+                    continue
+                with self._lock:
+                    # Re-checked under the lock: `release` may have run while
+                    # the process table was being read, and a `killpg` after
+                    # that names a group id the kernel is free to have reused.
+                    if group not in self._ceilings:
+                        continue
+                    self._killed[group] = held[group]
+                    with suppress(OSError):
+                        os.killpg(group, signal.SIGKILL)
+
+
+#: One per process, because `_run` is what registers and it has no run-wide
+#: object to hang this on -- `run` is a function, and a lane borrowed by
+#: `verify` or by a test goes through the same door.
+_WATCHED = _Lanes()
+
+
+def _end(probe: subprocess.Popen[bytes]) -> None:
+    """End a lane: the whole session, not just the process this holds a handle to.
+
+    `subprocess.run(timeout=...)` kills the child and returns, which for a suite
+    that forks `git`, `age`, `bash` and `python -m woswoar` leaves the
+    grandchildren running -- reparented to init, holding whatever they held, and
+    invisible to the run that started them. A sweep that times out often enough
+    accumulates them until the machine is gone, which is the slow half of #232;
+    the fast half is `_Lanes`.
+    """
+    with suppress(OSError):
+        os.killpg(probe.pid, signal.SIGKILL)
+    with suppress(OSError):
+        probe.kill()  # if the session is somehow gone, at least reap this one
+    with suppress(subprocess.TimeoutExpired):
+        probe.wait(timeout=_SAMPLE * 5)
+
+
 def _run(
     tests: Sequence[str],
     root: Path,
@@ -286,6 +504,12 @@ def _run(
     A timeout is its own outcome rather than an exception. A generated mutant can
     turn a loop bound into one that never fires, and with no limit here that
     holds a lane for the rest of the run.
+
+    Three limits, and each answers a failure the other two cannot see. `timeout`
+    is "this mutation never finishes"; `memory`, through `verdict.cap`, is "this
+    process never stops allocating"; and `_Lanes`, through the session started
+    here, is "this mutation spawns processes" -- which is neither of the others
+    and is the one that reached the OOM killer.
     """
     _clear_bytecode(root)
     # Both files land outside the sandbox on purpose: the copy is what the
@@ -294,39 +518,66 @@ def _run(
     with tempfile.TemporaryDirectory(prefix="woswoar-verdict-") as box:
         report = Path(box) / "verdict.json"
         noise = Path(box) / "stderr.txt"
+        with noise.open("w", encoding="utf-8") as spill:
+            probe = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-B",
+                    "-c",
+                    _probe(),
+                    str(report),
+                    "1" if failfast else "0",
+                    str(memory),
+                    *tests,
+                ],
+                cwd=root,
+                # `-B` covers this process; `PYTHONDONTWRITEBYTECODE` covers the
+                # real `age`, `git` and `bash` the suite spawns, which would
+                # otherwise leave a `.pyc` in a sandbox that a later mutation
+                # reuses. `_BUDGET` covers the *harness* the suite may spawn: a
+                # row mutating `tools/` runs tests that start this module again,
+                # and without it the inner one sizes itself for the whole host.
+                env={
+                    **os.environ,
+                    "PYTHONDONTWRITEBYTECODE": "1",
+                    _BUDGET: str(memory),
+                },
+                # A file rather than a pipe, and this is not a style choice. The
+                # suite's `python -m woswoar` grandchildren inherit the write
+                # end, so anything that drains a pipe before reaping -- which is
+                # what `subprocess.run` does on a timeout -- waits for *them*
+                # rather than for the probe. With a file there is nothing to
+                # drain, so `_end` can kill the session and be done.
+                stdout=subprocess.DEVNULL,
+                stderr=spill,
+                # Its own session, so this pid is also the group id and every
+                # process the suite forks is inside it -- which is what makes
+                # both `_Lanes`' count and `_end`'s kill cover the tree rather
+                # than the one process. `start_new_session` rather than a
+                # `preexec_fn` doing the same thing: `run` drives its lanes from
+                # threads, and this one is done in C between fork and exec.
+                start_new_session=True,
+            )
+        _WATCHED.watch(probe.pid, memory)
         try:
-            with noise.open("w", encoding="utf-8") as spill:
-                finished = subprocess.run(
-                    [
-                        sys.executable,
-                        "-B",
-                        "-c",
-                        _probe(),
-                        str(report),
-                        "1" if failfast else "0",
-                        str(memory),
-                        *tests,
-                    ],
-                    cwd=root,
-                    # `-B` covers this process; the variable covers the real
-                    # `age`, `git` and `bash` the suite spawns, which would
-                    # otherwise leave a `.pyc` in a sandbox that a later mutation
-                    # reuses.
-                    env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
-                    # A file rather than a pipe, and this is not a style choice.
-                    # On a timeout `subprocess.run` kills the child and then
-                    # drains the pipes with `communicate()` and *no* limit --
-                    # and the suite's `python -m woswoar` grandchildren inherit
-                    # the write end, so that drain waits for them. A hung
-                    # grandchild would hold the lane long past `timeout`, which
-                    # is the one thing this outcome exists to prevent.
-                    stdout=subprocess.DEVNULL,
-                    stderr=spill,
-                    check=False,
-                    timeout=timeout,
-                )
+            probe.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
+            _end(probe)
+            _WATCHED.release(probe.pid)
             return Verdict("timeout", f"no answer within {timeout:g}s")
+        held = _WATCHED.release(probe.pid)
+        if held:
+            # Before the report is read, not after. A killed lane may well have
+            # written one -- the kill lands on whichever process is running, and
+            # the probe's own `except BaseException` may have got there first --
+            # and reading it would report a verdict about a run that was
+            # stopped, which is the "broke counted as an answer" failure this
+            # module exists to prevent.
+            return Verdict(
+                "broke",
+                f"this lane's processes held {held >> 20} MiB between them, over the "
+                f"{memory >> 20} MiB share it was given, so the whole session was killed",
+            )
 
         try:
             written = json.loads(report.read_text(encoding="utf-8"))
@@ -337,7 +588,7 @@ def _run(
             # at all. It is exactly the case a host OOM-kill produces, which is
             # the failure this file now has a limit for, so it must not be the
             # one that says nothing.
-            return Verdict("broke", _tail(noise) or _signalled(finished.returncode))
+            return Verdict("broke", _tail(noise) or _signalled(probe.returncode))
         if not written["loaded"]:
             # The recorded traceback first. `verdict.main` writes it deliberately
             # and `_tail` is whatever happened to reach stderr, so preferring the
@@ -478,9 +729,26 @@ def _visible_memory() -> int:
         # way to tell that from a real limit.
         if said.isdigit():
             limits.append(int(said))
+    # A lane's share, when this harness is itself running inside one. Same
+    # question as the cgroup file above -- "how much may *this* process use" --
+    # and the same answer shape, which is why it is a limit here rather than a
+    # branch somewhere in `run`.
+    inherited = os.environ.get(_BUDGET, "")
+    if inherited.isdigit() and int(inherited) > 0:
+        limits.append(int(inherited))
     with suppress(AttributeError, OSError, ValueError):  # not POSIX
         limits.append(os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES"))
     return min(limits) if limits else _LANES * _LANE
+
+
+def _budget() -> int:
+    """What this run may spend in total.
+
+    Half of visible memory, because the other half belongs to whoever is using
+    the machine. Mutation testing is a background chore and has no claim on the
+    whole box.
+    """
+    return _visible_memory() // 2
 
 
 def _affordable() -> int:
@@ -494,11 +762,6 @@ def _affordable() -> int:
     crash was diagnosed, three of four lanes were running away simultaneously,
     all on the same source line.
 
-    Half of visible memory, because the other half belongs to whoever is using
-    the machine. Mutation testing is a background chore and has no claim on the
-    whole box; an explicit `--workers` still overrides this, as it overrides
-    every other bound below.
-
     Divided by `_LANE` -- what a lane is measured to *use* -- and not by
     `MEMORY`, which is the ceiling on what one may reach before being killed.
     Dividing by the ceiling was the first shape and it assumed every lane is
@@ -506,9 +769,59 @@ def _affordable() -> int:
     lanes to two, and a 7 GiB CI runner to one, to bound a case that the ceiling
     already truncates within seconds. The ceiling stops a runaway; this number
     decides how many honest lanes fit.
+
+    It is half the answer. `_share` is the other half, and the reason this one
+    is no longer wrong on its own: what the machine feels is lanes *times*
+    ceiling, and nothing here can see the ceiling.
     """
-    budget = _visible_memory() // 2
-    return max(1, budget // _LANE)
+    return max(1, _budget() // _LANE)
+
+
+class Share(NamedTuple):
+    """How many lanes run at once, and what each one may occupy."""
+
+    lanes: int
+    memory: int
+
+
+def _share(wanted: int, memory: int) -> Share:
+    """Pick both together, so that their product is something the machine has.
+
+    `verdict.cap` bounds one lane and `_affordable` counts lanes, and for one
+    release each was defensible while the pair was not: sixteen lanes at a 4 GiB
+    ceiling is 64 GiB on a 63 GiB machine, so a table could drive the host into
+    the OOM killer with every individual limit respected. That is #232, and it
+    happened three times.
+
+    The order of concessions is the argument:
+
+    - lanes first, from `_affordable`, because a lane's *measured* use is the
+      honest cost of running one and CPU is what the wall clock is made of;
+    - then the ceiling, lowered to the share that many lanes leaves, because a
+      ceiling is headroom for a pathological row rather than something an honest
+      one spends;
+    - and only when that share would fall under `_FLOOR` -- below which honest
+      runs start being killed -- are lanes given up instead.
+
+    So a big machine keeps its sixteen lanes and simply stops promising each of
+    them four gigabytes it cannot deliver, and a small one loses lanes rather
+    than reliability. An explicit `--workers` is still the caller's to set, and
+    it enters as `wanted`: it can ask for fewer lanes than the machine affords,
+    and asking for more still cannot conjure memory that is not there.
+
+    ``memory <= 0`` is `--memory 0`, "no cap", and it passes straight through.
+    There is no product to bound once one factor is infinite, and quietly
+    imposing one would be the flag lying.
+    """
+    if memory <= 0:
+        return Share(max(1, wanted), memory)
+    budget = _budget()
+    # An explicit `--memory` under the floor is the caller's call, not a mistake
+    # to correct: they may be reproducing a small machine on purpose. It still
+    # sets how many lanes fit.
+    floor = min(memory, _FLOOR)
+    lanes = max(1, min(wanted, _affordable(), budget // floor))
+    return Share(lanes, min(memory, max(floor, budget // lanes)))
 
 
 def run(
@@ -543,6 +856,7 @@ def run(
     table = list(mutations)
     if not table:
         return Report([])
+    asked = memory
     for mutation in table:
         check(mutation)
 
@@ -557,7 +871,18 @@ def run(
     # regressed). An earlier `cpu // 2` here gave two lanes on a four-core runner
     # and was 1.76x slower than this for eight runs. A sandbox is ~1 ms, so a lane
     # is nearly free.
-    lanes = workers or min(len(table) + len(shards), usable_cpus() * 2, _LANES, _affordable())
+    wanted = workers or min(len(table) + len(shards), usable_cpus() * 2, _LANES)
+    lanes, memory = _share(wanted, memory)
+    if lanes != wanted or memory != asked:
+        # Said out loud, for the reason `--limit` says what it dropped: a run
+        # that quietly took fewer lanes than the machine has cores reads as a
+        # slow tool rather than as a bounded one, and a ceiling lowered in
+        # silence is how the row that reports `ran out of memory` becomes
+        # inexplicable.
+        print(
+            f"{lanes} lane(s) at {memory >> 20} MiB each, from {_budget() >> 20} MiB "
+            f"of usable memory -- see tools.mutate._share."
+        )
 
     results: list[Result] = []
     red = False

--- a/tools/verdict.py
+++ b/tools/verdict.py
@@ -103,6 +103,14 @@ def cap(limit: int) -> None:
     forks. That is intended -- they are equally capable of running away -- and
     it is why `mutate.MEMORY`, which supplies `limit`, is a measured margin over
     an observed whole-suite peak rather than a round number.
+
+    **It bounds one process, and inheritance is not a total.** Each of those
+    children gets its own allowance of this size rather than a share of one, so
+    a mutation that spawns processes is unbounded here however small `limit` is:
+    the crash that prompted `mutate._Lanes` was 4,340 of them holding 26 GB
+    between them, none within two orders of magnitude of this ceiling. Nothing
+    in this function can see that, which is why the guard against it is a
+    sampler one level up rather than another rlimit here.
     """
     if limit <= 0:
         # 0 is "no cap", as `--memory 0` promises and as `--limit 0` beside it


### PR DESCRIPTION
Closes #232.

## What was wrong

`python -m tools.mutate --all --only tools/` OOM-killed a 63 GiB machine three
times, and the guard written to prevent exactly that never fired once. The
kernel log of the last crash says why:

| | count | RSS |
|---|---|---|
| python | **4,340** | 25.8 GiB |
| bash / zsh / git | 20 | 0.04 GiB |

Six megabytes each. Not one within two orders of magnitude of its own 4 GiB
`RLIMIT_AS` ceiling, so no cap fired, no row said `ran out of memory`, and
`_signalled`'s SIGKILL branch never got to speak. Nothing ran away; there were
simply thousands. The session was killed rather than any of them, because
everything under the tmux scope carries `oom_score_adj 200` and `claude` was
the fattest single process in that group at 103 MB — 0.4% of the problem.

## Three changes, one per way the old bound was the wrong shape

**The product.** `_share` picks the lane count and the per-lane ceiling
together. Sixteen lanes at 4 GiB was 64 GiB of promises on a 63 GiB box; the
ceiling now gives way first and lanes are surrendered only once the share would
fall below `_FLOOR`. This machine goes from 16×4 GiB to 15×2.1 GiB; a 16 GiB
laptop gets 4 lanes, not the 2 that dividing by the ceiling gave it, so #227's
complaint stays answered. An explicit `--workers` keeps its count — that is a
number a caller has reasons to fix, and `_Lanes` below bounds a pinned run by
measurement instead.

**The nesting.** A lane mutating `tools/` runs tests that start this harness
again, and the inner one read the *host's* memory as its own: sixteen lanes each
hosting sixteen. Each probe now inherits its share through `_BUDGET`, which
`_visible_memory` treats as one more limit beside the cgroup's.

**The tree.** Neither of those binds a mutant that decides for itself how many
processes to start, which is precisely what mutating `tools/run_tests.py` does.
Each probe is now its own session; `_Lanes` samples resident memory by process
group once a second; a group over its share is killed whole and reported as an
unanswered row rather than as a verdict. The same session is what `_end` kills
on a timeout — `subprocess.run` killed the probe and left its `git`, `age` and
`python -m woswoar` grandchildren running, reparented to init, which is the slow
half of the same crash.

## Measured

`_FLOOR` is measured rather than chosen: one whole-suite probe peaks at **838
MiB** of address space and **321 MiB** of tree RSS here (the recorded 317 MB
resident reproduces; the 1537 MB address-space figure does not). Under a 1 GiB
cap the suite does not fail so much as stall — it had not finished after 23
minutes against a 69-second baseline — which is the argument for a floor at
twice the smallest cap that works rather than tight to the peak.

The end-to-end proof is the same shape of run that crashed three times, this
time over the whole diff (140 rows, `tools/mutate.py` and `tools/verdict.py`,
both recursive):

```
=== 617s, peak 25808 MB used, peak 294 python processes, exit 1
```

25.8 GB includes ~9.5 GB of idle desktop, so the sweep held ~16 GB against a
31 GB budget, and 294 processes against 4,340. Belt and braces while testing:
the run was inside `systemd-run --user --scope -p MemoryMax=40G`, which never
came near firing.

## Rule 3

Hand-written table, for the reverts no AST rewrite can spell (`spec_232.py`):

```
12 lane(s) at 2667 MiB each, from 32007 MiB of usable memory -- see tools.mutate._share.
  caught    the ceiling is handed out whole, which is 16 lanes x 4 GiB again
  caught    an inherited budget is ignored, so a nested harness sizes itself for the host
  caught    the probe is never told its share
  caught    the probe shares the run's session, so the group is not the lane
  caught    a lane over its share is counted and left to run
  caught    a timeout kills the probe and leaves its children, as `subprocess.run` did
```

The fifth row is the one worth reading. It survived twice before it was caught,
and the fixture was wrong both times: deleting the `killpg` while keeping the
bookkeeping left the row reading `broke` from the recorded peak alone, and the
children — sleeping 20 seconds — outlived the sample and exited on their own. It
now takes a lane that outlasts the row's timeout, and reads the children's pids
back to assert they are gone. That also cut the class from 26 seconds to 2.

Generated table, `--base main`: **140 rows, 91 caught, 49 survived**, baseline
green. Four groups of the survivors were real gaps and now have tests —
`_Lanes.release`'s bookkeeping, `watch`'s "a ceiling of zero is not a ceiling",
`_from_ps`'s parser, and the share announcement — which catches 18 of them. The
remaining 31 are equivalent under any real input (`<=` against a byte-exact RSS,
`.get(x, 0)` defaults, `_end`'s redundant second kill, `len(fields) < 22` against
a 52-field line), cosmetic, or on pre-existing lines this branch only touched.
`_FLOOR`'s own `2 << 30` is among them: pinning a measured constant to itself is
not a test, and the measurement that justifies it is in its comment.

## Found on the way

The first sweep came back with a **red baseline**, and it was this branch's
fault: `TestItRunsThemInParallel` pins four lanes to assert that mutations
overlap at all, and `_share` was lowering it to one inside a lane — so the test
would have asserted the machine rather than the mechanism, which is what its own
comment says the pin is for. That is why `pinned` exists.

Also corrected in place rather than deleted: this module's docstring claimed
"there is no nested pool to oversubscribe", which is true of every file in
`woswoar/` and false of three in `tools/`; and `verdict.cap` now says out loud
that it bounds one process and that inheritance is not a total.

## Not done here

- A grandchild that calls `setsid` leaves its group and stops being counted.
  The thing that does that is a nested `_run`, which arrives already bounded by
  the share it inherited, so the hole is real and small; it is named in
  `_Lanes`' docstring rather than papered over.
- `--all --only tools/` in full is 1,306 rows and hours of wall clock. What is
  proven here is the 140-row recursive sweep above, not the whole file set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
