### PR TITLE
test: two tables are both the verdict, which one table cannot say

### DIFF
--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -1836,6 +1836,50 @@ class TestTheScriptEntryPoint(MutateTestCase):
         self.assertEqual(finished.returncode, 0, finished.stderr)
         self.assertNotIn("defines no MUTATIONS", finished.stderr)
 
+    def test_two_tables_are_both_the_verdict(self) -> None:
+        """The half of #213 its own test could not see.
+
+        `main` reduces a spec's exit status over *every* table the script ran,
+        and the guard for that is `all(...)` rather than the last report. A spec
+        with one table cannot tell the two apart, and one table is what the test
+        above it writes -- so the row `all` becomes `any` came back SURVIVED
+        from the first full sweep of `tools/`, on the line whose comment says
+        reverting it is #213's own symptom reintroduced.
+
+        Survivors first and clean second, because that is the order that exits
+        zero when the reduction is wrong. Reversed, both readings agree.
+        """
+        self.package(guarded=False)  # a test that cannot see its mutation
+        self.write(
+            "test_seen.py",
+            """
+            import unittest
+
+            import mod
+
+
+            class T(unittest.TestCase):
+                def test_it(self) -> None:
+                    self.assertEqual(mod.clamp(-5), 0)
+            """,
+        )
+        self.write(
+            "spec.py",
+            """
+            from tools.mutate import Mutation, verify
+
+            gone = "if value < 0:"
+            verify([Mutation("nothing sees this", "mod.py", gone, "if False:", "test_mod")])
+            verify([Mutation("but this is caught", "mod.py", gone, "if False:", "test_seen")])
+            """,
+        )
+        finished = self.drive("spec.py")
+        self.assertIn("SURVIVED", finished.stdout)
+        self.assertIn("caught", finished.stdout)
+        self.assertEqual(
+            finished.returncode, 1, f"the clean second table decided it: {finished.stdout}"
+        )
+
     def test_a_script_that_does_both_runs_the_table_once(self) -> None:
         """The quieter half of #213: minutes of wall clock, silently doubled."""
         self.package(guarded=True)


### PR DESCRIPTION
One test, from the survivor triage of the first full `tools/` sweep. Not a fix
for #235 — that issue is the missing coverage of `main()`'s *generated* branch,
and this is the one line of the spec branch that the sweep showed was guarded by
a fixture too weak to see it.

## What was unguarded

`main` reduces a spec's exit status over every table the script ran:

```python
mine = _RUNS[already:]
...
return 0 if all(report.clean for report in mine) else 1
```

The comment beside it says that reverting the reduction reintroduces #213's own
symptom — a run reported as the opposite of what it was. `all` becomes `any`
came back **SURVIVED**, because the test named for #213 writes a spec with *one*
table, and over one table `all` and `any` are the same function.

## The fixture

Two tables, survivors first and clean second. That order matters: it is the one
that exits zero when the reduction is wrong, and reversed, both readings agree.
It needs a second test module, because the two tables have to be caught by
different tests to produce two different verdicts from the same mutation — the
first mutation is applied against a test that cannot see it, the second against
one that can.

```
  caught    one clean table is enough, which is #213 inverted
  caught    a spec that ran its own tables always succeeds
  SURVIVED  the slice takes every table this process ever ran
```

## The row that still survives, and why it is not a gap

`mine = _RUNS[already:]` versus `_RUNS[:]` is **equivalent in the CLI as it is
invoked**: `main` runs once per process, so `already` is always 0 and the two
slices are the same list. It is distinguishable only from a caller that runs
`main` in-process after some other table has run — which nothing does today,
and which is exactly what an in-process test of the generated branch (#235)
would be. The line is left as it stands for that reason rather than simplified
to `_RUNS[:]`, which would be correct today and wrong the moment #235 is worked.

Quoting it rather than dropping it from the table, because a spec that reports
only its caught rows is the same omission this tool exists to find.

## Preflight

`ruff`, `ruff format`, `mypy`, and 1162 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
