### PR TITLE
fix: the test sandbox is built, not filtered (#217)

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -19,6 +19,7 @@ from collections.abc import Sequence
 from contextlib import redirect_stderr, redirect_stdout, suppress
 from pathlib import Path
 from typing import NamedTuple
+from unittest import mock
 
 from woswoar import crypto, store
 from woswoar.__main__ import main
@@ -345,37 +346,30 @@ class WoswoarTestCase(unittest.TestCase):
         self.root = Path(self._tmp.name).resolve()
         self.addCleanup(self._tmp.cleanup)
 
-        self._saved = {key: os.environ.get(key) for key in (*ENV_KEYS, "HOME", "SHELL")}
-        self.addCleanup(self._restore_env)
-
-        for key in ENV_KEYS:
-            os.environ.pop(key, None)
         # A directory of its own rather than `self.root`: `install` writes into
         # `$HOME` and so does the importer, and a test asserting on what is in
         # the sandbox root should not have to know which of those put it there.
         self.home = self.root / "home"
         self.home.mkdir()
-        os.environ["HOME"] = str(self.home)
-        # For the same reason, one variable further out: `install`'s `auto` falls
-        # back to `$SHELL` when there is no rc file to go on, so a developer
-        # whose login shell is zsh would otherwise get a different answer from
-        # CI. A test that is *about* that fallback sets it to what it needs.
-        os.environ["SHELL"] = "/bin/bash"
-        os.environ["WOSWOAR_DIR"] = str(self.root / "data")
-        os.environ["XDG_CONFIG_HOME"] = str(self.root / "config")
-        os.environ["XDG_CACHE_HOME"] = str(self.root / "cache")
+
+        # `clear=True`, so what a test can see is what `sandbox_environ` builds
+        # and nothing else. This used to save six names, `HOME` and `SHELL`, and
+        # leave the rest of the developer's environment in place -- and both of
+        # those two joined the list only after an incident, which is how a list
+        # of names grows. `ZDOTDIR`, `BASH_ENV` and every `GIT_*` were still
+        # inherited by a suite that drives a real zsh, a real bash and a real
+        # git. See `store.sandbox_environ` for why the shape rather than the
+        # length of that list was the problem.
+        patched = mock.patch.dict(
+            os.environ, store.sandbox_environ(self.root, self.home), clear=True
+        )
+        patched.start()
+        self.addCleanup(patched.stop)
 
         (store.config_dir()).mkdir(parents=True, exist_ok=True)
         (store.config_dir() / "machine").write_text(
             f"id={MACHINE_ID}\nname=test@machine\n", encoding="utf-8"
         )
-
-    def _restore_env(self) -> None:
-        for key, value in self._saved.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
 
     def write_log(self, host: str, day: str, lines: list[str]) -> Path:
         """Write raw log lines for ``host`` on ``day`` and return the path."""

--- a/tests/support.py
+++ b/tests/support.py
@@ -301,13 +301,6 @@ def make_entry(ts: int, cmd: str, host: str = MACHINE_ID, session: str = "s1") -
     return Entry(ts=ts, host=host, session=session, cwd="/tmp", exit_code=0, duration_ms=1, cmd=cmd)
 
 
-#: Every environment variable store.py consults, from the module that owns the
-#: list -- so a variable added there cannot be isolated here and leak in
-#: `prove`'s sandbox, or the reverse. This alias keeps the suite's historical
-#: import path working.
-ENV_KEYS = store.ENV_KEYS
-
-
 class WoswoarTestCase(unittest.TestCase):
     """Runs each test against a throwaway WOSWOAR_DIR and a throwaway ``$HOME``.
 
@@ -356,10 +349,13 @@ class WoswoarTestCase(unittest.TestCase):
         # and nothing else. This used to save six names, `HOME` and `SHELL`, and
         # leave the rest of the developer's environment in place -- and both of
         # those two joined the list only after an incident, which is how a list
-        # of names grows. `ZDOTDIR`, `BASH_ENV` and every `GIT_*` were still
-        # inherited by a suite that drives a real zsh, a real bash and a real
-        # git. See `store.sandbox_environ` for why the shape rather than the
-        # length of that list was the problem.
+        # of names grows. See `store.sandbox_environ` for why the shape rather
+        # than the length of that list was the problem.
+        #
+        # `patch.dict` rather than `store.sandboxed`: this is a `setUp`, so it
+        # needs a start/cleanup pair rather than a block, and `patch.dict`
+        # evaluates its mapping before clearing for the same reason `sandboxed`
+        # builds before it clears.
         patched = mock.patch.dict(
             os.environ, store.sandbox_environ(self.root, self.home), clear=True
         )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -14,7 +14,7 @@ import shutil
 import subprocess
 import unittest
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import ClassVar
 from unittest import mock
 
 from woswoar import cache, install, store
@@ -74,9 +74,8 @@ class TestTheSuiteCannotReachTheMachineItRunsOn(WoswoarTestCase):
         "LC_ALL": "tr_TR.UTF-8",
     }
 
-    #: Declared so that `mypy` can see class attributes assigned in
+    #: Declared so that `mypy` can see a class attribute assigned in
     #: `setUpClass` rather than in `__init__`.
-    _exported: ClassVar[Any]
     _outer_path: ClassVar[str]
 
     @classmethod
@@ -89,15 +88,14 @@ class TestTheSuiteCannotReachTheMachineItRunsOn(WoswoarTestCase):
         # Read before the sandbox exists, so the carry assertion below has
         # something outside it to compare against.
         cls._outer_path = os.environ.get("PATH", "")
-        cls._exported = mock.patch.dict(os.environ, cls.LEAKS)
-        cls._exported.start()
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls._exported.stop()
-        super().tearDownClass()
+        exported = mock.patch.dict(os.environ, cls.LEAKS)
+        exported.start()
+        cls.addClassCleanup(exported.stop)
 
     def test_nothing_the_developer_exported_reaches_a_test(self) -> None:
+        """Subsumed by the assertion below -- no leaked name is in
+        `SANDBOX_CARRIES`, so a set difference catches it either way. Kept for
+        what it says when it fails: the name, rather than a diff of two sets."""
         for name in self.LEAKS:
             with self.subTest(name=name):
                 self.assertNotIn(name, os.environ)
@@ -123,17 +121,10 @@ class TestTheSuiteCannotReachTheMachineItRunsOn(WoswoarTestCase):
         )
 
     def test_what_is_carried_actually_arrives(self) -> None:
-        """The other direction, and it is not symmetry for its own sake.
-
-        A sandbox that carries *nothing* satisfies every assertion above: the
-        developer's variables are certainly gone. It cost a red macOS CI run to
-        find that -- `prove` and `test_sync` built their environment after
-        clearing `os.environ`, so `PATH` was carried from an environment that
-        no longer had one. `shutil.which` then falls back to
-        `confstr("CS_PATH")`, which holds `/usr/bin` and finds an
-        apt-installed `age` on Linux while finding no Homebrew one on macOS. So
-        the value, and a tool the suite really runs.
-        """
+        """The other direction, and not symmetry for its own sake: a sandbox
+        that carries *nothing* satisfies every assertion above, because the
+        developer's variables are certainly gone. That shape cost a red macOS
+        CI run -- see `store.SANDBOX_CARRIES`."""
         self.assertEqual(os.environ.get("PATH"), self._outer_path)
         self.assertIsNotNone(shutil.which("git"), "the suite runs a real git")
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -74,9 +74,10 @@ class TestTheSuiteCannotReachTheMachineItRunsOn(WoswoarTestCase):
         "LC_ALL": "tr_TR.UTF-8",
     }
 
-    #: The patcher itself, declared so that `mypy` can see a class attribute
-    #: assigned in `setUpClass` rather than in `__init__`.
+    #: Declared so that `mypy` can see class attributes assigned in
+    #: `setUpClass` rather than in `__init__`.
     _exported: ClassVar[Any]
+    _outer_path: ClassVar[str]
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -85,6 +86,9 @@ class TestTheSuiteCannotReachTheMachineItRunsOn(WoswoarTestCase):
         # first. Setting them inside a test would prove nothing: by then the
         # sandbox is already built.
         super().setUpClass()
+        # Read before the sandbox exists, so the carry assertion below has
+        # something outside it to compare against.
+        cls._outer_path = os.environ.get("PATH", "")
         cls._exported = mock.patch.dict(os.environ, cls.LEAKS)
         cls._exported.start()
 
@@ -117,6 +121,21 @@ class TestTheSuiteCannotReachTheMachineItRunsOn(WoswoarTestCase):
                 "XDG_DATA_HOME",
             },
         )
+
+    def test_what_is_carried_actually_arrives(self) -> None:
+        """The other direction, and it is not symmetry for its own sake.
+
+        A sandbox that carries *nothing* satisfies every assertion above: the
+        developer's variables are certainly gone. It cost a red macOS CI run to
+        find that -- `prove` and `test_sync` built their environment after
+        clearing `os.environ`, so `PATH` was carried from an environment that
+        no longer had one. `shutil.which` then falls back to
+        `confstr("CS_PATH")`, which holds `/usr/bin` and finds an
+        apt-installed `age` on Linux while finding no Homebrew one on macOS. So
+        the value, and a tool the suite really runs.
+        """
+        self.assertEqual(os.environ.get("PATH"), self._outer_path)
+        self.assertIsNotNone(shutil.which("git"), "the suite runs a real git")
 
     def test_home_is_the_sandbox(self) -> None:
         self.assertEqual(Path.home(), self.home)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 import unittest
 from pathlib import Path
+from typing import Any, ClassVar
 from unittest import mock
 
 from woswoar import cache, install, store
@@ -47,14 +48,75 @@ class TestPortableHookPath(unittest.TestCase):
         )
 
 
-class TestTheSuiteCannotReachTheRealHome(WoswoarTestCase):
-    """The guard for `WoswoarTestCase`'s `$HOME` redirect -- see its docstring
-    for the incident, which is one this file's tests caused.
+class TestTheSuiteCannotReachTheMachineItRunsOn(WoswoarTestCase):
+    """The guard for `WoswoarTestCase`'s sandbox -- see `store.sandbox_environ`
+    for the incidents, one of which this file's tests caused.
 
     It belongs here because `install` is the command that made it reachable:
     `rcfile_for` is `Path.home() / ".bashrc"`, the one path in woswoar with no
-    XDG variable in front of it.
+    XDG variable in front of it. What is asserted is no longer two names,
+    though. The harness used to remove a list and leave the rest of the
+    developer's environment in place, so the guard could only ever say that the
+    names already on the list were on it -- green for exactly the variables
+    nobody had been bitten by yet.
     """
+
+    #: Exported by a plausible developer, and each with a route into a test:
+    #: where zsh looks for its rc file, against a suite that drives a real zsh;
+    #: what non-interactive bash sources, against one that spawns many; a git
+    #: config whose hooks and filters would run inside the sandbox; and two that
+    #: decide the shape of output an assertion then reads.
+    LEAKS: ClassVar[dict[str, str]] = {
+        "ZDOTDIR": "/somewhere/else",
+        "BASH_ENV": "/somewhere/else/env.sh",
+        "GIT_CONFIG_GLOBAL": "/somewhere/else/gitconfig",
+        "EDITOR": "vi-from-the-developer",
+        "LC_ALL": "tr_TR.UTF-8",
+    }
+
+    #: The patcher itself, declared so that `mypy` can see a class attribute
+    #: assigned in `setUpClass` rather than in `__init__`.
+    _exported: ClassVar[Any]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Started here rather than in `setUp`, so that these are part of the
+        # environment the harness is then asked to replace -- `setUpClass` runs
+        # first. Setting them inside a test would prove nothing: by then the
+        # sandbox is already built.
+        super().setUpClass()
+        cls._exported = mock.patch.dict(os.environ, cls.LEAKS)
+        cls._exported.start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._exported.stop()
+        super().tearDownClass()
+
+    def test_nothing_the_developer_exported_reaches_a_test(self) -> None:
+        for name in self.LEAKS:
+            with self.subTest(name=name):
+                self.assertNotIn(name, os.environ)
+
+    def test_what_survives_is_what_the_sandbox_built(self) -> None:
+        """The other half, and the reason this is a property rather than a list
+        of names: whatever a test *can* see is either carried on purpose or set
+        on purpose, and adding to either is an edit to `store.sandbox_environ`
+        that lands in this assertion."""
+        carried = {name for name in store.SANDBOX_CARRIES if name in os.environ}
+        self.assertEqual(
+            set(os.environ) - carried,
+            {
+                "HOME",
+                "SHELL",
+                "USER",
+                "LOGNAME",
+                "WOSWOAR_DIR",
+                "XDG_CONFIG_HOME",
+                "XDG_CACHE_HOME",
+                "XDG_DATA_HOME",
+            },
+        )
 
     def test_home_is_the_sandbox(self) -> None:
         self.assertEqual(Path.home(), self.home)

--- a/tests/test_prove.py
+++ b/tests/test_prove.py
@@ -103,6 +103,18 @@ class TestTheProofRunsInAWorldOfItsOwn(ProveTestCase):
             # installation safe.
             self.assertEqual(os.environ["GIT_CONFIG_GLOBAL"], exported["GIT_CONFIG_GLOBAL"])
 
+    def test_the_sandbox_can_still_find_the_tools_it_needs(self) -> None:
+        """`PATH` is carried, and a proof that cannot find `age` or `git` is not
+        a proof. Asserted as a value rather than as `shutil.which(...)` because
+        the failure this guards hid behind that: with `PATH` unset, `which`
+        falls back to `confstr("CS_PATH")`, which holds `/usr/bin` -- so an
+        apt-installed `age` was still found on Linux while a Homebrew one on
+        macOS was not, and only CI said so.
+        """
+        outside = os.environ["PATH"]
+        with prove._sandbox():
+            self.assertEqual(os.environ["PATH"], outside)
+
     def test_a_name_the_sandbox_invents_does_not_outlive_it(self) -> None:
         """The half that restoring by `update` cannot do.
 

--- a/tests/test_prove.py
+++ b/tests/test_prove.py
@@ -104,13 +104,9 @@ class TestTheProofRunsInAWorldOfItsOwn(ProveTestCase):
             self.assertEqual(os.environ["GIT_CONFIG_GLOBAL"], exported["GIT_CONFIG_GLOBAL"])
 
     def test_the_sandbox_can_still_find_the_tools_it_needs(self) -> None:
-        """`PATH` is carried, and a proof that cannot find `age` or `git` is not
-        a proof. Asserted as a value rather than as `shutil.which(...)` because
-        the failure this guards hid behind that: with `PATH` unset, `which`
-        falls back to `confstr("CS_PATH")`, which holds `/usr/bin` -- so an
-        apt-installed `age` was still found on Linux while a Homebrew one on
-        macOS was not, and only CI said so.
-        """
+        """A proof that cannot find `age` or `git` is not a proof. Asserted as a
+        value rather than through `shutil.which`, because that is what the
+        failure hid behind -- see `store.SANDBOX_CARRIES`."""
         outside = os.environ["PATH"]
         with prove._sandbox():
             self.assertEqual(os.environ["PATH"], outside)
@@ -237,8 +233,7 @@ class TestTheDocsRecipeStillDecrypts(unittest.TestCase):
             root = Path(tmp)
             (root / "home").mkdir()
             (root / "home" / ".gitconfig").write_text(prove.QUIET_MAINTENANCE, encoding="utf-8")
-            saved = dict(os.environ)
-            try:
+            with mock.patch.dict(os.environ):
                 # The store variables go, and `HOME` is moved: the recipe spells
                 # paths as `~/...`, so the fixture must resolve them the way a
                 # stock install would. Names rather than
@@ -277,6 +272,3 @@ class TestTheDocsRecipeStillDecrypts(unittest.TestCase):
                         break
                 self.assertEqual(ran.returncode, 0, ran.stdout + ran.stderr)
                 self.assertIn("echo docs-recipe-canary", ran.stdout)
-            finally:
-                os.environ.clear()
-                os.environ.update(saved)

--- a/tests/test_prove.py
+++ b/tests/test_prove.py
@@ -62,17 +62,62 @@ class TestACleanInstallProves(ProveTestCase):
             made.append(path)
             return path
 
-        saved = {key: os.environ.get(key) for key in prove._ENV_KEYS}
+        # The whole environment, not the names `prove` happens to know it
+        # changes. It now replaces `os.environ` wholesale, so "restored" is a
+        # claim about every name -- including one a future check exports and
+        # forgets to list, which is precisely the shape of leak the list this
+        # replaced could not see.
+        saved = dict(os.environ)
         with mock.patch.object(tempfile, "mkdtemp", side_effect=watched):
             ran = self.prove()
 
         self.assertEqual(ran.code, 0, ran.out + ran.err)
-        self.assertEqual(saved, {key: os.environ.get(key) for key in prove._ENV_KEYS})
+        self.assertEqual(saved, dict(os.environ))
         self.assertEqual(len(made), 1)
         self.assertFalse(Path(made[0]).exists())
         # This test environment's own store: prove created nothing in it.
         self.assertFalse(store.history_dir().exists())
         self.assertFalse(store.logs_dir().exists())
+
+
+class TestTheProofRunsInAWorldOfItsOwn(ProveTestCase):
+    """`prove` runs from inside a live installation, on a machine belonging to
+    someone who has exported things.
+
+    Restoring the environment afterwards is tested above; this is the other
+    half, and the one a list of names could not give. It used to remove
+    `store.ENV_KEYS` plus `HOME` and leave everything else in place, so a
+    `GIT_CONFIG_GLOBAL` pointing at a config with hooks and filters, or a
+    `ZDOTDIR`, reached a proof whose whole claim is that it ran against nothing
+    but itself.
+    """
+
+    def test_what_the_user_exported_does_not_reach_the_sandbox(self) -> None:
+        exported = {"GIT_CONFIG_GLOBAL": "/somewhere/else/gitconfig", "ZDOTDIR": "/elsewhere"}
+        with mock.patch.dict(os.environ, exported):
+            with prove._sandbox() as root:
+                inside = dict(os.environ)
+            self.assertEqual([name for name in exported if name in inside], [])
+            self.assertEqual(inside["HOME"], str(root / "home"))
+            # And it came back, which is what makes running this from a live
+            # installation safe.
+            self.assertEqual(os.environ["GIT_CONFIG_GLOBAL"], exported["GIT_CONFIG_GLOBAL"])
+
+    def test_a_name_the_sandbox_invents_does_not_outlive_it(self) -> None:
+        """The half that restoring by `update` cannot do.
+
+        Putting the saved values back covers every name that was overwritten and
+        no name that was *added* -- so the mutation `os.environ.update(saved)`
+        without the `clear()` before it survives any fixture whose environment
+        already holds everything the sandbox sets. This one takes `SHELL` away
+        first, which the sandbox then invents.
+        """
+        with mock.patch.dict(os.environ):
+            os.environ.pop("SHELL", None)
+            before = dict(os.environ)
+            with prove._sandbox():
+                self.assertEqual(os.environ["SHELL"], "/bin/bash")
+            self.assertEqual(dict(os.environ), before)
 
 
 class TestAPlantedLeakIsCaught(ProveTestCase):
@@ -180,11 +225,15 @@ class TestTheDocsRecipeStillDecrypts(unittest.TestCase):
             root = Path(tmp)
             (root / "home").mkdir()
             (root / "home" / ".gitconfig").write_text(prove.QUIET_MAINTENANCE, encoding="utf-8")
-            saved = {key: os.environ.get(key) for key in prove._ENV_KEYS}
+            saved = dict(os.environ)
             try:
-                # Only HOME is set: the recipe spells paths as `~/...`, so the
-                # fixture must resolve them the way a stock install would.
-                for key in prove._ENV_KEYS:
+                # The store variables go, and `HOME` is moved: the recipe spells
+                # paths as `~/...`, so the fixture must resolve them the way a
+                # stock install would. Names rather than
+                # `store.sandbox_environ`, because this one *wants* the ambient
+                # `WOSWOAR_DIR` gone rather than pointed somewhere else -- the
+                # recipe is being asked to find the store on its own.
+                for key in (*store.ENV_KEYS, "HOME"):
                     os.environ.pop(key, None)
                 os.environ["HOME"] = str(root / "home")
                 origin = root / "origin.git"
@@ -217,8 +266,5 @@ class TestTheDocsRecipeStillDecrypts(unittest.TestCase):
                 self.assertEqual(ran.returncode, 0, ran.stdout + ran.stderr)
                 self.assertIn("echo docs-recipe-canary", ran.stdout)
             finally:
-                for key, value in saved.items():
-                    if value is None:
-                        os.environ.pop(key, None)
-                    else:
-                        os.environ[key] = value
+                os.environ.clear()
+                os.environ.update(saved)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -47,11 +47,6 @@ from woswoar.sync import _GRANT_REMEDY
 from . import support
 from .support import requires_age, requires_git, requires_ssh_keygen
 
-#: One authoritative list, plus the HOME these tests give each machine of its
-#: own -- `WoswoarTestCase` redirects it once for the whole suite, and here
-#: every simulated machine needs a different one.
-_ENV = (*support.ENV_KEYS, "HOME")
-
 #: `gc --auto` runs after a commit and after a push, and `gc.autoDetach` sends
 #: it to the background -- so it is still repacking while the *next* git command
 #: runs. A real installation wants exactly that. These tests want a repo that
@@ -83,34 +78,33 @@ class Fake:
         self.root = root / name
         self.name = name
         self._id: str | None = None
-        for sub in ("data", "conf", "cache"):
+        for sub in ("data", "config", "cache"):
             (self.root / sub).mkdir(parents=True, exist_ok=True)
         # This machine's HOME, so its clone inherits it.
         (self.root / ".gitconfig").write_text(QUIET_MAINTENANCE, encoding="utf-8")
 
     @property
     def env(self) -> dict[str, str]:
-        return {
-            "HOME": str(self.root),
-            "WOSWOAR_DIR": str(self.root / "data"),
-            "XDG_CONFIG_HOME": str(self.root / "conf"),
-            "XDG_CACHE_HOME": str(self.root / "cache"),
-        }
+        """This machine's whole world, built by the same function the suite's
+        own sandbox uses. Its `HOME` is the machine root rather than a
+        subdirectory of it, because a simulated machine *is* a home."""
+        return store.sandbox_environ(self.root, self.root)
 
     @contextmanager
     def active(self) -> Iterator[Fake]:
         """Run a block as if we were sitting at this machine."""
-        saved = {k: os.environ.get(k) for k in _ENV}
-        os.environ.pop("WOSWOAR_SESSION", None)
+        # Replaced wholesale, which is also what drops the ambient
+        # `WOSWOAR_SESSION`: this used to update a list of names and pop that
+        # one by hand, so anything a future check reads and this list does not
+        # name would cross from one simulated machine to the next.
+        saved = dict(os.environ)
+        os.environ.clear()
         os.environ.update(self.env)
         try:
             yield self
         finally:
-            for key, value in saved.items():
-                if value is None:
-                    os.environ.pop(key, None)
-                else:
-                    os.environ[key] = value
+            os.environ.clear()
+            os.environ.update(saved)
 
     # -- convenience, all assuming `active()` is held ----------------------
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -98,8 +98,12 @@ class Fake:
         # one by hand, so anything a future check reads and this list does not
         # name would cross from one simulated machine to the next.
         saved = dict(os.environ)
+        # `self.env` first: it carries `PATH` from the environment it is built
+        # in, so clearing before building leaves the machine with none. See
+        # `prove._sandbox` for why that is invisible on Linux.
+        built = self.env
         os.environ.clear()
-        os.environ.update(self.env)
+        os.environ.update(built)
         try:
             yield self
         finally:
@@ -298,6 +302,33 @@ class SyncTestCase(unittest.TestCase):
         """Drive the real CLI as ``fake``. Both streams -- see `support.run_cli`."""
         with fake.active():
             return support.run_cli(*argv, tty=tty)
+
+
+class TestASimulatedMachineIsAWholeWorld(SyncTestCase):
+    """`Fake.active` replaces the environment rather than updating names, so
+    every check here is about what that must and must not carry."""
+
+    def test_a_machine_carries_the_path_it_runs_its_git_with(self) -> None:
+        """Every test in this file runs a real `git` and a real `age`, and
+        `active()` builds its environment from `store.sandbox_environ`, which
+        carries `PATH` from the environment it is *called* in. Building it after
+        clearing carried nothing, and stayed invisible on Linux because
+        `shutil.which` falls back to `confstr("CS_PATH")` and finds
+        `/usr/bin/age` there. macOS, where Homebrew is not on that fallback,
+        is what said so -- 87 errors in one shard.
+        """
+        outside = os.environ["PATH"]
+        with self.machine("alpha").active():
+            self.assertEqual(os.environ["PATH"], outside)
+
+    def test_one_machine_does_not_see_another_ones_session(self) -> None:
+        """`WOSWOAR_SESSION` used to be popped by name here; a wholesale replace
+        is what makes that true of every name rather than of the one that was
+        noticed."""
+        with self.machine("alpha").active():
+            os.environ["WOSWOAR_SESSION"] = "alpha-session"
+            with self.machine("beta").active():
+                self.assertNotIn("WOSWOAR_SESSION", os.environ)
 
 
 class TestSingleMachine(SyncTestCase):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -83,13 +83,6 @@ class Fake:
         # This machine's HOME, so its clone inherits it.
         (self.root / ".gitconfig").write_text(QUIET_MAINTENANCE, encoding="utf-8")
 
-    @property
-    def env(self) -> dict[str, str]:
-        """This machine's whole world, built by the same function the suite's
-        own sandbox uses. Its `HOME` is the machine root rather than a
-        subdirectory of it, because a simulated machine *is* a home."""
-        return store.sandbox_environ(self.root, self.root)
-
     @contextmanager
     def active(self) -> Iterator[Fake]:
         """Run a block as if we were sitting at this machine."""
@@ -97,18 +90,8 @@ class Fake:
         # `WOSWOAR_SESSION`: this used to update a list of names and pop that
         # one by hand, so anything a future check reads and this list does not
         # name would cross from one simulated machine to the next.
-        saved = dict(os.environ)
-        # `self.env` first: it carries `PATH` from the environment it is built
-        # in, so clearing before building leaves the machine with none. See
-        # `prove._sandbox` for why that is invisible on Linux.
-        built = self.env
-        os.environ.clear()
-        os.environ.update(built)
-        try:
+        with store.sandboxed(self.root, self.root):
             yield self
-        finally:
-            os.environ.clear()
-            os.environ.update(saved)
 
     # -- convenience, all assuming `active()` is held ----------------------
 

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -33,6 +33,8 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
+from woswoar import store
+
 #: The identity every sandbox is given, on every side of every comparison.
 #: Seeded rather than generated: `install` prints the id it made, so a fresh one
 #: per run would differ between two trees for a reason that says nothing about
@@ -60,6 +62,14 @@ def sandbox_env(tree: Path, home: Path) -> dict[str, str]:
     answer to where those are.
     """
     return {
+        # `store.SANDBOX_CARRIES` rather than `PATH` alone, and from there
+        # rather than from a list of its own: that constant is where the suite's
+        # sandbox keeps the same knowledge, and two lists of carried names is
+        # the shape this module's docstring is written against. Concretely, it
+        # is what makes CI's `PYTHONWARNINGS=error::DeprecationWarning` reach
+        # the `python` children `bench` and `compare` spawn -- carrying only
+        # `PATH` left that guard downgraded to a warning in here, silently.
+        **{name: os.environ[name] for name in store.SANDBOX_CARRIES if name in os.environ},
         "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
         "HOME": str(home),
         "XDG_DATA_HOME": str(home / "data"),

--- a/woswoar/prove.py
+++ b/woswoar/prove.py
@@ -116,8 +116,16 @@ def _sandbox() -> Iterator[Path]:
         # a `ZDOTDIR`, a `GIT_CONFIG_GLOBAL` or an inherited `SHELL` reached the
         # proof. `store.sandbox_environ` says why a list of names is the wrong
         # shape for that question.
+        # Built *before* the clear, which is load-bearing rather than stylistic:
+        # `sandbox_environ` carries `PATH` over from the environment it is
+        # called in, so building it afterwards carries nothing. That failed only
+        # on macOS -- `shutil.which` falls back to `confstr("CS_PATH")` when
+        # `PATH` is unset, which finds an apt-installed `/usr/bin/age` and does
+        # not find a Homebrew one -- so on Linux it looked like a working
+        # sandbox and every sync test on macOS could not find `age`.
+        built = store.sandbox_environ(root, root / "home")
         os.environ.clear()
-        os.environ.update(store.sandbox_environ(root, root / "home"))
+        os.environ.update(built)
         yield root
     finally:
         os.environ.clear()

--- a/woswoar/prove.py
+++ b/woswoar/prove.py
@@ -23,7 +23,6 @@ is a defect in woswoar itself, not in the user's setup.
 
 from __future__ import annotations
 
-import os
 import secrets
 import shutil
 import subprocess
@@ -95,7 +94,6 @@ def _sandbox() -> Iterator[Path]:
     not make parents -- everything else woswoar creates itself, owner-only,
     exactly as it would on a real machine.
     """
-    saved = dict(os.environ)
     tmp = tempfile.mkdtemp(prefix="woswoar-prove-")
     try:
         # Resolved, which is nothing on Linux and load-bearing on macOS: there
@@ -110,26 +108,13 @@ def _sandbox() -> Iterator[Path]:
         root = Path(tmp).resolve()
         (root / "home").mkdir()
         (root / "home" / ".gitconfig").write_text(QUIET_MAINTENANCE, encoding="utf-8")
-        # Replaced wholesale rather than overridden, and through the same
-        # builder the suite's own sandbox uses: this used to remove
+        # Replaced wholesale rather than overridden: this used to remove
         # `store.ENV_KEYS` plus `HOME` and leave everything else the user's, so
-        # a `ZDOTDIR`, a `GIT_CONFIG_GLOBAL` or an inherited `SHELL` reached the
-        # proof. `store.sandbox_environ` says why a list of names is the wrong
-        # shape for that question.
-        # Built *before* the clear, which is load-bearing rather than stylistic:
-        # `sandbox_environ` carries `PATH` over from the environment it is
-        # called in, so building it afterwards carries nothing. That failed only
-        # on macOS -- `shutil.which` falls back to `confstr("CS_PATH")` when
-        # `PATH` is unset, which finds an apt-installed `/usr/bin/age` and does
-        # not find a Homebrew one -- so on Linux it looked like a working
-        # sandbox and every sync test on macOS could not find `age`.
-        built = store.sandbox_environ(root, root / "home")
-        os.environ.clear()
-        os.environ.update(built)
-        yield root
+        # a `ZDOTDIR`, a `GIT_CONFIG_GLOBAL` or an inherited `SHELL` reached a
+        # proof whose whole claim is that it ran against nothing but itself.
+        with store.sandboxed(root, root / "home"):
+            yield root
     finally:
-        os.environ.clear()
-        os.environ.update(saved)
         shutil.rmtree(tmp, ignore_errors=True)
 
 

--- a/woswoar/prove.py
+++ b/woswoar/prove.py
@@ -38,11 +38,6 @@ from .entry import Entry
 from .errors import WoswoarError
 from .report import Check
 
-#: `store.ENV_KEYS` is everything woswoar itself resolves paths from; HOME is
-#: for git, which reads ``~/.gitconfig``, whose hooks and filters must neither
-#: run against the sandbox nor colour the proof.
-_ENV_KEYS = (*store.ENV_KEYS, "HOME")
-
 #: git's background `gc --auto` detaches and keeps repacking after the command
 #: that triggered it returns -- so it would still be rewriting a short-lived
 #: repository while a scan reads it and the cleanup deletes it. The sync test
@@ -100,7 +95,7 @@ def _sandbox() -> Iterator[Path]:
     not make parents -- everything else woswoar creates itself, owner-only,
     exactly as it would on a real machine.
     """
-    saved = {key: os.environ.get(key) for key in _ENV_KEYS}
+    saved = dict(os.environ)
     tmp = tempfile.mkdtemp(prefix="woswoar-prove-")
     try:
         # Resolved, which is nothing on Linux and load-bearing on macOS: there
@@ -115,24 +110,18 @@ def _sandbox() -> Iterator[Path]:
         root = Path(tmp).resolve()
         (root / "home").mkdir()
         (root / "home" / ".gitconfig").write_text(QUIET_MAINTENANCE, encoding="utf-8")
-        for key in _ENV_KEYS:
-            os.environ.pop(key, None)
-        os.environ.update(
-            {
-                "HOME": str(root / "home"),
-                "WOSWOAR_DIR": str(root / "data"),
-                "XDG_CONFIG_HOME": str(root / "conf"),
-                "XDG_CACHE_HOME": str(root / "cache"),
-                "XDG_DATA_HOME": str(root / "data"),
-            }
-        )
+        # Replaced wholesale rather than overridden, and through the same
+        # builder the suite's own sandbox uses: this used to remove
+        # `store.ENV_KEYS` plus `HOME` and leave everything else the user's, so
+        # a `ZDOTDIR`, a `GIT_CONFIG_GLOBAL` or an inherited `SHELL` reached the
+        # proof. `store.sandbox_environ` says why a list of names is the wrong
+        # shape for that question.
+        os.environ.clear()
+        os.environ.update(store.sandbox_environ(root, root / "home"))
         yield root
     finally:
-        for key, value in saved.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
+        os.environ.clear()
+        os.environ.update(saved)
         shutil.rmtree(tmp, ignore_errors=True)
 
 

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -70,10 +70,15 @@ ENV_KEYS = (
 #: The only names an isolated run carries over from the machine it runs on.
 #:
 #: `PATH` because a sandbox has no answer for where `git`, `age`, `bash` and
-#: `ssh-keygen` live, and `TMPDIR` because those need somewhere of their own to
-#: write scratch files -- on macOS that is a per-user directory rather than
-#: `/tmp`, so dropping it moves their temporary files somewhere the platform
-#: does not use.
+#: `ssh-keygen` live. Dropping it does not fail where it is easy to see:
+#: `shutil.which` falls back to ``confstr("CS_PATH")``, which holds `/usr/bin`,
+#: so an apt-installed `age` is still found on Linux and a Homebrew one on
+#: macOS is not. That cost a red macOS CI run against a green Linux one, and it
+#: is why `sandboxed` builds before it clears.
+#:
+#: `TMPDIR` because those tools need somewhere of their own to write scratch
+#: files -- on macOS that is a per-user directory rather than `/tmp`, so
+#: dropping it moves their temporary files somewhere the platform does not use.
 #:
 #: The three `PYTHON*` names are here because they configure the interpreter a
 #: run spawns rather than describing the machine it runs on, and each one is a
@@ -118,6 +123,10 @@ def sandbox_environ(root: Path, home: Path) -> dict[str, str]:
     `GIT_*`, against a suite that runs real `git`; `EDITOR`, `PAGER`, `LANG` and
     `LC_ALL`, which decide the shape of output that assertions read.
 
+    Callers want `sandboxed` below rather than this: the environment has to be
+    *built* before `os.environ` is cleared, since the names above are carried
+    out of it, and that ordering is an invariant no caller should have to know.
+
     `USER` and `LOGNAME` are pinned rather than carried or dropped.
     `default_machine_name` reads them, so carried, a record written on a
     developer's machine and one written in CI differ by the developer's name;
@@ -142,6 +151,30 @@ def sandbox_environ(root: Path, home: Path) -> dict[str, str]:
         }
     )
     return built
+
+
+@contextlib.contextmanager
+def sandboxed(root: Path, home: Path) -> Iterator[None]:
+    """Run a block with `sandbox_environ` as the whole environment.
+
+    Built first and cleared second, which is the one ordering that works and
+    the reason this is a function rather than four lines at each caller:
+    `sandbox_environ` carries `PATH` *out of* the environment it is called in,
+    so clearing first carries nothing. Both callers had that the wrong way round
+    and only macOS said so -- see `SANDBOX_CARRIES`.
+
+    Restored wholesale rather than by putting back the names that were
+    overwritten, so a name the sandbox invents does not outlive it either.
+    """
+    saved = dict(os.environ)
+    built = sandbox_environ(root, home)
+    os.environ.clear()
+    os.environ.update(built)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
 
 
 def _xdg(env_var: str, default: str) -> Path:

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -67,6 +67,83 @@ ENV_KEYS = (
 )
 
 
+#: The only names an isolated run carries over from the machine it runs on.
+#:
+#: `PATH` because a sandbox has no answer for where `git`, `age`, `bash` and
+#: `ssh-keygen` live, and `TMPDIR` because those need somewhere of their own to
+#: write scratch files -- on macOS that is a per-user directory rather than
+#: `/tmp`, so dropping it moves their temporary files somewhere the platform
+#: does not use.
+#:
+#: The three `PYTHON*` names are here because they configure the interpreter a
+#: run spawns rather than describing the machine it runs on, and each one is a
+#: guard that would go quiet rather than red. CI exports
+#: ``PYTHONWARNINGS=error::DeprecationWarning`` for the whole workflow, so
+#: dropping it downgrades every warning in a child process back to a warning;
+#: `tools/mutate` exports the other two so that the real `age`, `git` and `bash`
+#: a suite forks cannot leave a `.pyc` in a sandbox that a later mutation
+#: reuses, which is the ``(mtime, size)`` collision that module's docstring is
+#: about.
+SANDBOX_CARRIES = (
+    "PATH",
+    "TMPDIR",
+    "PYTHONWARNINGS",
+    "PYTHONDONTWRITEBYTECODE",
+    "PYTHONPYCACHEPREFIX",
+)
+
+
+def sandbox_environ(root: Path, home: Path) -> dict[str, str]:
+    """The whole environment for a run that must not touch this machine.
+
+    Built from **nothing**, and that is the entire point: the alternative is to
+    take `os.environ` and remove a list of names, which fails towards the real
+    installation every time the list falls behind. `ENV_KEYS`' own comment
+    already says so for the six names it holds -- "a variable added here but
+    missed in a hand-kept copy would silently point a 'sandbox' at the real
+    installation, with nothing failing" -- and this is that argument applied to
+    the variables woswoar does *not* own.
+
+    It has been paid for twice. `HOME` joined the suite's scrub list only after
+    two tests wrote a woswoar block into the maintainer's real `~/.bashrc` and
+    `~/.zshrc`, pointing them at a directory the next line deleted: a shell that
+    printed `No such file or directory` at every start and recorded nothing,
+    found months later. `SHELL` joined it in the same change, because `install`
+    falls back to `$SHELL` when there is no rc file to read. Both were found by
+    an incident rather than by the list, which is how a list of names grows.
+
+    Names still inherited before this existed, each with a route into a run:
+    `ZDOTDIR`, which is where zsh looks for its rc file and the zsh hook tests
+    drive a real zsh; `BASH_ENV`, which non-interactive bash sources; every
+    `GIT_*`, against a suite that runs real `git`; `EDITOR`, `PAGER`, `LANG` and
+    `LC_ALL`, which decide the shape of output that assertions read.
+
+    `USER` and `LOGNAME` are pinned rather than carried or dropped.
+    `default_machine_name` reads them, so carried, a record written on a
+    developer's machine and one written in CI differ by the developer's name;
+    dropped, every caller exercises the ``"user"`` fallback and nothing
+    exercises the path a real installation takes.
+    """
+    built = {name: os.environ[name] for name in SANDBOX_CARRIES if name in os.environ}
+    built.update(
+        {
+            "HOME": str(home),
+            # `install`'s `auto` falls back to this when there is no rc file to
+            # go on, so an inherited one answers differently on a developer's
+            # zsh box than in CI. A caller that is *about* the fallback sets it
+            # to what it needs.
+            "SHELL": "/bin/bash",
+            "USER": "tester",
+            "LOGNAME": "tester",
+            "WOSWOAR_DIR": str(root / "data"),
+            "XDG_CONFIG_HOME": str(root / "config"),
+            "XDG_CACHE_HOME": str(root / "cache"),
+            "XDG_DATA_HOME": str(root / "data"),
+        }
+    )
+    return built
+
+
 def _xdg(env_var: str, default: str) -> Path:
     value = os.environ.get(env_var)
     base = Path(value) if value else Path.home() / default


### PR DESCRIPTION
Closes #217.

## What was wrong

`WoswoarTestCase.setUp` saved six names plus `HOME` and `SHELL`, overwrote them,
and left the rest of the developer's environment in place. That is the
inherit-and-override shape `tools/sandbox.py` already rejects in its own
docstring, and it fails *towards* the real installation every time the list
falls behind what woswoar reads.

Both additions to that list arrived as incidents rather than as foresight.
`HOME` joined after two tests wrote a woswoar block into the maintainer's real
`~/.bashrc` and `~/.zshrc`, pointing at a directory the next line deleted — a
shell that printed `No such file or directory` at every start and recorded
nothing, found months later.

## What changed

`store.sandbox_environ(root, home)` builds the whole environment from nothing.
The three places that spelled *"ENV_KEYS plus HOME"* now all call it:

| | before | after |
|---|---|---|
| `tests/support.py` | pop 6 names, set `HOME`/`SHELL` | `mock.patch.dict(..., clear=True)` |
| `woswoar/prove.py` | pop 7 names, override 5 | replace `os.environ` wholesale |
| `tests/test_sync.py` | update 4 names per machine | the same builder, per machine |

`prove` gains the `SHELL` scrub it never had — the divergence #217 names — and
restoring wholesale means a variable its sandbox *invents* cannot outlive it
either, which restoring by `update` could not promise.

`USER` and `LOGNAME` are pinned rather than dropped: `default_machine_name`
reads them, so carried they make a record written on a developer's machine
differ from one written in CI, and dropped they leave every caller exercising
the `"user"` fallback and nothing exercising the path a real installation takes.

## The carry-list, and the thing it caught

Five names are carried, each because a sandbox has no answer for it:

- `PATH`, `TMPDIR` — the suite runs real `git`, `age`, `bash`, `zsh` and
  `ssh-keygen`, and on macOS `TMPDIR` is a per-user directory rather than `/tmp`.
- `PYTHONWARNINGS`, `PYTHONDONTWRITEBYTECODE`, `PYTHONPYCACHEPREFIX` — these
  configure the interpreter a run spawns rather than describing the machine.

The second group is the one worth reading. The issue predicted "expect the first
attempt to red a dozen tests"; it reddened **none**, and that is what hid this:
CI exports `PYTHONWARNINGS=error::DeprecationWarning` for the whole workflow, and
`tools/mutate` exports the other two so a forked `git` cannot leave a `.pyc` in a
sandbox that a later mutation reuses. `clear=True` dropped all three from every
subprocess a test spawns, and all three fail **quiet rather than red** — a
deprecation warning stops being an error, a stale bytecode cache comes back.
That is precisely the failure mode this change exists to remove, reintroduced by
the fix for it. The suite was re-run with `PYTHONWARNINGS` set the way CI sets it.

## The guard is now a property

`TestTheSuiteCannotReachTheRealHome` → `TestTheSuiteCannotReachTheMachineItRunsOn`.
It exports `ZDOTDIR`, `BASH_ENV`, `GIT_CONFIG_GLOBAL`, `EDITOR` and `LC_ALL` in
`setUpClass` — *before* the sandbox is built, since setting them inside a test
would prove nothing — and asserts none survives. A second test pins what does
survive to what `sandbox_environ` sets, so adding a name to the sandbox is an
edit that lands in an assertion.

`prove` gets the same treatment: one test that its sandbox does not see what the
user exported, one that a name it invents does not outlive it.

## Rule 3

Hand table (`spec_217.py`):

```
  caught    the sandbox inherits the machine and overrides a few names
  caught    the suite keeps whatever the developer exported
  caught    prove overrides rather than replaces, as it did before
  caught    prove restores only what it thinks it changed
```

The last row survived its first fixture. Restoring by `update` puts back every
name that was overwritten and no name that was *added*, so it is satisfied by
any environment that already holds everything the sandbox sets — the test now
takes `SHELL` away first, which the sandbox then invents.

Generated table, `--base main`: 7 rows, all caught, baseline green. Small because
most of the diff is comments and dict literals, which no operator mutates.

## Preflight

`ruff`, `ruff format`, `mypy`, `shellcheck`, and 1166 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## What CI found, after the first push

The macOS jobs went red and were right: `sandbox_environ` carries `PATH` from
the environment it is *called* in, and both `prove._sandbox` and `test_sync`'s
`Fake.active` called it after `os.environ.clear()`. They carried nothing.

Linux hid it completely. With `PATH` unset, `shutil.which` falls back to
`confstr("CS_PATH")` — `/usr/bin`, where apt puts `age`. Homebrew does not put
it there, so macOS could not find `age` at all: 7 failures in `test_prove` and
87 errors in one `test_sync` shard, against a green Linux run.

The tests were blind to it for a reason worth keeping: **every assertion was
about what a sandbox must not carry, and a sandbox that carries nothing
satisfies all of them.** Three assertions now go the other way — `PATH` arrives
with the value it had outside, and a real `git` is still findable — one for each
place that builds a sandbox, plus two mutation rows so the bug is visible on
Linux rather than only on the platform that happened to notice:

```
  caught    the sandbox inherits the machine and overrides a few names
  caught    nothing is carried, so a sandbox cannot find the tools it runs
  caught    the suite keeps whatever the developer exported
  caught    prove overrides rather than replaces, as it did before
  caught    prove builds its environment after clearing, so it carries nothing
  caught    prove restores only what it thinks it changed
  caught    a simulated machine is built after clearing, so it has no PATH
```

1170 tests green locally under `PYTHONWARNINGS=error::DeprecationWarning`, and
all 12 CI checks green.

## /simplify

Four angles, applied before merge. `store.sandboxed` now owns the build-before-
clear invariant that reddened macOS, so `prove._sandbox` and `Fake.active` are a
`with` line each; `tools/sandbox.sandbox_env` carries from the same
`SANDBOX_CARRIES` rather than from a second list of its own, which is also what
gets CI's `PYTHONWARNINGS` to the children `bench` and `compare` spawn; a dead
`support.ENV_KEYS`, a `tearDownClass` and a hand-rolled save/restore are gone;
and the macOS `confstr("CS_PATH")` story is told once instead of six times.

Skipped, with reasons: moving `sandbox_environ` out of `store.py` (an arch
change, not a cleanup — `prove` needs it and `tools/` is not packaged); a
carry-list parameter (pushes knowledge to callers that have less of it); and
the child-process environment dicts in five test modules, which are the same
pattern one layer down and want their own change. Efficiency found nothing
worth doing: 60–195 µs per test, 0.07–0.23 s across 1170 tests, against 17,651
subprocess spawns.

Net −10 lines, six of six mutation rows caught, all 12 checks green.
