### PR TITLE
fix: a lane is its group and its descendants, not one of the two (#234)

### DIFF
--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -1171,21 +1171,32 @@ class TestALaneCarriesItsShareIntoTheProbe(MutateTestCase):
 class TestCountingWhatALaneHolds(unittest.TestCase):
     """Both readers, on every platform, because one of them is macOS's only guard."""
 
+    def held(self, table: dict[int, mutate.Process]) -> int:
+        ours = os.getpgrp()
+        return sum(row.resident for row in table.values() if row.group == ours)
+
     def test_ps_sees_this_process_group(self) -> None:
-        self.assertGreater(mutate._from_ps().get(os.getpgrp(), 0), 1 << 20)
+        self.assertGreater(self.held(mutate._from_ps()), 1 << 20)
 
     @unittest.skipUnless(Path("/proc/self/stat").exists(), "no /proc on this platform")
     def test_proc_sees_this_process_group(self) -> None:
-        self.assertGreater(mutate._from_proc().get(os.getpgrp(), 0), 1 << 20)
+        self.assertGreater(self.held(mutate._from_proc()), 1 << 20)
 
     @unittest.skipUnless(Path("/proc/self/stat").exists(), "no /proc on this platform")
     def test_the_two_readers_agree_about_this_group(self) -> None:
         """Not to the byte -- `ps` and `/proc` count shared pages differently and
         the suite allocates between the two calls -- but within a factor, which
         is what a ceiling comparison actually needs."""
-        ours = os.getpgrp()
-        from_proc, from_ps = mutate._from_proc()[ours], mutate._from_ps()[ours]
+        from_proc, from_ps = self.held(mutate._from_proc()), self.held(mutate._from_ps())
         self.assertLess(max(from_proc, from_ps) / min(from_proc, from_ps), 4)
+
+    @unittest.skipUnless(Path("/proc/self/stat").exists(), "no /proc on this platform")
+    def test_the_two_readers_agree_about_who_is_whose_parent(self) -> None:
+        """`_lane` walks parents, so the field `ps` reports has to mean what the
+        one `/proc` reports means -- and only one of the two is ever read on the
+        machine this is developed on."""
+        self.assertEqual(mutate._from_ps()[os.getpid()].parent, os.getppid())
+        self.assertEqual(mutate._from_proc()[os.getpid()].parent, os.getppid())
 
 
 def reap(pid: int) -> None:
@@ -1352,35 +1363,41 @@ class TestTheSamplerAndTheLanesItHasLeft(unittest.TestCase):
 class TestReadingPsOutputThatIsNotWhatItExpects(unittest.TestCase):
     """`ps` is the reader macOS depends on, and the only one with a parser.
 
-    Every line real `ps` prints here is two numbers, so nothing in the suite
+    Every line real `ps` prints here is four numbers, so nothing in the suite
     distinguishes the check from no check at all -- a sweep of this file
     reported five surviving mutants on that one line. Junk is what it is for:
     a header, a truncated line, a `?` where a number was expected.
     """
 
-    def reading(self, said: str) -> dict[int, int]:
+    def reading(self, said: str) -> dict[int, mutate.Process]:
         listed = subprocess.CompletedProcess([""], 0, stdout=said, stderr="")
         with mock.patch.object(subprocess, "run", return_value=listed):
             return mutate._from_ps()
 
-    def test_only_lines_of_two_numbers_are_counted(self) -> None:
+    def test_only_lines_of_four_numbers_are_counted(self) -> None:
         self.assertEqual(
             self.reading(
-                "  PGID   RSS\n"  # a header, if the `=` suffixes ever stop working
-                "   501  1024\n"
-                "     ?    12\n"  # a field `ps` could not answer
-                "   502\n"  # truncated
-                "   503  4096 stray\n"  # more than was asked for
+                "  PID  PPID  PGID   RSS\n"  # a header, if the `=` suffixes stop working
+                "  501   500   501  1024\n"
+                "  502   501     ?    12\n"  # a field `ps` could not answer
+                "  503   501\n"  # truncated
+                "  504   501   501  4096 stray\n"  # more than was asked for
                 "\n"
-                "   501  2048\n"  # a second process in a group already seen
+                "  505   501   501  2048\n"
             ),
-            {501: 3072 * 1024},
+            {
+                501: mutate.Process(parent=500, group=501, resident=1024 * 1024),
+                505: mutate.Process(parent=501, group=501, resident=2048 * 1024),
+            },
         )
 
     def test_kibibytes_are_not_bytes(self) -> None:
         """The unit `ps` answers in, which is the difference between killing a
         lane at its share and killing it at a thousandth of it."""
-        self.assertEqual(self.reading("  700  2048\n"), {700: 2 << 20})
+        self.assertEqual(
+            self.reading("  700   699   700  2048\n"),
+            {700: mutate.Process(parent=699, group=700, resident=2 << 20)},
+        )
 
 
 class TestALaneThatSpawnsProcesses(MutateTestCase):
@@ -1456,6 +1473,133 @@ class TestALaneThatSpawnsProcesses(MutateTestCase):
         self.storm(children=2, held=8 << 20, sleeps=1)
         verdict = mutate._run(["test_storm"], self.root, memory=512 << 20, timeout=90.0)
         self.assertEqual(verdict.outcome, "survived", verdict.detail)
+
+
+class TestALaneThatLeavesItsOwnGroup(MutateTestCase):
+    """#234: a process group is not the whole lane.
+
+    `start_new_session` is what makes a lane's group cover the `git`, `age` and
+    `bash` a suite forks -- and a *nested* `_run` gives its own probes the same
+    treatment, which takes them out of the outer lane's group. Those were
+    counted by nobody and reached by no `killpg`: one was found alive eleven
+    minutes into a sweep whose per-row bound is 300 seconds, reparented to
+    init, with no process left that knew it was meant to stop.
+
+    Both halves are asserted here, because they fail apart. Counting an escapee
+    is what makes the lane go over its share at all; reaching it is what the
+    kill has to do afterwards.
+    """
+
+    def escaping(self, holds: int, sleeps: int, children: int = 1) -> Path:
+        """A lane whose children put themselves in sessions of their own."""
+        pids = self.root / "pids.txt"
+        self.write(
+            "test_escape.py",
+            f"""
+            import subprocess
+            import sys
+            import unittest
+            from pathlib import Path
+
+            PIDS = Path({str(pids)!r})
+
+
+            class T(unittest.TestCase):
+                def test_it_escapes(self) -> None:
+                    # `start_new_session`, exactly as `mutate._run` does it for
+                    # its own probes -- which is what a lane mutating `tools/`
+                    # ends up hosting, and why this is not a contrived shape.
+                    kids = [
+                        subprocess.Popen(
+                            [
+                                sys.executable,
+                                "-c",
+                                "import time; held = bytearray({holds}); time.sleep({sleeps})",
+                            ],
+                            start_new_session=True,
+                        )
+                        for _ in range({children})
+                    ]
+                    PIDS.write_text("\\n".join(str(kid.pid) for kid in kids), encoding="utf-8")
+                    for kid in kids:
+                        kid.wait()
+            """,
+        )
+        return pids
+
+    def escapees(self, pids: Path) -> list[int]:
+        found = [int(said) for said in pids.read_text(encoding="utf-8").split()]
+        for pid in found:
+            self.addCleanup(reap, pid)
+        return found
+
+    def test_what_an_escapee_holds_is_still_the_lanes_problem(self) -> None:
+        # Three at 200 MiB is 600 MiB against a 512 MiB share, and every one of
+        # them is outside the group -- so counting the group alone leaves the
+        # lane looking idle while the machine is not.
+        pids = self.escaping(holds=200 << 20, sleeps=120, children=3)
+        verdict = mutate._run(["test_escape"], self.root, memory=512 << 20, timeout=25.0)
+        self.assertEqual(verdict.outcome, "broke", verdict.detail)
+        self.assertIn("held", verdict.detail)
+        self.assertEqual(outliving(self.escapees(pids), 5.0), [], "an escapee outlived the kill")
+
+    def orphaning(self, holds: int, children: int) -> Path:
+        """A lane whose grandchildren outlive the child that started them.
+
+        The mirror of `escaping`, and the reason a lane is the *union* of two
+        answers: these stay in the group and stop being anyone's descendant, so
+        a walk down the tree misses exactly the ones `killpg` catches, and a
+        group sum misses exactly the ones the walk catches. A suite that
+        backgrounds a job in a shell that then exits produces this shape without
+        trying.
+
+        The launcher writes the pids to a file rather than to a pipe, and that
+        is not incidental: the processes it starts inherit its stdout, so a
+        `communicate()` on that pipe waits for *them* and the fixture hangs for
+        as long as the holders sleep. Same trap `_run` documents for its own
+        stderr, met again one level down.
+        """
+        pids = self.root / "pids.txt"
+        holder = f"import time; held = bytearray({holds}); time.sleep(120)"
+        launcher = (
+            "import subprocess, sys\n"
+            f"kids = [subprocess.Popen([sys.executable, '-c', {holder!r}],\n"
+            "        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)\n"
+            f"        for _ in range({children})]\n"
+            f"open({str(pids)!r}, 'w').write('\\n'.join(str(kid.pid) for kid in kids))\n"
+        )
+        self.write(
+            "test_orphan.py",
+            f"""
+            import subprocess
+            import sys
+            import time
+            import unittest
+
+
+            class T(unittest.TestCase):
+                def test_it_orphans(self) -> None:
+                    subprocess.run([sys.executable, "-c", {launcher!r}], check=True, timeout=30)
+                    # The launcher has exited, so what it started belongs to
+                    # init now -- and still to this lane's process group.
+                    time.sleep(60)
+            """,
+        )
+        return pids
+
+    def test_an_orphan_that_stayed_in_the_group_is_still_the_lanes(self) -> None:
+        pids = self.orphaning(holds=200 << 20, children=3)
+        verdict = mutate._run(["test_orphan"], self.root, memory=512 << 20, timeout=25.0)
+        self.assertEqual(verdict.outcome, "broke", verdict.detail)
+        self.assertEqual(outliving(self.escapees(pids), 5.0), [], "an orphan outlived the kill")
+
+    def test_a_timeout_reaches_them_too(self) -> None:
+        """The other route in, and the one that produced the eleven-minute
+        orphan: nothing here is over its share, the row simply does not finish."""
+        pids = self.escaping(holds=1 << 20, sleeps=120)
+        verdict = mutate._run(["test_escape"], self.root, timeout=5.0)
+        self.assertEqual(verdict.outcome, "timeout", verdict.detail)
+        self.assertEqual(outliving(self.escapees(pids), 10.0), [], "an escapee outlived the lane")
 
 
 class TestATimeoutEndsTheWholeSession(MutateTestCase):

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -294,11 +294,22 @@ def _signalled(returncode: int) -> str:
     macOS case the cap's own docstring admits to. Naming it is the difference
     between a row that reports nothing and a row that says the machine, not the
     mutation, ended the run.
+
+    It names two causes rather than one because a sweep of this module produced
+    the second: a mutation to `_lane` makes the *nested* harness inside a lane
+    compute the wrong membership and kill the session hosting it, and the row
+    then reported an out-of-memory that had not happened. A message that names
+    the wrong cause costs more than one that names none.
     """
     if returncode >= 0:
         return f"the probe exited {returncode} without writing a report"
     name = signal.Signals(-returncode).name if -returncode in set(signal.Signals) else "?"
-    killed = " -- the host ran out of memory, and this lane was chosen" if name == "SIGKILL" else ""
+    killed = (
+        " -- either the host ran out of memory and this lane was chosen, or a harness "
+        "running inside it killed the session it was in"
+        if name == "SIGKILL"
+        else ""
+    )
     return f"the probe was killed by {name}{killed}"
 
 

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -309,8 +309,16 @@ def _signalled(returncode: int) -> str:
 _SAMPLE = 1.0
 
 
-def _resident_by_group() -> dict[int, int]:
-    """Resident bytes held by each process group, for everything this user can see.
+class Process(NamedTuple):
+    """One row of the process table, in the three fields a lane cares about."""
+
+    parent: int
+    group: int
+    resident: int
+
+
+def _processes() -> dict[int, Process]:
+    """Every process this user can see, by pid.
 
     Resident rather than address space, because resident is what the OOM killer
     counts and what a fork storm actually spends. The one that took this machine
@@ -328,9 +336,9 @@ def _resident_by_group() -> dict[int, int]:
     return _from_proc() if Path("/proc/self/stat").exists() else _from_ps()
 
 
-def _from_proc() -> dict[int, int]:
-    """`_resident_by_group` where there is a `/proc`. Reads, never forks."""
-    total: dict[int, int] = {}
+def _from_proc() -> dict[int, Process]:
+    """`_processes` where there is a `/proc`. Reads, never forks."""
+    table: dict[int, Process] = {}
     page = os.sysconf("SC_PAGE_SIZE")
     for entry in Path("/proc").iterdir():
         if not entry.name.isdigit():
@@ -345,29 +353,79 @@ def _from_proc() -> dict[int, int]:
         # Everything after the comm field, which is the one that may itself
         # contain spaces and brackets -- so the split starts past its closing
         # one rather than at the beginning of the line. Counting from `pid`,
-        # `pgrp` is the fifth field and `rss` the twenty-fourth, which is why
-        # the indices below are those minus the three that come first.
+        # `ppid` is the fourth field, `pgrp` the fifth and `rss` the
+        # twenty-fourth, which is why the indices below are those minus three.
         fields = said.rpartition(") ")[2].split()
         if len(fields) < 22:
             continue
         with suppress(ValueError):
-            group = int(fields[2])
-            total[group] = total.get(group, 0) + int(fields[21]) * page
-    return total
+            table[int(entry.name)] = Process(
+                parent=int(fields[1]), group=int(fields[2]), resident=int(fields[21]) * page
+            )
+    return table
 
 
-def _from_ps() -> dict[int, int]:
-    """`_resident_by_group` where there is no `/proc`, which is macOS."""
-    total: dict[int, int] = {}
+def _from_ps() -> dict[int, Process]:
+    """`_processes` where there is no `/proc`, which is macOS."""
+    table: dict[int, Process] = {}
     listed = subprocess.run(
-        ["ps", "-eo", "pgid=,rss="], capture_output=True, text=True, check=False
+        ["ps", "-eo", "pid=,ppid=,pgid=,rss="], capture_output=True, text=True, check=False
     )
     for line in listed.stdout.splitlines():
         fields = line.split()
-        if len(fields) == 2 and fields[0].isdigit() and fields[1].isdigit():
+        if len(fields) == 4 and all(field.isdigit() for field in fields):
+            pid, parent, group, resident = (int(field) for field in fields)
             # Kibibytes, which POSIX does not promise and both platforms do.
-            total[int(fields[0])] = total.get(int(fields[0]), 0) + int(fields[1]) * 1024
-    return total
+            table[pid] = Process(parent=parent, group=group, resident=resident * 1024)
+    return table
+
+
+def _lane(leader: int, table: dict[int, Process]) -> set[int]:
+    """Every process belonging to the lane `leader` started.
+
+    Two answers unioned, because neither is enough on its own and the gap
+    between them is #234:
+
+    - everything in `leader`'s **process group**, which is what `start_new_session`
+      buys and covers the `git`, `age` and `bash` a suite forks;
+    - every **descendant** of `leader`, which is what catches a grandchild that
+      called `setsid` and thereby left that group. A nested `_run` does exactly
+      that, and one was found alive eleven minutes into a sweep whose per-row
+      bound is 300 seconds, reparented to init and counted by nobody.
+
+    A descendant whose parent has already died is in neither set: init has
+    adopted it and the link is gone. That is why callers enumerate *before*
+    killing rather than after -- while the lane is alive, the tree is still
+    connected.
+    """
+    kids: dict[int, list[int]] = {}
+    for pid, row in table.items():
+        kids.setdefault(row.parent, []).append(pid)
+    found = {pid for pid, row in table.items() if row.group == leader}
+    stack = [leader]
+    while stack:
+        pid = stack.pop()
+        if pid in found and pid != leader:
+            continue
+        found.add(pid)
+        stack.extend(kids.get(pid, ()))
+    return found & set(table)
+
+
+def _end_lane(leader: int, members: Iterable[int]) -> None:
+    """Kill the group, then everything that left it.
+
+    The group first because it is one syscall for most of the lane, and the
+    stragglers by pid because they are exactly the processes `killpg` cannot
+    reach. `members` is enumerated by the caller beforehand: after the first
+    kill the tree is no longer connected, so a walk done here would find less
+    than a walk done a moment earlier.
+    """
+    with suppress(OSError):
+        os.killpg(leader, signal.SIGKILL)
+    for pid in members:
+        with suppress(OSError):
+            os.kill(pid, signal.SIGKILL)
 
 
 class _Lanes:
@@ -386,13 +444,13 @@ class _Lanes:
     inherits is beside the point. `_BUDGET` shrinks an honest nested harness;
     this is what answers a mutant that ignores it.
 
-    Counted by process group, which is why `_run` gives each probe its own
-    session. Everything the suite forks -- `git`, `age`, `bash`, a nested
-    harness and its probes -- inherits the group, so one number covers the
-    subtree and one `killpg` ends all of it. A grandchild that calls `setsid`
-    leaves the group and is no longer counted; that is a real hole and a small
-    one, since the thing that does it is a nested `_run`, which arrives already
-    bounded by the share it inherited.
+    What counts as the lane is `_lane`: its process group, plus any descendant
+    that left that group by starting a session of its own. The group alone was
+    the first shape and it left a hole (#234) -- a nested `_run` gives its own
+    probes their own sessions, so those escaped both the count and the kill, and
+    one was found alive eleven minutes into a sweep whose per-row bound is 300
+    seconds. Counting the union is also what makes an escaped probe's memory
+    the lane's problem rather than nobody's.
 
     Sampling rather than a cgroup, for the reasons `verdict.cap` gives for
     `RLIMIT_AS` over `systemd-run --scope -p MemoryMax=`: no root, no delegated
@@ -443,19 +501,20 @@ class _Lanes:
                 watched = dict(self._ceilings)
             if not watched:
                 continue
-            held = _resident_by_group()
-            for group, ceiling in watched.items():
-                if held.get(group, 0) <= ceiling:
+            table = _processes()
+            for leader, ceiling in watched.items():
+                members = _lane(leader, table)
+                held = sum(table[pid].resident for pid in members)
+                if held <= ceiling:
                     continue
                 with self._lock:
                     # Re-checked under the lock: `release` may have run while
-                    # the process table was being read, and a `killpg` after
-                    # that names a group id the kernel is free to have reused.
-                    if group not in self._ceilings:
+                    # the process table was being read, and a kill after that
+                    # names ids the kernel is free to have reused.
+                    if leader not in self._ceilings:
                         continue
-                    self._killed[group] = held[group]
-                    with suppress(OSError):
-                        os.killpg(group, signal.SIGKILL)
+                    self._killed[leader] = held
+                _end_lane(leader, members)
 
 
 #: One per process, because `_run` is what registers and it has no run-wide
@@ -473,9 +532,14 @@ def _end(probe: subprocess.Popen[bytes]) -> None:
     invisible to the run that started them. A sweep that times out often enough
     accumulates them until the machine is gone, which is the slow half of #232;
     the fast half is `_Lanes`.
+
+    The walk happens *before* the first kill, which is #234: a grandchild that
+    started a session of its own is outside the group, so `killpg` never reaches
+    it -- and once its parent is dead it is no longer a descendant either, so a
+    walk done afterwards would not find it. Between those two moments is the
+    only time anything can see it.
     """
-    with suppress(OSError):
-        os.killpg(probe.pid, signal.SIGKILL)
+    _end_lane(probe.pid, _lane(probe.pid, _processes()))
     with suppress(OSError):
         probe.kill()  # if the session is somehow gone, at least reap this one
     with suppress(subprocess.TimeoutExpired):


### PR DESCRIPTION
Closes #234.

## What was wrong

A nested probe that outlived its lane was bounded by nothing: not the row's
`--timeout`, because the process counting it was dead, and not `_Lanes`,
because it had left the group being counted.

`start_new_session` is what makes a lane's group cover the `git`, `age` and
`bash` a suite forks — and a nested `_run` gives *its* probes the same
treatment, which takes them out of the outer lane's group. Found in the wild
during the `tools/mutate.py` sweep:

```
    PID    PPID    PGID     ELAPSED   RSS
1211360    1652 1211360       11:34 15804   <- ppid 1652 is systemd
1553738 1200330 1553738       01:02 74240   <- healthy lanes, ppid = the sweep
```

Eleven minutes into a run whose per-row bound is 300 seconds.

## The fix

`_lane(leader, table)` is the **union of two answers**, because each one misses
exactly what the other catches:

| | catches | misses |
|---|---|---|
| process group | a child whose parent exited, so init adopted it | a grandchild that called `setsid` |
| descendants of the leader | the grandchild that left the group | the orphan init now owns |

`_processes` returns a row per pid rather than a sum per group, since the walk
needs parents and the same `/proc` line already carries them. `_end_lane` kills
the group and then the stragglers by pid.

Both callers enumerate **before** the first kill. After it the tree is cut, so a
walk done afterwards finds strictly less than one done a moment earlier — that
ordering is the fix at the timeout call site, and it has its own row below.

## Rule 3

```
  caught    a lane is its process group, so anything that left it is nobody's
  caught    a lane is its descendants, so the group's own forks stop counting
  caught    killpg alone, as before -- the escapees are left running
  caught    the timeout path walks after killing, when the tree is already cut
```

The second row is the one that needed work. Dropping group membership entirely
passed every existing test, because every child in those fixtures is *also* a
descendant — the two halves were indistinguishable. It now takes a launcher that
spawns holders and exits, leaving them orphaned inside the group.

Writing those pids to a file rather than a pipe is load-bearing: the holders
inherit the launcher's stdout, so `communicate()` waits for *them* rather than
for the launcher, which hung the first version of that fixture for as long as
they sleep. Same trap `_run` documents for its own stderr, one level down.

Generated table, `--base main`: **33 caught, 0 survived**, baseline green, 333 s,
peak 18.5 GB and 194 processes. Three rows were unanswerable and the reason is
worth reading: a mutated `_lane` running *inside* a lane computes the wrong
membership and kills the session hosting it. That is the harness mutating its
own kill logic, not a defect — but it reported "the host ran out of memory",
which had not happened, so `_signalled` now names both causes. A message that
names the wrong cause costs more than one that names none.

## Preflight

`ruff`, `ruff format`, `mypy`, `shellcheck`, 1174 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
