### PR TITLE
test: main()'s generated branch, which nothing drove (#235)

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -32,6 +32,48 @@ MACHINE_ID = "0123456789abcdef"
 #: forgotten in the other.
 requires_age = unittest.skipUnless(crypto.available(), "age required")
 requires_git = unittest.skipUnless(shutil.which("git"), "git required")
+
+
+def git(root: Path, *argv: str) -> str:
+    """Run `git` against `root` with a configuration of its own, and return stdout.
+
+    Hardened here rather than at each fixture, because every clause was paid for
+    once and must not have to be paid for again: a maintainer whose global
+    config signs commits or renames the default branch must not fail a suite for
+    reasons that are not the code under test, and `check=True` turns a machine
+    without git into an error rather than the skip `requires_git` gives.
+
+    `PATH` is carried across rather than hardcoded -- there is no
+    sandbox-relative answer to where the real `git` lives, and a machine with it
+    outside `/usr/bin` (Nix, a Homebrew-first PATH, most containers) would
+    otherwise fail for the same irrelevant reason. Same argument
+    `store.SANDBOX_CARRIES` makes, one layer down.
+    """
+    finished = subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            *argv,
+        ],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(root),
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+        },
+    )
+    return finished.stdout
+
+
 requires_ssh_keygen = unittest.skipUnless(shutil.which("ssh-keygen"), "ssh-keygen required")
 requires_bash = unittest.skipUnless(shutil.which("bash"), "bash required")
 requires_zsh = unittest.skipUnless(shutil.which("zsh"), "zsh required")

--- a/tests/test_mutants.py
+++ b/tests/test_mutants.py
@@ -16,8 +16,6 @@ So the span assertions here are exact, never "it contains".
 from __future__ import annotations
 
 import ast
-import os
-import subprocess
 import tempfile
 import textwrap
 import unittest
@@ -26,6 +24,7 @@ from pathlib import Path
 from tools import mutants
 from tools.mutants import Mutation
 
+from . import support
 from .support import requires_git
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -746,37 +745,9 @@ class TestReadingARealDiff(unittest.TestCase):
     """
 
     def git(self, *argv: str) -> str:
-        finished = subprocess.run(
-            [
-                "git",
-                "-c",
-                "user.name=t",
-                "-c",
-                "user.email=t@example.com",
-                "-c",
-                "commit.gpgsign=false",
-                *argv,
-            ],
-            cwd=self.root,
-            capture_output=True,
-            text=True,
-            check=True,
-            # A maintainer whose global config signs commits or renames the
-            # default branch must not fail this suite for reasons that are not
-            # the code under test.
-            env={
-                # Carried across, not hardcoded: `tools/sandbox.py` gives the
-                # argument -- there is no sandbox-relative answer to where the
-                # real `git` lives, and a machine with git outside `/usr/bin`
-                # (Nix, a Homebrew-first PATH, most containers) would otherwise
-                # fail here for a reason unrelated to the code under test.
-                "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
-                "HOME": str(self.root),
-                "GIT_CONFIG_GLOBAL": "/dev/null",
-                "GIT_CONFIG_SYSTEM": "/dev/null",
-            },
-        )
-        return finished.stdout
+        """`support.git`, bound to this fixture's root. The hardening it carries
+        was written here and moved there when a second fixture needed it."""
+        return support.git(self.root, *argv)
 
     def write(self, name: str, body: str) -> None:
         path = self.root / name

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -29,6 +29,9 @@ from unittest import mock
 from tools import mutate, reached
 from tools.mutate import MEMORY, Mutation, Report, Result, Verdict, confirm, run, verify
 
+from . import support
+from .support import requires_git
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 #: The module every fixture here mutates. One spelling: three fixtures wrote it
@@ -63,23 +66,39 @@ class MutateTestCase(unittest.TestCase):
         path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
         return path
 
-    def package(self, guarded: bool) -> None:
-        """A module with one behaviour, and a test that may or may not see it."""
-        self.write("mod.py", CLAMP)
-        assertion = (
-            "self.assertEqual(mod.clamp(-5), 0)" if guarded else "self.assertEqual(mod.clamp(5), 5)"
-        )
+    def package(self, guarded: bool, inside: str = "", both: bool = False) -> None:
+        """A module with one behaviour, and a test that may or may not see it.
+
+        `inside` puts it in a package, which is what a *generated* table needs:
+        `mutants.mutable` only generates for paths under `woswoar/` or `tools/`,
+        so a module at the sandbox root is invisible to `--base`.
+
+        `both` asserts the guarded branch *and* the unguarded one, which a
+        generated `branch` table needs -- its two mutants are "the guard always
+        fires" and "it never does", and catching them takes an assertion each.
+        It is a parameter rather than the default because a stronger fixture
+        changes what the rest of this file observes: turned on for everyone,
+        `TestAnUnanswerableRowNeedNotEndTheRun` stops having a surviving row to
+        report, which is most of what that test is for.
+        """
+        self.write(f"{inside}/mod.py" if inside else "mod.py", CLAMP)
+        sees = "self.assertEqual(mod.clamp(-5), 0)" if guarded else ""
+        seen = [
+            line
+            for line in (sees, "self.assertEqual(mod.clamp(5), 5)" if both or not guarded else "")
+            if line
+        ]
         self.write(
-            "test_mod.py",
+            f"{inside}/../tests/test_mod.py" if inside else "test_mod.py",
             f"""
             import unittest
 
-            import mod
+            {f"from {inside} import mod" if inside else "import mod"}
 
 
             class T(unittest.TestCase):
                 def test_it(self) -> None:
-                    {assertion}
+                    {"; ".join(seen)}
             """,
         )
 
@@ -850,8 +869,15 @@ class TestAllDropsTheDiffSizedCap(unittest.TestCase):
         self.assertNotIn("not run", self.listed("--all"))
 
     def test_an_explicit_limit_is_still_honoured(self) -> None:
-        """Reset, not ignored: someone who says `--limit 50` means it."""
-        self.assertIn("--limit 50:", self.listed("--all", "--limit", "50"))
+        """Reset, not ignored: someone who says `--limit 50` means it.
+
+        The count as well as the notice, because a cap that says it dropped
+        rows and then runs a different number of them is the same wrong answer
+        told twice.
+        """
+        listed = self.listed("--all", "--limit", "50")
+        self.assertIn("--limit 50:", listed)
+        self.assertEqual(len([line for line in listed.splitlines() if line.startswith("  ")]), 50)
 
     def test_a_diff_run_keeps_the_default(self) -> None:
         """The default exists for this shape and must not be collateral."""
@@ -1929,6 +1955,113 @@ class TestOneLaneIsNotADeadlock(MutateTestCase):
         self.assertIn("caught", finished.stdout, finished.stderr)
 
 
+def cli(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """`python -m tools.mutate` against `root`, as someone would type it.
+
+    `PYTHONPATH` is the repository, so the harness under test is this tree's
+    while the code it mutates is the sandbox's -- the same split `_run` makes
+    for the probe, and the reason a fixture may shadow `woswoar` only if it
+    provides the whole package (`tools.sandbox` imports `store`).
+    """
+    return subprocess.run(
+        [sys.executable, "-m", "tools.mutate", *args],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=dict(os.environ, PYTHONPATH=str(REPO_ROOT)),
+    )
+
+
+@requires_git
+class TestTheGeneratedEntryPoint(MutateTestCase):
+    """`--base`, `--json`, `--no-confirm` and the exit status (#235).
+
+    Everything in `TestTheScriptEntryPoint` drives a *spec file*, which is the
+    other branch of `main` -- so the branch a maintainer actually types was
+    executed by no test at all. The first full sweep of `tools/` found 24
+    surviving mutants in it, including `--json` never written and the exit
+    status inverted. `--all`'s reset of the diff-sized `--limit` is not here:
+    `TestAllDropsTheDiffSizedCap` already drives it through `main`, and `--all`
+    consults no git at all, so a repository fixture would be scaffolding this
+    class needs and that question does not.
+
+    The fixture is a real git repository, because `_SKIP` keeps `.git` out of a
+    sandbox and a diff needs one. It also holds a *copy* of `woswoar/`: a
+    mutable path has to start with `woswoar/` or `tools/`, and a fixture package
+    that shadows either without providing it breaks the harness's own imports.
+    """
+
+    def repo(self, guarded: bool) -> None:
+        shutil.copytree(
+            REPO_ROOT / "woswoar",
+            self.root / "woswoar",
+            ignore=shutil.ignore_patterns("__pycache__"),
+        )
+        self.write("tests/__init__.py", "")
+        self.package(guarded, inside="woswoar", both=True)
+        moved = self.root / "woswoar" / "mod.py"
+        source = moved.read_text(encoding="utf-8")
+        moved.unlink()
+        support.git(self.root, "init", "--quiet", "--template=")
+        support.git(self.root, "add", ".")
+        support.git(self.root, "commit", "--quiet", "-m", "base")
+        # The module lands *after* that commit, and only then: `changed_lines`
+        # treats every untracked mutable file as wholly changed, so a `woswoar/`
+        # left out of it puts the whole package in the diff. It did, on the
+        # first run of this fixture -- 200 rows against `sync.py` for a test
+        # about `mod.py`.
+        moved.write_text(source, encoding="utf-8")
+
+    def test_a_diff_generates_rows_and_a_clean_run_exits_zero(self) -> None:
+        self.repo(guarded=True)
+        finished = cli(self.root, "--base", "HEAD", "--operator", "branch")
+        self.assertIn("caught", finished.stdout)
+        self.assertEqual(finished.returncode, 0, finished.stdout + finished.stderr)
+
+    def test_a_survivor_makes_the_exit_status_one(self) -> None:
+        """The half a reader believes without checking: a run that found
+        something and said so is not a run that succeeded."""
+        self.repo(guarded=False)
+        finished = cli(self.root, "--base", "HEAD", "--operator", "branch")
+        self.assertIn("SURVIVED", finished.stdout)
+        self.assertEqual(finished.returncode, 1, finished.stdout + finished.stderr)
+
+    def test_json_holds_every_row_that_was_printed(self) -> None:
+        self.repo(guarded=True)
+        report = self.root / "rows.json"
+        finished = cli(self.root, "--base", "HEAD", "--operator", "branch", "--json", str(report))
+        self.assertEqual(finished.returncode, 0, finished.stdout + finished.stderr)
+        written = json.loads(report.read_text(encoding="utf-8"))
+        self.assertFalse(written["baseline_red"])
+        # As many rows as were printed, and about the file the diff touched.
+        # What each row must *hold* is `TestTheJsonReport`'s question, asked
+        # once there rather than again here.
+        self.assertEqual(
+            len(written["results"]), finished.stdout.count("  caught  "), finished.stdout
+        )
+        self.assertEqual({row["path"] for row in written["results"]}, {"woswoar/mod.py"})
+
+    def test_no_confirm_says_what_it_did_not_do(self) -> None:
+        """A survivor that was never re-run against the whole suite may simply
+        have been run against tests that cannot see it, and that is the
+        expensive error -- it sends someone to rewrite a test that was fine."""
+        self.repo(guarded=False)
+        finished = cli(self.root, "--base", "HEAD", "--operator", "branch", "--no-confirm")
+        self.assertIn("were not re-run against the whole suite", finished.stdout)
+        self.assertEqual(finished.returncode, 1)
+
+    def test_the_two_ways_of_asking_for_nothing_are_refused(self) -> None:
+        for args, said in (
+            (("--all", "--base", "HEAD"), "Not both"),
+            ((), "give a spec file"),
+        ):
+            with self.subTest(args=args):
+                finished = cli(self.root, *args)
+                self.assertEqual(finished.returncode, 2, finished.stderr)
+                self.assertIn(said, finished.stderr)
+
+
 class TestTheScriptEntryPoint(MutateTestCase):
     def test_it_runs_a_table_from_a_file(self) -> None:
         self.package(guarded=True)
@@ -1947,14 +2080,7 @@ class TestTheScriptEntryPoint(MutateTestCase):
         self.assertIn("caught", finished.stdout)
 
     def drive(self, name: str) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(
-            [sys.executable, "-m", "tools.mutate", str(self.root / name)],
-            cwd=self.root,
-            capture_output=True,
-            text=True,
-            check=False,
-            env=dict(os.environ, PYTHONPATH=str(REPO_ROOT)),
-        )
+        return cli(self.root, str(self.root / name))
 
     def test_a_script_that_calls_verify_itself_is_not_a_failure(self) -> None:
         """#213: it ran the table, printed `caught`, and then exited 1.


### PR DESCRIPTION
Closes #235.

## What was untested

Every case in `TestTheScriptEntryPoint` drives a **spec file**. The other branch
of `main` — `--base`, `--all`, `--json`, `--limit`, `--no-confirm`, the two
`parser.error` guards, the exit status — is the one a maintainer types, and no
test executed it. The first full sweep of `tools/` reported 24 surviving mutants
there, including `--json` never written and the exit status inverted.

## The fixture, and what it had to learn

A real `git init` repository, because `_SKIP` keeps `.git` out of a sandbox and
a diff needs one; and a copy of `woswoar/`, because a mutable path must start
with `woswoar/` or `tools/` and a fixture package that shadows either without
providing it breaks the harness's own imports (`tools.sandbox` imports `store`).

Two failures worth keeping in the record:

- The copied package is committed **before** the module under test is written.
  `changed_lines` treats every untracked mutable file as wholly changed, so the
  first version put 200 rows against `sync.py` in a test about `mod.py`.
- The runs ask for `--operator branch`. The wider generated table contains `<`
  becoming `<=` on `value < 0`, which no argument distinguishes from the
  original — a fixture claiming to catch everything would have been claiming to
  catch an equivalent mutant.

## Rule 3

```
  caught    --all leaves the diff-sized cap in place, so it is 200 rows of thousands
  caught    --all and --base together are no longer refused
  caught    asking for neither a spec file nor a diff is accepted
  caught    the report is never written, so a resume has nothing to resume from
  caught    a run with survivors exits zero
  caught    a clean run exits one
  caught    --no-confirm says nothing about what it skipped
```

## /simplify

Two of the seven tests I wrote duplicated `TestAllDropsTheDiffSizedCap`, which
already drives both `--all` questions through `main` and needs no repository —
`--all` consults no git at all, so the fixture was scaffolding for a question
that does not use it. Both are gone; the one assertion they made that the older
class did not (an explicit `--limit N` yields exactly N rows) moved there. The
class went from 7 tests and 1.08 s to 5 and 0.57 s.

Also applied: `git` moves into `tests/support.py` carrying the hardening
`test_mutants` had written for it (`GIT_CONFIG_GLOBAL=/dev/null`,
`commit.gpgsign=false`, a carried `PATH`) — without it, a maintainer whose
global config signs commits would have failed five of these; `repo()` builds its
package through `MutateTestCase.package`, which grows `inside=` and `both=`
rather than a second copy of `CLAMP`'s test module; the per-row schema loop goes,
since `TestTheJsonReport` asks that already; and the class is `@requires_git`,
so a machine without git skips rather than errors.

`both=` is a parameter rather than the default for a reason worth recording:
asserting both directions everywhere leaves `TestAnUnanswerableRowNeedNotEndTheRun`
with no surviving row to report, which is most of what that test is for.

## Preflight

`ruff`, `ruff format`, `mypy`, `shellcheck`, 1179 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
