### PR TITLE
fix: a module that will not import is not a test that failed (#221)

### DIFF
--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -62,7 +62,9 @@ def fixture(*bodies: str) -> Iterator[list[str]]:
         try:
             with (
                 mock.patch.dict(os.environ, {"PYTHONPATH": path}),
-                mock.patch.object(run_tests, "discover", lambda: dict(classes)),
+                mock.patch.object(
+                    run_tests, "discover", lambda: run_tests.Found(dict(classes), {})
+                ),
             ):
                 yield list(classes)
         finally:
@@ -104,7 +106,7 @@ def tampering(mutate: Callable[[list[str]], list[str]]) -> Iterator[None]:
 class TestDiscovery(unittest.TestCase):
     def test_every_test_is_assigned_to_exactly_one_batch(self) -> None:
         """The batching must partition the real suite -- no gaps, no double runs."""
-        classes = run_tests.discover()
+        classes = run_tests.discover().classes
         ids = [tid for group in classes.values() for tid in group]
         self.assertEqual(len(ids), len(set(ids)), "a test landed in two batches")
 
@@ -314,6 +316,92 @@ class TestSkipsCanBeFatal(unittest.TestCase):
         with fixture(SKIPS):
             code, _ = run_main("--jobs", "2")
         self.assertEqual(code, 0)
+
+
+class TestAModuleThatWillNotImport(unittest.TestCase):
+    """#221: "this module contributed nothing" is not "a test failed".
+
+    `unittest.loader` substitutes a synthetic `_FailedTest` for a module it
+    cannot import, and that placeholder **is** a `TestCase` -- so before this it
+    packed into a batch as an ordinary class, ran nothing, and came out the far
+    end as `1 discovered test never ran`, naming `unittest.loader._FailedTest`.
+    Red, which is why nobody was hurt, and wrong about what happened.
+    """
+
+    @contextmanager
+    def tree(self, *modules: str) -> Iterator[Path]:
+        """A throwaway package of test modules, discovered for real.
+
+        For real, rather than through `fixture`'s patched `discover`, because
+        discovery is the thing under test here. In a directory of its own, and
+        that is not fastidiousness: writing a deliberately broken module into
+        this repository's `tests/` would be found by the 64 workers running this
+        very suite.
+        """
+        with tempfile.TemporaryDirectory(prefix="woswoar-unloadable-") as tmp:
+            root = Path(tmp)
+            for index, body in enumerate(modules):
+                (root / f"test_mod{index}.py").write_text(body, encoding="utf-8")
+            yield root
+
+    def test_a_broken_module_is_reported_as_unloadable_not_as_a_test(self) -> None:
+        with self.tree("import nosuchmodule_xyz\n") as root:
+            found = run_tests.discover(root)
+        self.assertEqual(found.classes, {})
+        self.assertEqual(list(found.unloadable), ["test_mod0"])
+        self.assertIn("Failed to import test module", found.unloadable["test_mod0"])
+
+    def test_the_modules_that_did_import_are_still_discovered(self) -> None:
+        """The half that fails if the placeholder is filtered by class rather
+        than by module: everything else must survive the filter."""
+        with self.tree(
+            "import nosuchmodule_xyz\n",
+            f"import unittest\n\n\nclass TestFixture(unittest.TestCase):\n{PASSES}",
+        ) as root:
+            found = run_tests.discover(root)
+        self.assertEqual(list(found.classes), ["test_mod1.TestFixture"])
+        self.assertEqual(list(found.unloadable), ["test_mod0"])
+
+    def test_the_run_is_red_and_says_which_module(self) -> None:
+        with mock.patch.object(
+            run_tests,
+            "discover",
+            lambda: run_tests.Found({}, {"tests.test_gone": "Failed to import test module: x"}),
+        ):
+            code, text = run_main("--jobs", "2")
+        self.assertEqual(code, 1)
+        self.assertIn("could not import tests.test_gone", text)
+        # Not the other thing. A reader who sees this looks for an assertion.
+        self.assertNotIn("never ran", text)
+
+    def test_only_naming_a_broken_module_says_so(self) -> None:
+        """`--only` on a module that will not import used to answer "no test
+        class matches" -- true, and the opposite of what the person typing it is
+        trying to find out."""
+        with mock.patch.object(
+            run_tests,
+            "discover",
+            lambda: run_tests.Found({}, {"tests.test_gone": "Failed to import test module: x"}),
+        ):
+            code, text = run_main("--only", "tests.test_gone", "--jobs", "2")
+        self.assertEqual(code, 1)
+        self.assertIn("could not import tests.test_gone", text)
+        self.assertNotIn("no test class matches", text)
+
+    def test_a_batch_reports_one_that_only_it_can_see(self) -> None:
+        """The belt to discovery's brace: a module can import in the parent and
+        not in the worker, and the batch must still run the classes that loaded.
+        `ran` stays honest -- the placeholder is not a test that ran."""
+        with fixture(PASSES) as names, tempfile.TemporaryDirectory() as out_dir:
+            out = Path(out_dir, "report.json")
+            with redirect_stderr(StringIO()):
+                code = run_tests.run_batch([*names, "zz_no_such_fixture"], out)
+            report = json.loads(out.read_text(encoding="utf-8"))
+        self.assertEqual(code, 1)
+        self.assertEqual(list(report["unloadable"]), ["zz_no_such_fixture"])
+        self.assertEqual(len(report["ran"]), 1)
+        self.assertEqual(report["failures"], [])
+        self.assertEqual(report["errors"], [])
 
 
 class TestOrdinaryOutcomes(unittest.TestCase):

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -54,17 +54,19 @@ import tempfile
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 ROOT = Path(__file__).resolve().parent.parent
 
 
 def _walk(suite: unittest.TestSuite) -> list[unittest.TestCase]:
-    """Flatten a suite, surfacing the placeholders unittest uses for load errors.
+    """Flatten a suite, placeholders and all, and let the caller decide.
 
-    A module that raises on import becomes a _FailedTest here rather than
-    vanishing. Keeping it means an import error is a red test, not a smaller
-    suite -- which is the whole point of this file.
+    A module that raises on import becomes a synthetic `_FailedTest` here rather
+    than vanishing, and both callers then drop it -- an import error is reported
+    as an unloadable module (#221), not as a test that failed. This function
+    keeping it is what makes that choice available: a filter here would leave
+    `loader.errors` as the only evidence the module existed at all.
     """
     found: list[unittest.TestCase] = []
     for item in suite:
@@ -75,16 +77,75 @@ def _walk(suite: unittest.TestSuite) -> list[unittest.TestCase]:
     return found
 
 
-def discover() -> dict[str, list[str]]:
-    """Map each test class to the ids it holds, in discovery order."""
-    suite = unittest.defaultTestLoader.discover(
-        str(ROOT), pattern="test_*.py", top_level_dir=str(ROOT)
-    )
+class Found(NamedTuple):
+    """What discovery says: the classes to run, and the modules that would not
+    import at all."""
+
+    classes: dict[str, list[str]]
+    #: Module name -> the first line of the import error, which is the one that
+    #: says which module and why.
+    unloadable: dict[str, str]
+
+
+def discover(root: Path = ROOT) -> Found:
+    """Map each test class to the ids it holds, in discovery order.
+
+    A module that will not import is *not* one of them, and telling those two
+    apart is the whole of #221. `unittest.loader` substitutes a synthetic
+    `_FailedTest` for it, which **is** a `TestCase` -- so left alone it packs
+    into a batch as an ordinary class, contributes an id to `expected`, runs
+    nothing, and surfaces at the end as "1 discovered test never ran" under a
+    private class name. Red, which is why nobody was hurt, and wrong about what
+    happened: nothing ran because nothing was *there*.
+
+    Told apart through `TestLoader.errors`, a public attribute, exactly as
+    `tools/verdict.py` argues at greater length -- no `isinstance` against a
+    name `unittest` is free to move.
+
+    `root` is a parameter so this can be pointed at a throwaway tree. It has one
+    caller in anger and one in the tests, and the alternative was writing a
+    deliberately broken module into `tests/` while the suite that finds it is
+    running in 64 parallel workers.
+    """
+    loader = unittest.TestLoader()
+    suite = loader.discover(str(root), pattern="test_*.py", top_level_dir=str(root))
+    unloadable = _unloadable(loader)
     classes: dict[str, list[str]] = {}
-    for test in _walk(suite):
+    for test in _loaded(suite, unloadable):
         name = f"{type(test).__module__}.{type(test).__qualname__}"
         classes.setdefault(name, []).append(test.id())
-    return classes
+    return Found(classes, unloadable)
+
+
+def _unloadable(loader: unittest.TestLoader) -> dict[str, str]:
+    """The modules a loader could not import, by name.
+
+    `TestLoader.errors` is public and holds a formatted traceback per module; its
+    first line is "Failed to import test module: tests.test_x", so the module is
+    the tail of it and the line itself is what a reader needs. Both the surgery
+    and the message shape live here rather than at the two call sites, because
+    they encode what `unittest` prints and that is one fact.
+    """
+    return {
+        said.splitlines()[0].rsplit(": ", 1)[-1]: said.splitlines()[0]
+        for said in (str(error) for error in loader.errors)
+    }
+
+
+def _loaded(suite: unittest.TestSuite, unloadable: dict[str, str]) -> list[unittest.TestCase]:
+    """The real tests in `suite`, without the placeholders for `unloadable`.
+
+    A placeholder's id is its class plus the module it could not import, so the
+    module is the tail. Matched that way rather than against
+    `unittest.loader._FailedTest`: that is the private name `tools/verdict.py`
+    refuses to make decisions from, and if `unittest` moves it this still
+    answers.
+    """
+    return [
+        test
+        for test in _walk(suite)
+        if not any(test.id().endswith(f".{name}") for name in unloadable)
+    ]
 
 
 def selects(name: str, only: str) -> bool:
@@ -147,8 +208,25 @@ class _Recorder(unittest.TextTestResult):
 
 
 def run_batch(names: list[str], out: Path) -> int:
-    """Run some classes and write what happened to `out` as JSON."""
-    suite = unittest.defaultTestLoader.loadTestsFromNames(names)
+    """Run some classes and write what happened to `out` as JSON.
+
+    Discovery in the parent already sets the unloadable modules aside, so this
+    check is the belt to that brace: a module can import there and not here --
+    a half-written file caught mid-save, an import with a side effect that
+    depends on which worker got there first -- and the batch must still run the
+    classes that did load. That is why this does not simply reuse
+    `tools/verdict.py`, whose answer to `loader.errors` is to run nothing at
+    all: the shared thing is the classification, not the control flow.
+    """
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromNames(names)
+    unloadable = _unloadable(loader)
+    if unloadable:
+        # The whole traceback, once, where a human reads it in context -- the
+        # summary carries only the first line, as it does for every other row.
+        for error in loader.errors:
+            print(error, file=sys.stderr)
+        suite = unittest.TestSuite(_loaded(suite, unloadable))
     # Tracebacks go to stderr, where they interleave with the tests' own output
     # and a human reads them in context. Only ids travel back to the parent:
     # shipping the traceback too would print every failure twice.
@@ -165,11 +243,15 @@ def run_batch(names: list[str], out: Path) -> int:
                 # The reason, unlike a traceback, is not printed by the child at
                 # this verbosity, so it would otherwise be lost.
                 "skipped": [[test.id(), why] for test, why in result.skipped],
+                # A new key rather than a new meaning for `errors`: the parent
+                # reads this file as a protocol, and an id that is a module
+                # rather than a test would be counted as a test that failed.
+                "unloadable": unloadable,
             }
         ),
         encoding="utf-8",
     )
-    return 0 if result.wasSuccessful() else 1
+    return 0 if result.wasSuccessful() and not unloadable else 1
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -205,10 +287,15 @@ def main(argv: list[str] | None = None) -> int:
         assert args.out
         return run_batch(args.worker, Path(args.out))
 
-    classes = discover()
+    classes, unloadable = discover()
     if args.only:
         classes = {name: ids for name, ids in classes.items() if selects(name, args.only)}
-        if not classes:
+        # The filter reaches the broken modules too, or `--only tests.test_x` on
+        # a module that will not import answers "no test class matches" -- true,
+        # unhelpful, and the opposite of what someone running that command is
+        # trying to find out.
+        unloadable = {name: why for name, why in unloadable.items() if selects(name, args.only)}
+        if not classes and not unloadable:
             print(f"::error::no test class matches {args.only!r}")
             return 1
     # One pattern at a time, and each has to match something. Checking only
@@ -268,13 +355,21 @@ def main(argv: list[str] | None = None) -> int:
                 # in setUpClass: no report, so nothing it would have said can be
                 # believed. Its ids come out below as never-run.
                 print(f"::error::batch died without reporting, exit {proc.returncode}: {names}")
-                return {"ran": [], "failures": [], "errors": list(names), "skipped": []}
+                return {
+                    "ran": [],
+                    "failures": [],
+                    "errors": list(names),
+                    "skipped": [],
+                    "unloadable": {},
+                }
             loaded: dict[str, Any] = json.loads(out.read_text(encoding="utf-8"))
             return loaded
 
         with ThreadPoolExecutor(max_workers=jobs) as pool:
             reports = list(pool.map(run, enumerate(batches)))
 
+    for report in reports:
+        unloadable.update(report["unloadable"])
     ran = [tid for report in reports for tid in report["ran"]]
     failures = [tid for report in reports for tid in report["failures"]]
     errors = [tid for report in reports for tid in report["errors"]]
@@ -286,7 +381,11 @@ def main(argv: list[str] | None = None) -> int:
         for tid in ids:
             print(f"  {label}: {tid}")  # the traceback is already above, from the batch
 
-    ok = not (failures or errors)
+    for name in sorted(unloadable):
+        # Its own line and its own wording: this is not a test that failed, and
+        # printing it as one is what sent a reader looking for an assertion.
+        print(f"::error::could not import {name}: {unloadable[name]}")
+    ok = not (failures or errors or unloadable)
     if missing := expected - set(ran):
         # The accounting check this script exists for.
         print(f"::error::{len(missing)} discovered tests never ran")


### PR DESCRIPTION
Closes #221.

## What was wrong, and how it differs from the issue

`unittest.loader` substitutes a synthetic `_FailedTest` for a module it cannot
import, and that placeholder **is** a `TestCase`. So it packed into a batch as
an ordinary class, ran nothing, and surfaced as:

```
::error::1 discovered tests never ran
  never ran: unittest.loader._FailedTest.tests.test_broken
```

Red — which is why nobody was hurt — and wrong about what happened: nothing ran
because nothing was *there*. And `--only tests.test_broken`, the obvious way to
look into it, answered `no test class matches`.

**The issue's reproduction does not hold as written**, and the difference
decided where the fix goes. It predicts "1 failure naming tests.test_broken";
the real behaviour is the accounting error above, because the placeholder is
created during *discovery* and never reaches a worker as a runnable test. So the
fix lives in `discover`, and `run_batch` gets the check as the belt the issue
asked for rather than as the whole of it.

## The fix

`discover(root=ROOT)` returns `Found(classes, unloadable)`, told apart through
`TestLoader.errors` — public — rather than by recognising a private class name,
exactly as `tools/verdict.py` argues at greater length. `main` reports those
modules in their own words, reddens the run for them, and lets `--only` reach
them. `run_batch` reports a new `unloadable` key rather than changing what
`errors` means, since the parent reads that file as a protocol.

`root` is a parameter so discovery can be pointed at a throwaway tree: the
alternative is writing a deliberately broken module into `tests/` while the
suite that finds it is running in 64 parallel workers.

## Rule 3

```
  caught    the placeholder is discovered as an ordinary class again
  caught    loader.errors is never read, so nothing is unloadable
  caught    an unloadable module no longer reddens the run
  caught    --only stops reaching the broken modules
  caught    the batch counts the placeholder as a test that ran
  caught    the batch reports nothing about what it could not load
```

## /simplify

`_walk`'s docstring said that keeping the placeholder "means an import error is
a red test, not a smaller suite — which is the whole point of this file". Both
callers now drop it, so that paragraph argued against its own code; it is
rewritten to say the caller decides. The `loader.errors` surgery and the
placeholder predicate became `_unloadable` and `_loaded` instead of living
twice, and the dead-batch fallback carries the new key so the parent reads it as
a protocol rather than defensively. Efficiency was measured and is nothing:
discovery is 74 ms for 1184 tests and the added filter is 0.15 ms of it.

## Not done, and said rather than filed

When a module imports in the parent and not in a worker, its ids are already in
`expected`, so the summary prints both `could not import X` and `N discovered
tests never ran` for one event. Suppressing the second needs a fixture where an
import succeeds once and then fails, which is more machinery than the extra line
costs.

## Preflight

`ruff`, `ruff format`, `mypy`, `shellcheck`, 1184 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
