### PR TITLE
test: a round trip on a machine that is not UTF-8 (#229)

### DIFF
--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -1,0 +1,125 @@
+"""Does woswoar still read its own history when the machine is not UTF-8?
+
+Every file this package opens passes `encoding="utf-8"`, and until #229 nothing
+proved it stays that way: the suite runs UTF-8 on every developer machine and on
+all three CI Pythons, and there `read_text()` and `read_text(encoding="utf-8")`
+are the same call. A whole-package `drop-kwarg` sweep made the gap countable --
+every `encoding=` row it generated survived (see `tests.test_mutants`'s note on
+why the operator no longer asks).
+
+The consequence is a user's own history: woswoar stores shell commands verbatim,
+and those routinely carry an em dash from a commit message, an accent in a path,
+a `✔` in a script. On a machine under `LC_ALL=C` -- a container, a cron job, a
+minimal image, a systemd unit with no locale -- a read missing its `encoding=`
+raises `UnicodeDecodeError` on that history, and a write missing it raises
+`UnicodeEncodeError` rather than recording.
+
+A module of its own because the guarantee is package-wide rather than any one
+module's, and because everything here costs a subprocess: the locale is chosen
+at interpreter start, so nothing set inside this process can move it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from woswoar import store
+
+from .support import MACHINE_ID, WoswoarTestCase
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: A command with characters outside ASCII in it, and a machine named by someone
+#: who types their own language. Two, because they take different routes: the
+#: command reaches disk through the importer's append and comes back through the
+#: cache, while the name is `read_text` in `store.host_name`.
+NON_ASCII = "git commit -m 'fix ✔ — done'"
+NON_ASCII_HOST = "café@büro"
+
+#: What it takes to make Python prefer ASCII for *files*. `LC_ALL` and `LANG`
+#: select the C locale; `PYTHONUTF8=0` turns off UTF-8 mode, which PEP 686 makes
+#: the default from 3.15 and which would otherwise paper over the thing being
+#: tested. `PYTHONIOENCODING` covers stdout only, so a child that reads its files
+#: correctly can still print what it read -- without it these tests would fail on
+#: a `UnicodeEncodeError` at the terminal and prove nothing about the files.
+ASCII_LOCALE = {"LC_ALL": "C", "LANG": "C", "PYTHONUTF8": "0", "PYTHONIOENCODING": "utf-8"}
+
+
+def _prefers_ascii() -> bool:
+    """Whether a child started this way really does prefer ASCII for files.
+
+    Asked by trying it rather than by reading a version number, for the reason
+    `tests.test_mutate.enforced` gives about `RLIMIT_AS`: a guard that decides
+    from `sys.version_info` goes green on the platform where it silently
+    protects nothing. Once per process, as `support.bash_major` is.
+    """
+    probe = "import locale; print(locale.getpreferredencoding(False))"
+    said = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        env={**os.environ, **ASCII_LOCALE},
+        check=False,
+    )
+    return "utf-8" not in said.stdout.strip().lower().replace("_", "-")
+
+
+requires_ascii_locale = unittest.skipUnless(
+    _prefers_ascii(), "this Python prefers UTF-8 whatever the locale says"
+)
+
+
+@requires_ascii_locale
+class TestARoundTripUnderAnAsciiLocale(WoswoarTestCase):
+    """Written and read back by children that prefer ASCII.
+
+    Both halves in the child on purpose. A fixture that wrote the log from this
+    process would test only the reading, and the write is the half that raises
+    rather than returning something subtly wrong.
+
+    What this witnesses is three paths, not the whole package: the day file
+    (the importer's append, and the cache's read of it), `.name`
+    (`store.host_name`), and `config/machine` (`store.machine`, which every run
+    below reads before it does anything else). The rest of the `encoding=` sites
+    carry ids, keys and offsets -- ASCII by construction, where dropping the
+    argument cannot change an answer.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # The harness writes an ASCII name here; a non-ASCII one costs nothing
+        # and puts `store.machine`'s own `read_text` on the path of every child
+        # this class starts.
+        (store.config_dir() / "machine").write_text(
+            f"id={MACHINE_ID}\nname={NON_ASCII_HOST}\n", encoding="utf-8"
+        )
+        self.env = {**os.environ, **ASCII_LOCALE, "PYTHONPATH": str(REPO_ROOT)}
+
+    def woswoar(self, *argv: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-m", "woswoar", *argv],
+            capture_output=True,
+            text=True,
+            env=self.env,
+            check=False,
+            timeout=120,
+        )
+
+    def test_a_command_written_under_it_is_read_back_whole(self) -> None:
+        history = self.root / "history"
+        history.write_text(f"{NON_ASCII}\n", encoding="utf-8")
+        imported = self.woswoar("import", "bash", "--file", str(history))
+        self.assertEqual(imported.returncode, 0, imported.stderr)
+
+        store.write_atomic(store.name_file(MACHINE_ID), f"{NON_ASCII_HOST}\n".encode())
+        # `stats` rather than `list`: it prints the host *names*, so it is the
+        # reader that opens `.name`, and it prints the commands too -- so one
+        # run answers both halves.
+        said = self.woswoar("stats")
+        self.assertEqual(said.returncode, 0, said.stderr)
+        self.assertIn(NON_ASCII_HOST, said.stdout)
+        self.assertIn(NON_ASCII, said.stdout)

--- a/tests/test_mutants.py
+++ b/tests/test_mutants.py
@@ -419,8 +419,15 @@ class TestDroppingAKeywordArgument(unittest.TestCase):
         Dropping `encoding="utf-8"` is a real defect -- under `LC_ALL=C` the same
         read raises `UnicodeDecodeError` -- but this suite runs in a UTF-8 locale
         everywhere, so `read_text()` and `read_text(encoding="utf-8")` are the
-        same call and no fixture can tell them apart. A row that can only ever
-        survive is not a question worth asking every run.
+        same call almost everywhere in it. A row that can only ever survive is
+        not a question worth asking every run.
+
+        "Almost", since #229: `tests/test_locale.py` drives one round trip in a
+        child that prefers ASCII, and the two `encoding=` arguments on that path
+        -- the day file's append and `store.host_name`'s read -- are answerable
+        now. The operator stays off because the other sites carry ids, keys and
+        offsets, which are ASCII by construction: putting it back would restore
+        dozens of unkillable rows to buy two killable ones.
         """
         self.assertEqual(self.dropped('p.read_text(encoding="utf-8")\n'), [])
 


### PR DESCRIPTION
Closes #229.

## What was untested

Every file this package opens passes `encoding="utf-8"`, and nothing proved it
stays that way: the suite runs UTF-8 on every developer machine and all three CI
Pythons, where `read_text()` and `read_text(encoding="utf-8")` are the same call.

The consequence is a user's own history. woswoar stores commands verbatim, and
those carry em dashes from commit messages, accents in paths, a `✔` in a script.
On a machine under `LC_ALL=C` — a container, a cron job, a minimal image, a
systemd unit with no locale — a read missing its `encoding=` raises
`UnicodeDecodeError` on that history, and a write missing it raises
`UnicodeEncodeError` rather than recording.

## The test

`tests/test_locale.py` drives one round trip in children that prefer ASCII for
files: the importer writes a day file holding `git commit -m 'fix ✔ — done'`,
then `stats` reads it back along with a host named `café@büro`. Four environment
variables, each load-bearing — `LC_ALL` and `LANG` for the locale, `PYTHONUTF8=0`
because PEP 686 makes UTF-8 mode the default from 3.15, and `PYTHONIOENCODING`
so a child that reads correctly can still print what it read rather than dying
at the terminal and proving nothing about files.

```
  caught    a host name is read in whatever the locale prefers
  caught    a day file is appended in whatever the locale prefers
```

Two earlier fixtures would have been decoration, and both are worth recording:

- `bytes.decode()` is UTF-8 **regardless of locale**, so mutating the
  log-reading path proved nothing — the day file is read as bytes and decoded
  explicitly, where no locale can reach it. The `read_text` sites are the
  vulnerable ones.
- `list` never opens `.name`, so asserting through it could not see the
  host-name read at all. `stats` is the reader that does — and it prints the
  commands too, so one run answers both halves.

## Not done, and the issue asks for it

**`encoding` stays out of `_DROPPABLE`.** The issue says that once this test
exists, "the 41 rows become answerable instead of noise". One round trip does
not make 41 sites answerable — it makes the two on its path answerable, and both
are caught above. The rest carry ids, keys and offsets: ASCII by construction,
where dropping the argument cannot change an answer. Restoring the operator
would put dozens of unkillable rows back into every sweep to buy two killable
ones, which is what #230 removed it for.

`tests/test_mutants.test_encoding_is_not_droppable` claimed "no fixture can tell
them apart". This makes that false; its docstring now names the two that can and
says why the operator stays off regardless.

## /simplify

Moved out of `tests/test_cache.py`, which it has nothing to do with, into a
module of its own. The third subprocess went — `stats` already prints the
commands, and `list` was reading the cache pickle rather than the day file, so
it proved less than the run before it. The locale probe became a module-level
`requires_ascii_locale` rather than a per-test call, matching `requires_bash5`.
And the sandbox's `config/machine` gets a non-ASCII name, which puts
`store.machine`'s own read on the path of every child for free.

## Preflight

`ruff`, `ruff format`, `mypy`, `shellcheck`, 1185 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
