### PR TITLE
fix: a spawned child inherits the sandbox, not a list of names (#239)

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -34,6 +34,27 @@ requires_age = unittest.skipUnless(crypto.available(), "age required")
 requires_git = unittest.skipUnless(shutil.which("git"), "git required")
 
 
+def child_env(**extra: str) -> dict[str, str]:
+    """The sandbox environment, plus whatever this child needs on top.
+
+    Built from `os.environ` rather than from a list of names, and that is only
+    correct since #217: the *parent* environment is now the sandbox itself --
+    `WoswoarTestCase` replaces it wholesale with `store.sandbox_environ` -- so
+    inheriting it hands a child exactly the sandbox and nothing of the
+    developer's machine.
+
+    What the literals cost while they were necessary is #239: none of the six
+    carried `PYTHONWARNINGS`, so in the suites where the shipped CLI actually
+    runs, CI's `error::DeprecationWarning` never applied. `tests/test_install`'s
+    `TestWhatASpawnedChildInherits` is the guard for that.
+
+    A test that is *about* a bare environment should not use this. Two are: both
+    drive a shell that has never met woswoar, and handing it a `WOSWOAR_DIR`
+    would quietly change what they prove.
+    """
+    return {**os.environ, **extra}
+
+
 def git(root: Path, *argv: str) -> str:
     """Run `git` against `root` with a configuration of its own, and return stdout.
 
@@ -66,6 +87,10 @@ def git(root: Path, *argv: str) -> str:
         check=True,
         env={
             "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            # And `TMPDIR` for the same reason `store.SANDBOX_CARRIES` gives:
+            # on macOS that is a per-user directory rather than `/tmp`, and a
+            # real `git` writes scratch files.
+            "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
             "HOME": str(root),
             "GIT_CONFIG_GLOBAL": "/dev/null",
             "GIT_CONFIG_SYSTEM": "/dev/null",

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -12,6 +12,7 @@ import io
 import os
 import shutil
 import subprocess
+import sys
 import unittest
 from pathlib import Path
 from typing import ClassVar
@@ -146,6 +147,39 @@ class TestTheSuiteCannotReachTheMachineItRunsOn(WoswoarTestCase):
         self.assertEqual(os.environ["SHELL"], "/bin/bash")
 
 
+class TestWhatASpawnedChildInherits(WoswoarTestCase):
+    """The other half of the class above: what a test's *child* can see.
+
+    Six fixtures built one as a literal list of six names, so none carried
+    `PYTHONWARNINGS` -- which CI exports as `error::DeprecationWarning` for the
+    whole workflow. In the pty and hook suites, where the shipped CLI actually
+    runs as `python -m woswoar`, a deprecation had therefore never been an
+    error (#239). It failed quiet, which is the only reason it lasted.
+
+    Asserted through the thing itself: a child that emits one must die when the
+    policy says so. A test comparing two dicts would pass just as happily on a
+    helper nobody calls.
+    """
+
+    def test_the_warning_policy_reaches_it(self) -> None:
+        warns = "import warnings; warnings.warn('x', DeprecationWarning)"
+        with mock.patch.dict(os.environ, {"PYTHONWARNINGS": "error::DeprecationWarning"}):
+            died = subprocess.run(
+                [sys.executable, "-c", warns],
+                capture_output=True,
+                env=support.child_env(),
+                check=False,
+            )
+        self.assertNotEqual(died.returncode, 0, died.stderr)
+
+    def test_and_is_not_invented_when_it_is_absent(self) -> None:
+        """Carried, not imposed. Without this, a helper that hardcoded the flag
+        would pass the test above while telling every child the same lie."""
+        with mock.patch.dict(os.environ):
+            os.environ.pop("PYTHONWARNINGS", None)
+            self.assertNotIn("PYTHONWARNINGS", support.child_env())
+
+
 class TestInstall(WoswoarTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -203,7 +237,7 @@ class TestInstall(WoswoarTestCase):
             text=True,
             check=True,
             timeout=30,
-            env={"HOME": str(self.home), "PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+            env=support.child_env(HOME=str(self.home)),
         ).stdout
         self.assertTrue(Path(resolved).is_file(), f"{resolved} was not written by install")
 
@@ -523,15 +557,7 @@ class TestBothShellsRecordIntoOneHistory(WoswoarTestCase):
             argv,
             input=f"source {self.home / rcfile}\necho {marker}\n",
             text=True,
-            env={
-                "HOME": str(self.home),
-                "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
-                "TERM": "dumb",
-                "WOSWOAR_DIR": os.environ["WOSWOAR_DIR"],
-                "XDG_CONFIG_HOME": os.environ["XDG_CONFIG_HOME"],
-                "XDG_CACHE_HOME": os.environ["XDG_CACHE_HOME"],
-                "WOSWOAR_SYNC_INTERVAL": "0",
-            },
+            env=support.child_env(HOME=str(self.home), TERM="dumb", WOSWOAR_SYNC_INTERVAL="0"),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=False,

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from woswoar import store
 
+from . import support
 from .support import MACHINE_ID, WoswoarTestCase
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -97,7 +98,7 @@ class TestARoundTripUnderAnAsciiLocale(WoswoarTestCase):
         (store.config_dir() / "machine").write_text(
             f"id={MACHINE_ID}\nname={NON_ASCII_HOST}\n", encoding="utf-8"
         )
-        self.env = {**os.environ, **ASCII_LOCALE, "PYTHONPATH": str(REPO_ROOT)}
+        self.env = support.child_env(**ASCII_LOCALE, PYTHONPATH=str(REPO_ROOT))
 
     def woswoar(self, *argv: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from woswoar import cache, search, store
 from woswoar.entry import Entry, format_line
 
+from . import support
 from .support import MACHINE_ID, WoswoarTestCase
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -157,7 +158,7 @@ class TestPerformance(WoswoarTestCase):
         cache.load_entries()  # warm the cache, as any real shell would have
 
         argv = [sys.executable, "-m", "woswoar", "list", "--scope", "global"]
-        env = dict(os.environ, PYTHONPATH=str(REPO_ROOT))
+        env = support.child_env(PYTHONPATH=str(REPO_ROOT))
         run = subprocess.run(argv, capture_output=True, env=env, check=True, timeout=120)
         lines = run.stdout.count(b"\n")
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -19,6 +19,7 @@ from woswoar import search, store
 from woswoar.__main__ import main
 from woswoar.entry import Entry, format_line
 
+from . import support
 from .support import (
     MACHINE_ID,
     Captured,
@@ -1631,6 +1632,31 @@ class TestThePreviewBinding(unittest.TestCase):
 
 
 @requires_fzf
+def shimmed(root: Path, **extra: str) -> dict[str, str]:
+    """The sandbox environment, with a `woswoar` on PATH that is *this* tree.
+
+    Not optional: `_self_command` prefers whatever `woswoar` it finds, and on a
+    machine with woswoar installed that is a released copy which may predate the
+    flag under test. The picker would then pass or fail on which version happens
+    to be on the developer's PATH.
+
+    Two fixtures here need it and had a copy each; they differed only in `HOME`,
+    which is what the keyword is for.
+    """
+    bin_dir = root / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    shim = bin_dir / "woswoar"
+    shim.write_text(f'#!/bin/sh\nexec {sys.executable} -m woswoar "$@"\n', encoding="utf-8")
+    shim.chmod(0o755)
+    return support.child_env(
+        PATH=f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+        TERM="xterm",
+        SHELL="/bin/sh",
+        PYTHONPATH=str(Path(__file__).resolve().parent.parent),
+        **extra,
+    )
+
+
 class TestTheDirectoryPromptUnderARealFzf(WoswoarTestCase):
     """The label on screen, and still the right scope after it.
 
@@ -1655,22 +1681,7 @@ class TestTheDirectoryPromptUnderARealFzf(WoswoarTestCase):
                 handle.write(format_line(entry) + "\n")
 
     def picker_env(self) -> dict[str, str]:
-        bin_dir = self.root / "bin"
-        bin_dir.mkdir(exist_ok=True)
-        shim = bin_dir / "woswoar"
-        shim.write_text(f'#!/bin/sh\nexec {sys.executable} -m woswoar "$@"\n', encoding="utf-8")
-        shim.chmod(0o755)
-        return {
-            "PATH": f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
-            "TERM": "xterm",
-            "HOME": str(self.home),
-            "PWD": str(self.home / "src/session-manager"),
-            "SHELL": "/bin/sh",
-            "PYTHONPATH": str(Path(__file__).resolve().parent.parent),
-            "WOSWOAR_DIR": os.environ["WOSWOAR_DIR"],
-            "XDG_CONFIG_HOME": os.environ["XDG_CONFIG_HOME"],
-            "XDG_CACHE_HOME": os.environ["XDG_CACHE_HOME"],
-        }
+        return shimmed(self.root, HOME=str(self.home), PWD=str(self.home / "src/session-manager"))
 
     def test_the_prompt_shows_the_directory_and_still_cycles_out_of_dir(self) -> None:
         """Two presses, and the markers are the assertions.
@@ -1736,24 +1747,7 @@ class TestThePreviewUnderARealFzf(WoswoarTestCase):
         predate `--show` entirely. The test would then pass or fail on which
         version happens to be on the developer's PATH.
         """
-        bin_dir = self.root / "bin"
-        bin_dir.mkdir(exist_ok=True)
-        shim = bin_dir / "woswoar"
-        shim.write_text(
-            f'#!/bin/sh\nexec {sys.executable} -m woswoar "$@"\n',
-            encoding="utf-8",
-        )
-        shim.chmod(0o755)
-        return {
-            "PATH": f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
-            "TERM": "xterm",
-            "HOME": str(self.root),
-            "SHELL": "/bin/sh",
-            "PYTHONPATH": str(Path(__file__).resolve().parent.parent),
-            "WOSWOAR_DIR": os.environ["WOSWOAR_DIR"],
-            "XDG_CONFIG_HOME": os.environ["XDG_CONFIG_HOME"],
-            "XDG_CACHE_HOME": os.environ["XDG_CACHE_HOME"],
-        }
+        return shimmed(self.root, HOME=str(self.root))
 
     def drive(self, steps: list[Typed]) -> list[str]:
         return run_in_pty([sys.executable, "-m", "woswoar", "search"], steps, env=self.picker_env())
@@ -1863,6 +1857,9 @@ class TestWhatFzfSubstitutesWhenNoRowIsCurrent(WoswoarTestCase):
                 Typed("\x14", "done"),
                 Typed("\x1b", ""),
             ],
+            # Deliberately bare, as in `test_shell_hook`: a shell that has
+            # never met woswoar is the subject, so `support.child_env` would
+            # hand it the sandbox and quietly change the question.
             env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "TERM": "xterm"},
         )
         self.assertEqual(recorded.read_text(encoding="utf-8"), "[]")

--- a/tests/test_shell_hook.py
+++ b/tests/test_shell_hook.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, ClassVar
 from woswoar import cache, search, store
 from woswoar.entry import MAX_CMD_CHARS, TRUNCATION_MARKER, Entry, escape, unescape
 
+from . import support
 from .credential_shapes import DOCUMENTED_GAPS, INNOCENT_SHAPES, SECRET_SHAPES
 from .support import (
     MACHINE_ID,
@@ -90,15 +91,9 @@ class ShellHookTestCase(WoswoarTestCase):
         """A minimal environment pointing the hook at this test's sandbox."""
         runtime = self.runtime_dir()
         runtime.mkdir(exist_ok=True)
-        env = {
-            "HOME": str(self.root),
-            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
-            "TERM": "dumb",
-            "WOSWOAR_DIR": os.environ["WOSWOAR_DIR"],
-            "XDG_CONFIG_HOME": os.environ["XDG_CONFIG_HOME"],
-            "XDG_CACHE_HOME": os.environ["XDG_CACHE_HOME"],
-            "XDG_RUNTIME_DIR": str(runtime),
-        }
+        # `HOME` is this test's root rather than the sandbox's home: the hook
+        # writes its own rc file and the shell reads it from here.
+        env = support.child_env(HOME=str(self.root), TERM="dumb", XDG_RUNTIME_DIR=str(runtime))
         env.update(extra or {})
         return env
 
@@ -1742,6 +1737,9 @@ class TestThePtyHarness(unittest.TestCase):
         chunks = run_in_pty(
             ["bash", "--norc", "-i"],
             [Typed("", "ps> "), Typed("stty size\n", "41 123")],
+            # Deliberately *not* `support.child_env`: this drives a shell that
+            # has never met woswoar, so handing it a `WOSWOAR_DIR` would change
+            # what the test proves. An opt-out, named here so it reads as one.
             env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "PS1": "ps> ", "TERM": "xterm"},
             size=(41, 123),
         )

--- a/tools/demo/seed.py
+++ b/tools/demo/seed.py
@@ -377,14 +377,16 @@ def _sandbox_env(root: Path, repo: Path) -> dict[str, str]:
     of the sandbox is that it is *this* checkout that answers, not a `pipx`
     install that happens to be on the machine and a release behind.
     """
-    env = dict(os.environ)
+    # Built from `store.sandbox_environ` rather than from `os.environ` plus
+    # overrides, which is what this was and which is the shape `tools/sandbox.py`
+    # rejects in its own docstring: that one overrode four of `store.ENV_KEYS`'
+    # six names, and this one missed `WOSWOAR_SESSION` -- exported by the
+    # installed hook in every interactive shell, so a demo recorded from a real
+    # terminal carried the maintainer's own session id into the sandbox.
+    env = store.sandbox_environ(root, root / "home")
     env.update(
-        HOME=str(root / "home"),
-        PATH=f"{root / 'bin'}:{env.get('PATH', '/usr/bin:/bin')}",
+        PATH=f"{root / 'bin'}:{os.environ.get('PATH', '/usr/bin:/bin')}",
         PYTHONPATH=str(repo),
-        WOSWOAR_DIR=str(root / "data"),
-        XDG_CONFIG_HOME=str(root / "config"),
-        XDG_CACHE_HOME=str(root / "cache"),
         # The recording is of a person searching, not of a machine syncing: a
         # background `git push` in the middle of a take would be a spinner
         # nobody asked about, and there is no remote here to push to anyway.


### PR DESCRIPTION
Closes #239.

## What was wrong

#217 replaced the hand-maintained name list for the *parent* process. One layer
down, six fixtures still built a child's environment as a literal dict of
`HOME`, `PATH`, `TERM`, `WOSWOAR_DIR`, `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`.

So none of them carried **`PYTHONWARNINGS`**, which CI exports as
`error::DeprecationWarning` for the whole workflow. In the pty and hook suites —
where the shipped CLI actually runs as `python -m woswoar` — a deprecation had
never been an error. It failed quiet, which is why it lasted.

## The fix

`support.child_env(**extra)` is `{**os.environ, **extra}`, and that is only
correct since #217: the parent environment *is* the sandbox now, so inheriting
it hands a child exactly the sandbox and nothing of the developer's machine.

```
  caught    the child is built from a list of names, as the six fixtures were
  caught    the policy is imposed rather than carried
```

The second row is why the guard has two halves. Asserting only that a
`DeprecationWarning` kills a child would pass just as well on a helper that
*hardcoded* the flag — which would then tell every child the same lie — so the
other half asserts the policy is carried rather than invented.

Two fixtures keep bare environments and now say so: both drive a shell that has
never met woswoar, and handing it a `WOSWOAR_DIR` would change what they prove.

## Beyond the issue, same defect one file over

`tools/demo/seed.py` built its environment as `dict(os.environ)` plus overrides
of four names. `store.ENV_KEYS` has six, and the one it missed is
**`WOSWOAR_SESSION`** — exported by the installed hook in every interactive
shell, so a demo recorded from a real terminal carried the maintainer's own
session id into the sandbox. That is the failure `tools/sandbox.py`'s docstring
already documents about `bench.py`, third time. It builds on
`store.sandbox_environ` now.

## /simplify

It found a **fifth** fixture I had missed — `TestThePreviewUnderARealFzf`, a
real fzf driving the shipped CLI under a pty, which is precisely the case the
issue names. Without that the PR fixed four of five and left the failure mode
live in the one that mattered most.

Also: the two `picker_env` copies, which differed only in `HOME`, became one
`shimmed()`; the guard moved next to its parent-side counterpart in
`tests/test_install.py` rather than into `tests/test_architecture.py`, whose
docstring says it holds two facts and names them; `support.git` gained the
`TMPDIR` that `SANDBOX_CARRIES` argues a real `git` needs on macOS; and
`tests/test_locale.py` and `tests/test_perf.py` were converted so that "two
sites opt out" is true rather than nearly true.

## Preflight

`ruff`, `ruff format`, `mypy`, `shellcheck`, 1187 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
