### PR TITLE
arch: the chunk codec leaves sync.py (#214)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,7 @@ jobs:
           git clone --quiet --no-local "$BASE/origin.git" "$ATTACK"
           DAY_PUB=$(cat "$ATTACK/hosts/$ALPHA_ID/keys/2023-11-14.pub")
           printf '1700000009\ts1\t~\t0\t5\tforged-marker-command\n' \
-            | python3 -c 'import sys; from woswoar import sync; sys.stdout.buffer.write(sync.pack(sys.stdin.buffer.read()))' \
+            | python3 -c 'import sys; from woswoar import codec; sys.stdout.buffer.write(codec.pack(sys.stdin.buffer.read()))' \
             | age -r "$DAY_PUB" \
             > "$ATTACK/hosts/$ALPHA_ID/2023-11-14/9999999999-ffffff.age"
           git -C "$ATTACK" add -A

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,7 @@ entry, errors        the record format, and the exceptions every layer raises
     cache            the parse index
       search         Ctrl-R
     gitrepo          every git fork woswoar makes
+  codec              a chunk compressed, and a bomb refused
   crypto             age and ssh-keygen
   credentials
     importer         bash, zsh, atuin
@@ -32,8 +33,8 @@ entry, errors        the record format, and the exceptions every layer raises
 deps, progress,      leaves: asked things by anyone, knowing nobody
 report
 
-sync      <- gitrepo, manifest, archive, crypto, progress, report, store,
-             entry, errors
+sync      <- gitrepo, manifest, archive, codec, crypto, progress, report,
+             store, entry, errors
 doctor    <- report, search, cache, crypto, deps, store, entry, errors
 prove     <- sync, and everything sync is made of, plus deps and report
 __main__  <- search, cache, importer, install, setup, report, store,
@@ -48,6 +49,7 @@ __main__  <- search, cache, importer, install, setup, report, store,
 | format | `entry`, `errors` | nothing else in the package |
 | platform | `store`, `crypto`, `deps`, `progress`, `report`, `credentials` | the format layer |
 | derived | `cache`, `archive`, `manifest`, `gitrepo` | the two above |
+| leaf | `codec` | nothing -- `zlib` and two bounds |
 | domains | `search`, `sync`, `importer`, `install` | everything below, and **never each other** |
 | composition | `setup`, `doctor`, `prove`, `__main__` | everything |
 
@@ -204,31 +206,29 @@ exists so that nobody has to rediscover it.
 
 **`sync.py` held five separable concerns** — the recipient-file grammar, trust
 and pinning, manifests, the chunk codec, and git plumbing — plus the
-orchestration that drives them and the status queries `doctor` asks. #201 has
-taken two of them out, as `manifest.py` and `gitrepo.py`, and stopped there on
-purpose: `run`, `export`, `merge` and `_Day` stay together for the reason
+orchestration that drives them and the status queries `doctor` asks. #201 took
+two of them out, as `manifest.py` and `gitrepo.py`, and #214 took the third as
+`codec.py`. What is left stays on purpose: `run`, `export`, `merge` and `_Day` stay together for the reason
 "Two costs shape everything" gives above — those operations are ordered and the
 ordering is the correctness argument. Each of the three is one line from being
 broken, and they want to be read in one sequence rather than found in three files.
 
-So the file came down by a tenth and is still well over 3000 lines, not the
-~1500 that [#203](https://github.com/martinus/woswoar/issues/203) asks for. That
-target is not met and is not being quietly dropped. What the two slices bought is
-the other criterion: a behaviour of either layer can now be reached without
-driving `run()`. `tests/test_manifest.py` is the first collection of that, and it
+So the file came down by an eighth and is still over 3000 lines, not the ~1500
+that [#203](https://github.com/martinus/woswoar/issues/203) asks for. That target
+is not met and is not being quietly dropped. What the three slices bought is the
+other criterion: a behaviour of any of them can now be reached without driving
+`run()`. `tests/test_manifest.py` and `tests/test_codec.py` are that, and it
 is not a tidiness exercise — `manifest.signs_and_verifies` is the check behind
 `doctor`'s `signing` line, and while it sat inline in `sync.signing_status`
 nothing in the suite reached it. Replacing the verify call with `return False`
 survived every one of the 966 tests.
 
-Of the three concerns still in there, two really are a redesign of `run` rather
+Of the two concerns still in there, both really are a redesign of `run` rather
 than a move — trust and pinning is a set of functions that each take `State` and
 record an `Outcome` into `Report`, and the recipients grammar has `add_recipient`
-sitting inside the `grant`/`revoke` flow. The third is not: the chunk codec
-(`pack`, `unpack`, `split_for_export` and the two size bounds) imports nothing
-from the package, and no ordering argument touches it. That is a cleaner slice
-than either of the two taken here, and it is
-[#214](https://github.com/martinus/woswoar/issues/214).
+sitting inside the `grant`/`revoke` flow. The one that was not is gone: the chunk
+codec imported nothing from the package and no ordering argument touched it,
+which made it a cleaner slice than either module #201 took.
 
 The visible symptom *was* `sync.Report`: seventeen fields, each a failure from a
 different one of those layers. #199 has collapsed it. The ten fields that were
@@ -331,3 +331,4 @@ outcome collapse in #199 is what turned #201 from a redesign into two moves.
 | 2 | ~~[#199](https://github.com/martinus/woswoar/issues/199) — one shape for outcome reporting~~ — **done**, in three parts: `report.Check`, `report.Notice`, and `sync.Outcome` collapsing `Report`'s seventeen fields to seven. |
 | 3 | ~~[#202](https://github.com/martinus/woswoar/issues/202) — lift the installer and the setup wizard out of `__main__.py`~~ — **done**, as `woswoar/install.py` and `woswoar/setup.py`. |
 | 4 | ~~[#201](https://github.com/martinus/woswoar/issues/201) — split `sync.py`, in slices, after the three above~~ — **done**, as `woswoar/manifest.py` and `woswoar/gitrepo.py`. The orchestration stayed; see above for why, and for the line count that did not reach its target. |
+| 5 | ~~[#214](https://github.com/martinus/woswoar/issues/214) — the chunk codec, the third slice~~ — **done**, as `woswoar/codec.py`. A pure move: `tools/compare.py` reports `identical` over `init status doctor sync grant stats`, scrubbing only freshly generated key material. |

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -47,10 +47,12 @@ REPO = Path(__file__).resolve().parent.parent
 #: this is for; a table that only caught *additions* would silently rot as
 #: modules lost dependencies and stop describing the package it claims to pin.
 #:
-#: The five leaves are leaves on purpose. `errors` holds the exceptions every
+#: The six leaves are leaves on purpose. `errors` holds the exceptions every
 #: layer raises; `deps`, `progress` and `report` are asked things by the layers
-#: above without knowing anything about them -- so each of them stays importable
-#: from anywhere without dragging a domain along. `report` in particular has to
+#: above without knowing anything about them; `codec` is `zlib` and a pair of
+#: bounds, which is why it could leave `sync` when nothing else could -- so each
+#: of them stays importable from anywhere without dragging a domain along.
+#: `report` in particular has to
 #: be free: a check is a value any module might hand back, and a value type that
 #: cost you an import of the CLI would not be used.
 LAYERS: dict[str, set[str]] = {
@@ -59,6 +61,7 @@ LAYERS: dict[str, set[str]] = {
     "deps": set(),
     "progress": set(),
     "report": set(),
+    "codec": set(),
     "credentials": {"errors"},
     "crypto": {"errors"},
     "store": {"entry"},
@@ -84,6 +87,7 @@ LAYERS: dict[str, set[str]] = {
     "manifest": {"archive", "crypto", "entry", "errors", "store"},
     "sync": {
         "archive",
+        "codec",
         "crypto",
         "entry",
         "errors",
@@ -100,9 +104,12 @@ LAYERS: dict[str, set[str]] = {
     #: `gitrepo` for the commit boilerplate it must not mistake for a leaked
     #: username; `manifest` only through `sync`. Both arrived when #201 turned
     #: two of sync's internal layers into modules, which is a name for an edge
-    #: that already existed rather than a new one.
+    #: that already existed rather than a new one. `codec` is the third and the
+    #: only one `prove` calls *directly* -- it unpacks a chunk itself to prove
+    #: the round trip, which is the whole of what it is for.
     "prove": {
         "archive",
+        "codec",
         "crypto",
         "deps",
         "entry",
@@ -228,7 +235,7 @@ MAY_SPAWN_GIT = {"gitrepo", "prove"}
 
 #: Modules whose functions the test suite patches to count what a sync did, and
 #: which therefore have to be reached by attribute rather than by ``from`` import.
-SPY_SEAMS = ("gitrepo", "manifest")
+SPY_SEAMS = ("codec", "gitrepo", "manifest")
 
 
 class TestOneModuleSpawnsGit(unittest.TestCase):

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,0 +1,135 @@
+"""The chunk codec: compression in, and a refusal on the way out.
+
+Its own file since #214 lifted `woswoar/codec.py` out of `sync.py`, and that is
+the point of the slice rather than a side effect: every test here is `zlib` and
+two bounds, with no sandbox, no age and no git, where reaching the same
+behaviour used to mean driving `sync.run()`.
+
+What stays in `tests/test_sync.py` is the half that needs a repository -- a bomb
+arriving in a real chunk, and the flushing that keeps a host's plaintext from
+being held all at once. Those are about what `merge` does with a refusal, not
+about the refusal.
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+import unittest
+import zlib
+
+from woswoar import codec
+
+
+class TestChunkPayload(unittest.TestCase):
+    """The chunk encoding, without needing age or git."""
+
+    def test_round_trip(self) -> None:
+        for data in (b"", b"x", b"a line\n", b"repeated line\n" * 500, bytes(range(256))):
+            self.assertEqual(codec.unpack(codec.pack(data)), data)
+
+    def test_repetitive_input_shrinks(self) -> None:
+        # Shell history is repetitive by nature, and this is the one moment it
+        # can be compressed: once sealed, ciphertext is incompressible forever.
+        data = b"1700000000\ts1\t~/src\t0\t5\tgit status\n" * 200
+        self.assertLess(len(codec.pack(data)), len(data) // 10)
+
+    def test_a_tiny_chunk_costs_only_a_few_bytes(self) -> None:
+        """Deflate has a floor, and one very short line can land above it.
+
+        This is what `pack` used to avoid by tagging each payload raw-or-
+        deflated and keeping the smaller. It was not worth it: the tag cost a
+        byte on every chunk that *did* compress, which is all but the shortest,
+        and the worst case it bought back is the handful of bytes below --
+        against a sealed chunk that already carries a 200-byte age header.
+        """
+        data = b"1700000000\ts1\t~\t0\t5\tls\n"
+        self.assertLess(len(codec.pack(data)) - len(data), 8)
+
+    def test_a_payload_we_cannot_read_is_refused(self) -> None:
+        # Loudly, rather than decoding into garbage that then gets appended to
+        # a log file and cached. `_merge_host` turns this into an unreadable
+        # chunk rather than letting it abort the sync.
+        truncated = zlib.compress(b"x" * 5000)[:20]
+        for blob in (b"\x7fanything", b"", b"1700000000\ts1\t~\t0\t5\tls\n", truncated):
+            with self.assertRaises(zlib.error):
+                codec.unpack(blob)
+
+
+class TestSplitForExport(unittest.TestCase):
+    """The splitter on its own, where the edges are cheap to state."""
+
+    def test_it_is_lossless_and_line_aligned(self) -> None:
+        data = b"".join(b"line %d\n" % i for i in range(50))
+        for limit in (1, 7, 8, 20, 1000):
+            with self.subTest(limit=limit):
+                pieces = list(codec.split_for_export(data, limit))
+                self.assertEqual(b"".join(pieces), data)
+                for piece in pieces:
+                    self.assertTrue(piece.endswith(b"\n"))
+
+    def test_a_tail_that_fits_is_one_piece(self) -> None:
+        data = b"one\ntwo\n"
+        self.assertEqual(list(codec.split_for_export(data, 1000)), [data])
+
+    def test_a_line_longer_than_the_budget_is_kept_whole(self) -> None:
+        """Splitting a record would drop it from every reader, not just one."""
+        long_line = b"y" * 100 + b"\n"
+        pieces = list(codec.split_for_export(long_line + b"short\n", 10))
+        self.assertEqual(pieces[0], long_line)
+        self.assertEqual(b"".join(pieces), long_line + b"short\n")
+
+    def test_the_budget_is_under_what_a_reader_accepts(self) -> None:
+        """The invariant the whole change exists for, stated once."""
+        self.assertLess(codec.MAX_EXPORT_BYTES, codec.MAX_CHUNK_BYTES)
+
+
+class TestADecompressionBomb(unittest.TestCase):
+    """One machine must not decide how much memory the others spend.
+
+    deflate reaches about 1030:1, so an unbounded decompress turned a 204 KB
+    commit into 200 MiB of log and 420 MiB of RSS -- on a timer that fires every
+    minute and asks nobody. Signing (#38) means the chunk has to come from a
+    machine you accepted, which is why this is not a P0; it is still one
+    compromised machine against every other one.
+    """
+
+    def test_a_bomb_is_refused_rather_than_expanded(self) -> None:
+        bomb = zlib.compress(b"\n" * (codec.MAX_CHUNK_BYTES * 2), 9)
+        self.assertLess(len(bomb), 1024 * 1024, "the fixture should be small to be a bomb")
+        with self.assertRaises(zlib.error):
+            codec.unpack(bomb)
+
+    def test_the_boundary_is_where_it_says_it_is(self) -> None:
+        """Exactly at the cap is legitimate; one byte past it is not.
+
+        An off-by-one here either refuses a chunk a machine legitimately sent or
+        leaves the last doubling unbounded, and neither shows up in a test that
+        only tries a 200 MiB bomb.
+        """
+        limit = codec.MAX_CHUNK_BYTES
+        self.assertEqual(len(codec.unpack(zlib.compress(b"x" * limit, 9))), limit)
+        with self.assertRaises(zlib.error):
+            codec.unpack(zlib.compress(b"x" * (limit + 1), 9))
+
+    def test_the_refusal_costs_a_bounded_allocation(self) -> None:
+        """`decompressobj` stops at the limit; `decompress` allocates first.
+
+        Refusing *after* materialising the payload would leave the memory
+        exhaustion in place and merely decline to write the file, so this
+        measures what `codec.unpack` actually allocates rather than asserting a
+        property of the standard library -- which is what it did first, and
+        which passed perfectly well with the fix reverted.
+        """
+        bomb = zlib.compress(b"\n" * (codec.MAX_CHUNK_BYTES * 4), 9)
+        tracemalloc.start()
+        try:
+            with self.assertRaises(zlib.error):
+                codec.unpack(bomb)
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        # The bomb expands to four times the cap, so unbounded this peaks at
+        # 256 MiB; bounded it peaks around 128 MiB -- the 64 MiB buffer plus the
+        # doubling zlib does while filling it. Three times the cap sits in the
+        # gap with room on both sides, which a tighter bound did not.
+        self.assertLess(peak, codec.MAX_CHUNK_BYTES * 3)

--- a/tests/test_prove.py
+++ b/tests/test_prove.py
@@ -22,7 +22,7 @@ import zlib
 from pathlib import Path
 from unittest import mock
 
-from woswoar import crypto, prove, store, sync
+from woswoar import codec, crypto, prove, store, sync
 
 from . import support
 from .support import WoswoarTestCase, requires_age, requires_bash, requires_git, requires_ssh_keygen
@@ -141,7 +141,7 @@ class TestAPlantedLeakIsCaught(ProveTestCase):
         with (
             mock.patch.object(crypto, "encrypt_to", lambda data, recipient: data),
             mock.patch.object(crypto, "encrypt_to_recipients", lambda data, recipients: data),
-            mock.patch.object(sync, "pack", lambda data: data),
+            mock.patch.object(codec, "pack", lambda data: data),
         ):
             ran = self.prove()
         self.assertEqual(ran.code, 1, ran.out + ran.err)
@@ -170,7 +170,7 @@ class TestAWrongChunkGoesRed(ProveTestCase):
 
     def test_a_chunk_without_the_canary_fails_sealed(self) -> None:
         with mock.patch.object(
-            sync, "pack", lambda data: zlib.compress(b"1700000000\tprove\t~\t0\t1\tnot it\n")
+            codec, "pack", lambda data: zlib.compress(b"1700000000\tprove\t~\t0\t1\tnot it\n")
         ):
             ran = self.prove()
         self.assertEqual(ran.code, 1, ran.out + ran.err)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -15,7 +15,6 @@ import shutil
 import subprocess
 import tempfile
 import time
-import tracemalloc
 import unittest
 import zlib
 from collections.abc import Callable, Iterator
@@ -27,6 +26,7 @@ from unittest import mock
 from woswoar import (
     archive,
     cache,
+    codec,
     crypto,
     errors,
     gitrepo,
@@ -771,41 +771,6 @@ class TestImmutability(SyncTestCase):
         )
 
 
-class TestChunkPayload(unittest.TestCase):
-    """The chunk encoding, without needing age or git."""
-
-    def test_round_trip(self) -> None:
-        for data in (b"", b"x", b"a line\n", b"repeated line\n" * 500, bytes(range(256))):
-            self.assertEqual(sync.unpack(sync.pack(data)), data)
-
-    def test_repetitive_input_shrinks(self) -> None:
-        # Shell history is repetitive by nature, and this is the one moment it
-        # can be compressed: once sealed, ciphertext is incompressible forever.
-        data = b"1700000000\ts1\t~/src\t0\t5\tgit status\n" * 200
-        self.assertLess(len(sync.pack(data)), len(data) // 10)
-
-    def test_a_tiny_chunk_costs_only_a_few_bytes(self) -> None:
-        """Deflate has a floor, and one very short line can land above it.
-
-        This is what `pack` used to avoid by tagging each payload raw-or-
-        deflated and keeping the smaller. It was not worth it: the tag cost a
-        byte on every chunk that *did* compress, which is all but the shortest,
-        and the worst case it bought back is the handful of bytes below --
-        against a sealed chunk that already carries a 200-byte age header.
-        """
-        data = b"1700000000\ts1\t~\t0\t5\tls\n"
-        self.assertLess(len(sync.pack(data)) - len(data), 8)
-
-    def test_a_payload_we_cannot_read_is_refused(self) -> None:
-        # Loudly, rather than decoding into garbage that then gets appended to
-        # a log file and cached. `_merge_host` turns this into an unreadable
-        # chunk rather than letting it abort the sync.
-        truncated = zlib.compress(b"x" * 5000)[:20]
-        for blob in (b"\x7fanything", b"", b"1700000000\ts1\t~\t0\t5\tls\n", truncated):
-            with self.assertRaises(zlib.error):
-                sync.unpack(blob)
-
-
 class TestGrantConfirmation(SyncTestCase):
     """`grant` widens who can read everything, so it says so and asks first."""
 
@@ -1288,7 +1253,7 @@ class TestARevokedMachineCannotPublish(SyncTestCase):
                 pub = archive.day_key_public(alpha.id, day)
                 entry = Entry(1_700_000_900, alpha.id, "s1", "~", 0, 5, "planted-under-alpha")
                 sealed = crypto.encrypt_to(
-                    sync.pack((format_line(entry) + "\n").encode("utf-8")),
+                    codec.pack((format_line(entry) + "\n").encode("utf-8")),
                     pub.read_text(encoding="utf-8").strip(),
                 )
                 target = archive.chunk_dir(alpha.id, day) / "9999999999-ffffff.age"
@@ -1364,7 +1329,7 @@ class TestExportNeverSignsWhatItDidNotWrite(SyncTestCase):
             sync.grant()
             entry = Entry(1_700_000_900, alpha.id, "s1", "~", 0, 5, "planted")
             pub = archive.day_key_public(alpha.id, "2023-11-14").read_text(encoding="utf-8").strip()
-            sealed = crypto.encrypt_to(sync.pack((format_line(entry) + "\n").encode("utf-8")), pub)
+            sealed = crypto.encrypt_to(codec.pack((format_line(entry) + "\n").encode("utf-8")), pub)
             (archive.chunk_dir(alpha.id, "2023-11-14") / "9999999999-ffffff.age").write_bytes(
                 sealed
             )
@@ -2427,7 +2392,7 @@ class TestChunkAuthenticity(SyncTestCase):
         """
         pub = (work / "hosts" / host_id / "keys" / f"{day}.pub").read_text(encoding="utf-8").strip()
         entry = Entry(1_700_000_900, host_id, "s1", "~", 0, 5, cmd)
-        payload = sync.pack((format_line(entry) + "\n").encode("utf-8"))
+        payload = codec.pack((format_line(entry) + "\n").encode("utf-8"))
         # Named far in the future so it sorts above whatever the real machine
         # has published; a forgery that lands among chunks already merged
         # proves nothing.
@@ -2895,47 +2860,6 @@ class TestADecompressionBomb(SyncTestCase):
     compromised machine against every other one.
     """
 
-    def test_a_bomb_is_refused_rather_than_expanded(self) -> None:
-        bomb = zlib.compress(b"\n" * (sync.MAX_CHUNK_BYTES * 2), 9)
-        self.assertLess(len(bomb), 1024 * 1024, "the fixture should be small to be a bomb")
-        with self.assertRaises(zlib.error):
-            sync.unpack(bomb)
-
-    def test_the_boundary_is_where_it_says_it_is(self) -> None:
-        """Exactly at the cap is legitimate; one byte past it is not.
-
-        An off-by-one here either refuses a chunk a machine legitimately sent or
-        leaves the last doubling unbounded, and neither shows up in a test that
-        only tries a 200 MiB bomb.
-        """
-        limit = sync.MAX_CHUNK_BYTES
-        self.assertEqual(len(sync.unpack(zlib.compress(b"x" * limit, 9))), limit)
-        with self.assertRaises(zlib.error):
-            sync.unpack(zlib.compress(b"x" * (limit + 1), 9))
-
-    def test_the_refusal_costs_a_bounded_allocation(self) -> None:
-        """`decompressobj` stops at the limit; `decompress` allocates first.
-
-        Refusing *after* materialising the payload would leave the memory
-        exhaustion in place and merely decline to write the file, so this
-        measures what `sync.unpack` actually allocates rather than asserting a
-        property of the standard library -- which is what it did first, and
-        which passed perfectly well with the fix reverted.
-        """
-        bomb = zlib.compress(b"\n" * (sync.MAX_CHUNK_BYTES * 4), 9)
-        tracemalloc.start()
-        try:
-            with self.assertRaises(zlib.error):
-                sync.unpack(bomb)
-            _, peak = tracemalloc.get_traced_memory()
-        finally:
-            tracemalloc.stop()
-        # The bomb expands to four times the cap, so unbounded this peaks at
-        # 256 MiB; bounded it peaks around 128 MiB -- the 64 MiB buffer plus the
-        # doubling zlib does while filling it. Three times the cap sits in the
-        # gap with room on both sides, which a tighter bound did not.
-        self.assertLess(peak, sync.MAX_CHUNK_BYTES * 3)
-
     def test_a_bomb_in_a_real_chunk_is_reported_and_merges_nothing(self) -> None:
         """Through the whole path: it is refused like any other unusable chunk,
         the sync completes, and everything else still merges."""
@@ -2950,7 +2874,7 @@ class TestADecompressionBomb(SyncTestCase):
             # A chunk alpha signs, holding a payload that unpacks far too big.
             day = "2023-11-14"
             pub = archive.day_key_public(alpha.id, day).read_text(encoding="utf-8").strip()
-            sealed = crypto.encrypt_to(zlib.compress(b"\n" * (sync.MAX_CHUNK_BYTES * 2), 9), pub)
+            sealed = crypto.encrypt_to(zlib.compress(b"\n" * (codec.MAX_CHUNK_BYTES * 2), 9), pub)
             path = archive.chunk_dir(alpha.id, day) / "1900000000-ffffff.age"
             path.write_bytes(sealed)
             listed = manifest.read(alpha.id, day, sync.signing_public())
@@ -3686,7 +3610,7 @@ class TestASingleChunkStaysUnderTheReadersCap(SyncTestCase):
         with alpha.active():
             for i in range(200):
                 alpha.record("2023-11-14", 1_700_000_000 + i, f"command number {i}")
-            with mock.patch.object(sync, "MAX_EXPORT_BYTES", 512):
+            with mock.patch.object(codec, "MAX_EXPORT_BYTES", 512):
                 report = sync.run()
 
             self.assertGreater(report.chunks_written, 1, "the tail was not split")
@@ -3694,7 +3618,7 @@ class TestASingleChunkStaysUnderTheReadersCap(SyncTestCase):
 
             secret = sync.open_day_key(store.machine(), alpha.id, "2023-11-14")
             for chunk in archive.iter_chunks(alpha.id):
-                plain = sync.unpack(crypto.decrypt_with_secret(chunk.path.read_bytes(), secret))
+                plain = codec.unpack(crypto.decrypt_with_secret(chunk.path.read_bytes(), secret))
                 self.assertLessEqual(len(plain), 512, f"{chunk.name} is over the budget")
 
     def test_a_peer_gets_every_line(self) -> None:
@@ -3703,7 +3627,7 @@ class TestASingleChunkStaysUnderTheReadersCap(SyncTestCase):
         with alpha.active():
             for i in range(200):
                 alpha.record("2023-11-14", 1_700_000_000 + i, f"command number {i}")
-            with mock.patch.object(sync, "MAX_EXPORT_BYTES", 512):
+            with mock.patch.object(codec, "MAX_EXPORT_BYTES", 512):
                 sync.run()
 
         with beta.active():
@@ -3731,11 +3655,11 @@ class TestASingleChunkStaysUnderTheReadersCap(SyncTestCase):
             for i in range(400):
                 alpha.record("2023-11-14", 1_700_000_000 + i, f"command number {i}")
                 if i % 40 == 39:
-                    with mock.patch.object(sync, "MAX_EXPORT_BYTES", 512):
+                    with mock.patch.object(codec, "MAX_EXPORT_BYTES", 512):
                         sync.run()
 
             before = {c.name for c in archive.iter_chunks(alpha.id)}
-            with mock.patch.object(sync, "MAX_EXPORT_BYTES", 512):
+            with mock.patch.object(codec, "MAX_EXPORT_BYTES", 512):
                 days, replaced, skipped = sync.compact(before="2023-12-01")
 
             self.assertEqual((days, replaced), (0, 0), "an over-budget day was merged")
@@ -3775,14 +3699,14 @@ class TestASingleChunkStaysUnderTheReadersCap(SyncTestCase):
                 real(path, data)
 
             with (
-                mock.patch.object(sync, "MAX_EXPORT_BYTES", 512),
+                mock.patch.object(codec, "MAX_EXPORT_BYTES", 512),
                 mock.patch.object(store, "write_atomic", die_after_two),
                 self.assertRaises(OSError),
             ):
                 sync.run()
 
             self.assertEqual(sync.State.load().exported, {}, "a dead run saved a watermark")
-            with mock.patch.object(sync, "MAX_EXPORT_BYTES", 512):
+            with mock.patch.object(codec, "MAX_EXPORT_BYTES", 512):
                 sync.run()
 
         with beta.active():
@@ -3795,34 +3719,6 @@ class TestASingleChunkStaysUnderTheReadersCap(SyncTestCase):
             sync.run()
             self.assertEqual(len(beta.commands()), 200)
             self.assertEqual(len(set(beta.commands())), 200, "a line arrived twice")
-
-
-class TestSplitForExport(unittest.TestCase):
-    """The splitter on its own, where the edges are cheap to state."""
-
-    def test_it_is_lossless_and_line_aligned(self) -> None:
-        data = b"".join(b"line %d\n" % i for i in range(50))
-        for limit in (1, 7, 8, 20, 1000):
-            with self.subTest(limit=limit):
-                pieces = list(sync.split_for_export(data, limit))
-                self.assertEqual(b"".join(pieces), data)
-                for piece in pieces:
-                    self.assertTrue(piece.endswith(b"\n"))
-
-    def test_a_tail_that_fits_is_one_piece(self) -> None:
-        data = b"one\ntwo\n"
-        self.assertEqual(list(sync.split_for_export(data, 1000)), [data])
-
-    def test_a_line_longer_than_the_budget_is_kept_whole(self) -> None:
-        """Splitting a record would drop it from every reader, not just one."""
-        long_line = b"y" * 100 + b"\n"
-        pieces = list(sync.split_for_export(long_line + b"short\n", 10))
-        self.assertEqual(pieces[0], long_line)
-        self.assertEqual(b"".join(pieces), long_line + b"short\n")
-
-    def test_the_budget_is_under_what_a_reader_accepts(self) -> None:
-        """The invariant the whole change exists for, stated once."""
-        self.assertLess(sync.MAX_EXPORT_BYTES, sync.MAX_CHUNK_BYTES)
 
 
 class TestADayThatGainsAChunkAfterCompaction(SyncTestCase):

--- a/woswoar/codec.py
+++ b/woswoar/codec.py
@@ -1,0 +1,138 @@
+"""Compressing a chunk on the way in, and refusing a bomb on the way out.
+
+A leaf: `zlib`, and nothing from the package. It came out of `sync.py` in #214
+as the third and cleanest of the three slices, participating in none of the
+orderings that keep `run`, `export`, `merge` and `_Day` together.
+
+Lifted because `unpack`'s bound is a claim in `docs/security.md` -- "a chunk
+that unpacks past the cap is refused and reported, and the peak allocation is
+measured to stay bounded rather than the payload being materialised first" --
+and claims there are backed by tests rather than prose. Until this moved,
+reaching it from a test meant driving `sync.run()`.
+
+**Reached by attribute, never by binding the names.** `sync` says
+`codec.pack(...)`, and eight tests patch `codec.MAX_EXPORT_BYTES` and
+`codec.pack` by name; a caller that imported those names directly would bind
+them at import and silently unhook every one of those patches. `manifest` and `gitrepo`
+carry the same rule, and `tests/test_architecture.py`'s `SPY_SEAMS` is what
+enforces it.
+
+`MAX_CHUNK_BYTES` and `MAX_EXPORT_BYTES` are a reader/writer pair and belong
+together; the argument for why there are two is on the second.
+"""
+
+from __future__ import annotations
+
+import zlib
+from collections.abc import Iterator
+
+
+def pack(data: bytes) -> bytes:
+    """Compress a chunk's lines before they are sealed.
+
+    This is the only moment compression is possible. age does not compress, and
+    ciphertext is incompressible by definition, so once the bytes are sealed
+    neither git's packfile nor anything else can ever shrink them again -- and
+    the repo is append-only, so there is no second chance. Shell history is
+    extremely repetitive, and the measured effect on repo size is in
+    docs/woswoar_design_summary.md.
+
+    Deliberately unconditional. An earlier version tagged each payload raw-or-
+    deflated and stored whichever was smaller, on the theory that a very short
+    chunk would inflate. On real line shapes it does not: a single-line chunk
+    is 42 bytes raw and 35 deflated, so the tag saved a byte exactly once and
+    cost one on every chunk after that.
+    """
+    return zlib.compress(data, 9)
+
+
+#: The most a single chunk may decompress to.
+#:
+#: deflate reaches about 1030:1, so an unbounded `zlib.decompress` turns a
+#: 204 KB commit into 200 MiB of log and 420 MiB of RSS -- measured -- and a
+#: 10 MB one into roughly 10 GB, on a timer that fires every minute and asks
+#: nobody. The cap is what stops one machine deciding how much memory every
+#: other machine spends.
+#:
+#: Sized against what a real chunk holds, measured on generated history:
+#:
+#:     a typical day                        0.03 MiB
+#:     a very heavy day                     0.35 MiB
+#:     an entire bash_history, imported     4.43 MiB
+#:
+#: so 64 MiB is about fifteen times the largest legitimate case anyone has --
+#: importing a whole shell history in one go -- and still two hundred times
+#: smaller than what the same bytes could otherwise expand to. The case it does
+#: refuse is a single chunk holding tens of thousands of *maximum-length*
+#: commands, which is 383 MiB of plaintext; that is legal but has never
+#: happened, and refusing it is reported rather than silent.
+MAX_CHUNK_BYTES = 64 * 1024 * 1024
+
+
+#: Most plaintext this machine will put in one chunk.
+#:
+#: `MAX_CHUNK_BYTES` is what a *reader* refuses. Nothing used to stop a writer
+#: exceeding it: `read_tail` is bounded by "everything since the last export",
+#: not by size, so a machine importing a decade of history in one go could seal
+#: a chunk every peer would then refuse -- silently and permanently, because
+#: `state.exported` has already moved past those bytes and its own copy in
+#: `logs/` looks fine.
+#:
+#: Eight times under the reader's cap rather than just below it, so the two
+#: numbers can move independently and the writer never has to reason about
+#: compression -- this bounds the plaintext, which is exactly what the reader
+#: measures. An entire imported bash_history is 4.43 MiB, so nothing anyone
+#: actually has is split at all; this is the shape of the failure, not its
+#: likelihood, and one-sided invariants are the ones that stay true.
+MAX_EXPORT_BYTES = 8 * 1024 * 1024
+
+
+def split_for_export(data: bytes, limit: int = MAX_EXPORT_BYTES) -> Iterator[bytes]:
+    """``data`` in pieces of at most ``limit`` bytes, split only at line ends.
+
+    A piece has to be whole lines: a chunk is decrypted, decompressed and parsed
+    line by line, so a record cut in half would be dropped by one reader and
+    never seen by any.
+
+    A single line longer than the limit is yielded whole rather than split,
+    which is why the limit is "at most" only for lines that fit. It cannot
+    happen today -- `entry.MAX_CMD_CHARS` bounds a record to about 8 KB against
+    a limit of 8 MiB -- but splitting mid-record to honour a size bound would
+    trade a bound nobody is near for corruption everybody would see.
+    """
+    start = 0
+    while len(data) - start > limit:
+        cut = data.rfind(b"\n", start, start + limit)
+        if cut < 0:
+            # No line end within the budget: take the whole over-long line.
+            cut = data.find(b"\n", start + limit)
+            if cut < 0:
+                break
+        yield data[start : cut + 1]
+        start = cut + 1
+    if start < len(data):
+        yield data[start:]
+
+
+def unpack(blob: bytes, limit: int = MAX_CHUNK_BYTES) -> bytes:
+    """Inverse of :func:`pack`, refusing anything implausibly large.
+
+    Not defensive about *shape* on purpose: zlib rejects anything that is not a
+    deflate stream, so a payload written by some future format fails here rather
+    than being appended to a log as garbage.
+
+    It is defensive about *size*, which is a different question and the one the
+    original version did not ask. `decompressobj` is what allows that: it stops
+    at ``limit`` instead of allocating whatever the stream asks for, so the
+    refusal costs one bounded buffer rather than the allocation being refused.
+    """
+    engine = zlib.decompressobj()
+    out = engine.decompress(blob, limit)
+    if not engine.eof:
+        # `eof` alone, not `eof or unconsumed_tail`: a stream stopped by the
+        # limit leaves both, and a truncated one leaves eof clear with no tail,
+        # so the tail says nothing the first test has not. The two are told
+        # apart for the message only -- to a caller they are one refusal.
+        stopped_early = "is longer than" if engine.unconsumed_tail else "was truncated before"
+        raise zlib.error(f"chunk {stopped_early} the {limit} byte limit")
+    return out

--- a/woswoar/prove.py
+++ b/woswoar/prove.py
@@ -32,7 +32,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
-from . import archive, crypto, deps, gitrepo, store, sync
+from . import archive, codec, crypto, deps, gitrepo, store, sync
 from .entry import Entry
 from .errors import WoswoarError
 from .report import Check
@@ -184,7 +184,7 @@ def _pushed_plaintext(origin: Path, known: store.Machine, day: str) -> bytes:
     pieces = []
     for name in listing.splitlines():
         blob = _git_bytes("cat-file", "blob", f"{tip}:{name}", cwd=origin)
-        pieces.append(sync.unpack(crypto.decrypt_with_secret(blob, day_secret)))
+        pieces.append(codec.unpack(crypto.decrypt_with_secret(blob, day_secret)))
     return b"".join(pieces)
 
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -25,7 +25,7 @@ stayed in one file because the *ordering* between them is the correctness
 argument rather than an implementation detail, and each of the three orderings
 that matter is one line from being broken. The list is in `docs/architecture.md`
 under "The repository is append-only", and each one is also commented where it is
-enforced. Two layers did come out cleanly: `manifest`, the authenticity layer,
+enforced. Three layers did come out cleanly: `manifest`, the authenticity layer,
 and `gitrepo`, every git fork and the only thing here that talks to the network
 -- so nothing in this module spawns a subprocess any more.
 """
@@ -42,7 +42,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NamedTuple
 
-from . import archive, crypto, gitrepo, manifest, progress, store
+from . import archive, codec, crypto, gitrepo, manifest, progress, store
 from .entry import make_inert
 from .errors import SyncError, WoswoarError
 from .report import Check, Notice
@@ -1346,117 +1346,6 @@ def apply_withdrawals(state: State, report: Report) -> None:
 # ---------------------------------------------------------------------------
 
 
-def pack(data: bytes) -> bytes:
-    """Compress a chunk's lines before they are sealed.
-
-    This is the only moment compression is possible. age does not compress, and
-    ciphertext is incompressible by definition, so once the bytes are sealed
-    neither git's packfile nor anything else can ever shrink them again -- and
-    the repo is append-only, so there is no second chance. Shell history is
-    extremely repetitive, and the measured effect on repo size is in
-    docs/woswoar_design_summary.md.
-
-    Deliberately unconditional. An earlier version tagged each payload raw-or-
-    deflated and stored whichever was smaller, on the theory that a very short
-    chunk would inflate. On real line shapes it does not: a single-line chunk
-    is 42 bytes raw and 35 deflated, so the tag saved a byte exactly once and
-    cost one on every chunk after that.
-    """
-    return zlib.compress(data, 9)
-
-
-#: The most a single chunk may decompress to.
-#:
-#: deflate reaches about 1030:1, so an unbounded `zlib.decompress` turns a
-#: 204 KB commit into 200 MiB of log and 420 MiB of RSS -- measured -- and a
-#: 10 MB one into roughly 10 GB, on a timer that fires every minute and asks
-#: nobody. The cap is what stops one machine deciding how much memory every
-#: other machine spends.
-#:
-#: Sized against what a real chunk holds, measured on generated history:
-#:
-#:     a typical day                        0.03 MiB
-#:     a very heavy day                     0.35 MiB
-#:     an entire bash_history, imported     4.43 MiB
-#:
-#: so 64 MiB is about fifteen times the largest legitimate case anyone has --
-#: importing a whole shell history in one go -- and still two hundred times
-#: smaller than what the same bytes could otherwise expand to. The case it does
-#: refuse is a single chunk holding tens of thousands of *maximum-length*
-#: commands, which is 383 MiB of plaintext; that is legal but has never
-#: happened, and refusing it is reported rather than silent.
-MAX_CHUNK_BYTES = 64 * 1024 * 1024
-
-
-#: Most plaintext this machine will put in one chunk.
-#:
-#: `MAX_CHUNK_BYTES` is what a *reader* refuses. Nothing used to stop a writer
-#: exceeding it: `read_tail` is bounded by "everything since the last export",
-#: not by size, so a machine importing a decade of history in one go could seal
-#: a chunk every peer would then refuse -- silently and permanently, because
-#: `state.exported` has already moved past those bytes and its own copy in
-#: `logs/` looks fine.
-#:
-#: Eight times under the reader's cap rather than just below it, so the two
-#: numbers can move independently and the writer never has to reason about
-#: compression -- this bounds the plaintext, which is exactly what the reader
-#: measures. An entire imported bash_history is 4.43 MiB, so nothing anyone
-#: actually has is split at all; this is the shape of the failure, not its
-#: likelihood, and one-sided invariants are the ones that stay true.
-MAX_EXPORT_BYTES = 8 * 1024 * 1024
-
-
-def split_for_export(data: bytes, limit: int = MAX_EXPORT_BYTES) -> Iterator[bytes]:
-    """``data`` in pieces of at most ``limit`` bytes, split only at line ends.
-
-    A piece has to be whole lines: a chunk is decrypted, decompressed and parsed
-    line by line, so a record cut in half would be dropped by one reader and
-    never seen by any.
-
-    A single line longer than the limit is yielded whole rather than split,
-    which is why the limit is "at most" only for lines that fit. It cannot
-    happen today -- `entry.MAX_CMD_CHARS` bounds a record to about 8 KB against
-    a limit of 8 MiB -- but splitting mid-record to honour a size bound would
-    trade a bound nobody is near for corruption everybody would see.
-    """
-    start = 0
-    while len(data) - start > limit:
-        cut = data.rfind(b"\n", start, start + limit)
-        if cut < 0:
-            # No line end within the budget: take the whole over-long line.
-            cut = data.find(b"\n", start + limit)
-            if cut < 0:
-                break
-        yield data[start : cut + 1]
-        start = cut + 1
-    if start < len(data):
-        yield data[start:]
-
-
-def unpack(blob: bytes, limit: int = MAX_CHUNK_BYTES) -> bytes:
-    """Inverse of :func:`pack`, refusing anything implausibly large.
-
-    Not defensive about *shape* on purpose: zlib rejects anything that is not a
-    deflate stream, so a payload written by some future format fails here rather
-    than being appended to a log as garbage.
-
-    It is defensive about *size*, which is a different question and the one the
-    original version did not ask. `decompressobj` is what allows that: it stops
-    at ``limit`` instead of allocating whatever the stream asks for, so the
-    refusal costs one bounded buffer rather than the allocation being refused.
-    """
-    engine = zlib.decompressobj()
-    out = engine.decompress(blob, limit)
-    if not engine.eof:
-        # `eof` alone, not `eof or unconsumed_tail`: a stream stopped by the
-        # limit leaves both, and a truncated one leaves eof clear with no tail,
-        # so the tail says nothing the first test has not. The two are told
-        # apart for the message only -- to a caller they are one refusal.
-        stopped_early = "is longer than" if engine.unconsumed_tail else "was truncated before"
-        raise zlib.error(f"chunk {stopped_early} the {limit} byte limit")
-    return out
-
-
 def export(known: Machine, state: State, report: Report, now: int) -> bool:
     """Seal each log file's new lines into a fresh chunk, and sign the day's list.
 
@@ -1579,13 +1468,13 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
 
         for relpath, data, new_offset in tails:
             # Split rather than capped: a reader refuses a chunk over
-            # `MAX_CHUNK_BYTES`, and the writer used to be able to exceed that
-            # with no idea it had. See `MAX_EXPORT_BYTES`. A day already holds
+            # `codec.MAX_CHUNK_BYTES`, and the writer used to be able to exceed that
+            # with no idea it had. See `codec.MAX_EXPORT_BYTES`. A day already holds
             # many chunks, so this needs no format change and is invisible to
             # anything whose tail fits -- which is everything anyone has.
             public = day_public_key(known, day)
-            for piece in split_for_export(data, MAX_EXPORT_BYTES):
-                sealed = crypto.encrypt_to(pack(piece), public)
+            for piece in codec.split_for_export(data, codec.MAX_EXPORT_BYTES):
+                sealed = crypto.encrypt_to(codec.pack(piece), public)
                 written = archive.new_chunk(known.id, day, now)
                 store.write_atomic(written, sealed)
                 listed[written.name] = manifest.ManifestEntry(manifest.digest_of(sealed))
@@ -1816,11 +1705,11 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
                 continue
 
             try:
-                plaintext = unpack(crypto.decrypt_with_secret(blob, secret))
+                plaintext = codec.unpack(crypto.decrypt_with_secret(blob, secret))
             except (crypto.AgeError, zlib.error, OSError):
                 # Same judgement as an unopenable day key above: a chunk we
                 # cannot consume -- damaged, written by a woswoar that packs it
-                # some other way, or expanding past `MAX_CHUNK_BYTES` -- must not
+                # some other way, or expanding past `codec.MAX_CHUNK_BYTES` -- must not
                 # abort the sync. Aborting would block this machine's own export
                 # and every other host's readable chunks, on this run and every
                 # run after it.
@@ -1995,7 +1884,7 @@ class _Day:
 
 
 #: How much merged plaintext to hold before writing it out. Not a correctness
-#: bound -- `MAX_CHUNK_BYTES` is -- just the point at which holding more stops
+#: bound -- `codec.MAX_CHUNK_BYTES` is -- just the point at which holding more stops
 #: buying fewer file opens. One open per day was the old behaviour and is still
 #: what happens for any host with less than this waiting.
 FLUSH_BYTES = 8 * 1024 * 1024
@@ -3012,7 +2901,7 @@ def compact(before: str | None = None) -> tuple[int, int, int]:
     where asking for it is what was meant.
 
     Returns (days compacted, chunks replaced, days left alone because merging
-    them would exceed `MAX_EXPORT_BYTES`).
+    them would exceed `codec.MAX_EXPORT_BYTES`).
     """
     crypto.require()
     crypto.require_signing()
@@ -3074,7 +2963,7 @@ def compact(before: str | None = None) -> tuple[int, int, int]:
                 )
             try:
                 plaintexts = [
-                    unpack(
+                    codec.unpack(
                         crypto.decrypt_with_secret(
                             manifest.open_chunk(c.path, listed[c.name].digest), secret
                         )
@@ -3083,15 +2972,15 @@ def compact(before: str | None = None) -> tuple[int, int, int]:
                 ]
             except (ValueError, zlib.error) as exc:
                 # `zlib.error` as well as `ValueError`, which it is not a
-                # subclass of: `manifest.open_chunk` raises the second and `unpack` the
+                # subclass of: `manifest.open_chunk` raises the second and `codec.unpack` the
                 # first, so catching only one let a chunk that will not
-                # decompress -- damaged, or past `MAX_CHUNK_BYTES` -- escape as
+                # decompress -- damaged, or past `codec.MAX_CHUNK_BYTES` -- escape as
                 # a bare zlib traceback instead of the guided refusal.
                 raise SyncError(f"refusing to compact {day}: {exc}") from exc
 
             # Compaction is the other producer of chunks, so it is bound by the
             # same budget: joining a whole day unbounded would rebuild exactly
-            # the over-cap chunk `MAX_EXPORT_BYTES` exists to prevent, and then
+            # the over-cap chunk `codec.MAX_EXPORT_BYTES` exists to prevent, and then
             # unlink the smaller ones that were fine -- leaving a day no peer
             # can read and no way to re-export it.
             #
@@ -3104,12 +2993,12 @@ def compact(before: str | None = None) -> tuple[int, int, int]:
             # large stays as the small chunks it already is, which is correct
             # if untidy.
             plain = b"".join(plaintexts)
-            if len(plain) > MAX_EXPORT_BYTES:
+            if len(plain) > codec.MAX_EXPORT_BYTES:
                 skipped += 1
                 continue
 
             merged = archive.new_chunk(known.id, day, int(chunks[-1].name.split("-")[0]))
-            sealed = crypto.encrypt_to(pack(plain), crypto.public_of(secret))
+            sealed = crypto.encrypt_to(codec.pack(plain), crypto.public_of(secret))
             store.write_atomic(merged, sealed)
             for chunk in chunks:
                 chunk.path.unlink()


### PR DESCRIPTION
Closes #214.

The third slice of #201, and the one that PR's own text said was a move rather
than a redesign: `pack`, `unpack`, `split_for_export` and the two size bounds
import `zlib` and nothing from the package, and no ordering argument touches
them. `woswoar/codec.py` is 134 lines; `sync.py` is 3063, from 3170.

Worth doing rather than filing because `unpack`'s bound is a claim in
`docs/security.md`, and claims there are backed by tests: until this moved,
reaching the codec from a test meant driving `run()`. `tests/test_codec.py` is
that collection now — eleven tests with no sandbox, no age and no git. What
stays in `tests/test_sync.py` is the half that needs a repository: a bomb
arriving in a real chunk, and the flushing that keeps a host's plaintext from
being held all at once.

## A pure move, checked rather than asserted

```
6 command(s) against main (07584aa), 67 lines
scrubs beyond $HOME and $TREE:
  age1[a-z0-9]{58} -> AGE_KEY
  SHA256:[A-Za-z0-9+/]{43} -> FINGERPRINT
identical
```

Those two scrubs are freshly generated key material and nothing else, which is
what the claim is worth.

## The constraints the issue named, both live

**Reached by attribute.** Eight tests patch `codec.MAX_EXPORT_BYTES` and
`codec.pack` by *string*, so binding the bare names in `sync` would have
silently unhooked every one of them — the exact failure
`TestTheSeamsAreReachedByAttribute` exists for. `codec` joins `SPY_SEAMS` so
that stays enforced rather than remembered.

**CI's attack job imports the name**, so `.github/workflows/ci.yml` moves in the
same commit; a stale import there fails in the disguise of a security
regression. A caller the issue did not list turned up as well: `prove` calls
`unpack` directly, which is now the only direct `codec` edge outside `sync`.

## /simplify

`docs/architecture.md` was the real finding, and nothing in CI could have caught
it: the canonical map still described a package with no `codec`, and its "where
the shape is under strain" section still argued for doing this work — five
places, in the one document that claims to hold the layering.

Also: the module docstring quoted a sentence that is **not** in
`docs/security.md`, so the cross-reference justifying the module's existence
promised a grep that fails; it now quotes the one that is there. `sync.py`'s own
"two layers did come out cleanly" is three. And seven comments in `sync.py`
still named `MAX_CHUNK_BYTES` and `unpack` as though they were local — a reader
greps, finds nothing, and concludes the comment is stale.

## Preflight

`ruff`, `ruff format`, `mypy`, `shellcheck`, 1187 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
