### PR TITLE
fix: a sweep cannot reach a real woswoar store (#245)

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -429,6 +429,18 @@ class WoswoarTestCase(unittest.TestCase):
         patched.start()
         self.addCleanup(patched.stop)
 
+        # Before the first write, and this is not belt and braces: on 19 August
+        # a `machine` file holding exactly the two lines below turned up in the
+        # maintainer's *real* installation, which reported "no identity
+        # configured" and recorded three hours of commands under a fixture id.
+        # Whatever reached it, a suite that writes a machine identity must fail
+        # loudly rather than land in `~/.config` (#245).
+        for where in (store.config_dir(), store.data_dir(), store.logs_dir()):
+            # `raise`, not `assert`: a guard that `python -O` removes is a guard
+            # that is absent exactly where somebody optimised the run.
+            if not where.resolve().is_relative_to(self.root):
+                raise RuntimeError(f"the sandbox did not take: {where} is outside {self.root}")
+
         (store.config_dir()).mkdir(parents=True, exist_ok=True)
         (store.config_dir() / "machine").write_text(
             f"id={MACHINE_ID}\nname=test@machine\n", encoding="utf-8"

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -11,13 +11,17 @@ watched by a person -- that is what `tools/demo/record.sh` is for.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
+from tools import mutants
+from tools.demo import seed
 from woswoar import search
 
 REPO = Path(__file__).resolve().parent.parent
@@ -31,6 +35,106 @@ _CTRL = re.compile(r"^Ctrl\+(\w)$", re.M)
 #: The `raw.githubusercontent.com` form the README embeds the GIF with, and the
 #: repo-relative path at the end of it.
 _RAW = re.compile(r"https://raw\.githubusercontent\.com/[^/]+/[^/]+/[^/]+/(\S+?\.gif)")
+
+
+class TestTheSeederCannotReachARealStore(unittest.TestCase):
+    """#245: this script builds a sandbox and writes a woswoar store into it.
+
+    One line of `_sandbox_env` is what points `store` at that sandbox, and a
+    mutation sweep rewrites this module -- so when that line broke, the seeder
+    wrote into the maintainer's live installation: three fabricated machines in
+    399 days of real history, a `machine` file overwritten with `THIS_HOST`, and
+    one of them published to a shared remote under the real machine's own
+    signing key.
+
+    Asserted against a poisoned environment rather than a broken `_sandbox_env`,
+    because that is the shape the accident had: the environment is what decides,
+    and the guard has to hold whatever put it there.
+    """
+
+    def test_it_refuses_a_store_outside_its_own_sandbox(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sandbox"
+            root.mkdir()
+            (root / seed.MARKER).touch()
+            elsewhere = Path(tmp) / "a-real-looking-installation"
+            elsewhere.mkdir()
+            with (
+                mock.patch.dict(os.environ, {"WOSWOAR_DIR": str(elsewhere)}),
+                self.assertRaises(SystemExit) as refused,
+            ):
+                seed._refuse_a_real_store(root)
+        self.assertIn("outside", str(refused.exception))
+
+    def test_it_refuses_a_directory_it_did_not_build(self) -> None:
+        """A developer who points `root` at their own store gets the same
+        answer: the marker is written by the run that built the sandbox, so its
+        absence means this is somebody's directory."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "not-a-sandbox"
+            root.mkdir()
+            with self.assertRaises(SystemExit) as refused:
+                seed._refuse_a_real_store(root)
+        self.assertIn(seed.MARKER, str(refused.exception))
+
+    def test_a_real_sandbox_passes(self) -> None:
+        """The other half, or the guard could be `raise SystemExit` and pass."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve() / "sandbox"
+            root.mkdir()
+            (root / seed.MARKER).touch()
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "WOSWOAR_DIR": str(root / "data"),
+                    "XDG_CONFIG_HOME": str(root / "config"),
+                    "XDG_CACHE_HOME": str(root / "cache"),
+                    "HOME": str(root / "home"),
+                },
+            ):
+                seed._refuse_a_real_store(root)
+
+    def test_build_refuses_before_it_writes_anything(self) -> None:
+        """The call site, not just the guard.
+
+        Removing `_refuse_a_real_store(root)` from `build` survived a table that
+        only called the guard directly -- and the call site is the whole of the
+        protection. Driven by breaking `_sandbox_env` the way a mutant does,
+        since with a working one the environment always takes and the guard can
+        never fire.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            real = Path(tmp) / "a-real-looking-installation"
+            real.mkdir()
+            root = Path(tmp) / "sandbox"
+            leaky = {**os.environ, "WOSWOAR_DIR": str(real)}
+            with (
+                mock.patch.object(seed, "_sandbox_env", lambda root, repo: leaky),
+                self.assertRaises(SystemExit) as refused,
+            ):
+                seed.build(root=root, repo=Path(tmp), entries=1, seed=1, now=1_700_000_000)
+            self.assertIn("outside", str(refused.exception))
+            self.assertEqual(list(real.iterdir()), [], "it wrote before refusing")
+
+
+class TestTheDemoIsNeverMutated(unittest.TestCase):
+    """The second lock, and the reason there are two.
+
+    A mutant can break the guard above as easily as the environment line it
+    guards -- they are both in the file being mutated. So the sweep does not
+    generate rows for `tools/demo/` at all, and nothing is lost: 68 of its rows
+    ran in the sweep that caused #245, and every one was an equivalent mutant in
+    a recording script nothing asserts on.
+    """
+
+    def test_the_demo_is_not_mutable(self) -> None:
+        self.assertFalse(mutants.mutable("tools/demo/seed.py"))
+        self.assertFalse(mutants.mutable("tools/demo/anything_else.py"))
+
+    def test_the_rest_of_tools_still_is(self) -> None:
+        """Excluding a directory must not quietly exclude the package."""
+        self.assertTrue(mutants.mutable("tools/mutate.py"))
+        self.assertTrue(mutants.mutable("woswoar/store.py"))
 
 
 class TestTheTapePressesKeysThePickerBinds(unittest.TestCase):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -147,6 +147,33 @@ class TestTheSuiteCannotReachTheMachineItRunsOn(WoswoarTestCase):
         self.assertEqual(os.environ["SHELL"], "/bin/bash")
 
 
+class TestTheHarnessRefusesARealStore(unittest.TestCase):
+    """#245: what a sandbox that did not take must do.
+
+    A `machine` file holding this suite's two fixture lines turned up in the
+    maintainer's real installation, which then reported "no identity configured"
+    and recorded three hours of commands under a fixture id. Whatever put it
+    there, a harness that writes a machine identity has to fail its own test
+    rather than land in `~/.config` -- so the check is before the first write,
+    and this drives it by breaking the sandbox the way an accident would.
+    """
+
+    def test_a_sandbox_that_did_not_take_errors_instead_of_writing(self) -> None:
+        class Probe(WoswoarTestCase):
+            def runTest(self) -> None:  # pragma: no cover - setUp is the subject
+                pass
+
+        # The builder hands back the *ambient* environment, so every store path
+        # resolves outside the sandbox -- which is precisely the shape that
+        # reached a real machine.
+        with mock.patch.object(store, "sandbox_environ", lambda root, home: dict(os.environ)):
+            outcome = Probe().run()
+
+        assert outcome is not None
+        self.assertEqual(len(outcome.errors), 1, "the sandbox not taking must be an error")
+        self.assertIn("sandbox did not take", outcome.errors[0][1])
+
+
 class TestWhatASpawnedChildInherits(WoswoarTestCase):
     """The other half of the class above: what a test's *child* can see.
 

--- a/tools/demo/seed.py
+++ b/tools/demo/seed.py
@@ -451,6 +451,36 @@ def _clear(root: Path) -> None:
         shutil.rmtree(root / name, ignore_errors=True)
 
 
+def _refuse_a_real_store(root: Path) -> None:
+    """Stop unless every path `store` resolves is inside the sandbox just built.
+
+    The environment is the only thing pointing `store` at that sandbox, and this
+    module is one a mutation sweep rewrites -- so a mutant that drops the
+    `WOSWOAR_DIR` line from `_sandbox_env` sends every write below into the
+    developer's live installation. That is not a hypothesis. It overwrote a real
+    `machine` file with `THIS_HOST`, put three fabricated machines into 399 days
+    of real history, and published one of them to a shared remote, where it
+    carried the real machine's own signing key (#245).
+
+    So the check is here rather than in `_sandbox_env`: one mutation can break
+    the environment or this guard, and it takes both to reach a real store. The
+    marker is required as well as the prefix, because a developer who points
+    `root` at `~/.local/share/woswoar` deserves the same refusal.
+    """
+    inside = root.resolve()
+    if not (root / MARKER).is_file():
+        raise SystemExit(
+            f"{root} has no {MARKER}: this run did not build it, so it is not a sandbox"
+        )
+    for where in (store.data_dir(), store.config_dir(), store.logs_dir()):
+        if not where.resolve().is_relative_to(inside):
+            raise SystemExit(
+                f"refusing to seed: store resolves to {where}, which is outside {inside}. "
+                f"The sandbox environment did not take, and writing there would land in a real "
+                f"installation -- see #245."
+            )
+
+
 def build(root: Path, repo: Path, entries: int, seed: int, now: int) -> None:
     _clear(root)
     root.mkdir(parents=True, exist_ok=True)
@@ -463,9 +493,13 @@ def build(root: Path, repo: Path, entries: int, seed: int, now: int) -> None:
             (home / project.removeprefix("~/")).mkdir(parents=True, exist_ok=True)
 
     env = _sandbox_env(root, repo)
-    # `store` reads the environment at call time, so pointing this process at the
-    # sandbox is all it takes to write the logs in the right place.
+    # Replaced, not updated: `os.environ.update` leaves everything it does not
+    # name, and `WOSWOAR_SESSION` is exported by the installed hook in every
+    # interactive shell -- so a demo recorded from a real terminal inherited the
+    # maintainer's own session id.
+    os.environ.clear()
     os.environ.update(env)
+    _refuse_a_real_store(root)
 
     store.private_dir(store.config_dir())
     store.save_machine(store.Machine(id=THIS_HOST, name=HOSTS[THIS_HOST]))

--- a/tools/mutants.py
+++ b/tools/mutants.py
@@ -105,6 +105,21 @@ NO_MUTATE = re.compile(r"#\s*pragma:\s*no\s+mutate\b")
 #: nothing about the fix, and the run would report the assertion it removed.
 MUTABLE = ("woswoar/", "tools/")
 
+#: Never generated for, whatever `MUTABLE` says. `tools/demo/seed.py` builds a
+#: sandbox and then *writes a woswoar store into it*, so a mutant that breaks
+#: the one line pointing it at that sandbox writes into whatever the ambient
+#: environment names -- which, for a sweep run from a developer's shell, is
+#: their live installation. It did: three fabricated machines in 399 days of
+#: real history, a clobbered `machine` file, and one of them published to a
+#: shared remote (#245).
+#:
+#: `seed.py` also guards itself now, and this is the second lock rather than a
+#: replacement: one mutation can break either, and it takes both to reach a real
+#: store. Nothing is lost by excluding it -- 68 of its rows ran in the sweep
+#: that found this, and every one was an equivalent mutant in a recording script
+#: nothing asserts on.
+UNMUTABLE = ("tools/demo/",)
+
 
 def mutable(path: str) -> bool:
     # No `not path.startswith("tests/")`: `MUTABLE` cannot match a `tests/` path,
@@ -112,7 +127,7 @@ def mutable(path: str) -> bool:
     # module gives twice elsewhere -- a guard nothing can reach is a guard
     # nobody can trust, and `tests/test_mutants.py` was passing off the tuple
     # above rather than off the clause it appeared to be testing.
-    return path.endswith(".py") and path.startswith(MUTABLE)
+    return path.endswith(".py") and path.startswith(MUTABLE) and not path.startswith(UNMUTABLE)
 
 
 def line_starts(source: str) -> list[int]:
@@ -975,14 +990,17 @@ def every_line(root: Path) -> dict[str, set[int]]:
     """
     found: dict[str, set[int]] = {}
     for prefix in MUTABLE:
-        # No `mutable(name)` filter: walking `MUTABLE` for `*.py` already
-        # satisfies both halves of it, so the check could never be false. A
-        # mutation removing it survived, and this module deletes a guard nothing
-        # can reach rather than keeping one nobody can trust -- as it does for
-        # the `tests/` conjunct in `mutable` and the `/dev/null` case in
-        # `parse_hunks`.
+        # The `mutable(name)` filter is back, and the comment that removed it is
+        # why it needs saying. It argued that walking `MUTABLE` for `*.py`
+        # already satisfies both halves, so the check could never be false --
+        # true when `mutable` was two clauses, and false the moment it grew
+        # `UNMUTABLE`. A guard "nothing can reach" stopped being unreachable
+        # without anybody visiting this line, which is how `tools/demo/` stayed
+        # in `--all` after being excluded (#245).
         for path in sorted((root / prefix).rglob("*.py")):
             name = path.relative_to(root).as_posix()
+            if not mutable(name):
+                continue
             body = path.read_text(encoding="utf-8").splitlines()
             if body:
                 found[name] = set(range(1, len(body) + 1))


### PR DESCRIPTION
Closes #245. **P0** — this is the one that ate a real installation.

## What happened

A mutation sweep over `tools/` wrote into the maintainer's live woswoar store.
`tools/demo/seed.py` builds a sandbox and then writes a woswoar store into it,
and a single line of `_sandbox_env` is what points `store` at that sandbox — so
a mutant that breaks that line writes wherever the ambient environment names.

The seeder's own constants are the proof: `THIS_HOST = "7f3a9c21c4e18b02"`
named `martin@thinkpad`, plus `b18d47e5a0c93f6a` and `2c5e0fa7d9b41e83`. Those
three ids turned up in 399 days of real history with 7–8 days of invented
commands each, visible in Ctrl-R beside the real machines. The `machine` file
was overwritten so the installation reported *"no identity configured"*, three
hours of real commands were recorded under a fixture id in a world-readable
directory, and `hosts/7f3a9c21c4e18b02/` was **published and pushed to the
shared remote**, carrying the real machine's own signing key and age recipient.

Nothing was lost — the identity key, the signing key and all 399 days survived,
and the machine file was reconstructible from `hosts/<id>/signer.pub` — but it
was silent until the maintainer noticed woswoar complaining.

## Two locks, and why two

One mutation can break either; it takes both to reach a real store.

1. **`_refuse_a_real_store`** runs after the environment is set and before the
   first write, requiring every path `store` resolves to be inside the sandbox
   this run built, keyed on a marker it wrote itself. `build` also *replaces*
   the environment instead of updating it, so `WOSWOAR_SESSION` — exported by
   the installed hook in every interactive shell — no longer survives into a
   demo recorded from a real terminal.
2. **`tools/demo/` is not mutable.** Nothing is lost: 68 of its rows ran in the
   sweep that caused this, and every one was an equivalent mutant in a recording
   script nothing asserts on.

`tests/support.WoswoarTestCase.setUp` gets the same shape, because the clobbered
`machine` file held *this suite's* two fixture lines (`id=0123456789abcdef`,
`name=test@machine`) and I could not establish which run wrote it. It refuses
before writing anything if the sandbox did not take — a `raise`, not an
`assert`, since `python -O` removes one of those.

## Rule 3

```
  caught    the seeder writes wherever the environment points, as it did
  caught    the prefix check passes anything
  caught    a directory this run did not build is treated as a sandbox
  caught    --all enumerates the demo again, whatever mutable() says
  caught    the demo is mutable again, which is the loaded gun
  caught    the suite writes a machine file wherever the environment points
```

Three of those are worth reading twice.

**Rows 1 and 6 guard call sites, not guards.** My first table only called
`_refuse_a_real_store` directly, and "delete the call from `build`" survived it
— the call site is the entire protection. The tests now break `_sandbox_env` the
way a mutant does and assert `build` refuses *before writing anything*.

**Row 4 is a comment that aged into a lie.** `every_line` had a paragraph
arguing that a `mutable(name)` filter "could never be false", which was true
when `mutable` was two clauses and false the moment it grew `UNMUTABLE`. So
`--all` kept enumerating `tools/demo/` after it was excluded, and nobody would
have visited that line to notice. The filter is back, and the comment now says
why removing it was wrong.

## Preflight

`ruff`, `ruff format`, `mypy`, `shellcheck`, 1194 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
