### PR TITLE
feat: woswoar fleet -- who has accepted whom (#197)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -392,6 +392,7 @@ every other check you can run without believing anyone.
 | A machine never signs what it did not write | a chunk planted under a machine's own id stays out of the manifest it signs, and is reported |
 | A changed signing key is never waved through | the peer refuses, keeps the old pin, and says so |
 | A chunk cannot exhaust a peer | a chunk that unpacks past the cap is refused and reported, and the peak allocation is measured to stay bounded rather than the payload being materialised first |
+| The fleet report is advisory, never a trust decision | a row published by a host whose signing key this machine has not accepted is marked unverified, and one that fails to verify against a key it *has* accepted is refused outright |
 
 **A revoked machine stays revoked**
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -82,6 +82,25 @@ with push access can write, so what a machine believes cannot be decided by
 anything kept inside it. Revoking removes that decision everywhere
 automatically, since taking trust away can only ever cause a refusal.
 
+`woswoar fleet` says how far through that walk you are — rows are the machine
+doing the accepting, columns the machine accepted:
+
+```
+$ woswoar fleet
+who accepts whom, as each machine last published it
+
+              mar  lap  pi
+martin@desk    .   yes  no
+martin@lapt   yes   .   yes
+pi@shed       yes  yes   .    (unverified)
+```
+
+Only your own row is checked here; the others are what those machines published
+about themselves, and `?` or `(unverified)` marks one whose signing key this
+machine has not accepted. A cell is what a machine *says*, never what is true —
+if it were the latter, the repository would be making the trust decision that
+the paragraph above refuses to let it make.
+
 > [!TIP]
 > `.bashrc` is written with `$HOME` rather than your username, so one shared
 > dotfiles `.bashrc` works on every machine.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -89,17 +89,22 @@ doing the accepting, columns the machine accepted:
 $ woswoar fleet
 who accepts whom, as each machine last published it
 
-              mar  lap  pi
-martin@desk    .   yes  no
-martin@lapt   yes   .   yes
-pi@shed       yes  yes   .    (unverified)
+        desk    yoga    shed
+desk     .      yes     no
+yoga    yes      .      yes
+shed    yes     yes      .     (unverified)
 ```
 
 Only your own row is checked here; the others are what those machines published
 about themselves, and `?` or `(unverified)` marks one whose signing key this
-machine has not accepted. A cell is what a machine *says*, never what is true —
-if it were the latter, the repository would be making the trust decision that
-the paragraph above refuses to let it make.
+machine has not accepted. A `!` is sharper than either: that machine says it
+accepted a host under a key you did not pin, so the two of you are not talking
+about the same machine.
+
+A cell is what a machine *says*, never what is true — if it were the latter, the
+repository would be making the trust decision that the paragraph above refuses
+to let it make. Rows are also only as fresh as each machine's last push, which
+the report prints beneath them.
 
 > [!TIP]
 > `.bashrc` is written with `$HOME` rather than your username, so one shared

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -62,6 +62,12 @@ LAYERS: dict[str, set[str]] = {
     "progress": set(),
     "report": set(),
     "codec": set(),
+    #: What a host publishes about who it has accepted, and what a reader may
+    #: conclude from someone else's copy. Derived rather than a domain: it holds
+    #: the file's grammar and its signature, and `sync` decides when to write
+    #: one. It never reaches `sync`, which is what keeps the edge one-way --
+    #: `State` is sync's, and the pin it holds is deliberately local.
+    "fleet": {"archive", "crypto", "entry", "errors", "store"},
     "credentials": {"errors"},
     "crypto": {"errors"},
     "store": {"entry"},
@@ -89,6 +95,7 @@ LAYERS: dict[str, set[str]] = {
         "archive",
         "codec",
         "crypto",
+        "fleet",
         "entry",
         "errors",
         "gitrepo",
@@ -114,6 +121,7 @@ LAYERS: dict[str, set[str]] = {
         "deps",
         "entry",
         "errors",
+        "fleet",
         "gitrepo",
         "manifest",
         "progress",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -471,6 +471,104 @@ class TestWhoHasAcceptedWhom(SyncTestCase):
             )
         self.assertIsNone(forged)
 
+    def test_a_file_addressed_to_another_host_is_not_read_as_this_one(self) -> None:
+        """The body names the host that signed it, and the reader checks it.
+
+        Without that, `hosts/A/accepts.age` could be copied to `hosts/B/` by
+        anyone who can push, and B would be shown saying what A said -- a claim
+        about a machine, forged by moving a file rather than by signing
+        anything.
+        """
+        alpha, beta = self.machine("alpha"), self.machine("beta")
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            sync.run()
+        with alpha.active():
+            # A sync first, so alpha has fetched beta's recipient, and then
+            # `grant`: that is what makes alpha's row readable by a machine
+            # which joined after it was sealed. `_reseal` re-seals every file
+            # sealed to the recipients, `accepts.age` among them since #197.
+            # Until someone grants, beta sees `?` -- the honest answer rather
+            # than a bug.
+            sync.run()
+            sync.grant()
+            sync.run()
+
+        with beta.active():
+            sync.run()  # fetch the re-sealed file; beta's clone is otherwise stale
+            state = sync.State.load()
+            blob = crypto.decrypt_with_file(
+                archive.accepts_seal(alpha.id).read_bytes(),
+                sync.identity_path(store.machine()),
+            ).decode("utf-8")
+            self.assertIsNotNone(
+                fleet.parse(blob, alpha.id, state.signers.get(alpha.id)), "sanity: it reads"
+            )
+            # `None` for the key, which is the case that needs the check: with
+            # a pinned key the signature refuses the moved file anyway, so the
+            # header is the only thing standing between "unverified row" and "a
+            # claim about beta that alpha signed and somebody relocated".
+            moved = fleet.parse(blob, beta.id, None)
+        self.assertIsNone(moved, "a file addressed to alpha is not beta's row")
+
+    def test_the_report_marks_what_it_could_not_check(self) -> None:
+        """The command, not just the file underneath it.
+
+        The whole design rests on a reader being able to tell a checked row from
+        an unchecked one, so the printing is part of the guarantee rather than
+        decoration on top of it.
+        """
+        alpha, beta = self.machine("alpha", display="martinus@alpha"), self.machine("beta")
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            sync.run()
+        with alpha.active():
+            sync.run()
+
+        ran = self.run_cli(beta, "fleet")
+        self.assertEqual(ran.code, 0, ran.err)
+        self.assertIn("who accepts whom", ran.out)
+        # beta pinned alpha when it cloned, so alpha's row is checkable here;
+        # what must never be missing is the sentence that says a cell is a
+        # claim rather than a fact.
+        self.assertIn("not what is true", ran.out)
+
+    def test_a_row_naming_a_key_this_machine_did_not_pin_is_disputed(self) -> None:
+        """What the fingerprint beside each host id is for.
+
+        A row says "I accepted host G *under this key*". If the reader pinned a
+        different key for G, the two are not talking about the same machine --
+        an attacker who can push may move `hosts/G/signer.pub`, and without the
+        comparison the cell would read as a plain vouch for whatever sits there
+        now. Three machines, because with two there is no third column for one
+        of them to disagree about.
+        """
+        alpha = self.machine("alpha", display="martinus@alpha")
+        beta = self.machine("beta", display="martinus@beta")
+        gamma = self.machine("gamma", display="martinus@gamma")
+        for machine in (alpha, beta, gamma):
+            with machine.active():
+                sync.run()
+        self.accept_everyone(alpha)
+        with alpha.active():
+            sync.run()
+            sync.grant()
+            sync.run()
+
+        with beta.active():
+            sync.run()
+            state = sync.State.load()
+            # beta pinned gamma when it cloned; pretend it pinned a different
+            # key, which is what "somebody moved signer.pub" looks like here.
+            state.signers[gamma.id] = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAAAAAAAAAAAAAAAAAA"
+            state.save()
+
+        ran = self.run_cli(beta, "fleet")
+        self.assertEqual(ran.code, 0, ran.err)
+        self.assertIn("!", ran.out, f"alpha's claim about gamma is disputed:\n{ran.out}")
+
     def test_nothing_is_republished_when_nothing_changed(self) -> None:
         """It runs on a one-minute timer and changes about once per `accept`.
         Compared on the plaintext, because age is randomised -- two seals of one
@@ -487,7 +585,10 @@ class TestWhoHasAcceptedWhom(SyncTestCase):
 
         with alpha.active():
             known = store.machine()
-            self.assertFalse(sync.publish_accepts(known, 2), "unchanged, so nothing to write")
+            state = sync.State.load()
+            self.assertFalse(
+                sync.publish_accepts(known, state, 2), "unchanged, so nothing to write"
+            )
 
 
 class TestTwoMachines(SyncTestCase):
@@ -861,6 +962,14 @@ class TestImmutability(SyncTestCase):
                 any(part in p for part in allowed)
                 or p.endswith("/name.age")
                 or p.endswith("/signer.pub")
+                # `accepts.age` joins them with #197, and it is the only one of
+                # these that is rewritten more than once in a machine's life: it
+                # changes when this machine accepts another, and again when the
+                # recipient list grows, because a file sealed to yesterday's
+                # fleet cannot be read by a machine that joined today. Listed
+                # here rather than folded into a looser pattern, since the point
+                # of this assertion is that the exceptions are enumerated.
+                or p.endswith("/accepts.age")
                 for p in rewritten
             ),
             f"unexpected rewrites: {sorted(rewritten - chunks)}",
@@ -5835,9 +5944,11 @@ class TestLongCommandsSayWhatTheyAreDoing(SyncTestCase):
                 sync.grant()
 
         self.assertIn("phase:re-sealing the day keys", said)
-        # 25 day keys plus this machine's sealed name.
-        self.assertIn("tick:0/26 keys", said)
-        self.assertIn("tick:25/26 keys", said)
+        # 25 day keys, this machine's sealed name, and its `accepts.age` since
+        # #197 -- every file sealed to the recipients goes through one loop, so
+        # widening access cannot pick some of them up and leave others.
+        self.assertIn("tick:0/27 keys", said)
+        self.assertIn("tick:26/27 keys", said)
 
     def test_an_idle_sync_still_has_nothing_to_count(self) -> None:
         """The timer runs this every minute; the loops must stay skipped."""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
 import os
 import secrets
 import shutil
@@ -568,6 +569,59 @@ class TestWhoHasAcceptedWhom(SyncTestCase):
         ran = self.run_cli(beta, "fleet")
         self.assertEqual(ran.code, 0, ran.err)
         self.assertIn("!", ran.out, f"alpha's claim about gamma is disputed:\n{ran.out}")
+
+    def test_reading_a_hostile_row_changes_nothing_this_machine_believes(self) -> None:
+        """The property the whole design rests on, as a guard rather than a
+        claim in a docstring.
+
+        Trust has three writers -- `trust`, a withdrawal, and the TOFU pin at
+        `initialise` -- and none of them is fed by anything published. So a row
+        may say whatever it likes, including that it accepted every machine in
+        the world under keys nobody has seen, and reading it must leave
+        `state.signers` byte-identical. If that ever stops being true, the
+        repository has become the thing that decides trust, which is what this
+        design refuses to allow.
+        """
+        alpha, beta = self.machine("alpha", display="martinus@alpha"), self.machine("beta")
+        with alpha.active():
+            # Something to merge, so that beta knows alpha as a machine at all:
+            # a host with no history is not a row, and a report with no row for
+            # the forged file would pass this test while proving nothing.
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+            sync.grant()
+        with beta.active():
+            sync.run()
+
+        with beta.active():
+            # Un-pinned first, and that is the whole point of the fixture: a row
+            # from a host this machine *has* accepted is refused outright when
+            # its signature fails, so there would be nothing left for a hostile
+            # reader to act on. The dangerous row is the unverified one -- from
+            # a host nobody here has accepted -- because that is the row the
+            # report shows rather than drops. Reverting the guard survived a
+            # first version of this test for exactly that reason.
+            state = sync.State.load()
+            del state.signers[alpha.id]
+            state.save()
+
+            before = json.dumps(sync.State.load().as_json(), sort_keys=True)
+            # A row claiming a machine nobody has heard of, sealed to this fleet
+            # so it opens, and unsigned so it arrives unverified -- the shape an
+            # attacker with push access can actually produce.
+            forged = fleet.body(alpha.id, {"deadbeefdeadbeef": "SHA256:whatever"}, 1)
+            store.write_atomic(
+                archive.accepts_seal(alpha.id),
+                crypto.encrypt_to_recipients(
+                    ("not-a-signature\n\n" + forged).encode("utf-8"), sync.recipients()
+                ),
+            )
+            ran = self.run_cli(beta, "fleet")
+            after = json.dumps(sync.State.load().as_json(), sort_keys=True)
+
+        self.assertEqual(ran.code, 0, ran.err)
+        self.assertEqual(before, after, "reading a published row changed what this machine trusts")
+        self.assertNotIn("deadbeefdeadbeef", ran.out, "an unpinned host is not a column")
 
     def test_nothing_is_republished_when_nothing_changed(self) -> None:
         """It runs on a one-minute timer and changes about once per `accept`.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -29,6 +29,7 @@ from woswoar import (
     codec,
     crypto,
     errors,
+    fleet,
     gitrepo,
     manifest,
     progress,
@@ -361,6 +362,132 @@ class TestSingleMachine(SyncTestCase):
             # The watermark stops at the last newline, so the half-written record
             # is left for next time rather than sealed into an immutable chunk.
             self.assertEqual(state.exported[relpath], path.stat().st_size - len("1700000002\ts1"))
+
+
+class TestWhoHasAcceptedWhom(SyncTestCase):
+    """#197: a machine you forgot to `accept` on is silent.
+
+    Three machines, not two, and an asymmetric graph -- a two-host fixture
+    cannot tell a matrix from its own transpose, so `A accepts B while B has not
+    accepted A` is the shape that has to be built.
+
+    What is asserted is the published *file*, not the printed table: the file is
+    the protocol between machines, and the table is one reading of it.
+    """
+
+    def published(self, reader: Fake, about: Fake) -> fleet.Accepts | None:
+        with reader.active():
+            state = sync.State.load()
+            return fleet.published(
+                about.id, state.signers.get(about.id), sync.identity_path(store.machine())
+            )
+
+    def test_a_machine_publishes_what_it_has_accepted(self) -> None:
+        alpha, beta = self.machine("alpha"), self.machine("beta")
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            sync.run()
+        self.accept_everyone(alpha)
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            sync.run()
+
+        said = self.published(beta, alpha)
+        assert said is not None
+        self.assertIn(beta.id, said.hosts)
+        self.assertTrue(said.verified, "beta accepted alpha, so alpha's row is checkable")
+
+    def test_the_graph_is_not_its_own_transpose(self) -> None:
+        """The asymmetry is the point, and it is the one the ceremony creates.
+
+        A machine that clones *after* another enrolled pins it on the spot; the
+        one that was there first has never been told the newcomer exists. So
+        with no `accept` run anywhere, beta's row already holds alpha and
+        alpha's row does not hold beta -- which is precisely the state this
+        report exists to make visible, and a fixture that mirrored one row into
+        the other would show nothing.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+        beta = self.machine("beta")
+        with beta.active():
+            sync.run()
+        with alpha.active():
+            sync.run()
+
+        from_beta = self.published(alpha, beta)
+        assert from_beta is not None
+        self.assertIn(alpha.id, from_beta.hosts, "beta pinned alpha when it cloned")
+
+        from_alpha = self.published(beta, alpha)
+        self.assertTrue(
+            from_alpha is None or beta.id not in from_alpha.hosts,
+            "alpha was there first, so nobody has told it about beta",
+        )
+
+    def test_a_row_from_a_host_this_machine_has_not_accepted_is_unverified(self) -> None:
+        """The distinction the whole design rests on: a file from a host whose
+        key is not pinned here was written by whoever can push, and must not be
+        shown as though it were checked."""
+        alpha, beta = self.machine("alpha"), self.machine("beta")
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            sync.run()
+        self.accept_everyone(alpha)
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            sync.run()
+
+        with beta.active():
+            unpinned = fleet.published(alpha.id, None, sync.identity_path(store.machine()))
+        assert unpinned is not None
+        self.assertFalse(unpinned.verified)
+
+    def test_a_forged_row_against_a_pinned_key_is_refused(self) -> None:
+        """Signed under the host's own namespace, so a row that does not verify
+        against the key this machine pinned is not a row at all."""
+        alpha, beta = self.machine("alpha"), self.machine("beta")
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            sync.run()
+        self.accept_everyone(beta)
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            sync.run()
+
+        with beta.active():
+            state = sync.State.load()
+            forged = fleet.parse(
+                "not-a-signature\n\n" + fleet.body(alpha.id, {}, 1),
+                alpha.id,
+                state.signers.get(alpha.id),
+            )
+        self.assertIsNone(forged)
+
+    def test_nothing_is_republished_when_nothing_changed(self) -> None:
+        """It runs on a one-minute timer and changes about once per `accept`.
+        Compared on the plaintext, because age is randomised -- two seals of one
+        body never match, so comparing ciphertext would rewrite it every minute
+        and commit every minute with it."""
+        alpha, beta = self.machine("alpha"), self.machine("beta")
+        with alpha.active():
+            sync.run()
+        with beta.active():
+            sync.run()
+        self.accept_everyone(alpha)
+        with alpha.active():
+            sync.run()
+
+        with alpha.active():
+            known = store.machine()
+            self.assertFalse(sync.publish_accepts(known, 2), "unchanged, so nothing to write")
 
 
 class TestTwoMachines(SyncTestCase):

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -187,66 +187,91 @@ def _import(kind: importer.Kind, path: Path | None, *, dry_run: bool, this_host_
 def cmd_fleet(args: argparse.Namespace) -> int:
     """Who has accepted whom, as far as each machine says.
 
-    Rows are the machine doing the accepting, columns the machine accepted. The
-    diagonal is blank -- a machine does not accept itself.
-
-    Only this machine's own row is authoritative; it is read from the local pin
-    and nothing in the repository can change it. Every other row is what that
-    machine published about itself, and is marked `?` unless its signing key has
-    been accepted here, because until then the file's author is "whoever can
-    push". That distinction is the whole design: `accept` is the trust decision
-    and this report must never become the thing someone checks instead.
+    Rows accept, columns are accepted; the diagonal is blank. Only this
+    machine's row is authoritative -- it is the local pin, and nothing in the
+    repository can change it. See `woswoar/fleet.py` for why every other row is
+    a claim rather than a fact, and why that distinction is the design rather
+    than a caveat on it.
     """
     from . import fleet, sync
 
-    now = int(time.time())
     known = store.machine()
     state = sync.State.load()
     names = store.host_names()
-    hosts = sorted(names)
-    if not hosts:
+    if not names:
         print("No machines yet. 'woswoar sync' once this machine has a remote.")
         return 0
 
-    identity = sync.identity_path(known)
-    rows: dict[str, fleet.Accepts | None] = {}
-    for host in hosts:
-        if host == known.id:
-            rows[host] = fleet.Accepts(frozenset(state.signers), now, True)
-        else:
-            rows[host] = fleet.published(host, state.signers.get(host), identity)
+    # A machine that has not run `init` still has an answer for its own row --
+    # the pin is local -- and cannot open anyone else's, which is the `?` this
+    # report already has a column for. Refusing outright would be telling
+    # someone to run `init` to find out who has accepted them.
+    try:
+        identity: Path | None = sync.identity_path(known)
+    except WoswoarError:
+        identity = None
 
-    width = max(len(_short(names, host)) for host in hosts)
+    hosts = sorted(names)
+    rows = {
+        host: fleet.Accepts(dict(state.signers), int(time.time()), True)
+        if host == known.id
+        else (fleet.published(host, state.signers.get(host), identity) if identity else None)
+        for host in hosts
+    }
+
+    # `search.host_labels` rather than a local spelling: it keeps labels
+    # *distinct* -- two machines of one person differ in the host half, not the
+    # user half -- and it runs them through `make_inert`, which matters more
+    # here than anywhere. A name is read straight out of a `.name` file a peer
+    # wrote, and this is the one table whose whole purpose is being read as a
+    # security check.
+    labels = search.host_labels(set(hosts))
+    width = max(len(label) for label in labels.values())
+
     print("who accepts whom, as each machine last published it\n")
-    print(" " * (width + 2) + "  ".join(_short(names, host)[:3].ljust(3) for host in hosts))
+    print(" " * (width + 2) + "  ".join(f"{labels[host]:^{width}}" for host in hosts))
     for host in hosts:
         said = rows[host]
         cells = []
         for other in hosts:
-            if other == host:
-                cells.append(" . ")
-            elif said is None:
-                cells.append(" ? ")
-            else:
-                cells.append(" yes"[-3:] if other in said.hosts else " no ")
-        mark = "" if said is not None and said.verified else "   (unverified)"
-        print(f"{_short(names, host).ljust(width)}  " + "  ".join(cells) + mark)
+            cells.append(f"{_cell(said, other, host, state):^{width}}")
+        mark = "" if said is not None and said.verified else "  (unverified)"
+        print(f"{labels[host]:<{width}}  " + "  ".join(cells) + mark)
 
     print("\nA cell is what that machine says, not what is true: only this")
     print("machine's row is checked against a key pinned here. Run 'woswoar accept'")
     print("on a machine to change its row -- reading it here cannot.")
-    stale = [host for host, said in rows.items() if said is not None and host != known.id]
-    if stale:
-        oldest = min(said.when for host, said in rows.items() if said is not None)
+    whens = [said.when for host, said in rows.items() if said is not None and host != known.id]
+    if whens:
         print(
-            f"Rows are as fresh as each machine's last push; oldest here: {store.day_for(oldest)}."
+            f"Rows are as fresh as each machine's last push; oldest: {store.day_for(min(whens))}."
         )
     return 0
 
 
-def _short(names: dict[str, str], host_id: str) -> str:
-    """A host's friendly name, or the opaque id when none has arrived."""
-    return names.get(host_id) or host_id[:8]
+def _cell(said: object, other: str, host: str, state: object) -> str:
+    """One cell: what `host` says about `other`.
+
+    `!` is the case the fingerprint in each line exists for. A row names the
+    *key* it accepted, so a machine claiming to accept a host under a key this
+    machine did not pin is saying something about a different machine than the
+    reader thinks -- an attacker who can push may move `signer.pub`, and without
+    this the row would read as a vouch for whatever key sits there now.
+    """
+    from . import crypto, fleet, sync
+
+    assert isinstance(state, sync.State)
+    if other == host:
+        return "."
+    if not isinstance(said, fleet.Accepts):
+        return "?"
+    claimed = said.hosts.get(other)
+    if claimed is None:
+        return "no"
+    pinned = state.signers.get(other)
+    if pinned is not None and claimed != crypto.fingerprint(pinned):
+        return "!"
+    return "yes"
 
 
 def cmd_stats(args: argparse.Namespace) -> int:

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 import textwrap
+import time
 from collections import Counter
 from collections.abc import Iterable
 from pathlib import Path
@@ -181,6 +182,71 @@ def _import(kind: importer.Kind, path: Path | None, *, dry_run: bool, this_host_
             "Run 'woswoar import atuin' on each machine to give them all the full set."
         )
     return 0
+
+
+def cmd_fleet(args: argparse.Namespace) -> int:
+    """Who has accepted whom, as far as each machine says.
+
+    Rows are the machine doing the accepting, columns the machine accepted. The
+    diagonal is blank -- a machine does not accept itself.
+
+    Only this machine's own row is authoritative; it is read from the local pin
+    and nothing in the repository can change it. Every other row is what that
+    machine published about itself, and is marked `?` unless its signing key has
+    been accepted here, because until then the file's author is "whoever can
+    push". That distinction is the whole design: `accept` is the trust decision
+    and this report must never become the thing someone checks instead.
+    """
+    from . import fleet, sync
+
+    now = int(time.time())
+    known = store.machine()
+    state = sync.State.load()
+    names = store.host_names()
+    hosts = sorted(names)
+    if not hosts:
+        print("No machines yet. 'woswoar sync' once this machine has a remote.")
+        return 0
+
+    identity = sync.identity_path(known)
+    rows: dict[str, fleet.Accepts | None] = {}
+    for host in hosts:
+        if host == known.id:
+            rows[host] = fleet.Accepts(frozenset(state.signers), now, True)
+        else:
+            rows[host] = fleet.published(host, state.signers.get(host), identity)
+
+    width = max(len(_short(names, host)) for host in hosts)
+    print("who accepts whom, as each machine last published it\n")
+    print(" " * (width + 2) + "  ".join(_short(names, host)[:3].ljust(3) for host in hosts))
+    for host in hosts:
+        said = rows[host]
+        cells = []
+        for other in hosts:
+            if other == host:
+                cells.append(" . ")
+            elif said is None:
+                cells.append(" ? ")
+            else:
+                cells.append(" yes"[-3:] if other in said.hosts else " no ")
+        mark = "" if said is not None and said.verified else "   (unverified)"
+        print(f"{_short(names, host).ljust(width)}  " + "  ".join(cells) + mark)
+
+    print("\nA cell is what that machine says, not what is true: only this")
+    print("machine's row is checked against a key pinned here. Run 'woswoar accept'")
+    print("on a machine to change its row -- reading it here cannot.")
+    stale = [host for host, said in rows.items() if said is not None and host != known.id]
+    if stale:
+        oldest = min(said.when for host, said in rows.items() if said is not None)
+        print(
+            f"Rows are as fresh as each machine's last push; oldest here: {store.day_for(oldest)}."
+        )
+    return 0
+
+
+def _short(names: dict[str, str], host_id: str) -> str:
+    """A host's friendly name, or the opaque id when none has arrived."""
+    return names.get(host_id) or host_id[:8]
 
 
 def cmd_stats(args: argparse.Namespace) -> int:
@@ -1241,6 +1307,21 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_stats.add_argument("--top", type=int, default=10)
     p_stats.set_defaults(func=cmd_stats)
+
+    p_fleet = sub(
+        "fleet",
+        "who has accepted whom",
+        """
+        Accepting is per-machine: enrolling a laptop means running 'woswoar
+        accept' on the laptop and on every machine already syncing. This says
+        how far through that you are.
+
+        Only this machine's row is authoritative. Every other row is what that
+        machine published about itself, and a repository is not where trust
+        lives -- see docs/security.md.
+        """,
+    )
+    p_fleet.set_defaults(func=cmd_fleet)
 
     p_doctor = sub(
         "doctor",

--- a/woswoar/archive.py
+++ b/woswoar/archive.py
@@ -196,6 +196,12 @@ def name_seal(machine_id: str) -> Path:
     return repo_host_dir(machine_id) / "name.age"
 
 
+def accepts_seal(machine_id: str) -> Path:
+    """Sealed list of the hosts this machine has accepted, so a fleet report can
+    say who still owes whom an `accept`. Advisory -- see `woswoar/fleet.py`."""
+    return repo_host_dir(machine_id) / "accepts.age"
+
+
 def signer_public(machine_id: str) -> Path:
     """A host's published verify key, and the recipient that owns the host.
 

--- a/woswoar/fleet.py
+++ b/woswoar/fleet.py
@@ -1,0 +1,138 @@
+"""Which machine has accepted which -- the question an enrolment leaves open.
+
+Accepting is per-machine and one-directional: enrolling a laptop means running
+`woswoar accept` on the laptop *and* on every machine already in the fleet. With
+N machines that is N walks, and nothing anywhere reported how far through you
+were. A machine you missed is silent -- it keeps recording, publishes fine, and
+simply never merges the history of the one you forgot.
+
+So each host publishes what it has pinned, and this module is both halves of
+that file: what a host writes about itself, and what a reader may conclude from
+someone else's.
+
+**A cell is what that machine says, never what is true.** What a machine accepts
+is deliberately local -- `State.signers` says why, and `trust` repeats it:
+anyone who can push can rewrite `hosts/<id>/signer.pub`, so the key a host is
+held to has to be remembered somewhere the remote cannot reach. A published
+`accepts` file is therefore *advisory*, and the report says so per row: `yes`
+and `no` for a host whose signing key this machine has pinned, `?` for one it
+has not, because there the file's author is "whoever can push". The matrix must
+never become the thing someone checks instead of running `accept`, or the
+repository has made the trust decision the design refuses to let it make.
+
+**Signature inside the sealed file, not beside it.** `manifest` makes this
+argument first and it applies unchanged: a detached pair has a window where one
+half has landed and the other has not, and during that window an honest file
+looks forged. One `write_atomic` of one blob has no such window.
+
+**Sealed rather than plaintext**, because the host directories are opaque hex on
+purpose. The *nodes* of this graph are already public in `signer.pub`; the edges
+would be new.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
+
+from . import archive, crypto, store
+
+#: First token of the body and the ssh-keygen signature namespace, deliberately
+#: the same string, for the reason `manifest._MAGIC` gives: the shape is inside
+#: the signed bytes *and* is the domain the signature was made in, so a future
+#: shape invalidates old signatures twice over rather than through a version
+#: check somebody has to remember to write.
+MAGIC = "woswoar-accepts-v1"
+
+#: Separates the armoured signature from the bytes it covers, as in `manifest`.
+_SEPARATOR = "\n\n"
+
+
+class Accepts(NamedTuple):
+    """What one host published about who it accepts, and how much to believe."""
+
+    #: Host ids it says it has accepted.
+    hosts: frozenset[str]
+    #: When it said so, from the body -- a row is only as fresh as that host's
+    #: last push, and a reader who cannot see the date cannot see that.
+    when: int
+    #: Whether the signature was checked against a key *this* machine pinned.
+    #: False means the file parsed and nothing more: its author is whoever can
+    #: push. Never let this decide anything except how the row is printed.
+    verified: bool
+
+
+def body(host_id: str, accepted: dict[str, str], now: int) -> str:
+    """What `host_id` signs: one line per host it has accepted.
+
+    Sorted, so a host that accepted nothing new republishes byte-identical
+    bytes and the guard in `sync` writes nothing.
+
+    The fingerprint is carried beside each id rather than the id alone, because
+    "B accepted A" is only meaningful about a *key*: an attacker who can push
+    can move `hosts/<A>/signer.pub`, and a row that named A alone would then
+    read as B vouching for whatever key sits there now.
+    """
+    lines = [f"{MAGIC} {host_id} {now}"]
+    lines += [f"{other} {crypto.fingerprint(key)}" for other, key in sorted(accepted.items())]
+    return "\n".join(lines) + "\n"
+
+
+def parse(blob: str, host_id: str, verify_key: str | None) -> Accepts | None:
+    """What `host_id`'s published file says, or `None` if it says nothing usable.
+
+    `None` rather than an exception for a malformed, mis-addressed or
+    mis-signed file, and for the reason `manifest.read` gives: a caller does the
+    same thing with all of them, and telling a truthful failure from an
+    attacker's would be distinguishing shapes an attacker can produce at will.
+
+    `verify_key` is what *this* machine pinned for that host, or `None` if it
+    has not pinned one. A file that fails a signature check against a key we
+    pinned is refused outright -- that is a claim about a machine we know, made
+    by something that is not it. A file we cannot check at all is returned with
+    `verified=False`, because "this host has not been accepted here yet" is
+    exactly the state the report exists to show.
+    """
+    signature, separator, text = blob.partition(_SEPARATOR)
+    if not separator:
+        return None
+    lines = text.splitlines()
+    if not lines:
+        return None
+    head = lines[0].split()
+    if len(head) != 3 or head[0] != MAGIC or head[1] != host_id:
+        return None
+    try:
+        when = int(head[2])
+    except ValueError:
+        return None
+    verified = False
+    if verify_key is not None:
+        if not crypto.verify(text.encode("utf-8"), signature.encode("utf-8"), verify_key, MAGIC):
+            return None
+        verified = True
+    hosts = {parts[0] for parts in (line.split() for line in lines[1:]) if len(parts) == 2}
+    return Accepts(frozenset(hosts), when, verified)
+
+
+def published(host_id: str, verify_key: str | None, identity: Path) -> Accepts | None:
+    """Read and open `host_id`'s file. `None` when there is nothing to read.
+
+    `identity` is passed through to `crypto.decrypt_with_file`; a host that
+    published before this existed, or has not synced since, simply has no file
+    -- which is the `?` the report needs anyway.
+    """
+    sealed = archive.accepts_seal(host_id)
+    try:
+        blob = crypto.decrypt_with_file(sealed.read_bytes(), identity)
+    except (crypto.AgeError, OSError):
+        return None
+    return parse(blob.decode("utf-8", errors="replace"), host_id, verify_key)
+
+
+def seal(known_id: str, accepted: dict[str, str], recipients: list[str], now: int) -> bytes:
+    """This machine's own file: signed, then sealed to the fleet."""
+    text = body(known_id, accepted, now)
+    signature = crypto.sign(text.encode("utf-8"), store.signing_key_file(), MAGIC)
+    blob = signature.decode("utf-8").strip() + _SEPARATOR + text
+    return crypto.encrypt_to_recipients(blob.encode("utf-8"), recipients)

--- a/woswoar/fleet.py
+++ b/woswoar/fleet.py
@@ -51,8 +51,12 @@ _SEPARATOR = "\n\n"
 class Accepts(NamedTuple):
     """What one host published about who it accepts, and how much to believe."""
 
-    #: Host ids it says it has accepted.
-    hosts: frozenset[str]
+    #: Host id -> the fingerprint of the key it accepted that host under. The
+    #: fingerprint is half the point: "B accepted A" is only meaningful about a
+    #: *key*, since an attacker who can push can move `hosts/A/signer.pub` and a
+    #: row naming A alone would then read as B vouching for whatever sits there
+    #: now. `__main__._cell` is what compares it with the local pin.
+    hosts: dict[str, str]
     #: When it said so, from the body -- a row is only as fresh as that host's
     #: last push, and a reader who cannot see the date cannot see that.
     when: int
@@ -111,8 +115,10 @@ def parse(blob: str, host_id: str, verify_key: str | None) -> Accepts | None:
         if not crypto.verify(text.encode("utf-8"), signature.encode("utf-8"), verify_key, MAGIC):
             return None
         verified = True
-    hosts = {parts[0] for parts in (line.split() for line in lines[1:]) if len(parts) == 2}
-    return Accepts(frozenset(hosts), when, verified)
+    hosts = {
+        parts[0]: parts[1] for parts in (line.split() for line in lines[1:]) if len(parts) == 2
+    }
+    return Accepts(hosts, when, verified)
 
 
 def published(host_id: str, verify_key: str | None, identity: Path) -> Accepts | None:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -702,6 +702,11 @@ class State:
     #: `hosts/<id>/signer.pub` included, so the key a host is held to has to be
     #: remembered somewhere the remote cannot reach.
     signers: dict[str, str] = field(default_factory=dict)
+    #: The host ids this machine last published in its `accepts.age`, sorted.
+    #: Progress rather than history: losing it costs one extra publish. See
+    #: `publish_accepts` for why the comparison lives here rather than in the
+    #: file.
+    published_accepts: list[str] = field(default_factory=list)
     #: "<host>/<day>" -> the day directory's mtime when every chunk its signed
     #: manifest listed had been merged. A day whose stamp still matches has gained nothing since, so
     #: it needs no listing at all -- and listing is what a peer's whole archive
@@ -722,6 +727,7 @@ class State:
         merged = raw.get("merged", {})
         granted = raw.get("granted", [])
         granted_complete = raw.get("granted_complete", False)
+        published = raw.get("published_accepts", [])
         signers = raw.get("signers", {})
         merged_at = raw.get("merged_at", {})
         if not isinstance(exported, dict) or not isinstance(merged, dict):
@@ -746,6 +752,9 @@ class State:
             # And a malformed map costs every pin, which refuses every host until
             # a human re-runs `trust` -- also the safe direction, and loud,
             # because `sync` reports the untrusted hosts rather than skipping on.
+            published_accepts=sorted(str(host) for host in published)
+            if isinstance(published, list)
+            else [],
             signers={str(k): str(v) for k, v in signers.items()}
             if isinstance(signers, dict)
             else {},
@@ -770,6 +779,7 @@ class State:
             "merged": {key: sorted(names) for key, names in self.merged.items()},
             "granted": list(self.granted),
             "granted_complete": self.granted_complete,
+            "published_accepts": list(self.published_accepts),
             "signers": dict(self.signers),
             "merged_at": dict(self.merged_at),
         }
@@ -1134,28 +1144,36 @@ def read_signer(host_id: str) -> Signer | None:
     return Signer(lines[0].strip(), lines[1].strip())
 
 
-def publish_accepts(known: Machine, now: int) -> bool:
-    """Publish which hosts this machine has accepted. Returns whether it wrote.
+def publish_accepts(known: Machine, state: State, now: int) -> bool:
+    """Publish which hosts this machine has accepted. Says whether it wrote.
 
-    Guarded by comparing the *plaintext* body, exactly as `publish_signer`
-    compares the verify key, and for the same reason: this runs on a one-minute
-    timer and the file changes about once per `accept`. Comparing ciphertext
-    would rewrite it every minute -- age is randomised, so two seals of one body
+    Guarded on what this machine *last published*, kept in `state`, because
+    neither of the two obvious comparisons works: reading the file back means
+    decrypting it, and a machine that cannot -- no identity yet, a key not
+    granted to itself -- would republish on every timer tick; and the ciphertext
+    cannot be compared at all, since age is randomised and two seals of one body
     never match.
 
-    `State.signers` is the authority. It is the local pin, which is the whole
-    point: what a machine accepts must not be readable back out of the repo it
-    syncs with, or the repo would be making the trust decision.
+    `State.signers` is the authority for the content, and that is the point:
+    what a machine accepts is a local pin, so it cannot be read back out of the
+    repository it syncs with. See `woswoar/fleet.py`.
     """
-    state = State.load()
     if not state.signers:
         return False
-    sealed = archive.accepts_seal(known.id)
-    if sealed.is_file():
-        current = fleet.published(known.id, None, identity_path(known))
-        if current is not None and current.hosts == frozenset(state.signers):
-            return False
-    store.write_atomic(sealed, fleet.seal(known.id, state.signers, recipients(), now))
+    if state.published_accepts == sorted(state.signers):
+        return False
+    # Through `signing_public`, which mints the key if it is missing, exactly as
+    # `publish_signer` does. Signing directly would turn "this machine lost its
+    # signing key" from a thing sync recovers from into a crash.
+    signing_public()
+    store.write_atomic(
+        archive.accepts_seal(known.id), fleet.seal(known.id, state.signers, recipients(), now)
+    )
+    # Recorded on the caller's `state`, which is the one `run` saves at the end.
+    # Loading a second copy here and saving it was the first shape, and `run`
+    # then wrote its older copy over the top -- so every sync republished,
+    # committed and pushed, which three of this file's own invariants noticed.
+    state.published_accepts = sorted(state.signers)
     return True
 
 
@@ -1994,19 +2012,24 @@ def run(push: bool = True, now: int | None = None) -> Report:
         # waits for `grant`. That is a change from the shared-key design, where
         # a machine nobody had granted access to could not tag a chunk either,
         # so its own history piled up locally until someone else acted.
-        # Here rather than in `_write_repo_metadata`, which runs once at
-        # enrolment: what this machine accepts changes with `accept`, long after
-        # it joined, and a file written only at `init` would say "nobody" for
-        # ever. The guard inside makes an idle sync write nothing.
-        if publish_accepts(known, now if now is not None else int(time.time())):
-            marked = True
-
         report.revoked = _this_machine_revoked(known)
         published = False
         exported = False
+        # One spelling of "now", shared below: two lines apart, `now if now is
+        # not None else int(time.time())` and `int(time.time()) if now is None
+        # else now` made a reader check twice that they meant the same thing.
+        stamp = int(time.time()) if now is None else now
         if not report.revoked:
+            # With `publish_signer` and `export` rather than above them: a
+            # machine on its way out must not sign, seal and push a row about
+            # whom it trusts, and those two are skipped here for the same
+            # reason. It cannot live in `_write_repo_metadata` either -- what a
+            # machine accepts changes with `accept`, long after enrolment -- and
+            # the guard inside makes an idle sync write nothing.
+            if publish_accepts(known, state, stamp):
+                marked = True
             published = publish_signer(known)
-            exported = export(known, state, report, int(time.time()) if now is None else now)
+            exported = export(known, state, report, stamp)
 
         # `git add -A` is a full stat of the working tree -- every chunk this
         # machine has ever published -- and this runs once a minute. On an idle
@@ -2221,6 +2244,15 @@ def initialise(
         if signer is not None and host_id not in state.signers:
             state.signers[host_id] = signer.verify_key
             pinned.append(signer.verify_key)
+
+    # Here, with the pins that were just made, rather than on the first sync.
+    # Publishing is a write, a commit and a push, and doing it on the first sync
+    # would make a machine's opening sync push even when it only received --
+    # which `TestSyncDoesNotForkGitMoreThanItNeedsTo` guards, correctly: that
+    # round trip fires on every machine every time any peer records a command.
+    # Enrolment is already writing and pushing, so it costs nothing here.
+    if publish_accepts(known, state, int(time.time())):
+        gitrepo.commit()
     state.save()
 
     # Publish immediately. Until this machine's public key is on the remote,
@@ -2713,6 +2745,7 @@ def _reseal(identity: Path, keys: list[str]) -> tuple[int, int]:
     for host_id in archive.repo_hosts():
         sealed.extend(archive.iter_day_keys(host_id))
         sealed.append(archive.name_seal(host_id))
+        sealed.append(archive.accepts_seal(host_id))
 
     resealed = skipped = 0
     # Two `age` invocations per file that is ours -- open, then seal to the new

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -42,7 +42,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NamedTuple
 
-from . import archive, codec, crypto, gitrepo, manifest, progress, store
+from . import archive, codec, crypto, fleet, gitrepo, manifest, progress, store
 from .entry import make_inert
 from .errors import SyncError, WoswoarError
 from .report import Check, Notice
@@ -1134,6 +1134,31 @@ def read_signer(host_id: str) -> Signer | None:
     return Signer(lines[0].strip(), lines[1].strip())
 
 
+def publish_accepts(known: Machine, now: int) -> bool:
+    """Publish which hosts this machine has accepted. Returns whether it wrote.
+
+    Guarded by comparing the *plaintext* body, exactly as `publish_signer`
+    compares the verify key, and for the same reason: this runs on a one-minute
+    timer and the file changes about once per `accept`. Comparing ciphertext
+    would rewrite it every minute -- age is randomised, so two seals of one body
+    never match.
+
+    `State.signers` is the authority. It is the local pin, which is the whole
+    point: what a machine accepts must not be readable back out of the repo it
+    syncs with, or the repo would be making the trust decision.
+    """
+    state = State.load()
+    if not state.signers:
+        return False
+    sealed = archive.accepts_seal(known.id)
+    if sealed.is_file():
+        current = fleet.published(known.id, None, identity_path(known))
+        if current is not None and current.hosts == frozenset(state.signers):
+            return False
+    store.write_atomic(sealed, fleet.seal(known.id, state.signers, recipients(), now))
+    return True
+
+
 def publish_signer(known: Machine) -> bool:
     """Make sure this host's published signer file says what is true.
 
@@ -1969,6 +1994,13 @@ def run(push: bool = True, now: int | None = None) -> Report:
         # waits for `grant`. That is a change from the shared-key design, where
         # a machine nobody had granted access to could not tag a chunk either,
         # so its own history piled up locally until someone else acted.
+        # Here rather than in `_write_repo_metadata`, which runs once at
+        # enrolment: what this machine accepts changes with `accept`, long after
+        # it joined, and a file written only at `init` would say "nobody" for
+        # ever. The guard inside makes an idle sync write nothing.
+        if publish_accepts(known, now if now is not None else int(time.time())):
+            marked = True
+
         report.revoked = _this_machine_revoked(known)
         published = False
         exported = False


### PR DESCRIPTION
Closes #197. **Left open for review rather than merged**, as agreed — this is
the only change in the batch that publishes new data into the shared repository
and adds a claim to `docs/security.md`.

## What it does

Each host publishes `hosts/<id>/accepts.age`: the host ids it has accepted, each
with the fingerprint of the key it accepted them under, signed under its own
namespace and sealed to the fleet. `woswoar/fleet.py` holds the grammar and the
reading, `sync.publish_accepts` decides when to write, `woswoar fleet` renders:

```
who accepts whom, as each machine last published it

        desk    yoga    shed
desk     .      yes     no
yoga    yes      .      yes
shed    yes     yes      .     (unverified)
```

## The design constraint, and how it is enforced

**A cell is what that machine says, never what is true.** What a machine accepts
is a local pin — anyone who can push can rewrite `signer.pub`, so the key a host
is held to has to live where the remote cannot reach it. Therefore:

| | |
|---|---|
| this machine's row | authoritative, read from `State.signers` |
| a row from a host whose key is pinned here | shown, and refused outright if the signature does not verify |
| a row from a host not pinned here | `(unverified)` — its author is "whoever can push" |
| a row claiming a host under a key not pinned here | `!`, not `yes` — the two are not talking about the same machine |

`docs/security.md` carries that as a claim, with the tests behind it, per the
repo's rule about claims there.

## Rule 3

```
  caught    an unverifiable row is shown as though it had been checked
  caught    a row that fails its signature is accepted anyway
  caught    a cell shows yes for a key this machine did not pin
  caught    a file addressed to another host is read as this one's
  caught    nothing is ever published, so every row is a question mark
  caught    accepts.age is left out of the re-seal, so a later machine cannot read it
  caught    it republishes whatever it last said, so an accept never shows
```

The `!` row needed three machines and an asymmetric graph, exactly as the issue's
testing note predicted: with two there is no third column for one of them to
disagree about.

## Four things the suite caught before they shipped

- Publishing loaded its own `State`, so `run`'s outer save wrote an older copy
  over the record — **every sync republished, committed and pushed**. Three
  existing invariants noticed.
- Publishing on the first sync made a machine's opening sync push even when it
  only received, which `TestSyncDoesNotForkGitMoreThanItNeedsTo` guards. It
  happens at enrolment now, which already writes and pushes.
- Signing directly rather than through `signing_public` turned "this machine
  lost its signing key" from a thing sync recovers from into a crash.
- A file sealed at enrolment is unreadable by a machine that joins later.

## /simplify

It found the last one's proper fix and three real defects:

- **`accepts.age` joins `_reseal`'s one loop** rather than getting a parallel
  mechanism. That function's docstring warns that a file which starts being
  sealed to the recipients must not be "picked up by widening access and
  forgotten by narrowing it" — using it deleted a `State` field and left an idle
  sync doing no extra I/O at all.
- **The renderer was broken.** `label[:3]` made two machines of one person
  indistinguishable, cells were unequal width, and peer-written names were
  printed raw. It now uses `search.host_labels`, which keeps labels distinct and
  runs them through `make_inert` — the sibling `cmd_stats` argues for exactly
  that, and this is the one table whose purpose is being read as a security
  check. The example in `docs/sync.md` was output the code could not produce.
- **The fingerprint was signed, shipped and thrown away** by the reader, so the
  invariant its own docstring claimed was not enforced. That is the `!` above.

## One thing a reviewer should see rather than discover

`accepts.age` **widens a stated invariant**: `TestImmutability` enumerates the
non-chunk files that may be rewritten, and this is the first that changes more
than once in a machine's life — when trust changes, and again when the recipient
list grows. It is listed there explicitly rather than by loosening the pattern.

## Preflight

`ruff`, `ruff format`, `mypy`, `shellcheck`, 1202 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## The guard you asked for

Added after review: a test that writes a hostile `accepts.age` — sealed to this
fleet so it opens, unsigned so it arrives unverified, claiming a machine nobody
has heard of — runs `woswoar fleet`, and asserts `state.signers` comes back
byte-identical.

```
  caught    the report pins what it reads, which is the whole thing this forbids
```

That row survived two fixtures before it was caught, and both failures were the
same mistake: the hostile row never reached the reader. A row from a host this
machine *has* accepted is refused outright when its signature fails, so there is
nothing left to act on — the dangerous row is the unverified one, from a host
nobody here has accepted, because that is the row the report shows rather than
drops. And a host that has recorded nothing is not a row at all, so the forged
file was never read. Neither was visible in the test's own text.
