### PR TITLE
release: 0.11.0

### DIFF
--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"


### PR DESCRIPTION
A minor rather than a patch, because `woswoar fleet` is a new command and a new
published file. Everything else since v0.10.0 is the mutation harness learning
not to take the machine down with it, and one incident that is the reason to
read the notes rather than the diff.

**New.** `woswoar fleet` prints who has accepted whom, so onboarding a machine
stops being N walks with no record of where you are (#247). Each host publishes
`hosts/<id>/accepts.age`, signed and sealed to the fleet. A cell is what that
machine *says*: only your own row is checked here, a row from a host you have
not accepted is marked unverified, and one naming a key you did not pin is `!`.
The report can never become the thing you check instead of running `accept` --
there is a test that reads a hostile row and asserts nothing this machine
believes has changed.

**Upgrade path.** Additive, both ways. A machine that has published no
`accepts.age` -- an older version, or one that has not synced since -- shows as
`?`, which the report needs anyway; and `state.json` gains one field that
`State.load` degrades to `[]`. Nothing existing moves.

**Fixed, and the one that matters.** A mutation sweep could write into a real
woswoar installation: `tools/demo/seed.py` builds a sandbox and writes a store
into it, and a mutant that broke the line pointing it at that sandbox wrote
wherever the environment named. On this machine it did -- three fabricated
machines in 399 days of real history, an overwritten `machine` file, and one
phantom host published to a shared remote (#246). Two independent locks now
stand between a sweep and a real store, and the test harness refuses to write a
machine identity outside its own sandbox.

The rest is the harness: a lane is bounded by what its whole process tree holds
rather than by one rlimit (#233, #238), sandboxes are built rather than filtered
in the suite and in its children (#237, #243), and four gaps the first full
sweep of `tools/` found are closed (#236, #240, #241, #242).

---

Bump only — `woswoar/__init__.py` is the single place the version lives. Tagging `v0.11.0` after this merges is what publishes; per `CONTRIBUTING.md` that step is deliberate and irreversible on PyPI, so it waits for the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)