### PR TITLE
docs: the four reasons a mutation survives, and a tool that points at the line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,13 @@ first such change, not during one.
   python -m tools.bench --importtime woswoar.__main__ --base main
   ```
 
+  **The generated sweep goes last.** Implement, write the hand table, preflight,
+  run `/simplify` *and apply it*, and only then `--base main`. The table is
+  generated from the lines as they stand, so any edit after it invalidates every
+  row — and a review that lands after the sweep always edits something. Three
+  sweeps were re-run for that reason in one session, at ten to thirty-five
+  minutes each.
+
   Three things to carry into a pull request, because they are about what you
   write rather than what the tool does:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,31 @@ passed review, and guarded nothing:
 Prefer driving the real thing over asserting on a mock. The suite already runs a
 real `bash` for the shell hook and real `age` and `git` for sync; follow that.
 
+**Four reasons a row survives, and the tell for each.** "Suspect the fixture" is
+true and not actionable; these are the four that keep happening, each drawn from
+a row that survived here. Check them in this order — the first two are the ones
+that look most like a passing test.
+
+| the row survived because | the tell |
+|---|---|
+| the test drives the **guard**, not its call site | the guard's own test passes while deleting the call from the caller survives. `_refuse_a_real_store` had a test; `build` calling it did not, and the call is the whole protection. |
+| the fixture has a **second way** to produce the same observable | the assertion holds for a reason you did not intend. Storm children exited on their own after twenty seconds, so "the lane was killed" and "the lane finished" looked identical, and deleting the `killpg` survived. |
+| the hostile input **never reaches** the code | the row is about a path the fixture does not enter. A forged `accepts.age` from a host the reader had *pinned* was refused for its signature before the check under test ran; and a host that has recorded nothing is not a row at all, so the file was never read. |
+| the mutation is **equivalent by construction** | no input can distinguish the two. `bytes.decode()` is UTF-8 whatever the locale says, so mutating a locale-sensitive read that decodes bytes proves nothing; `<` against `<=` on a byte-exact comparison is the same. Say so in the pull request rather than inventing a fixture. |
+
+A fifth, rarer: a mutation that removes one half of a **union** survives when the
+fixture cannot separate the halves. `_lane` is a process group *plus* the
+descendants that left it, and every child in the first fixtures was both — it
+took a grandchild orphaned into the group to tell them apart.
+
+**Guards about isolation need both directions.** A sandbox that carries
+*nothing* satisfies every "the developer's variables are gone" assertion. Assert
+what must arrive as well as what must not: `PATH` with the value it had outside,
+and a tool the suite really runs still findable. That one cost a red macOS CI
+run against a green Linux one, because `shutil.which` falls back to
+`confstr("CS_PATH")` and found an apt-installed `age` where Homebrew's was
+invisible.
+
 ## Before moving code
 
 [`docs/architecture.md`](docs/architecture.md) is the map: which module may

--- a/tests/test_mutants.py
+++ b/tests/test_mutants.py
@@ -432,6 +432,46 @@ class TestDroppingAKeywordArgument(unittest.TestCase):
         self.assertEqual(self.dropped('p.read_text(encoding="utf-8")\n'), [])
 
 
+class TestARowThatMatchesNothingSaysWhatIsClose(unittest.TestCase):
+    """The refusal is right and used to end the search there.
+
+    A hand-written row that matches nothing is almost always quoting the file's
+    past: an edit moved the line by a word after the row was written. The author
+    then greps for a string they believe is present, which is the one search
+    that cannot succeed. Five rows in one session ended that way.
+    """
+
+    def refusal(self, old: str) -> str:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "mod.py"
+            path.write_text("def clamp(value: int) -> int:\n    return value\n", encoding="utf-8")
+            with self.assertRaises(SystemExit) as refused:
+                mutants.check(Mutation("x", str(path), old, "pass", "t"))
+        return str(refused.exception)
+
+    def test_it_offers_the_closest_line(self) -> None:
+        said = self.refusal("def clamp(value: int) -> int :")
+        self.assertIn("closest line", said)
+        self.assertIn("def clamp(value: int) -> int:", said)
+
+    def test_it_offers_nothing_when_nothing_is_close(self) -> None:
+        """A suggestion that is not the intended line is worse than none."""
+        self.assertNotIn("closest line", self.refusal("import antigravity"))
+
+    def test_a_multi_line_row_gets_no_guess(self) -> None:
+        """There is no "nearest line" to a span, and picking one of its lines
+        would point at the half that still matches.
+
+        The first line here is deliberately *close* to a real one. With
+        something unlike the file, the distance check refuses it anyway and this
+        test passes whether or not the span check exists -- which is exactly
+        what it did until a mutation said so.
+        """
+        self.assertNotIn(
+            "closest line", self.refusal("def clamp(value: int) -> int :\n    return value\n")
+        )
+
+
 class TestSkippingAnOperator(unittest.TestCase):
     """`--skip-operator`, the escape hatch a pragma cannot serve.
 

--- a/tools/mutants.py
+++ b/tools/mutants.py
@@ -52,6 +52,7 @@ import copy
 import re
 import subprocess
 from collections.abc import Callable, Iterator, Sequence
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import NamedTuple
 
@@ -855,6 +856,31 @@ def cap(mutations: Sequence[Mutation], limit: int) -> tuple[list[Mutation], list
     return kept, dropped
 
 
+def _near_miss(original: str, wanted: str) -> str:
+    """The closest line in the file, when a hand-written row matches nothing.
+
+    Almost always the same cause: an edit moved the line by a word since the row
+    was written, and the row is now quoting the file's past. Without this the
+    author greps for a string they believe is there, which is the one search
+    that cannot work. With it the answer is in the refusal.
+
+    Only for a single-line `old`, and only when something is close enough to be
+    worth printing: a multi-line span has no "nearest line", and a suggestion
+    that is not the intended line is worse than none.
+    """
+    first = wanted.strip().splitlines()
+    if len(first) != 1 or not first[0]:
+        return ""
+    best, score = "", 0.0
+    for line in original.splitlines():
+        ratio = SequenceMatcher(None, first[0], line.strip()).ratio()
+        if ratio > score:
+            best, score = line, ratio
+    if score < 0.6:
+        return ""
+    return f"\n\nThe closest line there is:\n    {best.strip()}"
+
+
 def check(mutation: Mutation) -> None:
     """Refuse a row that cannot mean anything, reading the real file.
 
@@ -873,6 +899,7 @@ def check(mutation: Mutation) -> None:
                 f"{mutation.label}: {mutation.path} contains the text to replace "
                 f"{found} times, not once. A mutation that matches nothing tests "
                 f"nothing, and one that matches twice tests something else."
+                + _near_miss(original, mutation.old)
             )
     else:
         start, end = mutation.span


### PR DESCRIPTION
Three things from one long session, all about the loop between writing a test
and believing it.

**`CONTRIBUTING.md` gains a diagnosis table.** "Suspect the fixture" is true and
not actionable, and the same four causes came up eight times: the test drives
the guard rather than its call site; the fixture has a second way to produce the
same observable; the hostile input never reaches the code; the mutation is
equivalent by construction. Each row carries the instance it was learned from. A
fifth, rarer one goes with them -- a union whose halves the fixture cannot
separate -- and so does the macOS lesson, that a guard about isolation has to
assert what *arrives* as well as what does not leak, because a sandbox carrying
nothing satisfies every leak assertion.

**`tools/mutants.check` prints the closest line** when a hand-written row
matches nothing. That refusal is right and used to end the search there, so the
author greps for a string they believe is present -- the one search that cannot
succeed. Five rows ended that way in a session. Only for single-line text, and
only when something is close enough to be worth printing.

**`CLAUDE.md` puts the generated sweep last**, after `/simplify` has been
applied. The table is generated from the lines as they stand, so a review that
lands after it invalidates every row; three sweeps were re-run for that reason
in one session, at ten to thirty-five minutes each.

  caught    the refusal says nothing about what is close
  caught    it guesses however far the nearest line is
  caught    a multi-line row gets a guess at one of its lines

The third row survived its first fixture, and the reason is the second line of
the new table: a multi-line `old` whose first line is unlike anything in the
file is refused by the *distance* check, so the span check could be deleted with
nothing noticing. The fixture now quotes a first line that is close.

## Preflight

`ruff`, `ruff format`, `mypy`, 1206 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)