### PR TITLE
test: a sandbox that carries nothing satisfies every isolation test

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -15,7 +15,7 @@ import tempfile
 import termios
 import time
 import unittest
-from collections.abc import Sequence
+from collections.abc import Collection, Mapping, Sequence
 from contextlib import redirect_stderr, redirect_stdout, suppress
 from pathlib import Path
 from typing import NamedTuple
@@ -32,6 +32,64 @@ MACHINE_ID = "0123456789abcdef"
 #: forgotten in the other.
 requires_age = unittest.skipUnless(crypto.available(), "age required")
 requires_git = unittest.skipUnless(shutil.which("git"), "git required")
+
+
+#: A value for every name a sandbox has to carry, planted in the ambient
+#: environment before one is built from it.
+#:
+#: Planted rather than read, because on a developer's machine only `PATH` and
+#: sometimes `TMPDIR` are set -- so a carry assertion that looked at what
+#: happened to be there checked `PATH` and called it a property. Every carry
+#: assertion in this repository did exactly that, which is #251.
+#:
+#: **Written out rather than derived from `store.SANDBOX_CARRIES`**, and that
+#: is the whole of what makes it work. Derived was the first version of this
+#: and it was worth nothing: deleting `PYTHONWARNINGS` from `SANDBOX_CARRIES`
+#: shrank the expectation by the same name, and the full suite stayed green --
+#: 1213 tests, 0 failures -- against a mutant that silently stops carrying CI's
+#: ``error::DeprecationWarning`` into every child process. That is the shape
+#: #251's own text warns about, found by running the mutation rather than by
+#: reading the assertion, which reads correctly either way.
+#:
+#: `TestTheSuiteCannotReachTheMachineItRunsOn` asserts these are the same names
+#: `store.SANDBOX_CARRIES` holds, so the copy cannot drift in silence.
+PLANTED = {
+    "PATH": "/planted/bin",
+    "TMPDIR": "/planted/tmp",
+    # Values a real one could have, since nothing stops a future caller of this
+    # from spawning an interpreter that reads them.
+    "PYTHONWARNINGS": "always::DeprecationWarning",
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONPYCACHEPREFIX": "/planted/pycache",
+}
+
+
+def assert_carried(
+    case: unittest.TestCase,
+    built: Mapping[str, str],
+    *,
+    overridden: Collection[str] = (),
+) -> None:
+    """Assert a sandbox built under `PLANTED` carried what it cannot invent.
+
+    The direction an *empty* environment satisfies for free, which is why it
+    cannot be folded into the leak assertions beside it: those pass on whatever
+    is missing, and a sandbox that carries nothing is missing everything. #237
+    shipped that shape -- two builders called `store.sandbox_environ` after
+    `os.environ.clear()`, carried nothing, and stayed green on Linux because
+    `shutil.which` falls back to ``confstr("CS_PATH")`` and finds an
+    apt-installed `age` in `/usr/bin`. Homebrew does not put it there: 7
+    failures in `test_prove` and 87 errors in one `test_sync` shard, against a
+    fully green Linux run.
+
+    `overridden` names what a builder sets for itself instead of carrying. It
+    is a parameter rather than a subtraction made here because the caller has
+    to *say* which names, and then assert what they were set to -- an exception
+    nobody states is a hole, and one this function decided for itself would
+    make the assertion a restatement of the code it is checking.
+    """
+    expected = {name: value for name, value in PLANTED.items() if name not in overridden}
+    case.assertEqual({name: built.get(name) for name in expected}, expected)
 
 
 def child_env(**extra: str) -> dict[str, str]:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -129,6 +129,18 @@ class TestTheSuiteCannotReachTheMachineItRunsOn(WoswoarTestCase):
         self.assertEqual(os.environ.get("PATH"), self._outer_path)
         self.assertIsNotNone(shutil.which("git"), "the suite runs a real git")
 
+    def test_the_planted_names_are_the_names_a_sandbox_carries(self) -> None:
+        """`support.PLANTED` is a hand-written copy of `store.SANDBOX_CARRIES`,
+        and this is what keeps the copy honest.
+
+        Deriving it was the obvious version and it guarded nothing: an
+        expectation built from the list under test shrinks whenever the list
+        does, so removing a carried name passed 1213 tests. Written out, the
+        removal fails three carry assertions -- and this one, which is the only
+        place that says *why* they now disagree.
+        """
+        self.assertEqual(set(support.PLANTED), set(store.SANDBOX_CARRIES))
+
     def test_home_is_the_sandbox(self) -> None:
         self.assertEqual(Path.home(), self.home)
         self.assertEqual(install.rcfile_for("bash").parent, self.home)

--- a/tests/test_prove.py
+++ b/tests/test_prove.py
@@ -111,6 +111,17 @@ class TestTheProofRunsInAWorldOfItsOwn(ProveTestCase):
         with prove._sandbox():
             self.assertEqual(os.environ["PATH"], outside)
 
+    def test_the_sandbox_carries_every_name_a_sandbox_cannot_invent(self) -> None:
+        """The general form of the test above, and the reason it is a second
+        one: `PATH` was the name that broke, so `PATH` is what got asserted --
+        leaving the other four in `store.SANDBOX_CARRIES` guarded by nothing.
+        Three of them are unset on an ordinary machine, so they are planted
+        here rather than read. See `support.assert_carried` (#251).
+        """
+        with mock.patch.dict(os.environ, support.PLANTED), prove._sandbox():
+            inside = dict(os.environ)
+        support.assert_carried(self, inside)
+
     def test_a_name_the_sandbox_invents_does_not_outlive_it(self) -> None:
         """The half that restoring by `update` cannot do.
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -32,6 +32,8 @@ from tools.sandbox import (
 )
 from woswoar import store
 
+from . import support
+
 REPO = Path(__file__).resolve().parent.parent
 
 
@@ -103,6 +105,19 @@ class TestTheEnvironmentIsBuiltNotInherited(unittest.TestCase):
     def test_path_is_carried_because_age_and_git_have_to_be_found(self) -> None:
         env = sandbox_env(REPO, Path("/tmp/sandbox-home"))
         self.assertEqual(env["PATH"], os.environ["PATH"])
+
+    def test_everything_a_sandbox_cannot_invent_is_carried(self) -> None:
+        """The general form of the test above (#251).
+
+        `PYTHONPYCACHEPREFIX` is the one exception, and it is named rather than
+        skipped: this builder deliberately redirects it into the sandbox, which
+        `TestBytecodeStaysOutOfTheTree` below asserts and explains. Carrying the
+        caller's would put the comparison's bytecode wherever the developer
+        keeps theirs, which is the opposite of what that class is for.
+        """
+        with mock.patch.dict(os.environ, support.PLANTED):
+            env = sandbox_env(REPO, Path("/tmp/sandbox-home"))
+        support.assert_carried(self, env, overridden={"PYTHONPYCACHEPREFIX"})
 
     def test_the_home_is_where_woswoar_will_look(self) -> None:
         home = Path("/tmp/sandbox-home")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -306,6 +306,20 @@ class TestASimulatedMachineIsAWholeWorld(SyncTestCase):
         with self.machine("alpha").active():
             self.assertEqual(os.environ["PATH"], outside)
 
+    def test_a_machine_carries_every_name_a_sandbox_cannot_invent(self) -> None:
+        """The general form of the test above. `PATH` broke and `PATH` was
+        asserted; the other four names in `store.SANDBOX_CARRIES` were guarded
+        by nothing, and three of them are unset on an ordinary machine, so they
+        are planted rather than read (#251).
+
+        The `Fake` is built before the planting: constructing one writes files
+        and the planted `PATH` points nowhere real.
+        """
+        fake = self.machine("alpha")
+        with mock.patch.dict(os.environ, support.PLANTED), fake.active():
+            inside = dict(os.environ)
+        support.assert_carried(self, inside)
+
     def test_one_machine_does_not_see_another_ones_session(self) -> None:
         """`WOSWOAR_SESSION` used to be popped by name here; a wholesale replace
         is what makes that true of every name rather than of the one that was


### PR DESCRIPTION
Closes #251.

## What was wrong

Every isolation assertion here asserted one direction — that the developer's
environment does **not** reach the sandbox. A sandbox that carries *nothing*
satisfies all of them.

That shipped. #237 built the suite's environment from nothing, and
`store.sandbox_environ` carries `PATH` out of the environment it is *called* in,
so `prove._sandbox` and `test_sync`'s `Fake.active` — which called it after
`os.environ.clear()` — carried nothing. Green on Linux, because `shutil.which`
falls back to `confstr("CS_PATH")` and finds an apt-installed `age` in
`/usr/bin`. Homebrew does not put it there: 7 failures in `test_prove` and 87
errors in one `test_sync` shard, against a fully green Linux run.

The three assertions added then were all about `PATH` — the name that broke. The
other four in `store.SANDBOX_CARRIES` stayed guarded by nothing, and three of
them are unset on an ordinary developer machine, so an assertion that read the
ambient environment would have checked `PATH` a fourth time and called it a
property.

## What changed

`support.PLANTED` puts a value under every carried name; `support.assert_carried`
checks they all arrive. Applied at each of the four builders:

| builder | leak half | carry half |
|---|---|---|
| `WoswoarTestCase` | existed | existed (`PATH`) + list-agreement guard, new |
| `prove._sandbox` | existed | `PATH` only → **all five** |
| `test_sync`'s `Fake.active` | existed | `PATH` only → **all five** |
| `tools.sandbox.sandbox_env` | existed | `PATH` only → **all five** |

Kept as two assertions rather than one, per the issue's own constraint: folding
them together would restate the implementation and pass for any implementation.

## The first version was worthless, and only the mutation said so

`PLANTED` was originally derived from `store.SANDBOX_CARRIES`. Deleting
`PYTHONWARNINGS` from that list shrank the expectation by the same name:

```
Ran 1213 tests in 128 batches on 64 workers
OK (0 failures, 0 errors, 4 skipped)
```

A mutant that silently stops carrying CI's `error::DeprecationWarning` into
every child process, and the whole suite green. The assertion reads correctly
either way — this is only visible by running the mutation. `PLANTED` is written
out now, and `test_the_planted_names_are_the_names_a_sandbox_carries` fails if
the hand-written copy and `SANDBOX_CARRIES` ever disagree.

## That it fails without the change (rule 3)

The generated sweep reaches nothing — the diff is `tests/` only:

```
nothing mutable changed against main. Only woswoar/**.py and tools/**.py are
generated from; a change to tests/ is not a fix to test.
```

So the hand table is the whole verification. Each mutant was run against the
**full** suite, and what is listed is every test that failed:

| mutation | before this PR | after |
|---|---|---|
| **A.** drop `"PYTHONWARNINGS"` from `store.SANDBOX_CARRIES` | *nothing* — 1213 pass | **4 fail** |
| **B.** drop the `SANDBOX_CARRIES` spread from `tools.sandbox.sandbox_env` | *nothing* — 1213 pass | **1 fail** |
| **C.** `store.sandboxed` clears before it builds — the #237 shape | 2 fail (the `PATH` tests) | 4 fail |

Mutant A, after:

```
FAIL: tests.test_install.TestTheSuiteCannotReachTheMachineItRunsOn.test_the_planted_names_are_the_names_a_sandbox_carries
FAIL: tests.test_prove.TestTheProofRunsInAWorldOfItsOwn.test_the_sandbox_carries_every_name_a_sandbox_cannot_invent
FAIL: tests.test_sandbox.TestTheEnvironmentIsBuiltNotInherited.test_everything_a_sandbox_cannot_invent_is_carried
FAIL: tests.test_sync.TestASimulatedMachineIsAWholeWorld.test_a_machine_carries_every_name_a_sandbox_cannot_invent
```

Mutant B, after — one test, and it is the new one:

```
FAIL: tests.test_sandbox.TestTheEnvironmentIsBuiltNotInherited.test_everything_a_sandbox_cannot_invent_is_carried
```

Mutant C is caught by the old `PATH` assertions as well, which is expected —
they were written for exactly that bug. It is in the table because a carry
property that missed it would be the wrong property.

## One stated exception

`tools.sandbox.sandbox_env` deliberately overrides `PYTHONPYCACHEPREFIX` rather
than carrying it — bytecode belongs in the sandbox, which is what
`TestBytecodeStaysOutOfTheTree` is about. It is passed as `overridden={...}` at
the call site rather than subtracted inside the helper, so the exception is
named by the caller and asserted elsewhere. An exception nobody states is a hole.

Preflight green; 1214 tests, 0 failures. Review per rule 1: bottom row —
test-only, no new state, no user-reachable path. Re-read the diff, no agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)