### PR TITLE
feat: the fleet table says it in doctor's marks, with a key under it

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -83,23 +83,35 @@ anything kept inside it. Revoking removes that decision everywhere
 automatically, since taking trust away can only ever cause a refusal.
 
 `woswoar fleet` says how far through that walk you are — rows are the machine
-doing the accepting, columns the machine accepted:
+doing the accepting, columns the machine accepted, and the marks are the ones
+`woswoar doctor` uses, so a tick reads the same way in both:
 
 ```
 $ woswoar fleet
 who accepts whom, as each machine last published it
+rows accept, columns are accepted
 
-        desk    yoga    shed
-desk     .      yes     no
-yoga    yes      .      yes
-shed    yes     yes      .     (unverified)
+      desk  shed  yoga
+desk   ·     ✘     ✔
+shed   ✔     ·     ✔    (unverified)
+yoga   ✔     ✔     ·
+
+  ✔  accepted -- the row's machine merges the column's history
+  ✘  not accepted -- run 'woswoar accept' on the row's machine
+  ·  a machine and itself
+  (unverified)  nobody here has accepted that machine, so the row was checked
+                against nothing -- it is what somebody published, and no more
 ```
 
+The key lists only the symbols that are on screen, so it stays short enough to
+read. Two more can appear: `?` for a machine that has published no row this one
+can open, and `!`, sharper than either, for a machine that says it accepted a
+host under a key you did not pin — the two of you are not talking about the same
+machine. Piped rather than shown on a terminal, the three marks come out as
+`[ok]`, `[FAIL]` and `[--]`, exactly as `doctor`'s do.
+
 Only your own row is checked here; the others are what those machines published
-about themselves, and `?` or `(unverified)` marks one whose signing key this
-machine has not accepted. A `!` is sharper than either: that machine says it
-accepted a host under a key you did not pin, so the two of you are not talking
-about the same machine.
+about themselves.
 
 A cell is what a machine *says*, never what is true — if it were the latter, the
 repository would be making the trust decision that the paragraph above refuses

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -206,6 +206,46 @@ class TestRendering(unittest.TestCase):
         self.assertEqual(report.markers(io.StringIO()), report.PLAIN_MARKERS)
 
 
+class TestWidthAsATerminalSeesIt(unittest.TestCase):
+    """`fleet` puts markers in a grid, which is the one place a marker is not
+    the first thing on its line -- and the first thing on a line needs no
+    padding, so nothing measured a marker until there was a table of them.
+
+    A coloured tick is ten characters that draw one column. Every ordinary way
+    of padding counts the ten, so a table laid out with `str.center` or a format
+    spec loses its columns exactly when there is colour to align them by, and is
+    perfectly aligned in the pipe a test captures. That is why these assert on
+    `COLOUR_MARKERS` rather than on a string of the test's own.
+    """
+
+    def test_a_coloured_marker_measures_the_column_it_draws(self) -> None:
+        self.assertEqual(report.visible(report.COLOUR_MARKERS["ok"]), 1)
+        self.assertEqual(report.visible(report.PLAIN_MARKERS["fail"]), len("[FAIL]"))
+
+    def test_text_with_no_escapes_is_its_own_length(self) -> None:
+        self.assertEqual(report.visible("(unverified)"), len("(unverified)"))
+
+    def test_padding_is_counted_in_columns_not_characters(self) -> None:
+        """The bug this exists to prevent, stated as the difference it makes:
+        the format spec pads a coloured marker by nothing at all, because it is
+        already ten characters wide by its own reckoning."""
+        marker = report.COLOUR_MARKERS["ok"]
+        self.assertEqual(report.visible(report.centred(marker, 5)), 5)
+        self.assertEqual(f"{marker:^5}", marker, "sanity: what the format spec does instead")
+
+    def test_the_padding_is_split_with_the_odd_column_on_the_right(self) -> None:
+        """Which side the odd space goes is arbitrary; that it is *decided* is
+        not. A centring that rounded the other way in one branch and this way in
+        another would ripple through a table as a column that moves by one."""
+        self.assertEqual(report.centred("x", 4), " x  ")
+        self.assertEqual(report.centred("x", 5), "  x  ")
+
+    def test_something_wider_than_the_column_is_left_alone(self) -> None:
+        """As the format spec does: a cell that does not fit is better ragged
+        than cut, which is the same call `report.lines` makes for a long label."""
+        self.assertEqual(report.centred("[FAIL]", 2), "[FAIL]")
+
+
 class TestDoctorDecidesWithoutPrinting(WoswoarTestCase):
     """The checks `doctor` owns, asked directly.
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import contextlib
 import io
+import itertools
 import json
 import os
+import re
 import secrets
 import shutil
 import subprocess
@@ -35,11 +37,12 @@ from woswoar import (
     manifest,
     progress,
     prove,
+    report,
     search,
     store,
     sync,
 )
-from woswoar.__main__ import main
+from woswoar.__main__ import _LEGEND, _UNVERIFIED, main
 from woswoar.entry import Entry, format_line
 from woswoar.gitrepo import COMMIT_MESSAGE as COMMIT
 from woswoar.install import HOOKS
@@ -48,6 +51,11 @@ from woswoar.sync import _GRANT_REMEDY
 
 from . import support
 from .support import requires_age, requires_git, requires_ssh_keygen
+
+#: What a terminal eats before anybody reads a column of `woswoar fleet`. The
+#: tests below measure where a symbol sits, and a coloured one is ten characters
+#: sitting in one column -- so they have to strip what the terminal would.
+_ESCAPES = re.compile("\x1b\\[[0-9;]*m")
 
 #: `gc --auto` runs after a commit and after a push, and `gc.autoDetach` sends
 #: it to the background -- so it is still repacking while the *next* git command
@@ -550,6 +558,146 @@ class TestWhoHasAcceptedWhom(SyncTestCase):
         # claim rather than a fact.
         self.assertIn("not what is true", ran.out)
 
+    def two_machines_neither_of_which_has_accepted_the_other(self) -> tuple[Fake, Fake]:
+        """alpha and beta, read from beta, with one cell of each ordinary kind.
+
+        beta pinned alpha when it cloned and alpha was there first, so beta's
+        own row accepts alpha and alpha's published row does not name beta:
+        `yes`, `no` and the two diagonals, with no `!` and nothing unreadable.
+        That is the fixture the key's *absences* need -- a table already holding
+        every symbol cannot show that one is left out when it does not occur.
+        """
+        alpha = self.machine("alpha", display="martinus@alpha")
+        beta = self.machine("beta", display="martinus@beta")
+        with alpha.active():
+            # Something to publish: a machine that has recorded nothing is not
+            # a column, and a one-column table cannot hold a `yes` or a `no`.
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            sync.run()
+        with beta.active():
+            sync.run()
+        with alpha.active():
+            # `grant` and then a sync, because alpha sealed its name and its row
+            # before beta existed. Without the re-seal beta cannot open either,
+            # and every cell of alpha's row would be the `?` this fixture is
+            # meant not to have.
+            sync.run()
+            sync.grant()
+            sync.run()
+        with beta.active():
+            sync.run()
+        return alpha, beta
+
+    def test_this_machines_own_row_holds_fingerprints_like_every_other(self) -> None:
+        """`Accepts.hosts` is fingerprints, and `State.signers` is whole keys.
+
+        Every other row comes back from `parse`, which reads what `body` wrote;
+        this machine's own row has no file behind it and was assembled by hand
+        from the pins -- so it carried keys in a field of fingerprints, and
+        `_cell` compared the two and called every machine this one had accepted
+        `!`. The authoritative row, the only one the command promises anything
+        about, disputed itself.
+
+        Asserted against `body`, not against a fingerprint spelled out here: the
+        point is that the two agree, and a literal would pass while they drifted.
+        """
+        alpha, beta = self.two_machines_neither_of_which_has_accepted_the_other()
+        with beta.active():
+            state = sync.State.load()
+            own = fleet.mine(state.signers, 1)
+            # Read back the way a peer's row arrives, signature and all -- and
+            # unverified, because what is under test is which strings land in
+            # `hosts` rather than who wrote them.
+            published = fleet.parse(
+                "not-a-signature\n\n" + fleet.body(store.machine().id, state.signers, 1),
+                store.machine().id,
+                None,
+            )
+        assert published is not None
+        self.assertEqual(own.hosts, published.hosts)
+        self.assertIn(alpha.id, own.hosts, "sanity: beta pinned alpha when it cloned")
+
+    def test_a_machine_this_one_accepted_is_not_shown_as_disputed(self) -> None:
+        """The same defect through the command, because the docstring above is
+        about a dict and this is about what a person reads. `!` means "that
+        machine accepted a host under a key I did not pin", which is the alarm
+        this report exists to raise -- so raising it about a machine you
+        accepted yourself is worse than saying nothing.
+        """
+        _, beta = self.two_machines_neither_of_which_has_accepted_the_other()
+        ran = self.run_cli(beta, "fleet")
+        self.assertEqual(ran.code, 0, ran.err)
+        self.assertNotIn(_LEGEND["disputed"], ran.out, f"beta pinned alpha itself:\n{ran.out}")
+
+    def test_the_table_says_it_in_doctors_markers_not_in_words(self) -> None:
+        """#247 printed `yes` and `no`, which is a fourth vocabulary for the
+        thing `doctor` already has three markers for. `report.markers` decides
+        which pair of forms those are, so the assertion here is on the plain
+        ones -- a captured stream is not a terminal, exactly as a pipe is not.
+        """
+        _, beta = self.two_machines_neither_of_which_has_accepted_the_other()
+        ran = self.run_cli(beta, "fleet")
+        self.assertEqual(ran.code, 0, ran.err)
+        self.assertIn(report.PLAIN_MARKERS["ok"], ran.out)
+        self.assertIn(report.PLAIN_MARKERS["fail"], ran.out)
+        self.assertNotIn("yes", ran.out, f"a cell is a marker now:\n{ran.out}")
+
+    def test_the_key_explains_the_symbols_that_are_in_the_table(self) -> None:
+        """The half of #247 this is about: a grid of ticks says nothing to
+        somebody who has not read `fleet.py`."""
+        _, beta = self.two_machines_neither_of_which_has_accepted_the_other()
+        ran = self.run_cli(beta, "fleet")
+        for kind in ("yes", "no", "self"):
+            with self.subTest(kind=kind):
+                self.assertIn(_LEGEND[kind], ran.out, f"no key for {kind}:\n{ran.out}")
+
+    def test_the_key_leaves_out_the_symbols_that_are_not(self) -> None:
+        """Why the key is filtered rather than printed whole. The ordinary
+        table is ticks and dots, and a five-line key under a three-line table is
+        mostly about states that are not in it -- which is how a key stops being
+        read at all. The fixture has no `!` and nothing unreadable, so those two
+        lines and the `(unverified)` note must not be there.
+        """
+        _, beta = self.two_machines_neither_of_which_has_accepted_the_other()
+        ran = self.run_cli(beta, "fleet")
+        for kind in ("disputed", "unknown"):
+            with self.subTest(kind=kind):
+                self.assertNotIn(_LEGEND[kind], ran.out, f"{kind} is not here:\n{ran.out}")
+        self.assertNotIn(_UNVERIFIED, ran.out, f"every row is checked here:\n{ran.out}")
+
+    def test_a_coloured_table_keeps_its_columns(self) -> None:
+        """A cell is a marker now, and on a terminal a marker is ten characters
+        drawing one column. Every ordinary way of padding counts the ten, so a
+        table centred with a format spec is perfectly aligned in the pipe a test
+        captures and collapses into a row of touching symbols on the terminal
+        the user is looking at. Hence `tty=True`, and hence measuring where each
+        symbol sits rather than trusting that something was printed.
+        """
+        _, beta = self.two_machines_neither_of_which_has_accepted_the_other()
+        ran = self.run_cli(beta, "fleet", tty=True)
+        self.assertEqual(ran.code, 0, ran.err)
+        self.assertIn("\x1b[", ran.out, "sanity: this is the coloured rendering")
+
+        lines = _ESCAPES.sub("", ran.out).splitlines()
+        header = next(line for line in lines if line.startswith(" ") and line.strip())
+        body = list(itertools.takewhile(bool, lines[lines.index(header) + 1 :]))
+        self.assertTrue(body, f"no rows under the header:\n{ran.out}")
+
+        # Where each column header sits, in order and without assuming which
+        # machine sorted first.
+        spans, at = [], 0
+        for label in header.split():
+            at = header.index(label, at)
+            spans.append(range(at, at + len(label)))
+            at += len(label)
+
+        for row in body:
+            with self.subTest(row=row):
+                marks = [i for i, char in enumerate(row) if i >= spans[0].start and char != " "]
+                self.assertEqual(len(marks), len(spans), f"one symbol per column:\n{header}\n{row}")
+                for mark, span in zip(marks, spans, strict=True):
+                    self.assertIn(mark, span, f"a symbol left its column:\n{header}\n{row}")
+
     def test_a_row_naming_a_key_this_machine_did_not_pin_is_disputed(self) -> None:
         """What the fingerprint beside each host id is for.
 
@@ -583,6 +731,9 @@ class TestWhoHasAcceptedWhom(SyncTestCase):
         ran = self.run_cli(beta, "fleet")
         self.assertEqual(ran.code, 0, ran.err)
         self.assertIn("!", ran.out, f"alpha's claim about gamma is disputed:\n{ran.out}")
+        # And the key says what that `!` means, because this is the one symbol
+        # in the table whose meaning nobody can guess from the symbol.
+        self.assertIn(_LEGEND["disputed"], ran.out, f"unexplained `!`:\n{ran.out}")
 
     def test_reading_a_hostile_row_changes_nothing_this_machine_believes(self) -> None:
         """The property the whole design rests on, as a guard rather than a

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -184,16 +184,46 @@ def _import(kind: importer.Kind, path: Path | None, *, dry_run: bool, this_host_
     return 0
 
 
+#: What a cell can say: the sentence the key under the table prints for it, in
+#: the order it prints them. Three of the five borrow `doctor`'s markers rather
+#: than spelling `yes` and `no`, so that one glance reads the same way in both
+#: reports and `report.markers` decides in one place whether that is a tick or
+#: `[ok]` -- honouring NO_COLOR for this table as it already does for that one.
+#:
+#: The other two are a matrix's own, because `doctor`'s three cannot carry them.
+#: `!` is sharper than "no" rather than a louder version of it, and `?` is not a
+#: verdict at all -- folding either into `fail` would print a machine's silence
+#: as a finding about it, which is the one thing `woswoar/fleet.py` forbids.
+_LEGEND = {
+    "yes": "accepted -- the row's machine merges the column's history",
+    "no": "not accepted -- run 'woswoar accept' on the row's machine",
+    "disputed": "accepted, but under a signing key this machine did not pin",
+    "unknown": "no row this machine can open, so nothing is known either way",
+    "self": "a machine and itself",
+}
+
+#: What a row rather than a cell can be marked with, and what it means. Not in
+#: `_LEGEND`, and not because it would not fit: that dict is what a *cell* can
+#: say, and this is about a whole row -- the difference between "what that
+#: machine says about one column" and "whether that machine is who wrote the
+#: row at all". Printing them as one list would blur exactly that.
+_UNVERIFIED = "(unverified)"
+_UNVERIFIED_MEANS = (
+    "nobody here has accepted that machine, so the row was checked",
+    "against nothing -- it is what somebody published, and no more",
+)
+
+
 def cmd_fleet(args: argparse.Namespace) -> int:
     """Who has accepted whom, as far as each machine says.
 
-    Rows accept, columns are accepted; the diagonal is blank. Only this
-    machine's row is authoritative -- it is the local pin, and nothing in the
-    repository can change it. See `woswoar/fleet.py` for why every other row is
-    a claim rather than a fact, and why that distinction is the design rather
+    Rows accept, columns are accepted; the diagonal is the machine itself. Only
+    this machine's row is authoritative -- it is the local pin, and nothing in
+    the repository can change it. See `woswoar/fleet.py` for why every other row
+    is a claim rather than a fact, and why that distinction is the design rather
     than a caveat on it.
     """
-    from . import fleet, sync
+    from . import fleet, report, sync
 
     known = store.machine()
     state = sync.State.load()
@@ -212,11 +242,15 @@ def cmd_fleet(args: argparse.Namespace) -> int:
         identity = None
 
     hosts = sorted(names)
+    now = int(time.time())
     rows = {
-        host: fleet.Accepts(dict(state.signers), int(time.time()), True)
+        host: fleet.mine(state.signers, now)
         if host == known.id
         else (fleet.published(host, state.signers.get(host), identity) if identity else None)
         for host in hosts
+    }
+    grid = {
+        (host, other): _cell(rows[host], other, host, state) for host in hosts for other in hosts
     }
 
     # `search.host_labels` rather than a local spelling: it keeps labels
@@ -226,17 +260,42 @@ def cmd_fleet(args: argparse.Namespace) -> int:
     # wrote, and this is the one table whose whole purpose is being read as a
     # security check.
     labels = search.host_labels(set(hosts))
-    width = max(len(label) for label in labels.values())
+    symbols = _symbols(report.markers())
+    # Wide enough for the widest marker as well as the widest label. Without
+    # colour a marker is `[FAIL]`, six columns rather than one, so a fleet whose
+    # machines are called `pi` would otherwise print a header that does not sit
+    # over the cells it names.
+    mark_width = max(report.visible(symbol) for symbol in symbols.values())
+    width = max(mark_width, *(len(label) for label in labels.values()))
 
-    print("who accepts whom, as each machine last published it\n")
-    print(" " * (width + 2) + "  ".join(f"{labels[host]:^{width}}" for host in hosts))
+    print("who accepts whom, as each machine last published it")
+    print("rows accept, columns are accepted\n")
+    print((" " * (width + 2) + "  ".join(f"{labels[host]:^{width}}" for host in hosts)).rstrip())
+    unverified = False
     for host in hosts:
         said = rows[host]
-        cells = []
-        for other in hosts:
-            cells.append(f"{_cell(said, other, host, state):^{width}}")
-        mark = "" if said is not None and said.verified else "  (unverified)"
-        print(f"{labels[host]:<{width}}  " + "  ".join(cells) + mark)
+        cells = [report.centred(symbols[grid[host, other]], width) for other in hosts]
+        checked = said is not None and said.verified
+        unverified = unverified or not checked
+        mark = "" if checked else f"  {_UNVERIFIED}"
+        print((f"{labels[host]:<{width}}  " + "  ".join(cells) + mark).rstrip())
+
+    print()
+    shown = set(grid.values())
+    for kind, meaning in _LEGEND.items():
+        # Only the symbols that are on screen. The ordinary table is ticks and
+        # dots, and a five-line key under a three-line table is mostly about
+        # states that are not in it -- which is how a key stops being read.
+        if kind in shown:
+            print(f"  {report.centred(symbols[kind], mark_width)}  {meaning}")
+    if unverified:
+        first, *rest = _UNVERIFIED_MEANS
+        print(f"  {_UNVERIFIED}  {first}")
+        # Under the sentence rather than under the mark: `(unverified)` is a
+        # word, not a one-column symbol, so the hanging indent is its own width
+        # and not `mark_width`.
+        for line in rest:
+            print(" " * (len(_UNVERIFIED) + 4) + line)
 
     print("\nA cell is what that machine says, not what is true: only this")
     print("machine's row is checked against a key pinned here. Run 'woswoar accept'")
@@ -249,28 +308,48 @@ def cmd_fleet(args: argparse.Namespace) -> int:
     return 0
 
 
-def _cell(said: object, other: str, host: str, state: object) -> str:
-    """One cell: what `host` says about `other`.
+def _symbols(marks: dict[str, str]) -> dict[str, str]:
+    """The character each kind of cell prints as.
 
-    `!` is the case the fingerprint in each line exists for. A row names the
-    *key* it accepted, so a machine claiming to accept a host under a key this
-    machine did not pin is saying something about a different machine than the
-    reader thinks -- an attacker who can push may move `signer.pub`, and without
-    this the row would read as a vouch for whatever key sits there now.
+    `marks` is what `doctor` renders with, passed in rather than fetched here so
+    that the width the table is laid out to and the symbols in it cannot come
+    from two different answers to "is this a terminal?".
+    """
+    return {
+        "self": marks["info"],
+        "yes": marks["ok"],
+        "no": marks["fail"],
+        "disputed": "!",
+        "unknown": "?",
+    }
+
+
+def _cell(said: object, other: str, host: str, state: object) -> str:
+    """Which kind of cell `host` says `other` is: a key of `_LEGEND`.
+
+    A kind rather than the character, because the character depends on whether
+    anyone is watching and this does not -- and because the key under the table
+    lists exactly the kinds that came back from here.
+
+    `disputed` is the case the fingerprint in each line exists for. A row names
+    the *key* it accepted, so a machine claiming to accept a host under a key
+    this machine did not pin is saying something about a different machine than
+    the reader thinks -- an attacker who can push may move `signer.pub`, and
+    without this the row would read as a vouch for whatever key sits there now.
     """
     from . import crypto, fleet, sync
 
     assert isinstance(state, sync.State)
     if other == host:
-        return "."
+        return "self"
     if not isinstance(said, fleet.Accepts):
-        return "?"
+        return "unknown"
     claimed = said.hosts.get(other)
     if claimed is None:
         return "no"
     pinned = state.signers.get(other)
     if pinned is not None and claimed != crypto.fingerprint(pinned):
-        return "!"
+        return "disputed"
     return "yes"
 
 
@@ -1340,6 +1419,10 @@ def build_parser() -> argparse.ArgumentParser:
         Accepting is per-machine: enrolling a laptop means running 'woswoar
         accept' on the laptop and on every machine already syncing. This says
         how far through that you are.
+
+        Rows accept, columns are accepted, and a key under the table says what
+        each symbol in it means. They are doctor's, so a tick reads the same
+        way in both reports.
 
         Only this machine's row is authoritative. Every other row is what that
         machine published about itself, and a repository is not where trust

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -1421,8 +1421,8 @@ def build_parser() -> argparse.ArgumentParser:
         how far through that you are.
 
         Rows accept, columns are accepted, and a key under the table says what
-        each symbol in it means. They are doctor's, so a tick reads the same
-        way in both reports.
+        each symbol in it means. The marks are doctor's own, so a tick reads
+        the same way in both reports.
 
         Only this machine's row is authoritative. Every other row is what that
         machine published about itself, and a repository is not where trust

--- a/woswoar/fleet.py
+++ b/woswoar/fleet.py
@@ -14,11 +14,12 @@ someone else's.
 is deliberately local -- `State.signers` says why, and `trust` repeats it:
 anyone who can push can rewrite `hosts/<id>/signer.pub`, so the key a host is
 held to has to be remembered somewhere the remote cannot reach. A published
-`accepts` file is therefore *advisory*, and the report says so per row: `yes`
-and `no` for a host whose signing key this machine has pinned, `?` for one it
-has not, because there the file's author is "whoever can push". The matrix must
-never become the thing someone checks instead of running `accept`, or the
-repository has made the trust decision the design refuses to let it make.
+`accepts` file is therefore *advisory*, and the report says so per row: a
+verdict -- `doctor`'s own tick or cross -- for a host whose signing key this
+machine has pinned, and `?` for one it has not, because there the file's author
+is "whoever can push". The matrix must never become the thing someone checks
+instead of running `accept`, or the repository has made the trust decision the
+design refuses to let it make.
 
 **Signature inside the sealed file, not beside it.** `manifest` makes this
 argument first and it applies unchanged: a detached pair has a window where one
@@ -64,6 +65,28 @@ class Accepts(NamedTuple):
     #: False means the file parsed and nothing more: its author is whoever can
     #: push. Never let this decide anything except how the row is printed.
     verified: bool
+
+
+def mine(signers: dict[str, str], now: int) -> Accepts:
+    """This machine's own row, from its pins rather than from a published file.
+
+    Through here rather than assembled at the call site, and that is worth a
+    function: `hosts` is fingerprints and `State.signers` is whole keys, so
+    `Accepts(dict(state.signers), ...)` type-checks, reads correctly, and is
+    wrong in the one row nothing can catch it in. Every other row arrives
+    through `parse`, which puts fingerprints there because `body` wrote them;
+    the row a machine keeps about itself is the only one with no file behind it,
+    and it was the only one built by hand -- so `__main__._cell` compared a key
+    with a fingerprint and reported every machine this one had accepted as
+    accepted under a key it had not pinned.
+
+    ``verified`` is `True` and is not a claim about a signature: there is no
+    signature, because there is no file. It is the local pin, which is the one
+    thing in this module that the repository cannot reach.
+    """
+    return Accepts(
+        {host: crypto.fingerprint(key) for host, key in signers.items()}, now, verified=True
+    )
 
 
 def body(host_id: str, accepted: dict[str, str], now: int) -> str:

--- a/woswoar/report.py
+++ b/woswoar/report.py
@@ -36,6 +36,7 @@ must never become the thing those depend on.
 from __future__ import annotations
 
 import os
+import re
 import sys
 from typing import NamedTuple, TextIO
 
@@ -50,6 +51,38 @@ COLOUR_MARKERS = {
     "fail": "\x1b[31m✘\x1b[0m",
     "info": "\x1b[2m·\x1b[0m",
 }
+
+#: What `visible` discounts. Only the SGR form, because that is all
+#: `COLOUR_MARKERS` holds and a general terminal-escape parser here would be a
+#: guess at input nothing in this package produces.
+_SGR = re.compile("\x1b\\[[0-9;]*m")
+
+
+def visible(text: str) -> int:
+    """How many columns `text` occupies once the terminal has eaten its escapes.
+
+    `len` is ten for a coloured tick that draws one column. That does not matter
+    where a marker starts the line, which is every caller `doctor` has -- it
+    matters to `fleet`, which puts markers in a grid and has to know how wide
+    its columns are before it prints the header.
+    """
+    return len(_SGR.sub("", text))
+
+
+def centred(text: str, width: int) -> str:
+    """`text` centred in `width` columns as a terminal will show it.
+
+    `str.center` and `f"{text:^{width}}"` both count characters, so a table of
+    coloured markers built with either loses its alignment exactly when there is
+    colour to align -- the padding goes to the escape sequences. Wider than
+    `width` is returned unpadded, as the format spec does.
+    """
+    padding = width - visible(text)
+    if padding <= 0:
+        return text
+    left = padding // 2
+    return " " * left + text + " " * (padding - left)
+
 
 #: How wide the label column is. One number, because the continuation lines in
 #: `note` are indented to sit under the detail rather than under the marker.


### PR DESCRIPTION
`woswoar fleet` printed `yes` and `no` in its cells — a fourth vocabulary for
the thing `doctor` already has three markers for — and nothing on screen said
what any of the five cell states meant. A reader who had not read `fleet.py` had
a grid and a caveat.

```
who accepts whom, as each machine last published it
rows accept, columns are accepted

      desk  shed  yoga
desk   ·     ✘     ✔
shed   ✔     ·     ✔    (unverified)
yoga   ✔     ✔     ·

  ✔  accepted -- the row's machine merges the column's history
  ✘  not accepted -- run 'woswoar accept' on the row's machine
  ·  a machine and itself
  (unverified)  nobody here has accepted that machine, so the row was checked
                against nothing -- it is what somebody published, and no more
```

Generated from a real three-machine fixture, not typed; the same block is now in
`docs/sync.md`.

## What the cells are

`report.markers()`, the same pair of forms `doctor` renders with and chosen by
the same rule: the tick on a terminal, `[ok]`/`[FAIL]`/`[--]` in a pipe, and
`NO_COLOR` honoured for both reports at once rather than twice.

`!` and `?` stayed as they were, and deliberately. Neither is a verdict
`doctor`'s three can carry: `!` is *sharper* than "not accepted" rather than a
louder version of it, and `?` is not a verdict at all. Folding either into
`fail` would print a machine's silence as a finding about it, which is the one
thing `woswoar/fleet.py`'s docstring forbids.

The key lists only the symbols that are on screen. An ordinary healthy fleet is
ticks and dots, and a five-line key under a three-line table is mostly about
states that are not there — which is how a key stops being read. Both
directions are tested: one fixture proves the lines that should be there are,
another that the two that should not be there are not.

## Two supporting pieces

**`report.visible` and `report.centred`.** A coloured marker is ten characters
drawing one column, and `str.center` and `f"{...:^{width}}"` both count the ten.
A table laid out with either is perfectly aligned in the pipe a test captures
and collapses into touching symbols on the terminal the user is looking at — so
`tests.test_sync` asserts with `tty=True` and measures where each symbol sits
against the span of its column header, rather than trusting that something was
printed.

**`fleet.mine`, which fixes a defect this change ran into.** This machine's own
row was built as `Accepts(dict(state.signers), ...)` — whole keys in a field of
fingerprints. Every other row arrives through `parse`, which puts fingerprints
there because `body` wrote them; the own row was the only one assembled by hand.
So `_cell` compared a key with a fingerprint and marked **every machine this one
had accepted** as `!`. The authoritative row, the only one the command promises
anything about, disputed itself.

It type-checks and reads correctly, which is why it shipped. It now goes through
a constructor that owns the invariant, with two regression tests — one on the
dict, against what `body` writes rather than against a literal fingerprint, and
one through the command, because the first is about a dict and the second is
about what a person reads.

## Mutation

`python -m tools.mutate --base main`, 57 mutants, every one caught. Four
survived the narrow test selection and were caught by the confirmation pass:

```
  caught    woswoar/report.py:81 in centred() -- `<=` becomes `<`
  caught    woswoar/report.py:81 in centred() -- the `if` is never taken
  caught    woswoar/report.py:81 in centred() -- `0` becomes `1`
  caught    woswoar/report.py:81 in centred() -- `0` becomes `-1`
4 of them were caught by a test the selection had not run.
```

**The run also printed `BASELINE NOT GREEN`, and that is not this branch.** It
names `tests.test_sandbox.TestBytecodeStaysOutOfTheTree.test_running_under_it_leaves_no_pycache_in_the_tree`,
which fails inside `mutate` on unmodified `main` too: `tools/mutate.py` exports
`PYTHONDONTWRITEBYTECODE=1` for the probe, `SANDBOX_CARRIES` carries it into
`sandbox_env`, and the test's own child then writes no bytecode anywhere — so
its guard against a vacuous pass fails. One line reproduces it, with no mutation
run involved:

```sh
$ PYTHONDONTWRITEBYTECODE=1 python -B -m unittest \
    tests.test_sandbox.TestBytecodeStaysOutOfTheTree
AssertionError: False is not true : bytecode did not reach the sandbox
```

Filed as #258 rather than fixed here — it is in `tools/` and `tests/`, which
this diff does not otherwise touch, and the argument for where to cut belongs
with the issue. By the tool's own rule the verdicts above are therefore
unconfirmed; they were identical across two independent runs, and the baseline
failure is the same one both times and demonstrably not about this change.

## Review

Rule 1, middle row — behaviour on a path a user reaches, no new state, nothing
that reaches disk — so a careful read of the diff rather than agents. That read
is what found the `!`-on-your-own-row defect above; it was already on `main` and
this branch only made it visible by running the fixture.

## Checks

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` matches `origin/main` in this container: the three
reds are environmental and each was confirmed on a `main` worktree —
git 2.43 does not populate `origin/HEAD` (two `TestTheRepoSaysWhichShapeItIs`
errors), and the container runs as root, which ignores the mode bits
`test_an_unwritable_runtime_dir_falls_back_instead_of_giving_up` depends on. The
four `fzf` failures were this container lacking `fzf`; installing CI's pinned
0.74.2 turns them green. `shellcheck` was not available here — CI covers it.

## One thing left as it is

In a pipe the three doctor marks become `[ok]`/`[FAIL]`/`[--]` while `!` and `?`
stay bare, which reads slightly mixed. Inventing `[!]`/`[?]` plain forms would
give the table two vocabularies again for no reader's benefit, and on a terminal
— where this is read — every cell is one column. Mentioned rather than filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF


---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_