### PR TITLE
docs: a rule for the loop an issue number is shorthand for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,14 +30,18 @@ change under review.
 If a finding is wrong or its fix would exceed the task's scope, say so
 explicitly in the PR description rather than silently dropping it.
 
-## 2. Never merge without explicit approval
+## 2. Merge only where a rule says you may
 
-Open the PR, report its CI status, and stop. Wait for the maintainer to say to
-merge.
+By default: open the PR, report its CI status, and stop. Wait for the maintainer
+to say to merge.
 
 Approval is per-PR and does not carry over. "Merge it" for one PR is not
 standing authority for the next one, even when the next one is a direct
 follow-up to the same task. Ask again.
+
+The one exception is rule 9's list mode, where "work the issues" is itself the
+approval -- given once, for that run, and spent on green CI. Nothing else grants
+it and it does not outlive the run.
 
 ## 3. Every fix and every new behaviour gets a regression test
 
@@ -192,6 +196,40 @@ The distinction that decides how much care a change needs:
 Nothing in the repo records which version wrote it, so a change to the *repo*
 format has no marker to hang an upgrade on. That is worth fixing before the
 first such change, not during one.
+
+## 9. One line naming an issue is the whole task, and it ends at an open PR
+
+"Do #258" means: branch (7), fix it with the test that fails without it (3),
+prove that with `tools/mutate.py` (3), review in proportion and **apply** what
+that finds (1), preflight, open the pull request, report its CI, stop (2).
+Anything noticed on the way gets one of rule 4's three answers on the spot
+instead of becoming a question. The branch is whatever the harness named, else
+`claude/<issue>-<slug>`.
+
+**Ask only** when proceeding under any assumption would be unsafe or would waste
+the work if the guess went the other way, when it reverses something already
+decided, or when the instruction names something that does not exist. Everything
+else -- which fixture, what to call it, P2 or P3, which of rule 4's answers a
+discovery earns -- is yours: decide it and put the reasoning in the PR body,
+where it can be argued with for the cost of one read. A question asked mid-task
+stops the work and is answered by someone holding less context than the agent
+asking it.
+
+One issue is one PR. A change that acquires a second subject has stopped being
+the issue it was given.
+
+**"Work the issues" is the same loop down the open list**, in label order, one
+PR per issue, each branched from `main`. Do not wait between them: open the PR,
+let CI finish, and **merge it when every check is green** -- that one
+instruction is the approval rule 2 otherwise requires. A red check stops the run
+and is reported rather than retried into submission; so does an issue that needs
+an earlier PR merged first. An issue that turns out to be a non-issue is closed
+with the reason rather than made true.
+
+Green CI is not review, and this is installed software. So the rule 1 pass still
+happens before the PR opens -- it is now the only review the change will get --
+and a change in that table's top row (stored data, a security claim, a cache)
+opens its PR and waits for a person regardless of what CI says.
 
 ## Repository conventions worth matching
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,7 +283,8 @@ reach for the wrong fix is doing the main thing.
   none.
 
 Nothing is merged without the maintainer saying so, including by the maintainer's
-own agents.
+own agents — said per pull request, or once for a run that works the whole open
+issue list.
 
 ## Re-recording the demo
 


### PR DESCRIPTION
Rules 1–8 already held every step of the loop. What was missing was **when to
interrupt the maintainer** — nothing in the file said, so an agent handed "do
#258" had to invent an answer, and the answers would not agree between sessions.

So rule 9 names the sequence as pointers rather than restating it, and spends
its length on the part that was not written down:

- work to an open pull request without check-ins;
- **ask only** where proceeding under any assumption would be unsafe or would
  waste the work if the guess went the other way, where it reverses something
  already decided, or where the instruction names something that does not exist;
- everything else — which fixture, what to call it, P2 or P3, which of rule 4's
  three answers a discovery earns — is decided and recorded in the PR body,
  where it can be argued with for the cost of one read.

Deliberately **not** restated: rule 4's triage. It already says fix-it-here /
file-it / say-it-and-let-it-go, with the argument for why filing is not the
default and six issues closed unworked as the evidence. A second copy is a
second thing to keep true, and this file's own culture is against that — rule 8
is a rule that deleted its predecessor, and rule 6 says a stale warning is worse
than none.

## What this changes about rule 2

Rule 9 also defines "work the issues": the open list in label order, one PR per
issue, none waiting on another. That cannot stop for approval per PR and still
be one instruction — so the instruction *is* the approval, given once for the
run and spent on green CI.

Rule 2 therefore keeps its default and names the exception, and `CONTRIBUTING.md`
says the same in its own words. That sentence is exactly the one the two files
would drift on, and the header of `CONTRIBUTING.md` promises they cannot.

Two things green CI does not buy, both in the rule:

- the rule 1 review still happens **before** the PR opens, because it is now the
  only review the change will get;
- a change in that table's top row — stored data, a security claim, a cache —
  waits for a person whatever CI says. That is the row where "the prune in #91
  introduced a P1 regression", and CI would not have caught that one either.

## What I left out

A green `tools/mutate.py` run as a merge condition. It belongs there, and I
drafted it — but #258 means the baseline is red on any change whose test
selection pulls in `tests.test_sandbox`, so the condition would block essentially
every auto-merge until that is fixed. Worth adding once #258 lands.

## Checks

Prose only, so no mutation run applies — `mutate` generates from `woswoar/**.py`
and `tools/**.py`, and would say nothing mutable changed. Rule 1's bottom row
(mechanical, no new state): re-read the diff, no agents.

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` and
`tests.test_docs` all clean — the last matters here, since it is what checks the
links and headings these two files carry, and rule 2's heading changed. Nothing
in the repository linked its old anchor. `python -m tools.run_tests` is unchanged
from `main` in this container: git 2.43 does not populate `origin/HEAD` (two
errors), and running as root ignores the mode bits one shell-hook test needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF


---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_