### PR TITLE
fix: the bytecode check is about sandbox_env, not about who ran the suite (#258)

### DIFF
--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -146,10 +146,24 @@ class TestBytecodeStaysOutOfTheTree(unittest.TestCase):
 
     def test_running_under_it_leaves_no_pycache_in_the_tree(self) -> None:
         """The property rather than the variable: drives a real interpreter over a
-        throwaway module and checks where the bytecode landed."""
+        throwaway module and checks where the bytecode landed.
+
+        `PYTHONDONTWRITEBYTECODE` is cleared for the whole of it, and that is the
+        fix for #258 rather than tidiness. `sandbox_env` carries the name out of
+        `os.environ` -- deliberately, so that the real `age`, `git` and `bash` a
+        suite forks cannot leave a `.pyc` behind -- and `tools/mutate` exports it
+        for exactly that reason. Inherited here, the child writes no bytecode at
+        all, the second assertion below fails, and every `mutate` run whose
+        selection reaches this module ends `BASELINE NOT GREEN`, which tells the
+        reader that verdicts about their own change mean nothing. The claim under
+        test is about what `sandbox_env` produces, so it must not change answer
+        with who invoked the suite; cleared before the environment is *built*,
+        not merely before the child runs, because that is when the name is read.
+        """
         import tempfile
 
-        with tempfile.TemporaryDirectory() as area:
+        with tempfile.TemporaryDirectory() as area, mock.patch.dict(os.environ):
+            os.environ.pop("PYTHONDONTWRITEBYTECODE", None)
             root = Path(area)
             tree, home = root / "tree", root / "home"
             tree.mkdir()
@@ -168,6 +182,51 @@ class TestBytecodeStaysOutOfTheTree(unittest.TestCase):
             self.assertTrue(
                 any((home / "pycache").rglob("*.pyc")), "bytecode did not reach the sandbox"
             )
+
+
+class TestTheBytecodeCheckIsNotDecidedByItsCaller(unittest.TestCase):
+    """#258: the class above must answer the same under `mutate` as under `python`.
+
+    A guard rather than a duplicate. `TestBytecodeStaysOutOfTheTree` asserts
+    where bytecode landed, and the thing that broke was not that claim but its
+    *independence* -- one exported variable in the parent turned it red, and the
+    tool that exported it was `tools/mutate`, whose whole job is to say whether
+    the tests are good. That is a property of the harness rather than of
+    `sandbox_env`, so nothing inside that class can hold it: reverting the
+    `patch.dict` leaves both of its assertions reading exactly as they do now.
+
+    Driven by starting a real interpreter with the variable set, for the reason
+    `CLAUDE.md` rule 3 gives for the shell hook and for sync -- the failure was
+    an interaction between two processes' environments, and a mock of either end
+    would be asserting the thing that was already believed.
+    """
+
+    def test_the_case_passes_with_pythondontwritebytecode_exported(self) -> None:
+        # Inherited and overridden, which is the shape this file's docstring
+        # rejects everywhere else -- and right here, because the child is the
+        # *suite* rather than a sandboxed woswoar. The claim is "an ordinary
+        # invocation that happens to export this stays green", so the ordinary
+        # invocation is what has to be reproduced; the sandbox the child then
+        # builds for itself is the thing under test and is still built from
+        # nothing.
+        exported = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+        # `-B` as well, because that is how `mutate` starts its probe: the flag
+        # covers the probe and the variable covers what the suite forks, and it
+        # was the pair that reached this module.
+        ran = subprocess.run(
+            [
+                sys.executable,
+                "-B",
+                "-m",
+                "unittest",
+                f"{__name__}.TestBytecodeStaysOutOfTheTree",
+            ],
+            cwd=REPO,
+            env=exported,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(ran.returncode, 0, ran.stderr)
 
 
 class TestSeeding(unittest.TestCase):


### PR DESCRIPTION
Closes #258.

`python -m tools.mutate` ended every run whose selection reached `tests.test_sandbox` with `BASELINE NOT GREEN` — so, by the tool's own correct rule, it was telling the reader that every verdict above that line meant nothing.

## The cut, and why it is at the test

Three deliberate decisions that did not compose: `mutate` exports `PYTHONDONTWRITEBYTECODE` for the real `age`, `git` and `bash` a suite forks; `store.SANDBOX_CARRIES` carries it since #237; and the test asserts both that no `__pycache__` reached the tree *and* that a `.pyc` reached `home/pycache` — the second stopping the first from passing vacuously. Under `mutate` the child wrote no bytecode anywhere, so the second assertion failed. Every end was right, which is why the issue's own analysis lands on the test, and this follows it.

Two details that are load-bearing:

- **Cleared before the environment is built**, not merely before the child runs. `sandbox_env` reads `os.environ` when it is *called*, so a `patch.dict` around the `subprocess.run` alone would have fixed nothing.
- **The second assertion stays.** Deleting it also goes green and destroys the test: "no `__pycache__` in the tree" passes trivially in precisely the state that caused this.

## The guard is a separate class

Independence from the caller is a property of the harness, not of `sandbox_env`, so nothing inside `TestBytecodeStaysOutOfTheTree` can hold it — reverting the fix leaves both of its assertions reading exactly as they do now. `TestTheBytecodeCheckIsNotDecidedByItsCaller` starts a real interpreter with the variable exported and asserts the case is green, which is the two-process interaction that broke rather than a mock of either end. It inherits-and-overrides the environment, which this file's docstring rejects everywhere else; the comment says why that is right here — the child is the *suite*, and the sandbox it then builds for itself is still built from nothing.

## Rule 3

The diff is `tests/` only, so the generated sweep has nothing to say, verbatim:

```
$ python -m tools.mutate --base main
nothing mutable changed against main. Only woswoar/**.py and tools/**.py are generated from; a change to tests/ is not a fix to test.
```

So the loop was run by hand instead:

- fix reverted in the working tree → `FAIL: test_the_case_passes_with_pythondontwritebytecode_exported`, suite red
- fix restored → green, six runs out of six
- end to end: `python -m tools.mutate --all --only tools/sandbox.py --limit 1` printed the `BASELINE NOT GREEN` line before and prints no such line after

## Review

Rule 1's bottom row — no new state, nothing on a user path, and a measured before and after — so this was a re-read of the diff rather than agents. That read added the comment explaining why inheriting the environment is correct in the guard.

## Noticed on the way, not filed

Three tests fail on this container and on unmodified `main` alike, for the machine rather than for the code: `test_an_unwritable_runtime_dir_falls_back_instead_of_giving_up` (running as root, so `chmod` does not block), and two in `TestTheRepoSaysWhichShapeItIs` (git 2.43 does not write `origin/HEAD` on fetch; ≥ 2.46 does). Rule 4's third answer — said here rather than filed, since CI's runners have neither property.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_