### PR TITLE
feat: woswoar forget, and a digest so it stays forgotten (#256)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -21,6 +21,7 @@ Every command and every environment variable, in one place. `woswoar --help` and
 | `woswoar grant` | let newly enrolled machines read the older history |
 | `woswoar trust` | accept another machine's published history here |
 | `woswoar compact` | merge old chunks to reduce the working-tree file count |
+| `woswoar forget <text>` | remove recorded commands from this machine (dry run without `--yes`) |
 
 ## Environment
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -421,6 +421,8 @@ every other check you can run without believing anyone.
 | Compaction does not duplicate history | a peer that already merged a day, and one that merged only part of it, both end up holding each command exactly once |
 | A day whose signed list is gone is refused, not re-signed | deleting a manifest and syncing publishes nothing further for that day, rather than signing a replacement that names only the newest chunk and disowns every earlier one |
 | A day whose sealed key is gone is refused, not written over | deleting one and syncing publishes nothing further for that day and says so, rather than adding chunks no machine could ever read |
+| A forgotten command stays forgotten | two real machines: after `woswoar forget --yes`, dropping the merge bookkeeping and syncing again leaves the row gone and the rest of its day intact |
+| Forgetting a published row does not shorten the next chunk | the sealed-bytes watermark moves down by exactly what was removed below it, so the unsealed tail is still exactly the lines that were never sealed |
 | This machine never writes a chunk its peers would refuse | a tail past the export budget is split into several chunks and a peer merges every line of it; compaction, the other producer, leaves a day alone rather than merging it past the same budget |
 
 **Nothing woswoar reads can run**
@@ -481,7 +483,12 @@ Being straight about the limits is part of the security story:
 >   recorded long before woswoar existed, and additionally recognises well-known
 >   token formats, which is where the risk is concentrated. But **no pattern
 >   catches everything**. [What it does and does not catch](shell-integration.md#commands-that-are-never-recorded)
->   is written down; read it before relying on it.
+>   is written down; read it before relying on it. When one gets through,
+>   `woswoar forget <text>` removes it from this machine — out of `logs/`, out
+>   of Ctrl-R, out of `stats` — and remembers it so a later sync cannot merge it
+>   back. It prints what it would remove and does nothing without `--yes`.
+>   `woswoar forget --credentials` runs the filter over what is already
+>   recorded. What it cannot do is the next bullet.
 >
 >   For a sense of scale rather than a promise: measured against one
 >   maintainer's real atuin history of **55,017 commands**, the rules skipped 32
@@ -495,6 +502,13 @@ Being straight about the limits is part of the security story:
 >   a new one and carries on recording, but every peer refuses its history until
 >   a human there runs `woswoar trust --replace` — deliberately, because a
 >   changed signing key and an impersonation look identical from the outside.
+> - **Forgetting is local; publishing is not.** `woswoar forget` rewrites this
+>   machine's plaintext logs, and that is all it can do. Chunks are never
+>   rewritten — history is append-only and every peer's signature rests on that
+>   — so a row that has already synced stays in the repository and on every
+>   machine that merged it. `forget` says which of the rows it found are in that
+>   position, and names the day. If one of them is a credential, rotate it: that
+>   is the only thing that takes it out of use.
 > - **Revoking cannot take back what was already published.** `woswoar revoke`
 >   stops a machine both reading and publishing from that moment on, but a copy
 >   it already made is a copy it keeps. It also refuses history that machine

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -79,6 +79,12 @@ LAYERS: dict[str, set[str]] = {
     "install": {"entry", "errors", "report", "store"},
     "cache": {"entry", "store"},
     "search": {"cache", "entry", "store"},
+    #: `forget` is deliberately absent: both import paths reach it inside the
+    #: function that writes, so a keypress -- which imports this module at
+    #: the top, for the parser -- does not pay for it. The edge is real and
+    #: load-bearing: `logs/` has two doors and this is the other one, since a
+    #: row `forget` took out is no longer in `existing_keys` and a re-import
+    #: would write it back verbatim.
     "importer": {"credentials", "entry", "errors", "store"},
     #: Reached from `sync`, and pointedly not the other way. `forget` knows how
     #: to take a row out of `logs/` and how to recognise one coming back; when
@@ -89,7 +95,7 @@ LAYERS: dict[str, set[str]] = {
     #: rather than as a second verb -- and `find` asks for it itself, so a
     #: background sync, which reaches this module once a minute to ask what is
     #: suppressed, does not pay to import the importer's credential rules.
-    "forget": {"entry", "store"},
+    "forget": {"entry", "errors", "store"},
     #: `importer` and `sync` are deliberately absent: the wizard asks about them
     #: inside the two functions that need them.
     "setup": {"entry", "errors", "install", "report", "store"},

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -80,6 +80,16 @@ LAYERS: dict[str, set[str]] = {
     "cache": {"entry", "store"},
     "search": {"cache", "entry", "store"},
     "importer": {"credentials", "entry", "errors", "store"},
+    #: Reached from `sync`, and pointedly not the other way. `forget` knows how
+    #: to take a row out of `logs/` and how to recognise one coming back; when
+    #: that happens is `merge`'s business, and an edge back to `sync` would put
+    #: the suppression list on the wrong side of the module that has to consult
+    #: it on every chunk. `credentials` is deliberately absent: `--credentials`
+    #: is the CLI's selector -- #54's read-only scan arriving as a selector
+    #: rather than as a second verb -- and `find` asks for it itself, so a
+    #: background sync, which reaches this module once a minute to ask what is
+    #: suppressed, does not pay to import the importer's credential rules.
+    "forget": {"entry", "store"},
     #: `importer` and `sync` are deliberately absent: the wizard asks about them
     #: inside the two functions that need them.
     "setup": {"entry", "errors", "install", "report", "store"},
@@ -98,6 +108,7 @@ LAYERS: dict[str, set[str]] = {
         "fleet",
         "entry",
         "errors",
+        "forget",
         "gitrepo",
         "manifest",
         "progress",
@@ -122,6 +133,7 @@ LAYERS: dict[str, set[str]] = {
         "entry",
         "errors",
         "fleet",
+        "forget",
         "gitrepo",
         "manifest",
         "progress",

--- a/tests/test_forget.py
+++ b/tests/test_forget.py
@@ -17,7 +17,8 @@ import json
 from pathlib import Path
 from unittest import mock
 
-from woswoar import cache, entry, forget, importer, store, sync
+from woswoar import __main__ as main_module
+from woswoar import cache, entry, forget, importer, search, store, sync
 
 from . import support
 
@@ -399,3 +400,133 @@ class TestTheTwoSpellingsOfTheDigestAgree(support.WoswoarTestCase):
         make a row forgettable and un-suppressable at the same time."""
         line = _line(1_755_600_001, "café ☕ --token=abc")
         self.assertEqual(forget.digest(line), forget._of(line.encode("utf-8", "surrogateescape")))
+
+
+class TestTheListingSaysEnoughToAnswerWith(ForgetTestCase):
+    """What is on screen is the whole basis for a `--yes`, so it is asserted.
+
+    Every one of these was a mutation that survived the first sweep: the count
+    header, the clip, the pluralisation and both summary lines could all be
+    deleted or inverted with the suite still green. A listing nothing checks is
+    a listing that can go wrong in the one place this command asks somebody to
+    make a decision.
+    """
+
+    def test_it_says_how_many_it_found(self) -> None:
+        self.assertIn("1 matching command(s)", support.run_cli("forget", "AWS_SECRET").out)
+
+    def test_one_match_is_singular_and_several_are_not(self) -> None:
+        """Both halves, because a sentence that always says "them" satisfies the
+        first assertion on its own."""
+        self.assertIn("to remove it from", support.run_cli("forget", "AWS_SECRET").out)
+        # "a" is in all three fixture commands.
+        self.assertIn("to remove them from", support.run_cli("forget", "a").out)
+
+    def test_a_long_command_is_clipped_and_says_so(self) -> None:
+        """`FORGET_PREVIEW` characters and the picker's own ellipsis. Clipped from
+        the *end*, unlike `search._clip`: a row somebody is about to delete is one
+        they typed, so the beginning is what identifies it."""
+        long = "curl --header 'authorization: Bearer " + "x" * 200 + "'"
+        self.write_log(support.MACHINE_ID, self.DAY, [_line(1_755_600_001, long)])
+        out = support.run_cli("forget", "Bearer").out
+        self.assertIn(long[: main_module.FORGET_PREVIEW] + search.ELLIPSIS, out)
+        self.assertNotIn(long, out, "the whole command was printed rather than a preview")
+
+    def test_a_short_command_is_not_clipped(self) -> None:
+        """The fixture that stops the assertion above passing on a clip that
+        always fires."""
+        out = support.run_cli("forget", "make -j8").out
+        self.assertIn("make -j8", out)
+        self.assertNotIn(search.ELLIPSIS, out)
+
+    def test_it_says_what_it_removed(self) -> None:
+        out = support.run_cli("forget", "AWS_SECRET", "--yes").out
+        self.assertIn("removed 1 row(s) from 1 day file(s)", out)
+        self.assertIn("cache", out)
+
+
+class TestEveryPublishedDayIsNamed(ForgetTestCase):
+    """One day cannot tell a sorted list from an unsorted one, or from a list
+    that prints only its first entry -- which is `CLAUDE.md` rule 3's first
+    weak-fixture example, one type over."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.later = "2026-08-20"
+        self.other = _line(1_755_690_000, "export AWS_SECRET_ACCESS_KEY=second")
+        self.write_log(support.MACHINE_ID, self.later, [self.other])
+        store.save_json(
+            store.state_file(),
+            {
+                "exported": {
+                    f"hosts/{support.MACHINE_ID}/{self.DAY}.tsv": sum(
+                        len(line) + 1 for line in self.lines
+                    ),
+                    f"hosts/{support.MACHINE_ID}/{self.later}.tsv": len(self.other) + 1,
+                }
+            },
+        )
+
+    def test_both_days_are_listed_in_order(self) -> None:
+        out = support.run_cli("forget", "AWS_SECRET").out
+        self.assertIn(f"on {self.DAY}, {self.later}.", out)
+
+    def test_the_count_matches_the_days(self) -> None:
+        self.assertIn(
+            "2 of these have already been published", support.run_cli("forget", "AWS_SECRET").out
+        )
+
+
+class TestTheWatermarkBoundaryIsInclusive(ForgetTestCase):
+    """A row ending *exactly* at the sealed prefix has been sealed.
+
+    Both `<=` comparisons survived a sweep whose fixtures only ever put a match
+    strictly inside the watermark, which cannot tell `<=` from `<`. One is the
+    line that decides whether somebody is told to rotate a credential; the other
+    is how far the watermark moves.
+    """
+
+    def test_the_last_sealed_row_reads_as_published(self) -> None:
+        self.mark_exported(2)
+        out = support.run_cli("forget", "AWS_SECRET").out
+        self.assertIn("published", out)
+        self.assertIn("rotate", out)
+
+    def test_removing_it_moves_the_watermark_by_its_whole_length(self) -> None:
+        self.mark_exported(2)
+        support.run_cli("forget", "AWS_SECRET", "--yes")
+        self.assertEqual(self.exported(), len(self.lines[0]) + 1)
+
+
+class TestALineThatIsNotARecordIsSkipped(ForgetTestCase):
+    """`parse_line` returns None for a torn line rather than raising, and
+    `find` has to honour that: a shell killed mid-append leaves one, and a
+    `forget` that fell over on it would be unusable exactly when the history is
+    already damaged."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.log.write_text(
+            f"not a record at all\n{self.lines[1]}\n\t\t\t\n{self.lines[2]}\n", encoding="utf-8"
+        )
+
+    def test_the_search_still_answers(self) -> None:
+        ran = support.run_cli("forget", "AWS_SECRET")
+        self.assertEqual(ran.code, 0)
+        self.assertIn("1 matching", ran.out)
+
+    def test_the_junk_is_left_where_it_was(self) -> None:
+        support.run_cli("forget", "AWS_SECRET", "--yes")
+        self.assertEqual(self.remaining(), ["not a record at all", "\t\t\t", self.lines[2]])
+
+
+class TestRemovingNothingIsNotAnError(ForgetTestCase):
+    """`forget_rows` intersects with what was shown, so it can legitimately end
+    up with nothing to do -- and `apply`'s early return is what stops the caller
+    updating `state.exported` with a `None`."""
+
+    def test_an_empty_intersection_changes_nothing(self) -> None:
+        before = self.log.read_bytes()
+        self.assertEqual(sync.forget_rows("AWS_SECRET", False, set()), [])
+        self.assertEqual(self.log.read_bytes(), before)
+        self.assertFalse(store.forgotten_file().exists())

--- a/tests/test_forget.py
+++ b/tests/test_forget.py
@@ -166,6 +166,23 @@ class TestTheSealedPrefixMovesWithTheFile(ForgetTestCase):
         support.run_cli("forget", "make -j8", "--yes")
         self.assertEqual(self.exported(), len(self.lines[0]) + 1)
 
+    def test_a_long_unsealed_row_is_still_not_counted(self) -> None:
+        """The fixture the test above is too short to be.
+
+        `offset + length <= watermark` decides which removed rows move the mark.
+        With rows of ordinary length, writing that as `offset - length` picks out
+        the same set, so the arithmetic reads as tested when it is not. A row
+        longer than everything sealed before it is what separates them: its
+        `offset - length` falls below the watermark while `offset + length` is
+        well past it, and counting it would silently stop that many bytes of real
+        history from ever being published.
+        """
+        self.lines = [_line(1_755_600_001, "cd /tmp"), _line(1_755_600_002, "echo " + "y" * 300)]
+        self.log = self.write_log(support.MACHINE_ID, self.DAY, self.lines)
+        self.mark_exported(1)
+        support.run_cli("forget", "yyy", "--yes")
+        self.assertEqual(self.exported(), len(self.lines[0]) + 1)
+
 
 class TestWhatItSaysAboutWhatItCannotDo(ForgetTestCase):
     def test_a_published_row_is_named_with_its_day(self) -> None:
@@ -419,8 +436,14 @@ class TestTheListingSaysEnoughToAnswerWith(ForgetTestCase):
         """Both halves, because a sentence that always says "them" satisfies the
         first assertion on its own."""
         self.assertIn("to remove it from", support.run_cli("forget", "AWS_SECRET").out)
-        # "a" is in all three fixture commands.
-        self.assertIn("to remove them from", support.run_cli("forget", "a").out)
+        # Exactly two, which is the boundary `len(matches) > 1` sits on: three
+        # cannot tell it from `> 2`.
+        self.write_log(
+            support.MACHINE_ID,
+            self.DAY,
+            [_line(1_755_600_001, "one token"), _line(1_755_600_002, "two token")],
+        )
+        self.assertIn("to remove them from", support.run_cli("forget", "token").out)
 
     def test_a_long_command_is_clipped_and_says_so(self) -> None:
         """`FORGET_PREVIEW` characters and the picker's own ellipsis. Clipped from
@@ -438,6 +461,14 @@ class TestTheListingSaysEnoughToAnswerWith(ForgetTestCase):
         out = support.run_cli("forget", "make -j8").out
         self.assertIn("make -j8", out)
         self.assertNotIn(search.ELLIPSIS, out)
+
+    def test_a_command_that_exactly_fills_the_preview_is_not_clipped(self) -> None:
+        """The boundary `>` sits on. A command one character over is clipped and
+        one exactly at the limit is not, and only a fixture of exactly that
+        length can tell the two comparisons apart."""
+        exact = "x" * main_module.FORGET_PREVIEW
+        self.write_log(support.MACHINE_ID, self.DAY, [_line(1_755_600_001, exact)])
+        self.assertNotIn(search.ELLIPSIS, support.run_cli("forget", "xxx").out)
 
     def test_it_says_what_it_removed(self) -> None:
         out = support.run_cli("forget", "AWS_SECRET", "--yes").out

--- a/tests/test_forget.py
+++ b/tests/test_forget.py
@@ -14,8 +14,10 @@ what the listing says about a published row, and the exit code.
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from unittest import mock
 
-from woswoar import entry, forget, store
+from woswoar import cache, entry, forget, importer, store, sync
 
 from . import support
 
@@ -198,12 +200,12 @@ class TestTheSelector(ForgetTestCase):
         you mean all of it" that is worth the chance of a yes.
         """
         ran = support.run_cli("forget", "", "--yes")
-        self.assertEqual(ran.code, 2)
+        self.assertEqual(ran.code, 1)
         self.assertEqual(self.remaining(), self.lines)
 
     def test_no_pattern_at_all_is_refused(self) -> None:
         ran = support.run_cli("forget", "--yes")
-        self.assertEqual(ran.code, 2)
+        self.assertEqual(ran.code, 1)
         self.assertEqual(self.remaining(), self.lines)
 
     def test_it_is_a_substring_and_not_a_regex(self) -> None:
@@ -273,3 +275,127 @@ class TestSurvivingIsByteExact(support.WoswoarTestCase):
         every byte of every peer's history, on a one-minute timer."""
         plaintext = b"anything at all\n"
         self.assertIs(forget.surviving(plaintext, set()), plaintext)
+
+
+class TestARowStillBeingWrittenIsNotARow(ForgetTestCase):
+    """`_rows` stops where `store.read_tail` stops, and that is not tidiness.
+
+    The shell hook appends with `>>` on every prompt and takes no lock -- it
+    must not fork on the record path, and CI asserts that. So the last line of
+    a live day file is routinely half there. Treating it as a record lets
+    `forget` offer to delete something still being written, on the primary copy,
+    and leaves the writer's remaining bytes to land on whatever line follows.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Two complete lines and a third with no newline, which is exactly the
+        # shape a `>>` caught mid-write leaves behind.
+        self.log.write_text(
+            f"{self.lines[0]}\n{self.lines[2]}\n{_line(1_755_600_009, 'ssh secret-box')}",
+            encoding="utf-8",
+        )
+
+    def test_it_is_not_offered(self) -> None:
+        ran = support.run_cli("forget", "secret-box")
+        self.assertIn("nothing recorded", ran.out)
+
+    def test_it_survives_a_rewrite_that_removes_a_line_above_it(self) -> None:
+        before = self.log.read_bytes()
+        support.run_cli("forget", "git status", "--yes")
+        self.assertEqual(self.log.read_bytes(), before.replace(f"{self.lines[0]}\n".encode(), b""))
+
+
+class TestACommandRecordedDuringTheRewriteIsNotLost(ForgetTestCase):
+    """The one operation in the tree that can shorten the primary copy.
+
+    `store.write_atomic` replaces the inode, and the hook is appending to the
+    old one without a lock -- so a command typed in that window lands on a file
+    that is about to be unlinked. `apply` holds the handle across the
+    replacement and reads on afterwards, which recovers exactly those bytes:
+    they are well defined because the logs are append-only.
+    """
+
+    LATE = "echo typed while the rewrite was happening"
+
+    def test_the_append_is_recovered(self) -> None:
+        late = _line(1_755_600_004, self.LATE)
+        real = store.write_atomic
+
+        def racing(path: Path, data: bytes) -> None:
+            # Straight onto the old inode, through the same door the hook uses,
+            # in the window between `apply`'s read and its replace.
+            if path == self.log:
+                with store.private_append(path) as hook:
+                    hook.write(f"{late}\n")
+            real(path, data)
+
+        with mock.patch.object(store, "write_atomic", racing):
+            support.run_cli("forget", "AWS_SECRET", "--yes")
+        self.assertEqual(self.remaining(), [self.lines[0], self.lines[2], late])
+
+
+class TestOnlyWhatWasShownIsRemoved(ForgetTestCase):
+    """`sync.forget_rows` searches again under the lock -- a merge may have moved
+    every offset -- but a row recorded since the listing was never on screen, and
+    for a command that deletes history that is the thing that must not happen."""
+
+    def test_a_row_recorded_after_the_listing_is_left_alone(self) -> None:
+        real = sync.forget_rows
+
+        def racing(needle: str, only_credentials: bool, shown: set[str]) -> object:
+            self.write_log(
+                support.MACHINE_ID,
+                self.DAY,
+                [*self.lines, _line(1_755_600_004, "export AWS_SECRET_ACCESS_KEY=later")],
+            )
+            return real(needle, only_credentials, shown)
+
+        with mock.patch.object(sync, "forget_rows", racing):
+            support.run_cli("forget", "AWS_SECRET", "--yes")
+        self.assertIn("AWS_SECRET_ACCESS_KEY=later", self.log.read_text(encoding="utf-8"))
+        self.assertNotIn("wharrgarbl", self.log.read_text(encoding="utf-8"))
+
+
+class TestAReImportDoesNotBringItBack(support.WoswoarTestCase):
+    """`logs/` has two doors and `merge` is only one of them.
+
+    Both importers deduplicate against `store.existing_keys`, which reads the
+    log files -- so once `forget` has taken a row out, an import no longer sees
+    it as already present and writes it back verbatim. The credential filter is
+    the only thing in the way, and it is the filter whose misses this command
+    exists for.
+    """
+
+    HISTORY = "#1753000000\ngit status\n#1753000100\nssh prod -- cat /etc/shadow\n"
+
+    def source(self) -> Path:
+        path = self.root / "history"
+        path.write_text(self.HISTORY, encoding="utf-8")
+        return path
+
+    def test_a_forgotten_row_is_not_re_imported(self) -> None:
+        importer.run("bash", self.source())
+        self.assertEqual(support.run_cli("forget", "etc/shadow", "--yes").code, 0)
+        # What a restored machine looks like: the importer's own watermark is
+        # progress, not history, so losing it re-reads the whole file.
+        store.save_json(store.config_dir() / "imported.json", {})
+        importer.run("bash", self.source())
+        self.assertNotIn("etc/shadow", " ".join(e.cmd for e in cache.load_entries()))
+
+    def test_the_rest_of_the_history_still_comes_back(self) -> None:
+        """The fixture that stops the assertion above passing on an import that
+        silently did nothing at all."""
+        importer.run("bash", self.source())
+        support.run_cli("forget", "etc/shadow", "--yes")
+        store.save_json(store.config_dir() / "imported.json", {})
+        importer.run("bash", self.source())
+        self.assertIn("git status", [e.cmd for e in cache.load_entries()])
+
+
+class TestTheTwoSpellingsOfTheDigestAgree(support.WoswoarTestCase):
+    def test_bytes_and_text_name_the_same_row(self) -> None:
+        """`surviving` hashes bytes and `apply` hashes text; a divergence would
+        make a row forgettable and un-suppressable at the same time."""
+        line = _line(1_755_600_001, "café ☕ --token=abc")
+        self.assertEqual(forget.digest(line), forget._of(line.encode("utf-8", "surrogateescape")))

--- a/tests/test_forget.py
+++ b/tests/test_forget.py
@@ -1,0 +1,275 @@
+"""`woswoar forget`: removing a recorded command, and keeping it removed.
+
+The command exists because `docs/security.md` says the credential filter is
+best-effort and that publication is final, and both are true -- but the *local*
+half of that gap was answerable all along and had no answer. These tests are
+mostly about the ways a delete can quietly undo itself: a watermark left where
+it was, a cache still holding the row, a digest never written.
+
+They drive the real CLI through `support.run_cli` rather than calling
+`forget.apply`, because everything a user reaches is in between: the dry run,
+what the listing says about a published row, and the exit code.
+"""
+
+from __future__ import annotations
+
+import json
+
+from woswoar import entry, forget, store
+
+from . import support
+
+
+def _line(ts: int, cmd: str, session: str = "s1") -> str:
+    """One log line exactly as the hook writes it."""
+    return entry.format_line(support.make_entry(ts, cmd, session=session))
+
+
+class ForgetTestCase(support.WoswoarTestCase):
+    """A day of this machine's history, and a way to look at it afterwards."""
+
+    DAY = "2026-08-19"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.lines = [
+            _line(1_755_600_001, "git status"),
+            _line(1_755_600_002, "export AWS_SECRET_ACCESS_KEY=wharrgarbl"),
+            _line(1_755_600_003, "make -j8"),
+        ]
+        self.log = self.write_log(support.MACHINE_ID, self.DAY, self.lines)
+
+    def remaining(self) -> list[str]:
+        return self.log.read_text(encoding="utf-8").splitlines()
+
+    def mark_exported(self, through: int) -> None:
+        """Say the first ``through`` lines have been sealed into a chunk.
+
+        Spelled in lines and converted to bytes here, because the number
+        `state.exported` holds is a byte count and a test that computed one by
+        hand would be asserting its own arithmetic.
+        """
+        sealed = sum(len(line) + 1 for line in self.lines[:through])
+        relpath = f"hosts/{support.MACHINE_ID}/{self.DAY}.tsv"
+        store.save_json(store.state_file(), {"exported": {relpath: sealed}})
+
+    def exported(self) -> int:
+        raw = json.loads(store.state_file().read_text(encoding="utf-8"))
+        return int(next(iter(raw["exported"].values())))
+
+
+class TestADryRunIsTheDefault(ForgetTestCase):
+    def test_it_lists_the_match_and_changes_nothing(self) -> None:
+        before = self.log.read_bytes()
+        ran = support.run_cli("forget", "AWS_SECRET")
+        self.assertEqual(ran.code, 0)
+        self.assertIn("AWS_SECRET_ACCESS_KEY", ran.out)
+        self.assertIn("--yes", ran.out)
+        self.assertEqual(self.log.read_bytes(), before)
+
+    def test_it_writes_no_digest(self) -> None:
+        """The half that would make a dry run permanent without deleting anything.
+
+        A digest written here suppresses the row on the next merge, so the
+        command would have acted while reporting that it had not -- and on a
+        machine whose copy came from a peer, that is the whole effect.
+        """
+        support.run_cli("forget", "AWS_SECRET")
+        self.assertFalse(store.forgotten_file().exists())
+
+    def test_nothing_matching_says_so_and_succeeds(self) -> None:
+        ran = support.run_cli("forget", "no-such-command")
+        self.assertEqual(ran.code, 0)
+        self.assertIn("nothing recorded", ran.out)
+
+
+class TestRemoving(ForgetTestCase):
+    def test_the_row_goes_and_the_others_are_untouched(self) -> None:
+        ran = support.run_cli("forget", "AWS_SECRET", "--yes")
+        self.assertEqual(ran.code, 0)
+        self.assertEqual(self.remaining(), [self.lines[0], self.lines[2]])
+
+    def test_the_digest_is_recorded(self) -> None:
+        support.run_cli("forget", "AWS_SECRET", "--yes")
+        self.assertEqual(
+            store.forgotten_file().read_text(encoding="utf-8").split(),
+            [forget.digest(self.lines[1])],
+        )
+
+    def test_the_parse_cache_is_dropped(self) -> None:
+        """Keyed by (file, offset), and both just moved.
+
+        Left in place, the next Ctrl-R reads its cached copy of a row that is no
+        longer in the log -- so the command would appear to have done nothing at
+        exactly the moment somebody checks.
+        """
+        store.private_dir(store.cache_dir())
+        store.cache_file().write_bytes(b"stale")
+        support.run_cli("forget", "AWS_SECRET", "--yes")
+        self.assertFalse(store.cache_file().exists())
+
+    def test_a_repeated_forget_does_not_repeat_the_digest(self) -> None:
+        support.run_cli("forget", "make", "--yes")
+        support.run_cli("forget", "git", "--yes")
+        recorded = store.forgotten_file().read_text(encoding="utf-8").split()
+        self.assertEqual(len(recorded), len(set(recorded)))
+
+    def test_it_takes_every_match_rather_than_the_first(self) -> None:
+        self.write_log(
+            support.MACHINE_ID,
+            self.DAY,
+            [_line(1_755_600_001, "curl -H 'token: abc'"), _line(1_755_600_002, "echo token")],
+        )
+        support.run_cli("forget", "token", "--yes")
+        self.assertEqual(self.remaining(), [])
+
+
+class TestTheSealedPrefixMovesWithTheFile(ForgetTestCase):
+    """`state.exported` is a byte count, so a rewrite that ignores it loses history.
+
+    `sync.export` takes the tail from that offset and its own comment says a
+    *truncated* log simply has no tail -- so a file that loses bytes below the
+    watermark while the number stays put stops publishing exactly that many
+    bytes of real history, silently and for good. Nothing else in the suite
+    would notice: the rows are still in `logs/`, and every local command shows
+    them.
+    """
+
+    def test_removing_a_sealed_row_moves_the_watermark_down_by_its_length(self) -> None:
+        self.mark_exported(3)
+        support.run_cli("forget", "AWS_SECRET", "--yes")
+        self.assertEqual(self.exported(), len(self.lines[0]) + len(self.lines[2]) + 2)
+
+    def test_the_watermark_still_points_at_a_line_boundary(self) -> None:
+        """The property the number has to keep, stated without arithmetic.
+
+        Everything up to the watermark is what has been sealed; everything after
+        it is what the next sync publishes. If the two no longer meet at a line
+        boundary, the next chunk begins mid-record.
+        """
+        self.mark_exported(2)
+        support.run_cli("forget", "git status", "--yes")
+        tail, _ = store.read_tail(self.log, self.exported())
+        self.assertEqual(
+            tail.decode("utf-8"),
+            f"{self.lines[2]}\n",
+            "the unsealed tail is no longer exactly the lines that were never sealed",
+        )
+
+    def test_removing_an_unsealed_row_leaves_the_watermark_alone(self) -> None:
+        """Only what was below it moves it. A row still waiting to be published
+        was never counted, so subtracting it would re-publish the line before."""
+        self.mark_exported(1)
+        support.run_cli("forget", "make -j8", "--yes")
+        self.assertEqual(self.exported(), len(self.lines[0]) + 1)
+
+
+class TestWhatItSaysAboutWhatItCannotDo(ForgetTestCase):
+    def test_a_published_row_is_named_with_its_day(self) -> None:
+        self.mark_exported(3)
+        ran = support.run_cli("forget", "AWS_SECRET")
+        self.assertIn(self.DAY, ran.out)
+        self.assertIn("rotate", ran.out)
+
+    def test_an_unpublished_row_is_not_called_published(self) -> None:
+        """The fixture that would make the assertion above vacuous.
+
+        A message printed for every row would satisfy it, so the case that must
+        *not* print it is the one that gives it meaning.
+        """
+        ran = support.run_cli("forget", "AWS_SECRET")
+        self.assertNotIn("rotate", ran.out)
+        self.assertIn("local only", ran.out)
+
+    def test_another_machines_row_is_published_by_construction(self) -> None:
+        """It is here because that host sealed it and pushed it, so there is no
+        watermark to consult -- it left its machine before it reached this one."""
+        self.write_log("beefcafe", self.DAY, [_line(1_755_600_009, "ssh prod")])
+        ran = support.run_cli("forget", "ssh prod")
+        self.assertIn("published", ran.out)
+        self.assertIn("rotate", ran.out)
+
+
+class TestTheSelector(ForgetTestCase):
+    def test_an_empty_pattern_is_refused(self) -> None:
+        """`"" in cmd` is true of every command, so this would take the history.
+
+        A refusal rather than a confirmation prompt: there is no answer to "did
+        you mean all of it" that is worth the chance of a yes.
+        """
+        ran = support.run_cli("forget", "", "--yes")
+        self.assertEqual(ran.code, 2)
+        self.assertEqual(self.remaining(), self.lines)
+
+    def test_no_pattern_at_all_is_refused(self) -> None:
+        ran = support.run_cli("forget", "--yes")
+        self.assertEqual(ran.code, 2)
+        self.assertEqual(self.remaining(), self.lines)
+
+    def test_it_is_a_substring_and_not_a_regex(self) -> None:
+        """`logs/` is the primary copy, so a mistyped `.*` has to match nothing.
+
+        The row here contains the literal characters; a regex reading of the
+        same pattern matches every command in the file.
+        """
+        self.write_log(support.MACHINE_ID, self.DAY, [*self.lines, _line(1_755_600_004, "a.*b")])
+        ran = support.run_cli("forget", ".*", "--yes")
+        self.assertEqual(ran.code, 0)
+        self.assertEqual(len(self.remaining()), 3)
+
+    def test_it_matches_the_command_and_not_the_directory(self) -> None:
+        """A person forgetting something is naming what they typed."""
+        ran = support.run_cli("forget", "/tmp")
+        self.assertIn("nothing recorded", ran.out)
+
+    def test_credentials_selects_what_the_filter_would_have_caught(self) -> None:
+        ran = support.run_cli("forget", "--credentials", "--yes")
+        self.assertEqual(ran.code, 0)
+        self.assertEqual(self.remaining(), [self.lines[0], self.lines[2]])
+
+
+class TestTheDigest(support.WoswoarTestCase):
+    def test_two_runs_of_the_same_command_are_different_rows(self) -> None:
+        """Why the digest covers the whole line rather than the command.
+
+        Over the command alone, forgetting one `terraform apply` would suppress
+        every future one -- a delete that keeps deleting, arriving later and
+        without a prompt.
+        """
+        first = _line(1_755_600_001, "terraform apply")
+        second = _line(1_755_600_099, "terraform apply")
+        self.assertNotEqual(forget.digest(first), forget.digest(second))
+
+    def test_a_malformed_line_in_the_file_is_skipped_not_fatal(self) -> None:
+        """`sync` reads this file on every run, so an unreadable line must cost
+        one row's suppression rather than every future sync on this machine."""
+        good = forget.digest(_line(1_755_600_001, "git status"))
+        store.private_dir(store.data_dir())
+        store.forgotten_file().write_text(f"not-a-digest\n{good}\n", encoding="utf-8")
+        self.assertEqual(forget.load_digests(), {good})
+
+
+class TestSurvivingIsByteExact(support.WoswoarTestCase):
+    """What `merge` hands to the log file has to be the peer's bytes exactly.
+
+    A filter that re-joined with the wrong separator, or dropped a final line
+    without a newline, would corrupt the day it was meant to clean.
+    """
+
+    def test_the_lines_that_stay_are_unchanged(self) -> None:
+        lines = [_line(1_755_600_001, "one"), _line(1_755_600_002, "two")]
+        plaintext = "".join(f"{line}\n" for line in lines).encode("utf-8")
+        kept = forget.surviving(plaintext, {forget.digest(lines[0])})
+        self.assertEqual(kept, f"{lines[1]}\n".encode())
+
+    def test_a_block_with_no_final_newline_keeps_its_shape(self) -> None:
+        lines = [_line(1_755_600_001, "one"), _line(1_755_600_002, "two")]
+        plaintext = f"{lines[0]}\n{lines[1]}".encode()
+        kept = forget.surviving(plaintext, {forget.digest(lines[1])})
+        self.assertEqual(kept, f"{lines[0]}\n".encode())
+
+    def test_nothing_forgotten_returns_the_same_object(self) -> None:
+        """The fast path every machine that has never run `forget` takes, on
+        every byte of every peer's history, on a one-minute timer."""
+        plaintext = b"anything at all\n"
+        self.assertIs(forget.surviving(plaintext, set()), plaintext)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2016,10 +2016,10 @@ class TestTheDirectoryInThePrompt(DirScopeCase):
 
         prompt = search._prompt_for("dir")
         self.assertLessEqual(len(prompt), len("woswoar (dir ) ") + search._PROMPT_LABEL_MAX)
-        # `_ELLIPSIS`, the same one-column character `_clip` uses on the machine
+        # `ELLIPSIS`, the same one-column character `_clip` uses on the machine
         # column -- three dots would spend two more of the columns this constant
         # exists to save.
-        self.assertIn(search._ELLIPSIS, prompt)
+        self.assertIn(search.ELLIPSIS, prompt)
         self.assertIn("eight", prompt, "the end of the path is what it had to keep")
 
     def test_a_path_either_parser_would_read_is_not_shown_at_all(self) -> None:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -6674,3 +6674,80 @@ class TestTheRepoSaysWhichShapeItIs(SyncTestCase):
         self.assertRegex(out, r"\[FAIL\] repo format")
         self.assertIn(str(archive.REPO_FORMAT + 1), out)
         self.assertIn("upgrade woswoar", out)
+
+
+class TestAForgottenRowIsNotMergedBack(SyncTestCase):
+    """The half of `forget` that a local delete alone does not buy (#256).
+
+    Removing a row from `logs/` is durable only while `state.merged` remembers
+    that the chunk holding it was already read. That record is progress, not
+    history -- rule 8 says losing it costs a re-merge -- so a re-merge, a
+    restored machine or a fresh clone walks the chunk store and writes every
+    forgotten row straight back. The chunk cannot be edited: history is
+    append-only and every peer's signature rests on it. So the only place a
+    forgotten row can be stopped is on its way back out, every time, which is
+    what the digest file is for.
+
+    Driven end to end for the reason rule 3 gives: the property is an
+    interaction between `forget`, `state.json` and the merge path, and a test of
+    any one of the three would be asserting the part that was already believed.
+    """
+
+    SECRET = "export AWS_SECRET_ACCESS_KEY=wharrgarbl"
+
+    def two_machines(self) -> tuple[Fake, Fake]:
+        """alpha publishes a day holding the secret; beta merges it."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            alpha.record("2023-11-14", 1_700_000_001, "git status")
+            alpha.record("2023-11-14", 1_700_000_002, self.SECRET)
+            sync.run()
+
+        beta = self.machine("beta")
+        with beta.active():
+            sync.run()
+        with alpha.active():
+            sync.grant()
+        with beta.active():
+            sync.run()
+            self.assertIn(self.SECRET, beta.commands())
+        return alpha, beta
+
+    @staticmethod
+    def remerge() -> None:
+        """What a restored `state.json` or a fresh clone looks like from here.
+
+        Only the merge bookkeeping is dropped. Deleting the whole file would
+        also drop `signers`, and beta would then refuse alpha's history as
+        unpinned -- which is a different, louder thing than the silent
+        resurrection this is about.
+        """
+        state = sync.State.load()
+        state.merged.clear()
+        state.merged_at.clear()
+        state.save()
+        sync.run()
+
+    def test_forgetting_removes_it_from_this_machine(self) -> None:
+        """The control. Without this the test below passes on a `forget` that
+        never did anything in the first place."""
+        _, beta = self.two_machines()
+        with beta.active():
+            self.assertEqual(support.run_cli("forget", "AWS_SECRET", "--yes").code, 0)
+            self.assertNotIn(self.SECRET, beta.commands())
+
+    def test_a_re_merge_does_not_bring_it_back(self) -> None:
+        _, beta = self.two_machines()
+        with beta.active():
+            support.run_cli("forget", "AWS_SECRET", "--yes")
+            self.remerge()
+            self.assertNotIn(self.SECRET, beta.commands())
+
+    def test_the_rest_of_the_day_survives_the_re_merge(self) -> None:
+        """The fixture that keeps the assertion above from passing vacuously: a
+        merge that dropped the whole chunk would satisfy it too."""
+        _, beta = self.two_machines()
+        with beta.active():
+            support.run_cli("forget", "AWS_SECRET", "--yes")
+            self.remerge()
+            self.assertIn("git status", beta.commands())

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -17,6 +17,7 @@ from .errors import WoswoarError
 from .report import Check, paragraphs
 
 if TYPE_CHECKING:  # `sync` is imported lazily; only the annotations need it.
+    from .forget import Match
     from .sync import Failure, Reader, ReencryptReport
 
 
@@ -1207,6 +1208,94 @@ def cmd_compact(args: argparse.Namespace) -> int:
     return 0
 
 
+#: How much of a command a `forget` listing shows. Long enough that two similar
+#: rows are told apart, short enough that fifty of them are still a list. The
+#: full text is in the log until the moment `--yes` is given, so nothing is lost
+#: by clipping the preview -- and the row a person is about to delete is one
+#: they typed, so the beginning is the half that identifies it.
+FORGET_PREVIEW = 96
+
+
+def _forget_row(found: Match) -> str:
+    """One line of the listing: where it was recorded, when, and what it says."""
+    when = time.strftime("%Y-%m-%d %H:%M", time.localtime(found.record.ts))
+    who = store.host_name(found.host_id) or found.host_id
+    # `make_inert` for the same reason the picker uses it: a recorded command
+    # can contain escape sequences, and this listing is read on a terminal
+    # immediately before somebody answers a question about it.
+    shown = make_inert(found.record.cmd)
+    if len(shown) > FORGET_PREVIEW:
+        shown = shown[:FORGET_PREVIEW] + "..."
+    mark = "published" if found.published else "local only"
+    return f"  {who}  {when}  [{mark}]  {shown}"
+
+
+def cmd_forget(args: argparse.Namespace) -> int:
+    """Remove recorded commands from this machine, and keep them removed."""
+    from . import forget, sync
+
+    state = sync.State.load()
+    try:
+        matches = forget.find(
+            args.pattern or "",
+            only_credentials=args.credentials,
+            exported=state.exported,
+        )
+    except ValueError as exc:
+        print(f"woswoar: {exc}", file=sys.stderr)
+        return 2
+
+    if not matches:
+        what = "look like credentials" if args.credentials else f"contain {args.pattern!r}"
+        print(f"nothing recorded here seems to {what}")
+        return 0
+
+    print(f"{len(matches)} matching command(s):\n")
+    for match in matches:
+        print(_forget_row(match))
+
+    published = sorted({match.day for match in matches if match.published})
+    if published:
+        # Before the prompt rather than after, as `revoke` argues: this is the
+        # reason somebody might answer no and go and rotate a key first, so
+        # printing it alongside the result would be printing it too late to act
+        # on.
+        print(
+            f"\n{sum(1 for m in matches if m.published)} of these have already been published,"
+            f"\non {', '.join(published)}. Published chunks are never rewritten -- history"
+            "\nis append-only and every peer's signature rests on that -- so those rows"
+            "\nstay in the repository and on every machine that has merged them."
+            "\nIf one of them is a credential, rotate it: that is the only thing that"
+            "\nactually takes it out of use."
+        )
+
+    if not args.yes:
+        it = "them" if len(matches) > 1 else "it"
+        print(f"\nNothing was changed. Re-run with --yes to remove {it} from this machine.")
+        return 0
+
+    # Under the sync lock: a sync running alongside this would either seal the
+    # rows being removed or merge into a file being replaced, and both races end
+    # with the forgotten row still on a machine.
+    with sync.lock():
+        # Re-read inside the lock. The listing above was taken outside it, and a
+        # sync that ran in between moves `state.exported` -- which is the number
+        # the rewrite adjusts.
+        state = sync.State.load()
+        removal = forget.apply(
+            forget.find(
+                args.pattern or "", only_credentials=args.credentials, exported=state.exported
+            ),
+            state.exported,
+        )
+        state.exported.update(removal.exported)
+        state.save()
+
+    print(f"\nremoved {removal.rows} row(s) from {removal.files} day file(s)")
+    print("the parse cache was dropped; the next search rebuilds it")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="woswoar",
@@ -1605,6 +1694,40 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_compact.add_argument("--before", help="only days before this YYYY-MM-DD (default: today)")
     p_compact.set_defaults(func=cmd_compact)
+
+    p_forget = sub(
+        "forget",
+        "remove recorded commands from this machine",
+        """
+        For when a secret is typed and the credential filter misses it. The
+        matching rows are removed from the plaintext logs, so they stop being
+        offered by Ctrl-R and stop being counted in stats, and their digests are
+        remembered so that a later sync cannot merge them back.
+
+        It prints what it would remove and changes nothing until you pass --yes.
+        The pattern is a plain substring of the command, not a regular
+        expression: logs/ is the only copy of anything this machine has not
+        published yet, and a mistyped .* there is not recoverable.
+
+        What it cannot do is un-publish. Chunks are never rewritten -- every
+        peer's signature depends on that -- so a row that has already been
+        synced stays in the repository and on every machine that merged it. The
+        listing says which rows those are. If one is a credential, rotate it.
+        """,
+    )
+    p_forget.add_argument(
+        "pattern", nargs="?", help="substring of the command to remove (case-sensitive)"
+    )
+    p_forget.add_argument(
+        "--credentials",
+        action="store_true",
+        help="select every recorded command that looks like it carries a secret",
+    )
+    # Not `_confirm`'s flag. There it means "skip the prompt"; here it is what
+    # makes the command do anything at all, because a dry run that has to be
+    # asked for is a dry run nobody gets when they most need one.
+    p_forget.add_argument("--yes", action="store_true", help="actually remove them")
+    p_forget.set_defaults(func=cmd_forget)
 
     return parser
 

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -1217,34 +1217,38 @@ FORGET_PREVIEW = 96
 
 
 def _forget_row(found: Match) -> str:
-    """One line of the listing: where it was recorded, when, and what it says."""
+    """One line of the listing: where it was recorded, when, and what it says.
+
+    Both peer-controlled fields go through the same door the picker uses.
+    `search.host_label` for the machine, because `_merge_name` writes whatever
+    decrypted out of a peer's `name.age` and sealing one needs no secret -- so
+    the name is chosen by anyone who can push, and this listing is read on a
+    terminal immediately before somebody answers a delete question about it.
+    `make_inert` for the command, for the same reason one step closer to home.
+    """
     when = time.strftime("%Y-%m-%d %H:%M", time.localtime(found.record.ts))
-    who = store.host_name(found.host_id) or found.host_id
-    # `make_inert` for the same reason the picker uses it: a recorded command
-    # can contain escape sequences, and this listing is read on a terminal
-    # immediately before somebody answers a question about it.
     shown = make_inert(found.record.cmd)
     if len(shown) > FORGET_PREVIEW:
-        shown = shown[:FORGET_PREVIEW] + "..."
+        # `search._ELLIPSIS` is the picker's and trims the *tail*; a row about to
+        # be deleted is one the person typed, so the beginning identifies it and
+        # the clip goes the other way. The character is the same on purpose.
+        shown = shown[:FORGET_PREVIEW] + search.ELLIPSIS
     mark = "published" if found.published else "local only"
-    return f"  {who}  {when}  [{mark}]  {shown}"
+    return f"  {search.host_label(found.host_id)}  {when}  [{mark}]  {shown}"
 
 
 def cmd_forget(args: argparse.Namespace) -> int:
     """Remove recorded commands from this machine, and keep them removed."""
     from . import forget, sync
 
-    state = sync.State.load()
-    try:
-        matches = forget.find(
-            args.pattern or "",
-            only_credentials=args.credentials,
-            exported=state.exported,
-        )
-    except ValueError as exc:
-        print(f"woswoar: {exc}", file=sys.stderr)
-        return 2
-
+    # `State` only to answer "has this row left the machine yet", which is the
+    # difference between a row somebody can simply be rid of and one whose
+    # credential has to be rotated. The removal reloads it under the lock.
+    matches = forget.find(
+        args.pattern or "",
+        only_credentials=args.credentials,
+        exported=sync.State.load().exported,
+    )
     if not matches:
         what = "look like credentials" if args.credentials else f"contain {args.pattern!r}"
         print(f"nothing recorded here seems to {what}")
@@ -1254,19 +1258,19 @@ def cmd_forget(args: argparse.Namespace) -> int:
     for match in matches:
         print(_forget_row(match))
 
-    published = sorted({match.day for match in matches if match.published})
-    if published:
+    gone = [match for match in matches if match.published]
+    if gone:
         # Before the prompt rather than after, as `revoke` argues: this is the
         # reason somebody might answer no and go and rotate a key first, so
         # printing it alongside the result would be printing it too late to act
-        # on.
+        # on. One list, so the count and the days provably describe the same rows.
+        days = ", ".join(sorted({store.day_of_log(match.relpath) for match in gone}))
         print(
-            f"\n{sum(1 for m in matches if m.published)} of these have already been published,"
-            f"\non {', '.join(published)}. Published chunks are never rewritten -- history"
-            "\nis append-only and every peer's signature rests on that -- so those rows"
-            "\nstay in the repository and on every machine that has merged them."
-            "\nIf one of them is a credential, rotate it: that is the only thing that"
-            "\nactually takes it out of use."
+            f"\n{len(gone)} of these have already been published, on {days}."
+            "\nPublished chunks are never rewritten -- history is append-only and every"
+            "\npeer's signature rests on that -- so those rows stay in the repository and"
+            "\non every machine that has merged them. If one of them is a credential,"
+            "\nrotate it: that is the only thing that actually takes it out of use."
         )
 
     if not args.yes:
@@ -1274,24 +1278,13 @@ def cmd_forget(args: argparse.Namespace) -> int:
         print(f"\nNothing was changed. Re-run with --yes to remove {it} from this machine.")
         return 0
 
-    # Under the sync lock: a sync running alongside this would either seal the
-    # rows being removed or merge into a file being replaced, and both races end
-    # with the forgotten row still on a machine.
-    with sync.lock():
-        # Re-read inside the lock. The listing above was taken outside it, and a
-        # sync that ran in between moves `state.exported` -- which is the number
-        # the rewrite adjusts.
-        state = sync.State.load()
-        removal = forget.apply(
-            forget.find(
-                args.pattern or "", only_credentials=args.credentials, exported=state.exported
-            ),
-            state.exported,
-        )
-        state.exported.update(removal.exported)
-        state.save()
-
-    print(f"\nremoved {removal.rows} row(s) from {removal.files} day file(s)")
+    # Only what was on screen. `forget_rows` searches again under the lock, so a
+    # row recorded since the listing would otherwise be deleted without ever
+    # having been shown.
+    removed = sync.forget_rows(
+        args.pattern or "", args.credentials, {forget.digest(match.line) for match in matches}
+    )
+    print(f"\nremoved {len(removed)} row(s) from {len({m.relpath for m in removed})} day file(s)")
     print("the parse cache was dropped; the next search rebuilds it")
     return 0
 

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -1229,7 +1229,7 @@ def _forget_row(found: Match) -> str:
     when = time.strftime("%Y-%m-%d %H:%M", time.localtime(found.record.ts))
     shown = make_inert(found.record.cmd)
     if len(shown) > FORGET_PREVIEW:
-        # `search._ELLIPSIS` is the picker's and trims the *tail*; a row about to
+        # `search.ELLIPSIS` is the picker's and trims the *tail*; a row about to
         # be deleted is one the person typed, so the beginning identifies it and
         # the clip goes the other way. The character is the same on purpose.
         shown = shown[:FORGET_PREVIEW] + search.ELLIPSIS

--- a/woswoar/forget.py
+++ b/woswoar/forget.py
@@ -1,0 +1,304 @@
+"""Removing a recorded command from this machine, and keeping it removed.
+
+`docs/security.md` already said two true things: that no pattern catches every
+credential, and that "Revoking cannot take back what was already published."
+Neither was the gap. The gap was that the **local** half had no answer either: a
+secret typed once stayed in `logs/`, was offered by every Ctrl-R, and counted in
+`stats`, with nothing to run and nothing documented except rebuilding the
+repository. That half is entirely within this machine's power, and this module
+is it -- the document now says so as "Forgetting is local; publishing is not."
+
+Three things decide the shape.
+
+**`logs/` is the primary copy.** Rule 8 calls it that: `history/` is derived and
+rebuildable, `logs/` is not. So the selector is a plain substring rather than a
+regex -- a mistyped `.*` deletes history no copy anywhere can return -- the
+matches are printed in full before anything is written, nothing happens without
+`--yes`, and the rewrite goes through `store.write_atomic` so a crash leaves the
+day as it was rather than half of it.
+
+**Chunks are never rewritten.** `docs/security.md` and
+`tests/test_sync.py::TestImmutability` both rest on history being append-only,
+and the signatures rest on it too. A `forget` that edited a published chunk
+would break the invariant and every peer would refuse the result anyway. So what
+is published stays published, and the command's job there is to *say so*, by
+name and day, rather than to fall silent -- the person needs to rotate the
+credential, and that is the only honest answer available.
+
+**A local delete undoes itself without a digest.** `state.merged` is what stops
+a merged chunk being read again, and `state.exported` is what stops this
+machine's own lines being sealed twice -- but `state.json` is progress, not
+history, and rule 8 says losing it costs a re-merge. A re-merge, or a fresh
+clone, walks the chunk store and writes every forgotten row straight back into
+`logs/`. So the digests live in their own file, outside `state.json` and outside
+the repository, and `merge` drops any line whose digest is in it. Storing a
+digest rather than the text is the point: this has to *recognise* the row, not
+keep a plaintext copy of the thing somebody asked to be rid of.
+
+What is deliberately not here is propagating a forget to peers. woswoar has the
+shape for it -- `recipients.txt` is `merge=union` with tombstones -- but a
+published tombstone is a new signed record type that publishes the fact and the
+time that something was forgotten, which is metadata that did not exist before.
+That is its own issue if the local command turns out not to be enough.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import re
+from typing import NamedTuple
+
+from . import entry, store
+from .entry import Entry
+
+#: One digest per line, lowercase hex, in the order they were forgotten.
+_DIGEST = re.compile(r"^[0-9a-f]{64}$")
+
+
+def digest(line: str) -> str:
+    """The name a forgotten row is remembered by.
+
+    The **whole stored line**, not the command: six fields, exactly as they sit
+    in the log and exactly as they arrive again inside a chunk. Two runs of the
+    same command differ in their timestamp, so a digest over the command alone
+    would quietly suppress a future row nobody asked to forget -- which is the
+    same class of mistake as a regex selector, arriving later and without a
+    prompt.
+
+    sha256 rather than something shorter: this is compared against every line of
+    every chunk a peer publishes, so a collision is a line that vanishes from
+    somebody's history for no reason they could ever find.
+    """
+    return hashlib.sha256(line.encode("utf-8", "surrogateescape")).hexdigest()
+
+
+def load_digests() -> set[str]:
+    """Every digest this machine has been told to forget.
+
+    A malformed line is skipped rather than fatal, and that direction is
+    deliberate: the failure of skipping is that one forgotten row could come
+    back on a re-merge, which is visible and can be forgotten again. The failure
+    of raising is that `sync` stops working on every machine that ever ran this
+    command, which is not.
+    """
+    try:
+        text = store.forgotten_file().read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    return {line.strip() for line in text.splitlines() if _DIGEST.match(line.strip())}
+
+
+def remember(digests: list[str]) -> None:
+    """Add ``digests`` to the file, keeping what is already there.
+
+    Appended rather than rewritten, and read back first so a repeated `forget`
+    does not grow the file with names it already holds. Order is the order they
+    were forgotten in, which is the only order this file has any claim to.
+    """
+    known = load_digests()
+    fresh = [name for name in dict.fromkeys(digests) if name not in known]
+    if not fresh:
+        return
+    with store.private_append(store.forgotten_file()) as out:
+        for name in fresh:
+            out.write(f"{name}\n")
+
+
+class Match(NamedTuple):
+    """One recorded row that the selector picked out."""
+
+    #: Path relative to ``logs/``, which is also `state.exported`'s key.
+    relpath: str
+    host_id: str
+    day: str
+    #: Byte offset of the line in its file, and its length *including* the
+    #: newline. Both are needed to move `state.exported` by the right amount.
+    offset: int
+    length: int
+    #: The line as stored, without its newline. What `digest` is taken over.
+    line: str
+    record: Entry
+    #: Whether this row has left the machine. For this machine's own logs that
+    #: is `state.exported`'s watermark; for another host's it is simply true --
+    #: the row is here because that host published it.
+    published: bool
+
+
+def _lines(raw: bytes) -> list[tuple[int, bytes]]:
+    """``(offset, line-with-newline)`` for each line of a log file.
+
+    `bytes.splitlines` on `\\r` as well as `\\n` would be wrong for a format
+    that escapes both, so the split is on `\\n` alone and the newline is put
+    back -- a final line without one (a shell killed mid-append) keeps its exact
+    bytes, which is what makes the rewrite below byte-preserving for everything
+    it does not remove.
+    """
+    found: list[tuple[int, bytes]] = []
+    offset = 0
+    for piece in raw.split(b"\n"):
+        if not piece and offset == len(raw):
+            break  # the empty piece after a trailing newline
+        line = piece + b"\n" if offset + len(piece) < len(raw) else piece
+        found.append((offset, line))
+        offset += len(line)
+    return found
+
+
+def find(
+    needle: str = "",
+    *,
+    only_credentials: bool = False,
+    exported: dict[str, int] | None = None,
+) -> list[Match]:
+    """Every recorded row the selector picks, oldest file first.
+
+    ``needle`` is a substring of the command as it was typed -- see the module
+    docstring for why it is not a regex. ``only_credentials`` runs
+    `credentials.looks_like_credential` instead, which is the read-only `scan`
+    #54 asked for without a second verb to learn.
+
+    Matched against the command alone. The directory and the session are
+    recorded rather than typed, and a person asking to forget something is
+    naming what they typed; a substring that happened to appear in a path would
+    take rows they never looked at.
+    """
+    if not needle and not only_credentials:
+        # An empty substring is in every command, so this would select the whole
+        # history. Refused here rather than at the CLI because `find` is what
+        # any future caller reaches, and the cost of getting it wrong is the
+        # primary copy.
+        raise ValueError("forget needs something to match; an empty pattern selects everything")
+
+    # Imported here rather than at the top, and that is what keeps this module
+    # cheap enough for `sync` to hold. `merge` consults `load_digests` and
+    # `surviving` on a one-minute timer and never selects anything; the
+    # credential rules are the CLI's alone, and 277 us of import for them on
+    # every background sync is 277 us for nothing.
+    from . import credentials
+
+    watermarks = exported or {}
+    extra = credentials.user_pattern() if only_credentials else None
+    mine = store.machine().id
+    found: list[Match] = []
+    for log in store.iter_log_files():
+        try:
+            raw = log.path.read_bytes()
+        except OSError:
+            # Gone between the listing and the read. Nothing to forget in a file
+            # that is not there, and refusing the whole run over it would make
+            # an ordinary race fatal.
+            continue
+        day = store.day_of_log(log.relpath)
+        watermark = watermarks.get(log.relpath, 0)
+        # Another host's rows reached this machine inside a chunk that host
+        # signed and published, so they are published by construction. Only this
+        # machine's own logs have a not-yet-sealed tail, and `state.exported` is
+        # where its length is kept.
+        theirs = log.host_id != mine
+        for offset, blob in _lines(raw):
+            text = blob.decode("utf-8", "surrogateescape").rstrip("\n")
+            record = entry.parse_line(text, log.host_id)
+            if record is None:
+                continue
+            if not (
+                credentials.looks_like_credential(record.cmd, extra)
+                if only_credentials
+                else needle in record.cmd
+            ):
+                continue
+            found.append(
+                Match(
+                    relpath=log.relpath,
+                    host_id=log.host_id,
+                    day=day,
+                    offset=offset,
+                    length=len(blob),
+                    line=text,
+                    record=record,
+                    published=theirs or offset + len(blob) <= watermark,
+                )
+            )
+    return found
+
+
+class Removal(NamedTuple):
+    """What `apply` did, for the caller to print."""
+
+    rows: int
+    files: int
+    #: New `state.exported` values for the files whose sealed prefix shrank.
+    exported: dict[str, int]
+
+
+def apply(matches: list[Match], exported: dict[str, int] | None = None) -> Removal:
+    """Rewrite each affected day file without ``matches``, and remember them.
+
+    The watermark arithmetic is the part that is easy to leave out and silent
+    when it is. `state.exported[relpath]` is a byte count into the plaintext
+    log, and `sync.export` takes the tail from there -- so a file that loses
+    bytes *below* the watermark and keeps the old number would stop publishing
+    exactly as many bytes of real history as were removed, with nothing said.
+    Every removed line that ended at or before the watermark therefore moves it
+    down by its own length.
+
+    The digests are written **before** the files, so a crash between the two
+    leaves a machine that will not re-merge a row it still holds -- an ordinary
+    duplicate-suppression state -- rather than one that has deleted a row and
+    forgotten it was told to.
+    """
+    if not matches:
+        return Removal(0, 0, {})
+
+    watermarks = dict(exported or {})
+    remember([digest(match.line) for match in matches])
+
+    by_file: dict[str, list[Match]] = {}
+    for match in matches:
+        by_file.setdefault(match.relpath, []).append(match)
+
+    moved: dict[str, int] = {}
+    for relpath, taken in by_file.items():
+        path = store.logs_dir() / relpath
+        try:
+            raw = path.read_bytes()
+        except OSError:
+            continue
+        drop = {match.offset for match in taken}
+        kept = b"".join(blob for offset, blob in _lines(raw) if offset not in drop)
+        store.write_atomic(path, kept)
+        watermark = watermarks.get(relpath)
+        if watermark is not None:
+            below = sum(m.length for m in taken if m.offset + m.length <= watermark)
+            if below:
+                moved[relpath] = watermark - below
+
+    # Derived from `logs/`, keyed by (path, offset), and both just moved. Rule 8
+    # calls a cache the cheap thing to throw away, and this is cheaper still
+    # than reasoning about which of its offsets survived.
+    with contextlib.suppress(OSError):
+        store.cache_file().unlink()
+
+    return Removal(len(matches), len(by_file), moved)
+
+
+def surviving(plaintext: bytes, suppressed: frozenset[str] | set[str]) -> bytes:
+    """``plaintext`` with every forgotten line removed, for `sync.merge`.
+
+    The whole reason the digests are not in `state.json`. A chunk keeps the row
+    for ever -- history is append-only and that is a security property -- so the
+    only place a forgotten row can be stopped is on its way back out, every time.
+
+    Returns the argument itself when nothing is forgotten, which is the case on
+    every machine that has never run `forget`: one set lookup guards a path that
+    otherwise splits and rejoins every byte of every peer's history on every
+    sync.
+    """
+    if not suppressed:
+        return plaintext
+    kept = [
+        blob
+        for _, blob in _lines(plaintext)
+        if digest(blob.decode("utf-8", "surrogateescape").rstrip("\n")) not in suppressed
+    ]
+    return b"".join(kept)

--- a/woswoar/forget.py
+++ b/woswoar/forget.py
@@ -14,8 +14,9 @@ Three things decide the shape.
 rebuildable, `logs/` is not. So the selector is a plain substring rather than a
 regex -- a mistyped `.*` deletes history no copy anywhere can return -- the
 matches are printed in full before anything is written, nothing happens without
-`--yes`, and the rewrite goes through `store.write_atomic` so a crash leaves the
-day as it was rather than half of it.
+`--yes`, and a row still being appended is not a row at all: `_rows` stops where
+`store.read_tail` stops, so every pipeline that reads these files agrees on
+where one ends.
 
 **Chunks are never rewritten.** `docs/security.md` and
 `tests/test_sync.py::TestImmutability` both rest on history being append-only,
@@ -31,15 +32,21 @@ machine's own lines being sealed twice -- but `state.json` is progress, not
 history, and rule 8 says losing it costs a re-merge. A re-merge, or a fresh
 clone, walks the chunk store and writes every forgotten row straight back into
 `logs/`. So the digests live in their own file, outside `state.json` and outside
-the repository, and `merge` drops any line whose digest is in it. Storing a
-digest rather than the text is the point: this has to *recognise* the row, not
-keep a plaintext copy of the thing somebody asked to be rid of.
+the repository, and every writer into `logs/` consults it: `sync._Day` on the
+merge path and `importer` through `keep` on the import one. Storing a digest
+rather than the text is the point: this has to *recognise* the row, not keep a
+plaintext copy of the thing somebody asked to be rid of.
 
-What is deliberately not here is propagating a forget to peers. woswoar has the
-shape for it -- `recipients.txt` is `merge=union` with tombstones -- but a
-published tombstone is a new signed record type that publishes the fact and the
-time that something was forgotten, which is metadata that did not exist before.
-That is its own issue if the local command turns out not to be enough.
+The transaction itself is deliberately **not** here. Rewriting a log and moving
+`state.exported` is one operation, and what `state.exported` means belongs to
+`sync` -- so `sync.forget_rows` owns the lock, the load, the apply and the save,
+and this module keeps the one-way edge it was given.
+
+What is deliberately not here at all is propagating a forget to peers. woswoar
+has the shape for it -- `recipients.txt` is `merge=union` with tombstones -- but
+a published tombstone is a new signed record type that publishes the fact and
+the time that something was forgotten, which is metadata that did not exist
+before. That is its own issue if the local command turns out not to be enough.
 """
 
 from __future__ import annotations
@@ -47,13 +54,33 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import re
+from collections.abc import Iterator
 from typing import NamedTuple
 
 from . import entry, store
 from .entry import Entry
+from .errors import WoswoarError
 
 #: One digest per line, lowercase hex, in the order they were forgotten.
 _DIGEST = re.compile(r"^[0-9a-f]{64}$")
+
+#: How a stored line becomes bytes, in the one place both spellings agree on.
+#: ``surrogateescape`` rather than the ``replace`` used for display: two distinct
+#: byte sequences must not collapse into one string here, or a digest could
+#: suppress a row nobody named.
+_CODEC = ("utf-8", "surrogateescape")
+
+
+def _of(row: bytes) -> str:
+    """`digest`, for a caller that already has the bytes.
+
+    The hot path: `surviving` runs this over every line of every chunk a peer
+    publishes. Hashing the bytes directly rather than decoding and re-encoding
+    them saves two allocations a line, measured at 50.7 ms against 58.0 ms over
+    52,000 lines. The two spellings are the same function -- the round trip is a
+    bijection under ``surrogateescape`` -- and `TestTheDigest` pins that.
+    """
+    return hashlib.sha256(row).hexdigest()
 
 
 def digest(line: str) -> str:
@@ -70,7 +97,7 @@ def digest(line: str) -> str:
     every chunk a peer publishes, so a collision is a line that vanishes from
     somebody's history for no reason they could ever find.
     """
-    return hashlib.sha256(line.encode("utf-8", "surrogateescape")).hexdigest()
+    return _of(line.encode(*_CODEC))
 
 
 def load_digests() -> set[str]:
@@ -108,48 +135,60 @@ def remember(digests: list[str]) -> None:
 class Match(NamedTuple):
     """One recorded row that the selector picked out."""
 
-    #: Path relative to ``logs/``, which is also `state.exported`'s key.
+    #: Path relative to ``logs/``, which is also `state.exported`'s key. The day
+    #: is `store.day_of_log` of this, derived rather than carried so that a
+    #: `Match` cannot hold a day and a path that disagree.
     relpath: str
     host_id: str
-    day: str
     #: Byte offset of the line in its file, and its length *including* the
     #: newline. Both are needed to move `state.exported` by the right amount.
+    #:
+    #: These stay valid between `find` and `apply` only because the logs are
+    #: append-only: a command recorded in between lands past every offset here
+    #: and shifts nothing. That is the load-bearing assumption of this module,
+    #: and the reason `sync.forget_rows` re-finds under the lock anyway -- a
+    #: merge may rewrite a *peer's* day file wholesale, which does shift them.
     offset: int
     length: int
-    #: The line as stored, without its newline. What `digest` is taken over.
+    #: The line as stored, without its newline. What `digest` is taken over, and
+    #: not reconstructible from `record`, which has been unescaped and truncated.
     line: str
     record: Entry
-    #: Whether this row has left the machine. For this machine's own logs that
-    #: is `state.exported`'s watermark; for another host's it is simply true --
-    #: the row is here because that host published it.
+    #: Whether this row has left the machine. For this machine's own logs that is
+    #: `state.exported`'s watermark; for another host's it is simply true -- the
+    #: row is here because that host published it.
     published: bool
 
 
-def _lines(raw: bytes) -> list[tuple[int, bytes]]:
-    """``(offset, line-with-newline)`` for each line of a log file.
+def _rows(raw: bytes) -> Iterator[tuple[int, bytes]]:
+    """``(offset, line-with-newline)`` for each **complete** line of a log file.
 
-    `bytes.splitlines` on `\\r` as well as `\\n` would be wrong for a format
-    that escapes both, so the split is on `\\n` alone and the newline is put
-    back -- a final line without one (a shell killed mid-append) keeps its exact
-    bytes, which is what makes the rewrite below byte-preserving for everything
-    it does not remove.
+    Complete, and that is the whole subtlety. `store.read_tail` deliberately
+    leaves a partly written final line unconsumed -- a shell killed mid-append,
+    or, far more often, the hook appending right now -- and this has to give the
+    same answer. Otherwise `forget` offers to delete a record that is still
+    being written, on the primary copy, and leaves its writer's remaining bytes
+    to land on some other line. `read_tail`'s own docstring says the two
+    pipelines reading these files must agree on where one ends; this is the
+    third.
+
+    A generator rather than a list: as a list, 52,000 lines retained 9.3 MiB,
+    3.4x the file they came from, and every caller walks them once in order.
+
+    Split on ``\\n`` alone, because the format escapes ``\\r`` -- so
+    `bytes.splitlines` would invent a line break inside a recorded command.
     """
-    found: list[tuple[int, bytes]] = []
     offset = 0
-    for piece in raw.split(b"\n"):
-        if not piece and offset == len(raw):
-            break  # the empty piece after a trailing newline
-        line = piece + b"\n" if offset + len(piece) < len(raw) else piece
-        found.append((offset, line))
-        offset += len(line)
-    return found
+    while (end := raw.find(b"\n", offset)) >= 0:
+        yield offset, raw[offset : end + 1]
+        offset = end + 1
 
 
 def find(
     needle: str = "",
     *,
     only_credentials: bool = False,
-    exported: dict[str, int] | None = None,
+    exported: dict[str, int],
 ) -> list[Match]:
     """Every recorded row the selector picks, oldest file first.
 
@@ -158,6 +197,11 @@ def find(
     `credentials.looks_like_credential` instead, which is the read-only `scan`
     #54 asked for without a second verb to learn.
 
+    ``exported`` is `state.exported`, and is required rather than defaulted
+    because there is no safe value to guess: without it every one of this
+    machine's own rows reports ``local only``, which is the line telling somebody
+    they do *not* need to rotate a credential.
+
     Matched against the command alone. The directory and the session are
     recorded rather than typed, and a person asking to forget something is
     naming what they typed; a substring that happened to appear in a path would
@@ -165,10 +209,13 @@ def find(
     """
     if not needle and not only_credentials:
         # An empty substring is in every command, so this would select the whole
-        # history. Refused here rather than at the CLI because `find` is what
-        # any future caller reaches, and the cost of getting it wrong is the
-        # primary copy.
-        raise ValueError("forget needs something to match; an empty pattern selects everything")
+        # history. Refused here rather than at the CLI because `find` is what any
+        # future caller reaches, and the cost of getting it wrong is the primary
+        # copy. A `WoswoarError` so `main`'s own handler prints it, rather than a
+        # second copy of that handler at the call site.
+        raise WoswoarError(
+            "forget needs something to match; an empty pattern would select everything"
+        )
 
     # Imported here rather than at the top, and that is what keeps this module
     # cheap enough for `sync` to hold. `merge` consults `load_digests` and
@@ -177,7 +224,6 @@ def find(
     # every background sync is 277 us for nothing.
     from . import credentials
 
-    watermarks = exported or {}
     extra = credentials.user_pattern() if only_credentials else None
     mine = store.machine().id
     found: list[Match] = []
@@ -186,18 +232,17 @@ def find(
             raw = log.path.read_bytes()
         except OSError:
             # Gone between the listing and the read. Nothing to forget in a file
-            # that is not there, and refusing the whole run over it would make
-            # an ordinary race fatal.
+            # that is not there, and refusing the whole run over it would make an
+            # ordinary race fatal.
             continue
-        day = store.day_of_log(log.relpath)
-        watermark = watermarks.get(log.relpath, 0)
+        watermark = exported.get(log.relpath, 0)
         # Another host's rows reached this machine inside a chunk that host
         # signed and published, so they are published by construction. Only this
         # machine's own logs have a not-yet-sealed tail, and `state.exported` is
         # where its length is kept.
         theirs = log.host_id != mine
-        for offset, blob in _lines(raw):
-            text = blob.decode("utf-8", "surrogateescape").rstrip("\n")
+        for offset, blob in _rows(raw):
+            text = blob.decode(*_CODEC).rstrip("\n")
             record = entry.parse_line(text, log.host_id)
             if record is None:
                 continue
@@ -211,7 +256,6 @@ def find(
                 Match(
                     relpath=log.relpath,
                     host_id=log.host_id,
-                    day=day,
                     offset=offset,
                     length=len(blob),
                     line=text,
@@ -222,25 +266,19 @@ def find(
     return found
 
 
-class Removal(NamedTuple):
-    """What `apply` did, for the caller to print."""
+def apply(matches: list[Match], exported: dict[str, int]) -> dict[str, int]:
+    """Rewrite each affected day file without ``matches``; return moved watermarks.
 
-    rows: int
-    files: int
-    #: New `state.exported` values for the files whose sealed prefix shrank.
-    exported: dict[str, int]
-
-
-def apply(matches: list[Match], exported: dict[str, int] | None = None) -> Removal:
-    """Rewrite each affected day file without ``matches``, and remember them.
+    Called only by `sync.forget_rows`, which holds the lock and owns saving what
+    this returns. See `Match.offset` for why the offsets are still good.
 
     The watermark arithmetic is the part that is easy to leave out and silent
-    when it is. `state.exported[relpath]` is a byte count into the plaintext
-    log, and `sync.export` takes the tail from there -- so a file that loses
-    bytes *below* the watermark and keeps the old number would stop publishing
-    exactly as many bytes of real history as were removed, with nothing said.
-    Every removed line that ended at or before the watermark therefore moves it
-    down by its own length.
+    when it is. `state.exported[relpath]` is a byte count into the plaintext log
+    and `sync.export` takes the tail from there, so a file that loses bytes
+    *below* the watermark while the number stays put would stop publishing
+    exactly that many bytes of real history, with nothing said. Every removed
+    line ending at or before the watermark therefore moves it down by its own
+    length.
 
     The digests are written **before** the files, so a crash between the two
     leaves a machine that will not re-merge a row it still holds -- an ordinary
@@ -248,9 +286,8 @@ def apply(matches: list[Match], exported: dict[str, int] | None = None) -> Remov
     forgotten it was told to.
     """
     if not matches:
-        return Removal(0, 0, {})
+        return {}
 
-    watermarks = dict(exported or {})
     remember([digest(match.line) for match in matches])
 
     by_file: dict[str, list[Match]] = {}
@@ -261,25 +298,47 @@ def apply(matches: list[Match], exported: dict[str, int] | None = None) -> Remov
     for relpath, taken in by_file.items():
         path = store.logs_dir() / relpath
         try:
-            raw = path.read_bytes()
+            # The handle is held **across** the replacement, and that is what
+            # makes this safe on a file the shell hook appends to. The hook takes
+            # no lock -- it must not fork on the record path, and CI asserts that
+            # -- so a command can land between the read and the `os.replace`, on
+            # an inode this is about to unlink. Reading on afterwards recovers
+            # exactly those bytes, and they are well defined because the logs are
+            # append-only. Without this, `forget` is the one operation in the
+            # tree that can silently drop a line from the primary copy.
+            with path.open("rb") as handle:
+                raw = handle.read()
+                drop = {match.offset for match in taken}
+                kept = b"".join(blob for offset, blob in _rows(raw) if offset not in drop)
+                # Whatever follows the last newline is a line still being
+                # written. `_rows` does not yield it, `find` never matched it,
+                # and it has to survive the rewrite. `rfind` of -1 means no
+                # complete line at all, and then all of it is that tail.
+                kept += raw[raw.rfind(b"\n") + 1 :]
+                store.write_atomic(path, kept)
+                late = handle.read()
         except OSError:
             continue
-        drop = {match.offset for match in taken}
-        kept = b"".join(blob for offset, blob in _lines(raw) if offset not in drop)
-        store.write_atomic(path, kept)
-        watermark = watermarks.get(relpath)
+        if late:
+            with store.private_append(path, binary=True) as out:
+                out.write(late)
+        watermark = exported.get(relpath)
         if watermark is not None:
             below = sum(m.length for m in taken if m.offset + m.length <= watermark)
             if below:
                 moved[relpath] = watermark - below
 
-    # Derived from `logs/`, keyed by (path, offset), and both just moved. Rule 8
-    # calls a cache the cheap thing to throw away, and this is cheaper still
-    # than reasoning about which of its offsets survived.
+    # Belt and braces rather than the load-bearing step, and worth saying which:
+    # `cache.refresh` already re-parses a file whose size went *down*, so the
+    # ordinary case heals itself. What it does not catch is a file that ended in
+    # a partial line, where the size can be unchanged from its point of view.
+    # Dropping the whole cache costs one rebuild on the next search and needs no
+    # reasoning about which of its offsets survived -- rule 8's judgement about
+    # derived things, applied to the one command that shortens a log.
     with contextlib.suppress(OSError):
         store.cache_file().unlink()
 
-    return Removal(len(matches), len(by_file), moved)
+    return moved
 
 
 def surviving(plaintext: bytes, suppressed: frozenset[str] | set[str]) -> bytes:
@@ -289,16 +348,51 @@ def surviving(plaintext: bytes, suppressed: frozenset[str] | set[str]) -> bytes:
     for ever -- history is append-only and that is a security property -- so the
     only place a forgotten row can be stopped is on its way back out, every time.
 
-    Returns the argument itself when nothing is forgotten, which is the case on
-    every machine that has never run `forget`: one set lookup guards a path that
-    otherwise splits and rejoins every byte of every peer's history on every
-    sync.
+    Returns the argument itself when there is nothing to drop, which covers both
+    common cases: a machine that has never run `forget`, where this is one truth
+    test per chunk, and one that has, whose chunks almost all hold none of what
+    it forgot. Rebuilding a 4 MB block that lost nothing measured 4.4 ms and a
+    full second copy of it.
+
+    No offsets here, unlike `_rows`: nothing downstream wants them, and
+    computing them cost 28 ms of this function's 100 ms per 52,000 lines.
     """
     if not suppressed:
         return plaintext
-    kept = [
-        blob
-        for _, blob in _lines(plaintext)
-        if digest(blob.decode("utf-8", "surrogateescape").rstrip("\n")) not in suppressed
-    ]
-    return b"".join(kept)
+    kept: list[bytes] = []
+    dropped = False
+    offset = 0
+    while offset < len(plaintext):
+        end = plaintext.find(b"\n", offset)
+        stop = len(plaintext) if end < 0 else end
+        # Hashed without the newline, because that is how the line sits in the
+        # log and therefore what `digest` was taken over; kept *with* it, so a
+        # block that never had a final one keeps its shape.
+        if _of(plaintext[offset:stop]) in suppressed:
+            dropped = True
+        else:
+            kept.append(plaintext[offset : stop + 1])
+        offset = stop + 1
+    return b"".join(kept) if dropped else plaintext
+
+
+def keep(entries: list[Entry]) -> list[Entry]:
+    """``entries`` without the ones this machine has been told to forget.
+
+    For `importer`, which is the *other* door into `logs/`, and the reason the
+    module docstring says every writer consults the list rather than just the
+    merge path. `run_atuin` deduplicates against `store.existing_keys`, which
+    reads the log files -- so once `forget` has taken a row out, the next import
+    no longer sees it as already present and writes it back verbatim, same six
+    fields and same digest. The credential filter is the only thing in the way,
+    and it is the filter whose misses `forget` exists for.
+
+    Honest limit: this recognises a row only when the re-import reproduces the
+    same six fields. An atuin re-import does, since the session and the
+    timestamps come out of atuin's own database. A shell-history import that
+    synthesises different values does not, and no digest over the record could.
+    """
+    suppressed = load_digests()
+    if not suppressed:
+        return entries
+    return [item for item in entries if digest(entry.format_line(item)) not in suppressed]

--- a/woswoar/importer.py
+++ b/woswoar/importer.py
@@ -415,6 +415,18 @@ def run_atuin(
             )
         entries_by_host[host_id] = fresh
 
+    # Deferred, as `sqlite3` is above and for the same reason: `__main__`
+    # imports this module at the top for the parser, so a keypress would
+    # otherwise pay 295 us of module body for a command it is not running.
+    from . import forget
+
+    # The other door into `logs/`. This deduplicates against
+    # `store.existing_keys`, which reads the log files -- so a row `forget` took
+    # out is no longer seen as already present, and would be written back
+    # verbatim by the next run. See `forget.keep` for what it can and cannot
+    # recognise.
+    entries_by_host = {host: forget.keep(rows) for host, rows in entries_by_host.items()}
+
     imported = sum(len(v) for v in entries_by_host.values())
     if not dry_run:
         for host_id, entries in entries_by_host.items():
@@ -523,6 +535,12 @@ def run(
                 cmd=item.cmd,
             )
         )
+
+    # As in `run_atuin` above, deferred for the same reason: `forget` has to
+    # survive a re-import, and this is the other writer into `logs/`.
+    from . import forget
+
+    entries = forget.keep(entries)
 
     if not dry_run:
         store.append_entries(machine_id, entries)

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -160,7 +160,10 @@ _HOST_WIDTH = 20
 #: Cut here rather than at the end. A name is `user@host`, and the *host* is
 #: what tells two of your machines apart -- it is also the part a long username
 #: pushes off the end.
-_ELLIPSIS = "\u2026"
+#: Public because `__main__`'s `forget` listing clips too, in the other
+#: direction. One spelling of the character, two decisions about which half
+#: of a string it replaces.
+ELLIPSIS = "\u2026"
 
 
 def host_label(host_id: str) -> str:
@@ -199,7 +202,7 @@ def host_labels(hosts: set[str]) -> dict[str, str]:
 
 
 def _clip(label: str, width: int = _HOST_WIDTH) -> str:
-    """Trim to ``width``, keeping the end -- see `_ELLIPSIS`.
+    """Trim to ``width``, keeping the end -- see `ELLIPSIS`.
 
     The default is the machine column, which is where this started. The prompt's
     directory label wants the same operation at a different width, and for the
@@ -208,7 +211,7 @@ def _clip(label: str, width: int = _HOST_WIDTH) -> str:
     """
     if len(label) <= width:
         return label
-    return _ELLIPSIS + label[-(width - 1) :]
+    return ELLIPSIS + label[-(width - 1) :]
 
 
 def command_from_line(line: str, host_width: int = 0) -> str:
@@ -319,7 +322,7 @@ def _safe_for_prompt(label: str) -> str:
     Cut from the left, because `.../woswoar/tests` says which directory it is
     and `~/src/very/deep/...` does not -- and because a machine called
     `martinus@DT-24YY` is told apart by its end too, which is the argument
-    `_ELLIPSIS` already makes for the machine column.
+    `ELLIPSIS` already makes for the machine column.
     """
     if not label or any(
         not char.isalnum() and char not in _PROMPT_SAFE_PUNCTUATION for char in label

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -593,6 +593,27 @@ def state_file() -> Path:
     return data_dir() / "state.json"
 
 
+def forgotten_file() -> Path:
+    """Digests of rows `forget` removed, so a re-merge cannot bring them back.
+
+    Its own file rather than a field in `state.json`, and that is the whole
+    reason it works. `state.json` is progress: rule 8 says losing it costs a
+    re-merge and an export, never a command, and `State.load` degrades every
+    unreadable value to a safe default on purpose. A suppression list cannot
+    live under that promise -- losing it silently un-forgets everything, on the
+    one path (a fresh clone, a restored machine) where somebody is least likely
+    to look. Outside the repository too: what this machine chose to forget is
+    not something the remote needs to know, and publishing it would publish the
+    fact and the time that something was forgotten.
+
+    Not a JSON object either. It is appended to and read whole, one lowercase
+    sha256 per line, so a truncated write costs the last digest rather than the
+    file -- which is the failure mode `write_atomic` exists to avoid for
+    everything that is rewritten instead.
+    """
+    return data_dir() / "forgotten"
+
+
 def sync_stamp_file() -> Path:
     """When a sync was last *started*, as decimal seconds on one line.
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -841,10 +841,11 @@ def forget_rows(needle: str, only_credentials: bool, shown: set[str]) -> list[fo
     The files are rewritten before the watermarks are saved, and that order is
     load-bearing rather than incidental. A crash in between leaves a watermark
     pointing past a file that is now shorter, so `export` publishes nothing for
-    that day until it grows back -- one line lost, and #262 is about making that
-    unreachable. The other order is worse *for this command specifically*: a
-    watermark saved low with the rows still in `logs/` re-seals and re-publishes
-    them, and the row in question is the one somebody just asked to be rid of.
+    that day until it grows back -- one line lost, and #263 is about making that
+    unreachable by checking the mark lands on a line boundary. The other order
+    is worse *for this command specifically*: a watermark saved low with the
+    rows still in `logs/` re-seals and re-publishes them, and the row in
+    question is the one somebody just asked to be rid of.
     """
     with lock():
         state = State.load()

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -820,6 +820,46 @@ def lock() -> Iterator[None]:
         handle.close()
 
 
+def forget_rows(needle: str, only_credentials: bool, shown: set[str]) -> list[forget.Match]:
+    """Remove ``shown`` from this machine's logs, and reseat what that moves.
+
+    Here rather than in `forget` because it is one operation and half of it is
+    `sync`'s: `state.exported` is a byte count into a plaintext log that only
+    `export` knows how to read, and `lock` is what every other command that
+    touches `State` already takes. Split across the two modules it was five
+    ordered steps a second caller would have to rediscover from the CLI, and
+    `forget` would have needed an edge back to this module to hold them.
+
+    ``shown`` is the digests of the rows a person was actually shown. The search
+    is run again in here because the listing was taken outside the lock -- a
+    sync since then may have rewritten a peer's day file and moved every offset
+    -- but only rows that were on screen are removed. Without that intersection,
+    a command recorded between the listing and the ``--yes`` could be deleted
+    having never been displayed, which for this command is the one thing that
+    must not happen.
+
+    The files are rewritten before the watermarks are saved, and that order is
+    load-bearing rather than incidental. A crash in between leaves a watermark
+    pointing past a file that is now shorter, so `export` publishes nothing for
+    that day until it grows back -- one line lost, and #262 is about making that
+    unreachable. The other order is worse *for this command specifically*: a
+    watermark saved low with the rows still in `logs/` re-seals and re-publishes
+    them, and the row in question is the one somebody just asked to be rid of.
+    """
+    with lock():
+        state = State.load()
+        matches = [
+            match
+            for match in forget.find(
+                needle, only_credentials=only_credentials, exported=state.exported
+            )
+            if forget.digest(match.line) in shown
+        ]
+        state.exported.update(forget.apply(matches, state.exported))
+        state.save()
+    return matches
+
+
 class Failure(NamedTuple):
     """A recorded sync failure, and when it happened."""
 
@@ -1640,7 +1680,7 @@ def _merge_host(
     host_id: str,
     state: State,
     report: Report,
-    suppressed: frozenset[str] = frozenset(),
+    suppressed: frozenset[str],
 ) -> None:
     verify_key = _trusted_signer(host_id, state, report)
     if verify_key is None:
@@ -1720,7 +1760,7 @@ def _merge_host(
             continue
 
         listed = manifest.read(host_id, chunk_day, verify_key)
-        day = _Day(host_id, chunk_day, listed, already, suppressed)
+        day = _Day(host_id, chunk_day, listed, already)
         pending = names if day.rewrite else fresh
         directory = archive.chunk_dir(host_id, chunk_day)
         #: Chunk names whose plaintext reached `day`.
@@ -1771,7 +1811,19 @@ def _merge_host(
                 report.record(UNREADABLE, key)
                 continue
 
-            day.add(plaintext, report)
+            # Filtered before the day is assembled, not after, because a
+            # rewrite replaces the file from the chunks alone: anything let
+            # through is what the day *becomes*. `state.merged` stops a chunk
+            # being read twice, so on an ordinary machine this only ever sees
+            # new lines -- but a re-merge, a fresh clone or a compaction rebuild
+            # sends the whole day back through here, which is exactly when a
+            # forgotten row would otherwise return.
+            plaintext = forget.surviving(plaintext, suppressed)
+            if plaintext:
+                day.add(plaintext, report)
+            # Outside the guard on purpose: a chunk whose every line was
+            # forgotten has still been read, and leaving it out of `taken` would
+            # re-read it on every sync for as long as the chunk exists.
             taken.append(name)
 
         # A rewrite *replaces* the day's file, so it must not run on a partial
@@ -1867,10 +1919,8 @@ class _Day:
         day: str,
         listed: dict[str, manifest.ManifestEntry],
         already: frozenset[str],
-        suppressed: frozenset[str] = frozenset(),
     ) -> None:
         self.host_id = host_id
-        self.suppressed = suppressed
         self.day = day
         self.listed = listed
         self.compacted = {name for name, entry in listed.items() if entry.subsumes}
@@ -1906,19 +1956,6 @@ class _Day:
         self._bytes = 0
 
     def add(self, plaintext: bytes, report: Report) -> None:
-        # Filtered here rather than after the day is assembled, because a
-        # rewrite replaces the file from the chunks alone: anything let through
-        # is what the day *becomes*. `state.merged` already stops a chunk being
-        # read twice, so on an ordinary machine this only ever sees new lines --
-        # but a re-merge, a fresh clone or a compaction rebuild sends the whole
-        # day back through here, which is exactly when a forgotten row would
-        # otherwise return.
-        plaintext = forget.surviving(plaintext, self.suppressed)
-        if not plaintext:
-            # Every line in this chunk was forgotten. Recording no block keeps
-            # `flush` from replacing a day with nothing on a rewrite whose only
-            # chunk was entirely suppressed.
-            return
         self._blocks.append(plaintext)
         self._bytes += len(plaintext)
         if self._bytes > FLUSH_BYTES and not self.rewrite:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -42,7 +42,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NamedTuple
 
-from . import archive, codec, crypto, fleet, gitrepo, manifest, progress, store
+from . import archive, codec, crypto, fleet, forget, gitrepo, manifest, progress, store
 from .entry import make_inert
 from .errors import SyncError, WoswoarError
 from .report import Check, Notice
@@ -1573,10 +1573,16 @@ def merge(known: Machine, state: State, report: Report) -> None:
     # rather than skipped in the loop: the phase names the machine being read,
     # and `_merge_host` counts that machine's days underneath it.
     others = [host for host in archive.repo_hosts() if host != known.id]
+    # Read once for the whole merge rather than per host or per chunk. A chunk
+    # keeps a forgotten row for ever -- history is append-only, which is the
+    # point -- so the only place to stop it is here, on every sync, for as long
+    # as the chunk exists. Empty on every machine that has never run `forget`,
+    # and `forget.surviving` returns its argument unchanged for that case.
+    suppressed = frozenset(forget.load_digests())
     for host_id in others:
         progress.phase(f"reading history from {name_for(host_id).text}")
         report.hosts_seen.add(host_id)
-        _merge_host(known, host_id, state, report)
+        _merge_host(known, host_id, state, report, suppressed)
         _merge_name(known, host_id)
 
 
@@ -1629,7 +1635,13 @@ def _stamp(state: State, key: str, stamp: int | None, settled: bool) -> None:
         state.merged_at[key] = stamp
 
 
-def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> None:
+def _merge_host(
+    known: Machine,
+    host_id: str,
+    state: State,
+    report: Report,
+    suppressed: frozenset[str] = frozenset(),
+) -> None:
     verify_key = _trusted_signer(host_id, state, report)
     if verify_key is None:
         return
@@ -1708,7 +1720,7 @@ def _merge_host(known: Machine, host_id: str, state: State, report: Report) -> N
             continue
 
         listed = manifest.read(host_id, chunk_day, verify_key)
-        day = _Day(host_id, chunk_day, listed, already)
+        day = _Day(host_id, chunk_day, listed, already, suppressed)
         pending = names if day.rewrite else fresh
         directory = archive.chunk_dir(host_id, chunk_day)
         #: Chunk names whose plaintext reached `day`.
@@ -1855,8 +1867,10 @@ class _Day:
         day: str,
         listed: dict[str, manifest.ManifestEntry],
         already: frozenset[str],
+        suppressed: frozenset[str] = frozenset(),
     ) -> None:
         self.host_id = host_id
+        self.suppressed = suppressed
         self.day = day
         self.listed = listed
         self.compacted = {name for name, entry in listed.items() if entry.subsumes}
@@ -1892,6 +1906,19 @@ class _Day:
         self._bytes = 0
 
     def add(self, plaintext: bytes, report: Report) -> None:
+        # Filtered here rather than after the day is assembled, because a
+        # rewrite replaces the file from the chunks alone: anything let through
+        # is what the day *becomes*. `state.merged` already stops a chunk being
+        # read twice, so on an ordinary machine this only ever sees new lines --
+        # but a re-merge, a fresh clone or a compaction rebuild sends the whole
+        # day back through here, which is exactly when a forgotten row would
+        # otherwise return.
+        plaintext = forget.surviving(plaintext, self.suppressed)
+        if not plaintext:
+            # Every line in this chunk was forgotten. Recording no block keeps
+            # `flush` from replacing a day with nothing on a rewrite whose only
+            # chunk was entirely suppressed.
+            return
         self._blocks.append(plaintext)
         self._bytes += len(plaintext)
         if self._bytes > FLUSH_BYTES and not self.rewrite:


### PR DESCRIPTION
Closes #256.

`woswoar forget <substring>` removes recorded commands from this machine — out of `logs/`, out of Ctrl-R, out of `stats` — and remembers their digests so a later sync or import cannot write them back. Dry run by default; `--yes` to act; `--credentials` runs the filter over what is already recorded, which is #54's read-only scan arriving as a selector rather than a second verb to learn.

**This waits for a person regardless of CI.** Rule 9 says a change in rule 1's top row does, and this is all three of that row at once: it prunes stored data, it moves a claim in `docs/security.md`, and it drops the parse cache.

## The three constraints the issue names, and what each decided

**`logs/` is the primary copy.** So the selector is a plain substring, not a regex — a mistyped `.*` deletes history no copy anywhere can return. An empty pattern is refused rather than confirmed: there is no answer to "did you mean all of it" worth the chance of a yes. Matches are printed in full before anything is written.

**Chunks are never rewritten.** `TestImmutability` and the signature scheme both rest on it. A row that has already synced stays in the repository and on every machine that merged it, so the command's job there is to *say so* — which rows, which day — and to say that a credential among them needs rotating.

**A local delete undoes itself without a digest.** `state.merged` stops a merged chunk being read twice, but `state.json` is progress: rule 8 says losing it costs a re-merge, and a re-merge or a fresh clone writes every forgotten row straight back. So the digests live in their own file, outside `state.json` and outside the repository, and **every** writer into `logs/` consults it — `sync._Day` on the merge path and `importer` through `forget.keep` on the import one.

`state.exported` is the part that is easy to leave out and silent when it is. It is a byte count into the plaintext log and `export` takes the tail from there, so a file that loses bytes below the watermark while the number stays put stops publishing exactly that many bytes of real history, with nothing said.

## Decisions I made rather than asking

- **Substring, not regex**, and **command only, not cwd or session** — a person forgetting something is naming what they typed.
- **The digest covers the whole stored line**, not the command: over the command alone, forgetting one `terraform apply` would suppress every future one — a delete that keeps deleting, arriving later and without a prompt.
- **`--yes` means "act"**, not `_confirm`'s "skip the prompt". A dry run you have to ask for is a dry run nobody gets when they most need one.
- **The transaction lives in `sync.forget_rows`**, not in `forget` or the CLI: `state.exported`'s meaning belongs to `sync` and `lock` is what every other command touching `State` takes.

## What the rule 1 review changed

Full four-angle `/simplify`, as the top row requires. It found four defects in my own new code, each now with a test that fails when the fix is reverted:

- **A peer chose the machine name printed next to a delete prompt.** The listing hand-rolled `store.host_name(id) or id` — `search.host_label` minus the `make_inert` that function exists for. `_merge_name` writes whatever decrypts out of a peer's `name.age`, and sealing one needs no secret.
- **A line the hook was still writing could be deleted.** `store.read_tail` deliberately leaves a partial final line unconsumed and says the pipelines reading these files must agree where one ends; `_rows` was a third answer that disagreed.
- **A command recorded during the rewrite was lost.** `write_atomic` replaces the inode while the hook appends to the old one without a lock. The handle is now held across the replacement and read on afterwards. This was the one operation in the tree that could silently shorten the primary copy.
- **A re-import brought forgotten rows back.** Both importers dedup against `store.existing_keys`, which reads the log files.

Also from the review: `exported` required rather than defaulted (the default answer is "nothing is published" — the line telling somebody they need not rotate a credential); `suppressed` required on `_merge_host` and `_Day`, where the default was the value that un-forgets everything; `_rows` a generator (as a list it retained 9.3 MiB for 52k lines, 3.4× the file); `surviving` returns its argument when it dropped nothing and hashes bytes rather than a decode/encode round trip.

Not taken, and why: a bytes prefilter before `parse_line` in `find`, measured at 8.5× on the scan. `forget` is interactive and runs once; 130 ms on a 52k history is not worth a second definition of which characters the format escapes.

## Rule 3

Three sweeps were discarded before one was worth reading, and the reason is the point of the tool. The first reported `BASELINE NOT GREEN` naming `test_running_under_it_leaves_no_pycache_in_the_tree` — that is #258, fixed on `main` after this branch was cut, so `main` is merged in. The second named `test_an_unwritable_runtime_dir_falls_back_instead_of_giving_up`, which cannot pass as root.

**Those runs said 147 caught and nothing else. The first honest run said 115 caught, 32 survived** — which is exactly what that line warns about: a suite that already fails catches every mutation, including the ones no test can see.

Eighteen of the 32 were weak fixtures, then three more of the remaining seventeen. Final run, verbatim:

```
6 file(s), 628 changed lines -> 153 mutants
3 lane(s) at 2679 MiB each, from 8037 MiB of usable memory -- see tools.mutate._share.

confirming 14 survivor(s) against the whole suite...
1 of them were caught by a test the selection had not run.

13 survived. A test that cannot see the fix removed is decoration:
  - woswoar/forget.py:128 in remember() -- the `if` is never taken (tests.test_forget)
  - woswoar/forget.py:182 in _rows() -- `>=` becomes `>` (tests.test_forget)
  - woswoar/forget.py:182 in _rows() -- `0` becomes `1` (tests.test_forget)
  - woswoar/forget.py:238 in find() -- `0` becomes `1` (tests.test_forget)
  - woswoar/forget.py:238 in find() -- `0` becomes `-1` (tests.test_forget)
  - woswoar/forget.py:322 in apply() -- the `if` is always taken (tests.test_forget)
  - woswoar/forget.py:328 in apply() -- the `if` is always taken (tests.test_forget)
  - woswoar/forget.py:360 in surviving() -- the `if` is never taken (tests.test_forget)
  - woswoar/forget.py:365 in surviving() -- `<` becomes `<=` (tests.test_forget)
  - woswoar/forget.py:367 in surviving() -- `<` becomes `<=` (tests.test_forget)
  - woswoar/forget.py:367 in surviving() -- `0` becomes `1` (tests.test_forget)
  - woswoar/forget.py:396 in keep() -- the `if` is never taken (tests.test_forget)
  - woswoar/sync.py:1822 in _merge_host() -- the `if` is always taken (tests.test_forget tests.test_prove tests.test_report tests.test_sync)
Suspect the fixture before the mutation -- see CLAUDE.md rule 3.

6 asked nothing, so the table is that much smaller than it looks:
  - woswoar/forget.py:182 in _rows() -- `0` becomes `-1`: no answer within 300s
  - woswoar/forget.py:184 in _rows() -- `+` becomes `-`: no answer within 300s
  - woswoar/forget.py:184 in _rows() -- `1` becomes `0`: no answer within 300s
  - woswoar/forget.py:367 in surviving() -- `0` becomes `-1`: MemoryError
  - woswoar/forget.py:375 in surviving() -- `+` becomes `-`: MemoryError
  - woswoar/forget.py:375 in surviving() -- `1` becomes `0`: no answer within 300s
```

**134 caught, 13 survived, 6 asked nothing.** I claim all 13 are equivalent mutants, and here is why for each rather than a bare count:

| Survivor | Why nothing can kill it |
|---|---|
| `remember` / `surviving` / `keep` — `if not …` never taken | Fast-path guards. Removing one changes how long the same answer takes, not the answer. |
| `_rows` `>= 0` → `> 0`, and `>= 1`; `surviving` `end < 0` → `<= 0`, and `< 1` | All four differ only when a newline is at byte 0 — an empty first line, which the record format never writes. |
| `find` — `exported.get(relpath, 0)` → 1 or −1 | Only reached for a file with no watermark, and any real row is at least two bytes, so every row reads "not published" either way. |
| `apply` — `if late:` always taken | Appends zero bytes. |
| `apply` — `if below:` always taken | Re-stores the watermark unchanged. |
| `surviving` — `while offset < len` → `<=` | One extra iteration appending `b""`. |
| `sync._merge_host` — `if plaintext:` always taken | Hands `_Day` an empty block; the guard avoids a pointless write rather than changing what the day becomes. |

The 6 that asked nothing are the non-terminating mutants in the two byte-scanning loops — `offset = end + 1` → `end - 1` never advances, so it allocates until the 300 s timeout or the memory cap fires. Counted apart from both verdicts, never folded into either.

**The sweep ran in a copy of this tree with three tests skipped**, all machine-specific and all equally red on unmodified `main` in this container: `test_an_unwritable_runtime_dir_falls_back_instead_of_giving_up` (the suite runs as root, and root writes through mode `000`), and `TestTheRepoSaysWhichShapeItIs`'s two `origin/HEAD` tests (git 2.43 does not write it on fetch; 2.46+ does). `python -m tools.run_tests` in that copy: `OK (0 failures, 0 errors, 76 skipped)`. The skips fail in the safe direction — none of the three can reach `forget`, so a mutant caught only by them would report as a survivor rather than as a pass.

## One thing I did not fix, now filed as #263

A crash between the log rewrite and the watermark save leaves `state.exported` pointing past a file that is now shorter; `export` then publishes nothing for that day until it grows back, and resumes mid-record. I kept the write order deliberately — the alternative saves a lowered watermark with the rows still in `logs/` and **re-publishes the secret somebody just asked to be rid of**, which is worse for this command specifically. The durable fix is for `export` to check the watermark lands on a line boundary and rescan when it does not, which kills the class for any future truncation rather than asking each writer to be careful. That is a second subject by rule 9, so it is #263 rather than this PR.