### PR TITLE
feat: the session scope's prompt says how far back the shell goes (#257)

### DIFF
--- a/docs/searching.md
+++ b/docs/searching.md
@@ -25,6 +25,13 @@ again cycles global → host → session → dir — where **dir** is this direc
 everything below it, on every machine, because `~/src/woswoar` on your laptop and
 on your desktop is the same project.
 
+The prompt says which scope you are in, and for three of the four it also says
+*which one*: the directory for `dir`, the machine for `host`, and for `session`
+how long this shell has been open — `woswoar (session 3h42m)`. That last one is
+the question the scope raises and nothing else on screen answers; the shell's
+id is not shown, because nobody recognises it. The age is a snapshot taken when
+the picker opened, so it does not tick while you are looking at it.
+
 **A short machine name is also an ordinary word.** If yours is `box`, typing it
 finds `sandbox` and `~/dropbox` too — so anchor it: **`^box`** matches only the
 machine, because the search starts at the machine column and `^` sticks to the

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -9,6 +9,7 @@ import shutil
 import sqlite3
 import subprocess
 import sys
+import time
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -1973,6 +1974,60 @@ class TestTheMachineInThePrompt(WoswoarTestCase):
         self.assertIn(f"--scope {search._NEXT['host']})", out)
 
 
+class TestTheAgeOfTheSessionInThePrompt(support.WoswoarTestCase):
+    """`woswoar (session)` said which scope you were in and nothing else (#257).
+
+    The id was correctly ruled out -- nobody recognises `<second>-<pid>` in hex,
+    and "which shell am I in" is not a question anybody has. "How far back does
+    this shell go" is, and nothing else on screen answered it. The start second
+    is already in `WOSWOAR_SESSION`, so the label costs no row read.
+
+    It is inherited and exportable, so every test here is really about the
+    guard: what a hostile or simply stale value does to the Ctrl-R path.
+    """
+
+    def prompt_with(self, session: str) -> str:
+        with mock.patch.dict(os.environ, {"WOSWOAR_SESSION": session}):
+            return search._prompt_for("session")
+
+    def test_it_shows_how_long_the_shell_has_been_open(self) -> None:
+        started = int(time.time()) - 3 * 3600 - 42 * 60
+        self.assertEqual(self.prompt_with(f"{started:x}-1f4"), "woswoar (session 3h42m) ")
+
+    def test_a_shell_opened_moments_ago_still_reads_as_an_age(self) -> None:
+        """The common case for a fresh terminal, and the one a `<hour` unit has
+        to cover -- `relative_time` drops to a single unit below an hour."""
+        self.assertRegex(self.prompt_with(f"{int(time.time()) - 90:x}-1f4"), r"session 1m\)")
+
+    def test_an_unset_variable_says_nothing(self) -> None:
+        """A shell without the hook loaded. Not an error, and not a label."""
+        self.assertEqual(self.prompt_with(""), "woswoar (session) ")
+
+    def test_a_value_that_is_not_a_session_id_says_nothing(self) -> None:
+        """Exported, therefore inherited, therefore anything. Each of these is a
+        different way through `_session_age`, and silence is the answer to all
+        of them -- the scope still works, it just stops describing itself."""
+        for planted in ("nonsense", "zz-1f4", "-1f4", "68a4f1c2", "0-1f4"):
+            with self.subTest(planted=planted):
+                self.assertEqual(self.prompt_with(planted), "woswoar (session) ")
+
+    def test_a_start_in_the_future_does_not_raise_on_the_ctrl_r_path(self) -> None:
+        """A clock that went backwards, or a value from a machine ahead of this
+        one. `relative_time` answers "now" rather than raising, and this pins
+        that the prompt is where that promise is relied on."""
+        ahead = f"{int(time.time()) + 600:x}-1f4"
+        self.assertEqual(self.prompt_with(ahead), "woswoar (session now) ")
+
+    def test_the_label_still_has_to_pass_the_prompt_guard(self) -> None:
+        """Not a hypothetical about today's `relative_time`: the guard is what
+        stops a future unit spelling reaching two parsers unchecked, and the
+        cheapest way to keep it load-bearing is to assert it applies."""
+        self.assertEqual(
+            self.prompt_with(f"{int(time.time()) - 7200:x}-1f4"),
+            f"woswoar (session {search.relative_time(int(time.time()) - 7200)}) ",
+        )
+
+
 class TestTheDirectoryInThePrompt(DirScopeCase):
     """`woswoar (dir)` said which scope you were in and not which directory.
 
@@ -1991,20 +2046,18 @@ class TestTheDirectoryInThePrompt(DirScopeCase):
         self.stand_in(self.home / "src/woswoar")
         self.assertEqual(search._prompt_for("dir"), "woswoar (dir ~/src/woswoar) ")
 
-    def test_global_and_session_gain_nothing(self) -> None:
+    def test_global_gains_nothing(self) -> None:
         """A decision, not an omission.
 
         `global` is every machine, which is what the word says -- a count of
         them describes the history rather than the scope, and moves under
-        someone as they sync. `session` is the shell being typed into, and its
-        id is `<second>-<pid>` in hex, which nobody recognises.
+        someone as they sync. That is also the line `session` had to clear
+        before it could gain a label; see `TestTheAgeOfTheSessionInThePrompt`.
 
         `host` is deliberately absent from this list; it has its own class.
         """
         self.stand_in(self.home)
-        for scope in ("global", "session"):
-            with self.subTest(scope=scope):
-                self.assertEqual(search._prompt_for(scope), f"woswoar ({scope}) ")
+        self.assertEqual(search._prompt_for("global"), "woswoar (global) ")
 
     def test_a_long_path_is_cut_from_the_left(self) -> None:
         """The prompt and the query share a line, and the tail is the part that

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -338,15 +338,36 @@ def _prompt_suffix(scope: Scope) -> str:
     fact about the history rather than about the scope, and it would change
     under someone as they sync.
 
-    `session` is this shell -- the one being typed into. Its id is
-    `<start second>-<pid>` in hex, which nobody recognises, and "which shell am
-    I in" is not a question the person holding the keyboard has.
-
     `host` is the one that needed it. Below two machines the machine column is
     not drawn at all (`host_width_for`), so in that scope nothing on screen says
     *which* machine -- and being ssh'd somewhere is exactly when you press
     Ctrl-H.
+
+    `session` shows the shell's **age**, and the reason it is allowed where a
+    global count is not is the sentence above: a count changes under someone as
+    they sync, while a session's start second is fixed for the life of the
+    shell. What that paragraph ruled out was the *id*, correctly -- nobody
+    recognises `68a4f1c2-3b19`, and "which shell am I in" is not a question
+    anybody has. "How far back does this shell go" is one, and nothing else on
+    screen answers it: a session is a handful of commands when you count
+    sessions and an order of magnitude more when you count the commands you are
+    actually typing among, which is the case Ctrl-S is pressed in.
+
+    The age is free. Both hooks build the id as `<start second>-<pid>` in hex,
+    so the shell's first second is already in the environment and this needs no
+    row read and no extra pass -- which the session's most-used *directory*
+    would, on the picker's open path, for all four scopes at once. That half of
+    #257 is deliberately not here.
+
+    It is a snapshot, not a clock. `interactive` bakes all four labels into the
+    fzf `--bind` when the picker opens, so cycling repaints without re-entering
+    Python and the age does not tick while the picker is up. At
+    `relative_time`'s granularity that is invisible for any shell old enough to
+    be interesting, but it is a property of the mechanism rather than an
+    oversight.
     """
+    if scope == "session":
+        return _safe_for_prompt(_session_age())
     if scope == "dir":
         # `_here()` rather than `_here_label()`, which answers "this directory"
         # when there is none -- a sentence, in a slot the rest of this reads as
@@ -356,6 +377,35 @@ def _prompt_suffix(scope: Scope) -> str:
     if scope == "host":
         return _safe_for_prompt(_this_machine_label())
     return ""
+
+
+def _session_age() -> str:
+    """How long this shell has been open, or "" if that cannot be known.
+
+    `WOSWOAR_SESSION` is `<start second>-<pid>`, both hex, written by the two
+    hooks -- so the parse is `int(head, 16)` and the guard is the whole of the
+    rest of this function. The variable is exported, which means it is
+    inherited, which means anything at all can be in it: a value from a shell
+    that is not this one, a hand-set string, an empty string from a shell
+    without the hook. `_here` already applies this discipline to `$PWD` --
+    believed only when it passes an independent check -- and the same shape
+    belongs here.
+
+    `relative_time` answers "now" rather than raising for a start in the
+    future, so a clock that went backwards is a harmless label rather than a
+    traceback on the Ctrl-R path. What is left is the parse, and a bad one is
+    silence: the scope still works, it just says nothing extra about itself.
+    """
+    head, sep, _ = os.environ.get("WOSWOAR_SESSION", "").partition("-")
+    if not sep:
+        return ""
+    try:
+        started = int(head, 16)
+    except ValueError:
+        return ""
+    # A start before the epoch is not a shell, it is a variable somebody set.
+    # `relative_time` would happily render it as decades, which reads as a fact.
+    return relative_time(started) if started > 0 else ""
 
 
 def _this_machine_label() -> str:


### PR DESCRIPTION
Closes #257.

`woswoar (session)` becomes `woswoar (session 3h42m)`.

## The open decision, and which way I took it

The issue names three answers and picks none: age only, age plus the most-used directory, or age plus the leaf directory. **Age only**, for the reason the issue itself supplies against the other two.

`_prompt_for` builds all four scopes' labels at once, because the result is baked into a shell `case` inside the fzf `--bind` so that Ctrl-R cycling can repaint without re-entering Python. So a label that reads rows is paid on the picker's *open* path whether or not anyone ever presses Ctrl-S — against the ~105 ms the README claims for a 54k history. The age reads no rows: both hooks build the id as `<start second>-<pid>` in hex, so the shell's first second is already in the environment and this is `int(head, 16)` and `relative_time`.

The directory half is the part with that cost, and its cheap substitute is worse than nothing — "the directory the session started in" is confidently wrong most of the time, because a shell is opened somewhere and then `cd`-ed. If it is wanted later it needs the lazy call site the issue describes, which is a change to how the bind is built rather than to what a label says.

Age also always fits: `relative_time` is at most 7 characters against `_PROMPT_LABEL_MAX` of 28, so nothing clips.

## Extending the docstring's principle rather than ignoring it

`_prompt_suffix` ruled out a global count as "a fact about the history rather than about the scope", and that reasoning is what an age has to clear. It does: a count changes under someone as they sync, while a session's start second is fixed for the life of the shell. The docstring now says so, and says what the original paragraph was right about — the *id*, which nobody recognises.

## The guard, which is most of the function

`WOSWOAR_SESSION` is exported, therefore inherited, therefore can hold anything: a value from a shell that is not this one, a hand-set string, nothing at all. `_here` already applies that discipline to `$PWD` — believed only when an independent check agrees — and `_session_age` is the same shape. A bad parse is silence, not a traceback on the Ctrl-R path: the scope still works, it just stops describing itself. `relative_time` already answers `now` rather than raising for a start in the future, so a clock that went backwards is a label rather than a crash, and there is a test pinning that the prompt is where that promise is relied on.

## The snapshot property

The label is baked into the bind when the picker opens, so the age does not tick while the picker is up. At `relative_time`'s granularity that is invisible for any shell old enough to be interesting, but it is a property of the mechanism rather than an oversight, so it is written down in the docstring and in `docs/searching.md` rather than left to be rediscovered.

## Rule 1

Middle row — behaviour on a path a user reaches, no new state — so this was a careful read of the diff against the issue's own "constraint that makes the obvious fix wrong", not agents. All four constraints are answered above: the directory is out, the open path reads no rows, the variable is guarded, and the snapshot is documented. The existing round-trip test that builds `woswoar ({scope} <label>)` for every scope already covers a *labelled* session prompt being read back as the session scope, so the scope-cycling arms are exercised with the new shape.

## Rule 3

```
1 file(s), 54 changed lines -> 13 mutants
3 lane(s) at 2679 MiB each, from 8037 MiB of usable memory -- see tools.mutate._share.
  caught    woswoar/search.py:369 in _prompt_suffix() -- the `if` is always taken
  caught    woswoar/search.py:369 in _prompt_suffix() -- the `if` is never taken
  caught    woswoar/search.py:369 in _prompt_suffix() -- `==` becomes `!=`
  caught    woswoar/search.py:370 in _prompt_suffix() -- returns `None` instead of `_safe_for_prompt(_session_age…`
  caught    woswoar/search.py:400 in _session_age() -- the `if` is always taken
  caught    woswoar/search.py:400 in _session_age() -- the `if` is never taken
  caught    woswoar/search.py:400 in _session_age() -- the `not` is dropped
  SURVIVED  woswoar/search.py:401 in _session_age() -- returns `None` instead of `''`
  SURVIVED  woswoar/search.py:405 in _session_age() -- returns `None` instead of `''`
  caught    woswoar/search.py:408 in _session_age() -- returns `None` instead of `relative_time(started) if sta…`
  caught    woswoar/search.py:408 in _session_age() -- `>` becomes `>=`
  SURVIVED  woswoar/search.py:408 in _session_age() -- `0` becomes `1`
  caught    woswoar/search.py:408 in _session_age() -- `0` becomes `-1`

confirming 3 survivor(s) against the whole suite...
3 survived. A test that cannot see the fix removed is decoration:
  - woswoar/search.py:401 in _session_age() -- returns `None` instead of `''`
  - woswoar/search.py:405 in _session_age() -- returns `None` instead of `''`
  - woswoar/search.py:408 in _session_age() -- `0` becomes `1`
Suspect the fixture before the mutation -- see CLAUDE.md rule 3.
```

**10 of 13 caught. The three survivors are equivalent mutants**, and I checked rather than assumed:

- **Both `return None` instead of `""`.** The single call site is `_safe_for_prompt(_session_age())`, whose first test is `if not label`, so `None` and `""` take the same branch. Verified directly: `_safe_for_prompt(None)` returns `''`, exactly as `_safe_for_prompt("")` does. Killing these would mean giving `_session_age` a second caller that treats the two differently, which is contorting the code to satisfy the tool.
- **`started > 0` becomes `started > 1`.** These differ only for a session id whose start second is exactly `1` — one second after the epoch, which no clock produces and neither hook writes. Both readings are harmless there: `> 0` renders a label of about `56y`, `> 1` renders nothing. I did not add a fixture for it, because the test would pin an arbitrary floor rather than a property, and `0` is the value that matters — it is what an empty or zeroed variable produces, and there is a test for it.

## Preflight

`ruff`, `ruff format --check`, `mypy` and `shellcheck` clean. `python -m tools.run_tests` is green apart from three failures that are equally red on unmodified `main` in this container and are the machine rather than the code: `test_an_unwritable_runtime_dir_falls_back_instead_of_giving_up` (the suite runs as root, and root writes through mode `000`), and `TestTheRepoSaysWhichShapeItIs`'s two `origin/HEAD` tests (git 2.43 does not write it on fetch; 2.46+ does). The sweep above ran in a copy with exactly those three skipped, so its baseline was green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_