### PR TITLE
feat: one project, several directories, one dir scope (#255)

### DIFF
--- a/docs/searching.md
+++ b/docs/searching.md
@@ -40,10 +40,15 @@ unmarked one reads `woswoar (dir ~/src/api/app/routes)`. The trade is visible in
 that line: with a marker above you there is no longer a way to scope to just the
 subdirectory you are standing in.
 
-Only the file's *presence* counts. Nothing inside it is ever read, so it is safe
-to `cd` into somebody else's repository that has one — the worst it can do is
-make your <kbd>Ctrl</kbd>+<kbd>O</kbd> wider than you expected — and you can
-write a sentence in it explaining itself to whoever finds it.
+Only the file's *presence* counts — and only its own, since a marker that is a
+symlink is not followed. Nothing inside it is ever read, so it is safe to `cd`
+into somebody else's repository that has one: the worst it can do is make your
+<kbd>Ctrl</kbd>+<kbd>O</kbd> wider than you expected. You can write a sentence
+in it explaining itself to whoever finds it.
+
+The search for it stops at your home directory. Below a path outside home —
+`/opt/work/api`, say — it runs to the filesystem root instead, so that a project
+living outside home works the same way; a marker at `/` itself is ignored.
 
 **A short machine name is also an ordinary word.** If yours is `box`, typing it
 finds `sandbox` and `~/dropbox` too — so anchor it: **`^box`** matches only the

--- a/docs/searching.md
+++ b/docs/searching.md
@@ -25,6 +25,26 @@ again cycles global → host → session → dir — where **dir** is this direc
 everything below it, on every machine, because `~/src/woswoar` on your laptop and
 on your desktop is the same project.
 
+**When one project is several directories**, put an empty `.woswoar-dir` file at
+the top of it:
+
+```sh
+touch ~/src/api/.woswoar-dir
+```
+
+<kbd>Ctrl</kbd>+<kbd>O</kbd> then covers everything under `~/src/api` from
+anywhere inside it — which is what you want for `git worktree`, where a bare
+repo and its checkouts are one project split across sibling directories. The
+prompt shows the root, so a marked tree reads `woswoar (dir ~/src/api)` where an
+unmarked one reads `woswoar (dir ~/src/api/app/routes)`. The trade is visible in
+that line: with a marker above you there is no longer a way to scope to just the
+subdirectory you are standing in.
+
+Only the file's *presence* counts. Nothing inside it is ever read, so it is safe
+to `cd` into somebody else's repository that has one — the worst it can do is
+make your <kbd>Ctrl</kbd>+<kbd>O</kbd> wider than you expected — and you can
+write a sentence in it explaining itself to whoever finds it.
+
 **A short machine name is also an ordinary word.** If yours is `box`, typing it
 finds `sandbox` and `~/dropbox` too — so anchor it: **`^box`** matches only the
 machine, because the search starts at the machine column and `^` sticks to the

--- a/docs/security.md
+++ b/docs/security.md
@@ -429,6 +429,7 @@ every other check you can run without believing anyone.
 |---|---|
 | The cache cannot execute | a pickle that would run code on load is written to the cache path; it is refused and a witness file never appears |
 | A recalled command is one command | control characters never survive from the picker into the shell buffer |
+| A `.woswoar-dir` marker cannot configure anything | a marker holding settings, a different root and a shell substitution behaves exactly like an empty one; only its presence is read |
 | Nothing woswoar prints can drive your terminal | no C0 byte reaches the terminal raw from `list`, `search`, `stats`, `import` or the picker's preview pane -- a peer's command, directory and session are made inert on the way into the cache, a peer's machine name where it is read |
 | Shell and Python escaping agree | a command containing a literal tab and newline must round-trip byte-for-byte |
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -429,7 +429,7 @@ every other check you can run without believing anyone.
 |---|---|
 | The cache cannot execute | a pickle that would run code on load is written to the cache path; it is refused and a witness file never appears |
 | A recalled command is one command | control characters never survive from the picker into the shell buffer |
-| A `.woswoar-dir` marker cannot configure anything | a marker holding settings, a different root and a shell substitution behaves exactly like an empty one; only its presence is read |
+| A `.woswoar-dir` marker cannot configure anything | a marker holding settings, a different root and a shell substitution behaves exactly like an empty one; only its presence is read, and a marker that is a symlink is never followed |
 | Nothing woswoar prints can drive your terminal | no C0 byte reaches the terminal raw from `list`, `search`, `stats`, `import` or the picker's preview pane -- a peer's command, directory and session are made inert on the way into the cache, a peer's machine name where it is read |
 | Shell and Python escaping agree | a command containing a literal tab and newline must round-trip byte-for-byte |
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2459,3 +2459,92 @@ class TestTheWalkFollowsTheLogicalPath(DirScopeCase):
         self.stand_in(self.home / "link/app")
         self.assertEqual(search._prompt_for("dir"), "woswoar (dir ~/link) ")
         self.assertEqual(self.commands(), ["make test"])
+
+
+class TestTheMarkerIsAskedAboutItselfNotItsTarget(DirScopeCase):
+    """`lexists`, not `exists`, and the difference is a hang on the Ctrl-R path.
+
+    `exists` resolves the marker, so a `.woswoar-dir` that is a *symlink* --
+    in a repository somebody else wrote -- points the `stat` wherever they
+    chose. A dead NFS or FUSE mount, or an autofs path that mounting is
+    attempted for, blocks every keypress. `docs/searching.md` promises that
+    `cd`-ing into somebody else's marked repository can at worst widen your
+    Ctrl-O, and this is what makes that true.
+
+    A dangling symlink standing in for the unreachable target: `exists` says
+    False for it, `lexists` says True, and no other fixture separates them.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.home / "src/api"
+        (self.project / "app").mkdir(parents=True)
+        self.record("~/src/api/app", "make test")
+        self.stand_in(self.project / "app")
+
+    def test_a_symlinked_marker_pointing_nowhere_still_marks(self) -> None:
+        (self.project / search.PROJECT_MARKER).symlink_to(self.home / "no/such/mount")
+        self.assertEqual(search._prompt_for("dir"), "woswoar (dir ~/src/api) ")
+
+    def test_an_ordinary_marker_still_marks(self) -> None:
+        """The fixture that keeps the assertion above from passing on a walk
+        that stopped looking at the file altogether."""
+        (self.project / search.PROJECT_MARKER).write_text("", encoding="utf-8")
+        self.assertEqual(search._prompt_for("dir"), "woswoar (dir ~/src/api) ")
+
+
+class TestTheWalkOutsideHome(DirScopeCase):
+    """`$HOME` bounds the walk only for paths under `$HOME`, and that is stated
+    rather than guarded -- a project in `/opt/work` is an ordinary thing, and
+    refusing to look above a path outside home would remove the feature for it.
+
+    What is refused is `/` itself, because `_under` reads that root as every row
+    on every machine: a marker there would turn `dir` into `global` while the
+    prompt still said `dir`.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.outside = self.root / "opt/work/api"
+        (self.outside / "main").mkdir(parents=True)
+
+    def test_a_marker_above_a_path_outside_home_is_still_found(self) -> None:
+        # On `_here` rather than the prompt: a sandbox path outside `$HOME` has
+        # no `~` to shorten it and runs past `_PROMPT_LABEL_MAX`, so the prompt
+        # would be asserting the clip rather than the root.
+        (self.outside / search.PROJECT_MARKER).write_text("", encoding="utf-8")
+        self.stand_in(self.outside / "main")
+        self.assertEqual(search._here(), (str(self.outside),))
+
+    def test_without_a_marker_it_is_the_directory_it_always_was(self) -> None:
+        self.stand_in(self.outside / "main")
+        self.assertEqual(search._here(), (str(self.outside / "main"),))
+
+    def test_a_marker_at_the_filesystem_root_is_refused(self) -> None:
+        """The one place a wider scope stops being merely wider.
+
+        `_under` reads a root of `/` as every row on every machine, so a marker
+        there turns `dir` into `global` while the prompt still says `dir`.
+
+        The marker is faked rather than planted, and this is the one test here
+        that mocks: writing `/.woswoar-dir` needs root, so a fixture that did it
+        would pass on this container and fail in CI -- and asserting on a real
+        `/` with no marker passes whether or not the guard exists, which is the
+        decoration this repository's rule 3 is about. Only the *answer to one
+        `lexists`* is replaced; the walk, the boundary and the return are the
+        real ones.
+        """
+        deep = self.outside / "main"
+        self.stand_in(deep)
+        at_root = os.path.join(os.sep, search.PROJECT_MARKER)
+        with mock.patch("os.path.lexists", lambda where: where == at_root):
+            self.assertEqual(search._project_root(str(deep), ""), str(deep))
+
+    def test_the_same_fake_one_level_down_is_honoured(self) -> None:
+        """The fixture that stops the assertion above passing on a walk that had
+        simply stopped finding markers at all."""
+        deep = self.outside / "main"
+        self.stand_in(deep)
+        wanted = os.path.join(str(self.outside), search.PROJECT_MARKER)
+        with mock.patch("os.path.lexists", lambda where: where == wanted):
+            self.assertEqual(search._project_root(str(deep), ""), str(self.outside))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2311,3 +2311,151 @@ class TestAnEmptyDirScopeSaysWhereItLooked(DirScopeCase):
         for scope in ("global", "host", "session"):
             with self.subTest(scope=scope):
                 self.assertEqual(run_cli("list", "--scope", scope, tty=True).err, "")
+
+
+class TestAProjectThatIsSeveralDirectories(DirScopeCase):
+    """`dir` is a path prefix, so a project in more than one directory had no
+    scope at all (#255).
+
+    The common case is `git worktree`: a bare repo with sibling checkouts under
+    one umbrella is one project by every meaning that matters, and standing in
+    any one of them Ctrl-O showed that worktree only. A `.woswoar-dir` at the
+    umbrella makes the umbrella the root, for every worktree below it, present
+    and future, with nothing to enumerate.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.home / "src/api"
+        self.first = self.project / "main"
+        self.second = self.project / "feature"
+        for where in (self.first, self.second):
+            where.mkdir(parents=True)
+        self.record("~/src/api/main", "make test")
+        self.record("~/src/api/feature", "make bench")
+        self.record("~/src/other", "unrelated")
+
+    def mark(self, where: Path, text: str = "") -> None:
+        (where / search.PROJECT_MARKER).write_text(text, encoding="utf-8")
+
+    def test_without_a_marker_the_scope_is_the_directory_it_always_was(self) -> None:
+        """The fallback is not a new case; it is the scope as it stands."""
+        self.stand_in(self.first)
+        self.assertEqual(self.commands(), ["make test"])
+
+    def test_a_marker_above_covers_every_directory_below_it(self) -> None:
+        self.mark(self.project)
+        self.stand_in(self.first)
+        self.assertEqual(self.commands(), ["make bench", "make test"])
+
+    def test_it_still_stops_at_the_project_rather_than_taking_everything(self) -> None:
+        """The fixture that keeps the test above from passing on a scope that
+        quietly widened to the whole history."""
+        self.mark(self.project)
+        self.stand_in(self.first)
+        self.assertNotIn("unrelated", self.commands())
+
+    def test_the_prompt_shows_the_root_rather_than_where_you_stand(self) -> None:
+        """The widening is visible rather than silent, which is what makes the
+        cost of it -- no way to scope to just this subdirectory -- something a
+        person can see they have opted into."""
+        self.mark(self.project)
+        self.stand_in(self.first)
+        self.assertEqual(search._prompt_for("dir"), "woswoar (dir ~/src/api) ")
+
+    def test_a_sibling_whose_name_merely_starts_the_same_is_not_swept_in(self) -> None:
+        """The root goes through `_under`, not a bare `startswith`.
+
+        `~/src/api` must not match `~/src/apifoo`, and the umbrella layout this
+        issue is about makes adjacent names of exactly that shape ordinary
+        rather than contrived.
+        """
+        (self.home / "src/apifoo").mkdir(parents=True)
+        self.record("~/src/apifoo", "next door")
+        self.mark(self.project)
+        self.stand_in(self.first)
+        self.assertNotIn("next door", self.commands())
+
+    def test_the_nearest_marker_wins(self) -> None:
+        """Two markers is a project inside a project, and the answer is the one
+        you are standing in."""
+        self.mark(self.home / "src")
+        self.mark(self.project)
+        self.stand_in(self.first)
+        self.assertEqual(search._prompt_for("dir"), "woswoar (dir ~/src/api) ")
+
+
+class TestWhereTheMarkerWalkStops(DirScopeCase):
+    """Above `$HOME` are `/home` and `/`, where a marker would make the scope
+    meaningless -- and on a shared machine could be planted by another account."""
+
+    def test_a_marker_above_home_is_not_used(self) -> None:
+        deep = self.home / "src/api"
+        deep.mkdir(parents=True)
+        (self.home.parent / search.PROJECT_MARKER).write_text("", encoding="utf-8")
+        self.addCleanup((self.home.parent / search.PROJECT_MARKER).unlink)
+        self.stand_in(deep)
+        self.assertEqual(search._prompt_for("dir"), "woswoar (dir ~/src/api) ")
+
+    def test_a_marker_at_home_is_legal_and_degenerate(self) -> None:
+        """Not special-cased. `$HOME` is where the walk stops, not a place a
+        marker is refused, and one there means "all of my history under home"."""
+        deep = self.home / "src/api"
+        deep.mkdir(parents=True)
+        (self.home / search.PROJECT_MARKER).write_text("", encoding="utf-8")
+        self.stand_in(deep)
+        self.assertEqual(search._prompt_for("dir"), "woswoar (dir ~) ")
+
+
+class TestTheMarkersContentsAreNeverRead(DirScopeCase):
+    """Presence only, and it is a security property rather than a simplification.
+
+    A file found by walking up from `cwd` whose contents configure the tool is
+    the direnv problem: `cd` into somebody else's repository and their file
+    decides how yours behaves. `docs/security.md` says so under *Nothing woswoar
+    reads can run*, and this is the test behind that claim.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.home / "src/api"
+        (self.project / "app").mkdir(parents=True)
+        self.record("~/src/api/app", "make test")
+
+    def test_a_marker_full_of_instructions_still_only_marks(self) -> None:
+        (self.project / search.PROJECT_MARKER).write_text(
+            "scope = global\nroot = /etc\nname=somebody-elses-project\n$(touch /tmp/pwned)\n",
+            encoding="utf-8",
+        )
+        self.stand_in(self.project / "app")
+        self.assertEqual(search._prompt_for("dir"), "woswoar (dir ~/src/api) ")
+        self.assertEqual(self.commands(), ["make test"])
+
+    def test_an_empty_marker_and_a_full_one_behave_alike(self) -> None:
+        """The fixture that makes the assertion above mean something: if the
+        contents changed anything at all, these two would differ."""
+        (self.project / search.PROJECT_MARKER).write_text("", encoding="utf-8")
+        self.stand_in(self.project / "app")
+        empty = search._prompt_for("dir"), self.commands()
+        (self.project / search.PROJECT_MARKER).write_text("root = /etc\n", encoding="utf-8")
+        self.assertEqual((search._prompt_for("dir"), self.commands()), empty)
+
+
+class TestTheWalkFollowsTheLogicalPath(DirScopeCase):
+    """`$PWD` and `os.getcwd()` are different answers after a `cd` through a
+    symlink, and `_here` already documents at length why the hook's `$PWD` is
+    the one that matters. The walk has to agree: a root found by resolving the
+    path does not prefix-match the rows recorded under the link.
+    """
+
+    def test_the_root_is_spelled_the_way_the_rows_are(self) -> None:
+        real = self.home / "real/api"
+        (real / "app").mkdir(parents=True)
+        (real / search.PROJECT_MARKER).write_text("", encoding="utf-8")
+        (self.home / "link").symlink_to(real)
+        # Recorded the way the hook would, standing in the linked spelling.
+        self.record("~/link/app", "make test")
+
+        self.stand_in(self.home / "link/app")
+        self.assertEqual(search._prompt_for("dir"), "woswoar (dir ~/link) ")
+        self.assertEqual(self.commands(), ["make test"])

--- a/woswoar/__main__.py
+++ b/woswoar/__main__.py
@@ -1273,7 +1273,10 @@ def build_parser() -> argparse.ArgumentParser:
         leaving the picker.
 
         The directory scope spans machines on purpose: ~/src/woswoar on either
-        of your boxes is the same project.
+        of your boxes is the same project. Put an empty .woswoar-dir file at
+        the top of a project whose directories are several -- git worktrees,
+        say -- and Ctrl-O covers all of them from anywhere inside. Only the
+        file's presence is used; nothing in it is ever read.
 
         Ctrl-/ shows the rest of what was recorded for the highlighted command
         -- its directory, session, exit code and duration.

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -289,8 +289,11 @@ def _project_root(path: str, home: str) -> str:
     And it returns ``path`` unchanged when it finds nothing, which is not a
     fallback so much as the scope exactly as it stands.
     """
-    if not path:
-        return path
+    # No guard on an empty ``path``: `_here` returns `()` before it gets here, so
+    # a branch for it would be unreachable -- and an unreachable branch is a row
+    # that survives every mutation sweep for ever, which is how a survivor list
+    # stops being read.
+    #
     # `os.path` rather than `pathlib`, matching the rest of this module: these
     # are string operations on a path that is already absolute, and the only
     # syscall in the loop is the one asking the question. `os.path.exists` is

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -231,6 +231,73 @@ def _same_directory(path: str) -> bool:
         return False
 
 
+#: Put a file of this name at the top of a project and Ctrl-O covers all of it.
+#:
+#: **Presence only. The contents are never read**, and that is a security
+#: decision rather than a simplification. A file found by walking up from `cwd`
+#: whose contents configure the tool is the direnv problem: `cd` into somebody
+#: else's repository and their file decides how yours behaves. Presence-only
+#: caps the worst case at a wider Ctrl-O than expected, which is not a threat --
+#: and it means the file may hold a sentence explaining itself to whoever finds
+#: it. `docs/security.md` states this under *Nothing woswoar reads can run*, and
+#: `tests/test_search.py` asserts it, because the next request will be to put
+#: settings in it.
+PROJECT_MARKER = ".woswoar-dir"
+
+
+def _project_root(path: str, home: str) -> str:
+    """The nearest directory at or above ``path`` holding `PROJECT_MARKER`, else ``path``.
+
+    What this buys is the case `dir` could not express: a project that lives in
+    more than one directory. A bare repository with sibling `git worktree`
+    checkouts under one umbrella is one project by every meaning that matters,
+    and without a marker its history is split into as many `dir` scopes as there
+    are worktrees.
+
+    The cost is real and is not a free widening: with a marker above you there
+    is no longer a way to scope to just the subdirectory you are standing in.
+    That is judged rare against the case it buys, and it is visible rather than
+    silent -- the prompt shows the root, so a marked tree reads `~/src/api`
+    where an unmarked one reads `~/src/api/app/routes`.
+
+    Three things decide the walk.
+
+    It stops at ``home``. Above it are `/home` and `/`, where a marker would
+    make the scope meaningless -- and where one could be planted by another
+    account on a shared machine. One *at* `$HOME` is legal and degenerate, and
+    is not worth special-casing.
+
+    It walks the **logical** path it is given, never `Path.resolve()`. `_here`
+    documents at length why `$PWD` and `os.getcwd()` are different answers after
+    a `cd` through a symlink: the hook records `$PWD`, so a root resolved
+    through the link would not prefix-match the rows recorded under it.
+
+    And it returns ``path`` unchanged when it finds nothing, which is not a
+    fallback so much as the scope exactly as it stands.
+    """
+    if not path:
+        return path
+    # `os.path` rather than `pathlib`, matching the rest of this module: these
+    # are string operations on a path that is already absolute, and the only
+    # syscall in the loop is the one asking the question. `os.path.exists` is
+    # False for an unreadable directory rather than raising, which is the right
+    # answer on a keypress -- a directory this process cannot stat cannot hold
+    # the answer either.
+    candidate = path
+    while True:
+        if os.path.exists(os.path.join(candidate, PROJECT_MARKER)):
+            return candidate
+        if home and candidate == home:
+            break
+        parent = os.path.dirname(candidate)
+        if parent == candidate:
+            # `dirname("/")` is `"/"`, which is how the walk ends on a machine
+            # with no `$HOME` set rather than looping.
+            break
+        candidate = parent
+    return path
+
+
 def _here() -> tuple[str, ...]:
     """The current directory, in every form a recorded ``cwd`` might take.
 
@@ -269,6 +336,7 @@ def _here() -> tuple[str, ...]:
         return ()
 
     home = os.environ.get("HOME", "")
+    path = _project_root(path, home)
     tilde = make_inert(home_relative(path, home))
     absolute = make_inert(path)
     # Standing anywhere outside home makes the two spellings the same string,

--- a/woswoar/search.py
+++ b/woswoar/search.py
@@ -260,12 +260,26 @@ def _project_root(path: str, home: str) -> str:
     silent -- the prompt shows the root, so a marked tree reads `~/src/api`
     where an unmarked one reads `~/src/api/app/routes`.
 
-    Three things decide the walk.
+    Four things decide the walk.
 
-    It stops at ``home``. Above it are `/home` and `/`, where a marker would
-    make the scope meaningless -- and where one could be planted by another
-    account on a shared machine. One *at* `$HOME` is legal and degenerate, and
-    is not worth special-casing.
+    It stops at ``home``, where above are `/home` and `/` and a marker would
+    make the scope meaningless. One *at* `$HOME` is legal and degenerate, and is
+    not worth special-casing. **That stop only fires for a path under `$HOME`**,
+    which is the honest statement of it: standing in `/opt/work/api/main` the
+    walk runs to `/`, because a project outside home is an ordinary thing and
+    refusing to look would remove the feature for it. What that leaves is a
+    marker in a world-writable ancestor -- `/tmp`, `/var/tmp`, `/dev/shm` --
+    widening your Ctrl-O over your *own* history. A nuisance rather than a
+    disclosure: nothing is shown to whoever planted it, and nothing leaves the
+    machine. It is written down here rather than guarded because every guard for
+    it is a policy (ownership? mode? a list of paths?) that would be wrong on
+    somebody's machine.
+
+    ``/`` is refused outright, and that is the one place a wider scope stops
+    being merely wider: `_under` reads a root of `/` as *every row on every
+    machine*, so a marker there would silently turn `dir` into `global` while
+    the prompt still said `dir`. Only root can create it, so it is a foot-gun
+    rather than an attack, and one line settles it.
 
     It walks the **logical** path it is given, never `Path.resolve()`. `_here`
     documents at length why `$PWD` and `os.getcwd()` are different answers after
@@ -285,14 +299,23 @@ def _project_root(path: str, home: str) -> str:
     # the answer either.
     candidate = path
     while True:
-        if os.path.exists(os.path.join(candidate, PROJECT_MARKER)):
+        # `lexists`, not `exists`, and the difference is the whole of what
+        # "presence only" is worth. `exists` *resolves* the marker, so a
+        # `.woswoar-dir` that is a symlink -- in a repository somebody else
+        # wrote -- points this `stat` wherever they chose: a hung NFS mount, a
+        # dead FUSE mount, an autofs path like `/net/their-host/x` that mounting
+        # is attempted for. Every Ctrl-R would block there. `lexists` asks about
+        # the marker itself, which is the fact this wants, and it also makes a
+        # dangling symlink a marker rather than silently not one.
+        if os.path.lexists(os.path.join(candidate, PROJECT_MARKER)) and candidate != os.sep:
             return candidate
         if home and candidate == home:
             break
         parent = os.path.dirname(candidate)
         if parent == candidate:
-            # `dirname("/")` is `"/"`, which is how the walk ends on a machine
-            # with no `$HOME` set rather than looping.
+            # `dirname("/")` is `"/"`, which is how the walk ends for a path
+            # outside `$HOME`, or on a machine with no `$HOME` set, rather than
+            # looping.
             break
         candidate = parent
     return path


### PR DESCRIPTION
Closes #255.

`dir` is a path prefix — this directory and below — so a project living in more than one directory had no scope at all. The common case is `git worktree`: a bare repo with sibling checkouts under one umbrella is one project by every meaning that matters, and standing in any one of them Ctrl-O showed that worktree only.

An empty `.woswoar-dir` at the top of the project makes the umbrella the root, for every directory below it, present and future, with nothing to enumerate. No marker found is today's behaviour exactly — the fallback is not a new case, it is the scope as it stands.

`dir` is widened rather than a fifth scope added, for the reason the issue gives: five is a lot for a cycle pressed repeatedly, and none of the existing four is dead weight to trade against it.

## The four decisions the issue names

- **Presence only; the contents are never read.** A file found by walking up from `cwd` whose contents configure the tool is the direnv problem. Presence-only caps the worst case at a wider Ctrl-O than expected, and it means the file may hold a sentence explaining itself to whoever finds it. `docs/security.md` states it under *Nothing woswoar reads can run*, and the test compares a marker full of settings, a different root and a shell substitution against an empty one.
- **Stop at `$HOME`** — see the correction below for what that actually means.
- **Walk the logical `$PWD`, not the resolved path.** The hook records `$PWD`, so a root resolved through a symlink would not prefix-match the rows recorded under the link. The fixture records `~/link/app` and would get `~/real/api` from a resolving implementation.
- **No marker → today's behaviour exactly.**

The widened root goes through `_under` like any other, so `~/src/api` still does not match `~/src/apifoo` — and the umbrella layout makes adjacent names of exactly that shape ordinary rather than contrived.

The cost is stated rather than hidden: with a marker above you there is no longer a way to scope to just the subdirectory you are standing in. It is visible in the prompt, which shows the root.

## Rule 1

Middle row — behaviour on a path a user reaches, no stored data and no cache — so one agent, aimed at the hazard this change actually introduces: a file found by walking up from `cwd` deciding how the tool behaves. It confirmed the contents genuinely cannot reach anything (the walk extracts one boolean and returns a string built only from `$PWD` by repeated `dirname`, so no byte of the file reaches the prompt, the `printf` the cycle binding runs, or the cache), and found two holes in the walk plus one overclaim of mine:

- **`os.path.exists` follows the symlink.** A `.woswoar-dir` that is a symlink, in a repository somebody else wrote, points that `stat` wherever they chose — a dead NFS mount, a dead FUSE mount, an autofs path like `/net/their-host/x` that mounting is attempted for. Every Ctrl-R would block there, which is exactly what `docs/searching.md` promises cannot happen. Now `lexists`, which asks about the marker itself and also makes a dangling symlink a marker rather than silently not one.
- **A marker at `/` turned `dir` into `global` in silence.** `_under` reads that root as every row on every machine while the prompt still says `dir`. Only root can create it, so a foot-gun rather than an attack, and one clause settles it.
- **The `$HOME` stop only fires for a path under `$HOME`**, and my docstring claimed it guarded against a marker planted by another account. It does not: standing in `/tmp/build/x` the walk runs to `/`, and `/tmp` is world-writable. The behaviour is right — a project in `/opt/work` is ordinary, and refusing to look above a path outside home would remove the feature for it — so what changed is the claim. The residual is now written down where it was previously asserted away: a marker in a world-writable ancestor widens your Ctrl-O over your *own* history, a nuisance rather than a disclosure, and every guard for it is a policy that would be wrong on somebody's machine.

Both fixes verified by reverting: `exists` fails the dangling-symlink test, and dropping the root clause fails the faked-marker-at-`/` test.

**One test mocks, deliberately.** Writing `/.woswoar-dir` needs root, so a real fixture would pass in this container and fail in CI — and asserting on a real `/` with no marker passes whether or not the guard exists, which is the decoration rule 3 is about. Only the answer to one `lexists` is replaced; the walk, the boundary and the return are the real ones, and a companion test fakes a marker one level down to show the walk still honours one.

## Rule 3

The first sweep's only two survivors were an `if not path` guard that `_here` makes unreachable — it returns `()` for an empty path before `_project_root` is called. An unreachable branch is a row that survives every sweep for ever, which is how a survivor list stops being read, so the guard is gone and the reason it is not there is written where it was.

Final run, verbatim:

```
2 file(s), 98 changed lines -> 13 mutants
3 lane(s) at 2679 MiB each, from 8037 MiB of usable memory -- see tools.mutate._share.
  caught    woswoar/search.py:313 in _project_root() -- the `if` is always taken
  caught    woswoar/search.py:313 in _project_root() -- the `if` is never taken
  caught    woswoar/search.py:313 in _project_root() -- `and` becomes `or`
  caught    woswoar/search.py:313 in _project_root() -- `!=` becomes `==`
  caught    woswoar/search.py:314 in _project_root() -- returns `None` instead of `candidate`
  caught    woswoar/search.py:315 in _project_root() -- the `if` is always taken
  caught    woswoar/search.py:315 in _project_root() -- the `if` is never taken
  caught    woswoar/search.py:315 in _project_root() -- `and` becomes `or`
  caught    woswoar/search.py:315 in _project_root() -- `==` becomes `!=`
  caught    woswoar/search.py:318 in _project_root() -- the `if` is always taken
  TIMEOUT   woswoar/search.py:318 in _project_root() -- the `if` is never taken
           -- no answer within 300s
  caught    woswoar/search.py:318 in _project_root() -- `==` becomes `!=`
  caught    woswoar/search.py:324 in _project_root() -- returns `None` instead of `path`

1 asked nothing, so the table is that much smaller than it looks:
  - woswoar/search.py:318 in _project_root() -- the `if` is never taken: no answer within 300s
```

**12 of 13 caught, none survived.** The one that asked nothing is the `parent == candidate` guard removed, which leaves the walk looping at `/` for ever — a non-viable mutant, counted apart from both verdicts rather than folded into either.

Sweep ran in a copy with three machine-specific tests skipped, all equally red on unmodified `main` in this container: `test_an_unwritable_runtime_dir_falls_back_instead_of_giving_up` (running as root, so mode `000` does not block), and `TestTheRepoSaysWhichShapeItIs`'s two `origin/HEAD` tests (git 2.43 does not write it on fetch; 2.46+ does).

## Note

`main` is merged in for #257, which landed while this was in review. Both changes add to `search.py` in different functions; the only conflict was in `docs/searching.md`, where each had appended a paragraph after the same one. Both are kept — the prompt paragraph first, since the marker section refers to what the prompt shows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_