### PR TITLE
tools: watch a detached job, and say plainly when it dies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,7 @@ opens its PR and waits for a person regardless of what CI says.
   `python -m unittest discover -s . -t . -p 'test_*.py'` runs the same tests
   serially, and takes about three times as long.
 
-- Four tools in `tools/` exist because the same mistake was made more than
+- Five tools in `tools/` exist because the same mistake was made more than
   once. Each one's module docstring carries the full argument for why it is
   shaped as it is; reach for them rather than writing the loop again.
 
@@ -259,6 +259,7 @@ opens its PR and waits for a person regardless of what CI says.
   | a mutation run left more survivors than you can read | [`tools/reached.py`](tools/reached.py) |
   | a refactor is supposed to change no output | [`tools/compare.py`](tools/compare.py) |
   | a change might have cost time | [`tools/bench.py`](tools/bench.py) |
+  | a long job is running detached and silence is ambiguous | [`tools/watch.py`](tools/watch.py) |
 
   ```sh
   python -m tools.mutate --base main        # generated from the diff
@@ -266,7 +267,15 @@ opens its PR and waits for a person regardless of what CI says.
   python -m tools.reached r.json c.json     # which survivors are missing tests
   python -m tools.compare --base main --show .bashrc install doctor status
   python -m tools.bench --importtime woswoar.__main__ --base main
+  python -m tools.watch $PID --log sweep.log --done r.json --match 'caught|SURVIVED'
   ```
+
+  The last one is not about the code, it is about *reporting on* a job that
+  takes half an hour. Never answer "is it stuck?" with `pgrep -f`: the pattern
+  matches the asking shell's own command line, and it reported a dead sweep
+  alive twice in one session, to somebody who had asked twice. Record the pid at
+  launch and watch that — a death then arrives as a line and an exit status
+  rather than as more silence.
 
   **The generated sweep goes last.** Implement, write the hand table, preflight,
   run `/simplify` *and apply it*, and only then `--base main`. The table is

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -17,8 +17,10 @@ import re
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from tools import watch
 
@@ -54,6 +56,30 @@ class Fixture(unittest.TestCase):
         child.wait()
         return child.pid
 
+    def running(self) -> subprocess.Popen[bytes]:
+        """A process that will still be there in a second unless something kills it."""
+        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        self.addCleanup(child.wait)
+        self.addCleanup(child.kill)
+        return child
+
+    def command(self, *extra: str) -> list[str]:
+        return [
+            sys.executable,
+            "-m",
+            "tools.watch",
+            *extra,
+            "--log",
+            str(self.log),
+            "--done",
+            str(self.done),
+        ]
+
+    #: The tree, for a subprocess that must import `tools.watch` by module path.
+    @property
+    def repo(self) -> Path:
+        return Path(watch.__file__).resolve().parent.parent
+
 
 class TestWhetherAProcessIsThere(Fixture):
     def test_this_process_is_alive(self) -> None:
@@ -61,6 +87,43 @@ class TestWhetherAProcessIsThere(Fixture):
 
     def test_a_reaped_process_is_not(self) -> None:
         self.assertFalse(watch.alive(self.reaped()))
+
+    def test_asking_does_not_disturb_the_job(self) -> None:
+        """Signal 0 is the *only* number that asks without doing.
+
+        1 is SIGHUP and its default action is to terminate, so a watcher that
+        reached for it would kill the sweep it was hired to report on -- and
+        would then correctly report it dead, which is the worst available
+        outcome. Driven against a real child because the property is the
+        kernel's, not the code's: `wait` timing out is the child surviving.
+        """
+        child = self.running()
+        self.assertTrue(watch.alive(child.pid))
+        with self.assertRaises(subprocess.TimeoutExpired):
+            child.wait(timeout=0.5)
+
+    def test_one_is_a_pid_and_not_a_group(self) -> None:
+        """The guard's boundary, pinned where the kernel will answer anywhere.
+
+        The `PermissionError` test below is skipped as root, which left the
+        guard's `<= 0` free to become `<= 1` -- refusing init -- with the whole
+        suite still green. This asks only that 1 gets through, which is true on
+        every machine.
+        """
+        self.assertEqual(watch.a_pid("1"), 1)
+        watch.alive(1)  # must not raise; what it answers is the next test's business
+
+    def test_a_process_that_is_not_ours_is_alive(self) -> None:
+        """The `PermissionError` branch, forced.
+
+        Mocked, unlike everything else here, because as root there is no process
+        this one may not signal -- the test below skips for exactly that reason
+        and takes the branch's only coverage with it. What this pins is the
+        mapping from that error to an answer, which is where the bug would be;
+        that the kernel raises it at all is the other test's job.
+        """
+        with mock.patch("os.kill", side_effect=PermissionError):
+            self.assertTrue(watch.alive(4242))
 
     def test_pid_one_is_alive_though_it_is_not_ours(self) -> None:
         """`PermissionError` means the process exists and belongs to somebody
@@ -108,28 +171,6 @@ class TestAPidThatIsNotOne(Fixture):
             watch.alive(0)
         self.assertIn("process group", str(raised.exception))
 
-    def test_the_command_line_refuses_it_as_a_usage_error(self) -> None:
-        """Through argparse rather than as a traceback: the whole failure this
-        tool addresses is a reader who has stopped watching closely, and a
-        stack trace twenty seconds in is not where they are looking."""
-        ran = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "tools.watch",
-                "0",
-                "--log",
-                str(self.log),
-                "--done",
-                str(self.done),
-            ],
-            cwd=Path(watch.__file__).resolve().parent.parent,
-            capture_output=True,
-            text=True,
-        )
-        self.assertEqual(ran.returncode, 2)
-        self.assertIn("process group", ran.stderr)
-
     def test_an_ordinary_pid_still_gets_through(self) -> None:
         """The guard above passes on a converter that rejects everything."""
         self.assertEqual(watch.a_pid(str(os.getpid())), os.getpid())
@@ -148,6 +189,20 @@ class TestTheJobIsGone(Fixture):
         out, which is exactly what the reader did for an hour."""
         line, _ = self.watching(self.reaped()).step() or ("", -1)
         self.assertIn("gone, not slow", line)
+
+    def test_it_says_how_long_the_job_had_been_running(self) -> None:
+        """Back-dated rather than waited out: an hour of test suite to pin a
+        number is not a trade anyone would take, and the arithmetic is the same.
+
+        Without it every assertion here reads "0m", which is what `// 60`
+        becoming `* 60` also produces at these timescales -- so the minutes
+        figure in the DIED line, the one thing telling a reader how much work
+        was lost, was unguarded.
+        """
+        watching = self.watching(self.reaped())
+        watching.began -= 3600.0
+        line, _ = watching.step() or ("", 0)
+        self.assertIn("after 60m", line)
 
     def test_it_says_how_far_the_job_got(self) -> None:
         self.log.write_text("row\nrow\nrow\n", encoding="utf-8")
@@ -270,46 +325,52 @@ class TestItForksNothing(Fixture):
 
 
 class TestTheCommandLine(Fixture):
+    def ran(self, *extra: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(self.command(*extra), cwd=self.repo, capture_output=True, text=True)
+
     def test_it_exits_zero_when_the_job_finished(self) -> None:
         self.done.write_text("{}", encoding="utf-8")
-        ran = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "tools.watch",
-                str(self.reaped()),
-                "--log",
-                str(self.log),
-                "--done",
-                str(self.done),
-            ],
-            cwd=Path(watch.__file__).resolve().parent.parent,
-            capture_output=True,
-            text=True,
-        )
+        ran = self.ran(str(self.reaped()))
         self.assertEqual(ran.returncode, 0, ran.stderr)
         self.assertIn("FINISHED", ran.stdout)
 
     def test_it_exits_one_when_the_job_died(self) -> None:
         """The exit status matters as much as the line: a caller that only reads
         the status still learns the difference."""
-        ran = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "tools.watch",
-                str(self.reaped()),
-                "--log",
-                str(self.log),
-                "--done",
-                str(self.done),
-            ],
-            cwd=Path(watch.__file__).resolve().parent.parent,
-            capture_output=True,
-            text=True,
-        )
+        ran = self.ran(str(self.reaped()))
         self.assertEqual(ran.returncode, 1)
         self.assertIn("DIED", ran.stdout)
+
+    def test_it_repeats_nothing_while_nothing_changes(self) -> None:
+        """Twenty polls, one line -- the promise the whole tool rests on.
+
+        Only reachable end to end: `step` returning None is the ordinary quiet
+        poll, and every other test here stops at the first event, so the code
+        that has to *survive* a None had no coverage at all. Run at 50ms so a
+        second of wall clock is twenty of them, and terminated rather than
+        waited for, because a watcher of something still running never exits.
+
+        A traceback would also be one line per poll, so both halves are checked:
+        the count, and that the stream is clean.
+        """
+        watcher = subprocess.Popen(
+            self.command(str(self.running().pid), "--interval", "0.05"),
+            cwd=self.repo,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self.addCleanup(watcher.kill)
+        time.sleep(1.0)
+        watcher.terminate()
+        out = watcher.communicate(timeout=10)[0]
+        self.assertNotIn("Traceback", out)
+        self.assertEqual(out.count("working:"), 1, out)
+
+    def test_a_pid_that_is_a_group_is_a_usage_error(self) -> None:
+        ran = self.ran("0")
+        self.assertEqual(ran.returncode, 2)
+        self.assertIn("process group", ran.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import ast
 import os
 import re
+import resource
 import subprocess
 import sys
 import tempfile
@@ -57,8 +58,23 @@ class Fixture(unittest.TestCase):
         return child.pid
 
     def running(self) -> subprocess.Popen[bytes]:
-        """A process that will still be there in a second unless something kills it."""
-        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        """A process that will still be there in a second unless something kills it.
+
+        SIGHUP is reset to its default explicitly, and that line is the whole
+        test below. A disposition of SIG_IGN is inherited across fork *and*
+        exec, so a suite launched under `nohup` -- which is how a detached
+        mutation run gets started, and how this one was -- hands every child an
+        ignored SIGHUP. Without the reset the sweep reported "watching cannot
+        kill the job" as unproven on the machine that most needed to know it,
+        and would have proven it on CI by luck.
+        """
+        child = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import signal, time; signal.signal(signal.SIGHUP, signal.SIG_DFL); time.sleep(30)",
+            ]
+        )
         self.addCleanup(child.wait)
         self.addCleanup(child.kill)
         return child
@@ -365,6 +381,7 @@ class TestTheCommandLine(Fixture):
         A traceback would also be one line per poll, so both halves are checked:
         the count, and that the stream is clean.
         """
+        before = resource.getrusage(resource.RUSAGE_CHILDREN).ru_utime
         watcher = subprocess.Popen(
             self.command(str(self.running().pid), "--interval", "0.05"),
             cwd=self.repo,
@@ -374,10 +391,27 @@ class TestTheCommandLine(Fixture):
         )
         self.addCleanup(watcher.kill)
         time.sleep(1.0)
+        # Before the terminate, because "it exited on its own" and "it was still
+        # watching" are the two answers here and terminating erases the
+        # difference. Returning on a `working` line is a watcher that stops at
+        # the first sign of life, which is worse than not running it.
+        self.assertIsNone(watcher.poll(), "the watcher returned instead of carrying on")
         watcher.terminate()
         out = watcher.communicate(timeout=10)[0]
         self.assertNotIn("Traceback", out)
         self.assertEqual(out.count("working:"), 1, out)
+        # The sleep, measured rather than read. Dropping it changes no output at
+        # all -- same lines, same order -- and turns the tool into a spin on a
+        # machine that is already busy with the job it is watching, which is the
+        # one promise its docstring makes that nothing else here checks.
+        #
+        # `RUSAGE_CHILDREN` counts children that have been waited for, and
+        # `communicate` waited for this one; the sleeping process from
+        # `running()` is not reaped until cleanup. A loaded machine can only
+        # give the watcher *less* CPU than this, so the threshold has no false
+        # failure in it.
+        burned = resource.getrusage(resource.RUSAGE_CHILDREN).ru_utime - before
+        self.assertLess(burned, 0.5, f"a second of watching cost {burned:.2f}s of CPU")
 
     def test_a_pid_that_is_a_group_is_a_usage_error(self) -> None:
         ran = self.ran("0")

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,0 +1,316 @@
+"""`tools/watch.py`: the three answers, and the two ways they were got wrong.
+
+The tool exists because a mutation sweep was reported alive twice after it had
+died, so these tests are mostly about the *negative* cases -- a job that is gone
+must be called gone, and a job that finished must not be called gone.
+
+Driven against real processes and real files. The subject is the kernel's answer
+about a pid and the presence of a file on disk, and a fixture that mocked either
+would be asserting the belief that was wrong in the first place.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools import watch
+
+ANY = re.compile(".")
+
+
+class Fixture(unittest.TestCase):
+    """A scratch log and report path, and a way to make a pid that is really gone."""
+
+    def setUp(self) -> None:
+        box = tempfile.TemporaryDirectory()
+        self.addCleanup(box.cleanup)
+        self.root = Path(box.name)
+        self.log = self.root / "run.log"
+        self.done = self.root / "report.json"
+
+    def watching(self, pid: int, match: str = ".") -> watch.Watch:
+        return watch.Watch(pid, self.log, self.done, re.compile(match))
+
+    def reaped(self) -> int:
+        """A pid that has certainly exited *and been waited for*.
+
+        Waited for, which is the part that matters: an unreaped child is a
+        zombie, and signal 0 succeeds for one, so a fixture that only killed
+        would be asserting the opposite of what it meant. `Popen.wait` reaps, so
+        what this returns is a pid the kernel no longer knows.
+
+        `CompletedProcess` has no `pid`, which is why this is `Popen` and not
+        the shorter `subprocess.run` -- the first version of this file used the
+        latter and every test here errored.
+        """
+        child = subprocess.Popen([sys.executable, "-c", ""])
+        child.wait()
+        return child.pid
+
+
+class TestWhetherAProcessIsThere(Fixture):
+    def test_this_process_is_alive(self) -> None:
+        self.assertTrue(watch.alive(os.getpid()))
+
+    def test_a_reaped_process_is_not(self) -> None:
+        self.assertFalse(watch.alive(self.reaped()))
+
+    def test_pid_one_is_alive_though_it_is_not_ours(self) -> None:
+        """`PermissionError` means the process exists and belongs to somebody
+        else, which is alive for this purpose. Reporting it dead would be the
+        same false negative the pattern match was a false positive.
+
+        Skipped where this process *can* signal pid 1 -- running as root, or in
+        a container where the suite is pid 1's own tree -- because then the call
+        answers through the ordinary path and pins nothing about the branch.
+        """
+        try:
+            os.kill(1, 0)
+        except PermissionError:
+            pass
+        except (ProcessLookupError, OSError):
+            self.skipTest("no pid 1 to ask about")
+        else:
+            self.skipTest("this process may signal pid 1, so the branch is not reached")
+        self.assertTrue(watch.alive(1))
+
+
+class TestAPidThatIsNotOne(Fixture):
+    """The false positive that survives the move off `pgrep`.
+
+    `os.kill(0, 0)` signals the caller's own process group and always succeeds,
+    so a watcher handed a 0 -- from a launcher whose pid variable never got
+    set -- would report alive for ever while its job was gone. The point of the
+    tool is that liveness cannot be answered by accident; a group is an accident.
+    """
+
+    def test_pid_zero_is_refused_rather_than_answered(self) -> None:
+        with self.assertRaises(ValueError):
+            watch.alive(0)
+
+    def test_a_negative_pid_is_refused(self) -> None:
+        """Negatives are the explicit spelling of the same thing: `kill(-n, 0)`
+        addresses process group n."""
+        with self.assertRaises(ValueError):
+            watch.alive(-1)
+
+    def test_the_message_says_what_is_wrong_with_it(self) -> None:
+        """A `ValueError` reading "0" tells the reader nothing they did not
+        type."""
+        with self.assertRaises(ValueError) as raised:
+            watch.alive(0)
+        self.assertIn("process group", str(raised.exception))
+
+    def test_the_command_line_refuses_it_as_a_usage_error(self) -> None:
+        """Through argparse rather than as a traceback: the whole failure this
+        tool addresses is a reader who has stopped watching closely, and a
+        stack trace twenty seconds in is not where they are looking."""
+        ran = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tools.watch",
+                "0",
+                "--log",
+                str(self.log),
+                "--done",
+                str(self.done),
+            ],
+            cwd=Path(watch.__file__).resolve().parent.parent,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(ran.returncode, 2)
+        self.assertIn("process group", ran.stderr)
+
+    def test_an_ordinary_pid_still_gets_through(self) -> None:
+        """The guard above passes on a converter that rejects everything."""
+        self.assertEqual(watch.a_pid(str(os.getpid())), os.getpid())
+
+
+class TestTheJobIsGone(Fixture):
+    """The failure the tool was written for: a death that looked like patience."""
+
+    def test_a_dead_pid_is_reported_dead(self) -> None:
+        line, status = self.watching(self.reaped()).step() or ("", -1)
+        self.assertIn("DIED", line)
+        self.assertEqual(status, 1)
+
+    def test_it_says_gone_rather_than_slow(self) -> None:
+        """The wording is the point. "No report yet" reads as something to wait
+        out, which is exactly what the reader did for an hour."""
+        line, _ = self.watching(self.reaped()).step() or ("", -1)
+        self.assertIn("gone, not slow", line)
+
+    def test_it_says_how_far_the_job_got(self) -> None:
+        self.log.write_text("row\nrow\nrow\n", encoding="utf-8")
+        line, _ = self.watching(self.reaped()).step() or ("", -1)
+        self.assertIn("3 rows", line)
+
+
+class TestAFinishedJobIsNotADeadOne(Fixture):
+    """`done` is checked before `alive`, and this is the test for that order.
+
+    A job's last two acts are to write its report and to exit, so there is a
+    window where it is finished *and* gone. Asking about the process first
+    reports a successful run as a death -- the same false alarm as the original
+    bug, arriving from the other side.
+    """
+
+    def test_a_report_from_a_process_that_has_exited_is_a_finish(self) -> None:
+        self.done.write_text("{}", encoding="utf-8")
+        line, status = self.watching(self.reaped()).step() or ("", -1)
+        self.assertIn("FINISHED", line)
+        self.assertEqual(status, 0)
+
+    def test_without_the_report_the_same_pid_is_a_death(self) -> None:
+        """The fixture that keeps the test above from passing on a `step` that
+        can no longer report a death at all."""
+        line, status = self.watching(self.reaped()).step() or ("", -1)
+        self.assertIn("DIED", line)
+        self.assertEqual(status, 1)
+
+
+class TestWhatCountsAsProgress(Fixture):
+    def test_the_first_look_is_an_event_even_at_zero(self) -> None:
+        """`last` starts at -1 so that a job with nothing done yet still says so.
+        At 0 the opening silence would be indistinguishable from a job that never
+        starts, which is the shape this tool exists to remove."""
+        line, status = self.watching(os.getpid()).step() or ("", 0)
+        self.assertEqual((line, status), ("working: 0 rows after 0m", -1))
+
+    def test_an_unchanged_count_is_not_an_event(self) -> None:
+        """One line per twenty seconds for forty minutes is the same as no
+        signal, by a different route."""
+        watching = self.watching(os.getpid())
+        watching.step()
+        self.assertIsNone(watching.step())
+
+    def test_a_changed_count_is(self) -> None:
+        watching = self.watching(os.getpid())
+        watching.step()
+        self.log.write_text("row\n", encoding="utf-8")
+        line, _ = watching.step() or ("", 0)
+        self.assertIn("1 rows", line)
+
+    def test_only_matching_lines_are_counted(self) -> None:
+        self.log.write_text("caught one\nnoise\ncaught two\n", encoding="utf-8")
+        line, _ = self.watching(os.getpid(), match="^caught").step() or ("", 0)
+        self.assertIn("2 rows", line)
+
+    def test_a_log_that_does_not_exist_yet_is_zero_rather_than_an_error(self) -> None:
+        """A job that has not opened its log is at zero rows. Treating absence as
+        a failure would put a line on the stream nobody can act on."""
+        self.assertEqual(watch.counted(self.root / "not-yet", ANY), 0)
+
+
+class TestItForksNothing(Fixture):
+    """The property that keeps the original bug from coming back.
+
+    `pgrep`, `ps` and every other name-matching answer to "is it alive" shares
+    the hole that started this: they match on a command line, and the checker's
+    own command line is on it. `os.kill(pid, 0)` asks the kernel about one pid
+    and cannot be confused by what anything is called.
+
+    Asserted structurally, because the failure is a *future* edit reaching for a
+    subprocess again, and no behavioural test would notice until it had already
+    reported something dead as alive. The suite does the same for the shell
+    hook, which must not fork on the record path.
+    """
+
+    def parsed(self) -> ast.Module:
+        """The module as code, not as text.
+
+        Through `ast` rather than a grep, for the reason `test_docs` gives for
+        the same choice: the source is full of strings that are *prose*, and
+        this module's docstring names `pgrep`, `ps` and `/proc` at length
+        precisely because it is explaining why it does not use them. A grep
+        cannot tell the warning from the deed, and the first version of this
+        test failed on its own explanation.
+        """
+        return ast.parse(Path(watch.__file__).read_text(encoding="utf-8"))
+
+    def test_it_imports_nothing_that_starts_a_process(self) -> None:
+        imported = {
+            name.name.split(".")[0]
+            for node in ast.walk(self.parsed())
+            if isinstance(node, ast.Import)
+            for name in node.names
+        } | {
+            node.module.split(".")[0]
+            for node in ast.walk(self.parsed())
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        for forbidden in ("subprocess", "multiprocessing", "pty"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, imported)
+
+    def test_it_calls_nothing_that_starts_a_process(self) -> None:
+        """`os` is imported for `os.kill`, so the import check above cannot see
+        `os.system` or `os.popen`. These are the attribute names that would
+        bring a shell back."""
+        reached = {node.attr for node in ast.walk(self.parsed()) if isinstance(node, ast.Attribute)}
+        for forbidden in ("system", "popen", "spawnv", "fork"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, reached)
+
+    def test_the_guard_can_actually_fail(self) -> None:
+        """Both checks above pass on a module that does nothing at all, so this
+        pins that they are looking at something: `os.kill` is the one call the
+        tool is allowed, and it must be there."""
+        reached = {node.attr for node in ast.walk(self.parsed()) if isinstance(node, ast.Attribute)}
+        self.assertIn("kill", reached)
+
+
+class TestTheCommandLine(Fixture):
+    def test_it_exits_zero_when_the_job_finished(self) -> None:
+        self.done.write_text("{}", encoding="utf-8")
+        ran = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tools.watch",
+                str(self.reaped()),
+                "--log",
+                str(self.log),
+                "--done",
+                str(self.done),
+            ],
+            cwd=Path(watch.__file__).resolve().parent.parent,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(ran.returncode, 0, ran.stderr)
+        self.assertIn("FINISHED", ran.stdout)
+
+    def test_it_exits_one_when_the_job_died(self) -> None:
+        """The exit status matters as much as the line: a caller that only reads
+        the status still learns the difference."""
+        ran = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tools.watch",
+                str(self.reaped()),
+                "--log",
+                str(self.log),
+                "--done",
+                str(self.done),
+            ],
+            cwd=Path(watch.__file__).resolve().parent.parent,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(ran.returncode, 1)
+        self.assertIn("DIED", ran.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -72,11 +72,23 @@ class Fixture(unittest.TestCase):
             [
                 sys.executable,
                 "-c",
-                "import signal, time; signal.signal(signal.SIGHUP, signal.SIG_DFL); time.sleep(30)",
-            ]
+                "import signal, sys, time\n"
+                "signal.signal(signal.SIGHUP, signal.SIG_DFL)\n"
+                "sys.stdout.write('x')\n"
+                "sys.stdout.flush()\n"
+                "time.sleep(30)\n",
+            ],
+            stdout=subprocess.PIPE,
         )
         self.addCleanup(child.wait)
         self.addCleanup(child.kill)
+        assert child.stdout is not None
+        # Blocks until the reset above has actually run. Without this the caller
+        # signals a process that is still importing, the default is not restored
+        # yet, and the inherited SIG_IGN swallows it -- a fixture that proves the
+        # opposite of what it says while staying green. The sweep found it: the
+        # reset alone left the SIGHUP mutant alive.
+        self.assertEqual(child.stdout.read(1), b"x")
         return child
 
     def command(self, *extra: str) -> list[str]:

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -326,7 +326,19 @@ class TestItForksNothing(Fixture):
 
 class TestTheCommandLine(Fixture):
     def ran(self, *extra: str) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(self.command(*extra), cwd=self.repo, capture_output=True, text=True)
+        """Every invocation here is one that must *return*, so a hang is a
+        failure and not something to sit through.
+
+        The bound is not politeness. `main` is a `while True`, and the mutations
+        that stop it ever leaving -- dropping the `if` that returns on an event,
+        say -- turn a test without one into a test that never finishes. A
+        mutation run of this file spent ten minutes on its last ten rows for
+        exactly that reason, with the tool's own per-mutant timeout the only
+        thing left to catch them.
+        """
+        return subprocess.run(
+            self.command(*extra), cwd=self.repo, capture_output=True, text=True, timeout=30
+        )
 
     def test_it_exits_zero_when_the_job_finished(self) -> None:
         self.done.write_text("{}", encoding="utf-8")

--- a/tools/watch.py
+++ b/tools/watch.py
@@ -1,0 +1,210 @@
+"""Whether a long job is still working, still there, or gone -- said out loud.
+
+The other four tools in here do something. This one only watches, and it exists
+because two ways of *not* watching both failed in the same session.
+
+**Liveness came from `pgrep -f <name>`, and that answers about the asker.** A
+mutation sweep was checked with ``pgrep -f tools.mutate`` from a shell whose own
+command line contained ``tools.mutate`` -- so the check matched itself and
+reported a process alive that had been dead for ten minutes. Twice, to somebody
+who had asked twice whether it was stuck. Any liveness test that matches on a
+command line has this hole; the fix is not a better pattern but a different
+question, so this takes a **pid recorded at launch** and asks the kernel.
+
+**Silence was the only other signal.** A job that dies quietly looks exactly
+like a job still working, and the reader cannot tell them apart by waiting
+longer -- waiting longer is what both of them look like. So a death is an
+*event* here, with its own line and its own exit status, and the line says the
+job is gone rather than slow. `Monitor`'s own guidance is the same rule from the
+other end: a watcher that greps only for the success marker stays silent through
+a crash, and silence reads identically to progress.
+
+What that buys is a stream a person can leave running: one line when the count
+of finished work changes, one line when it ends, nothing in between. Emitting
+per poll instead would be a line every twenty seconds for forty minutes, which
+is the same as no signal at all by a different route.
+
+**It watches rather than wraps.** The obvious shape is to run the job itself and
+report as it goes, and that is wrong here: these jobs are already started
+detached, precisely so that a foreground call timing out does not take them
+with it. A watcher that insisted on being their parent would reintroduce the
+coupling they were detached to avoid.
+
+**It forks nothing and reads no `/proc`.** `os.kill(pid, 0)` is the whole of the
+liveness check, so this runs on macOS as well, and a watcher cannot itself
+become a source of load on a machine already busy with the thing it is
+watching. `tests/test_watch.py` asserts the no-fork property rather than
+trusting it, because a future "just shell out to `ps`" would restore exactly the
+class of bug the first paragraph is about.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import time
+from pathlib import Path
+
+#: Seconds between polls. Twenty rather than one: the events this reports are
+#: minutes apart, and the point of the tool is to be cheap enough to leave
+#: running beside a job that is already using the machine.
+INTERVAL = 20.0
+
+
+def alive(pid: int) -> bool:
+    """Whether ``pid`` still exists, asked of the kernel rather than of a name.
+
+    Signal 0 is the documented "check, do not deliver" spelling. Three answers
+    collapse into two on purpose:
+
+    - `ProcessLookupError` is the only one that means gone;
+    - `PermissionError` means the process is there and belongs to somebody else,
+      which is *alive* for this purpose -- reporting a job dead because it is not
+      ours would be the same false negative as the pattern match was a false
+      positive;
+    - anything else propagates, because a watcher that swallows the unexpected
+      is back to being silence.
+
+    Two honest limits. The first is why the jobs this watches are detached: a
+    *child* of this process that has exited but not been reaped is a zombie, and
+    signal 0 succeeds for a zombie. Nothing here reaps, so a watcher that had
+    spawned its subject could report it alive for ever. Watching something
+    started elsewhere has no such state -- see the module docstring on why it
+    does not wrap.
+
+    The second is unfixable from here: pids are recycled, so a long-dead job
+    whose number has been handed to something else reads as alive. Nothing short
+    of a start time from `/proc` distinguishes them, and that is Linux-only for
+    a window measured in tens of thousands of spawns. Said rather than guarded.
+    """
+    # 0 and the negatives are refused rather than answered, because `os.kill`
+    # reads them as *process groups* -- 0 meaning "every process in my own
+    # group", which signal 0 succeeds for unconditionally. A watcher handed one
+    # would report alive for ever: the same false positive as the pattern match,
+    # arriving through the front door. Raising is right where returning True
+    # would be a lie and returning False would be a different one.
+    if pid <= 0:
+        raise ValueError(f"{pid} names a process group, not a process")
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def counted(log: Path, pattern: re.Pattern[str]) -> int:
+    """How many lines of ``log`` match, or 0 while it does not exist yet.
+
+    Absent and empty are the same answer deliberately: a job that has not opened
+    its log is at zero rows, and distinguishing the two would put a line on the
+    stream for something nobody can act on.
+    """
+    try:
+        text = log.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return 0
+    return sum(1 for line in text.splitlines() if pattern.search(line))
+
+
+class Watch:
+    """One job being watched. Yields the lines a reader should see, in order.
+
+    A class rather than a loop with prints in it, so the decisions -- what counts
+    as an event, and in which order the two endings are checked -- can be tested
+    without a clock or a subprocess. `main` is the part that sleeps.
+    """
+
+    def __init__(self, pid: int, log: Path, done: Path, pattern: re.Pattern[str]) -> None:
+        self.pid = pid
+        self.log = log
+        self.done = done
+        self.pattern = pattern
+        self.began = time.monotonic()
+        #: -1 rather than 0, so a job that is already at zero rows still gets its
+        #: first "working" line. Starting at 0 would make the opening silence
+        #: indistinguishable from a job that never starts.
+        self.last = -1
+
+    def minutes(self) -> int:
+        return int((time.monotonic() - self.began) // 60)
+
+    def step(self) -> tuple[str, int] | None:
+        """The next line to print and an exit status, or None to keep watching.
+
+        **`done` is checked before `alive`, and the order is the whole
+        correctness of this function.** A job's last two acts are to write its
+        report and to exit, so there is a window in which it is finished *and*
+        gone. Asking about the process first reports a successful run as a death
+        -- the exact false alarm this tool exists to prevent, arriving from the
+        other direction.
+        """
+        rows = counted(self.log, self.pattern)
+        if self.done.exists():
+            return f"FINISHED after {self.minutes()}m: {rows} rows, report written", 0
+        if not alive(self.pid):
+            return (
+                f"DIED after {self.minutes()}m: {rows} rows done, no report written "
+                f"-- the job is gone, not slow",
+                1,
+            )
+        if rows != self.last:
+            self.last = rows
+            return f"working: {rows} rows after {self.minutes()}m", -1
+        return None
+
+
+def a_pid(text: str) -> int:
+    """``int``, minus the two values that name a group instead of a process.
+
+    A second copy of `alive`'s guard, on purpose: this one exists for the
+    *message*. argparse turns an `ArgumentTypeError` into a usage error naming
+    the argument, where letting `alive` raise would be a traceback arriving one
+    poll after the reader looked away.
+    """
+    pid = int(text)
+    if pid <= 0:
+        raise argparse.ArgumentTypeError(f"{pid} names a process group, not a process")
+    return pid
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.watch",
+        description="Report a long job's progress, and say plainly when it dies.",
+    )
+    parser.add_argument("pid", type=a_pid, help="the job's process id, recorded when it started")
+    parser.add_argument("--log", type=Path, required=True, help="the file it appends progress to")
+    parser.add_argument(
+        "--done",
+        type=Path,
+        required=True,
+        # A report left by an earlier run reads as an instant finish, because
+        # this asks whether the file is there and not who wrote it. Cheaper to
+        # say so than to date-stamp it and be wrong about clock skew.
+        help="the file it writes when it finishes; remove a previous run's first",
+    )
+    parser.add_argument(
+        "--match", default=".", help="count lines of --log matching this regex (default: all)"
+    )
+    parser.add_argument("--interval", type=float, default=INTERVAL, help="seconds between polls")
+    args = parser.parse_args(argv)
+
+    watch = Watch(args.pid, args.log, args.done, re.compile(args.match))
+    while True:
+        event = watch.step()
+        if event is not None:
+            line, status = event
+            # Flushed, because this is read as it happens rather than afterwards
+            # -- an unflushed pipe is a watcher that says nothing for an hour and
+            # then everything at once, which is the failure it was written for.
+            print(line, flush=True)
+            if status >= 0:
+                return status
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

A mutation sweep in the last session was reported alive twice **after it had
died**, to somebody who had asked twice whether it was stuck. The liveness check
was `pgrep -f tools.mutate`, run from a shell whose own command line contained
`tools.mutate` — so the pattern matched the asker. Any liveness test that matches
on a command line has that hole; the fix is not a better pattern but a different
question.

The second half of the failure is that silence was the only other signal. A job
that dies quietly looks exactly like a job still working, and waiting longer is
what both of them look like.

So: `tools/watch.py` takes a **pid recorded at launch**, asks the kernel with
`os.kill(pid, 0)`, and treats a death as an *event* with its own line and its own
exit status. One line when the count of finished work changes, one when it ends,
nothing in between — a stream a person can leave running.

```sh
python -m tools.watch $PID --log sweep.log --done r.json --match 'caught|SURVIVED'
```

It watches rather than wraps, because these jobs are started detached precisely
so a foreground call timing out does not take them with it; a watcher insisting
on being their parent would reintroduce the coupling they were detached to avoid.
It forks nothing and reads no `/proc`, and `tests/test_watch.py` asserts that
structurally (via `ast`, not grep — the module docstring names `pgrep`, `ps` and
`/proc` at length precisely because it is explaining why it does not use them,
and the first version of that test failed on its own explanation).

Fifth row added to CLAUDE.md's tools table, with the `pgrep` trap written down
beside it.

## It was used on itself

The three sweeps below were watched with the tool. The last one:

```
working: 44 rows after 0m
working: 58 rows after 0m
working: 63 rows after 0m
FINISHED after 1m: 68 rows, report written
```

And it earned its keep in a way I would rather report than not: **midway through
I declared the first sweep dead when it was merely slow.** The log had stopped at
58 of 68 rows, no report, and I called it reaped. It was still running — I found
it in the process table minutes later, next to the replacement I had started, two
sweeps competing for three lanes on four cores. That is the same error as the
original bug with the sign flipped, made by the same reasoning (silence read as a
verdict), and it is the reason the tool exists rather than an argument against it.

## Review (rule 1, middle row) found one real defect

`os.kill` reads **0 and the negatives as process groups** — 0 meaning "every
process in my own group", which signal 0 succeeds for unconditionally. A watcher
handed a `0` from a launcher whose pid variable never got set would have reported
alive for ever: the same false positive as the pattern match, arriving through
the front door. Now refused, in `alive()` for correctness and again in an
argparse converter so the message is a usage error rather than a traceback one
poll after the reader looked away.

Two limits are documented rather than guarded: a zombie child answers signal 0
(which is *why* it does not wrap), and pids are recycled — nothing short of a
start time from `/proc` distinguishes a recycled pid, and that is Linux-only.

## Mutation testing (rule 3)

`python -m tools.mutate --base main`, verbatim, three runs. The first found ten
survivors:

```
  SURVIVED  tools/watch.py:87 in alive() -- `0` becomes `1`
  SURVIVED  tools/watch.py:90 in alive() -- `0` becomes `1`
  SURVIVED  tools/watch.py:94 in alive() -- returns `False` instead of `True`
  SURVIVED  tools/watch.py:129 in Watch.__init__() -- `1` becomes `2`
  SURVIVED  tools/watch.py:132 in Watch.minutes() -- `//` becomes `*`
  SURVIVED  tools/watch.py:168 in a_pid() -- `0` becomes `1`
  SURVIVED  tools/watch.py:192 in main() -- the call to `parser.add_argument(...)` never happens
  SURVIVED  tools/watch.py:198 in main() -- the `if` is always taken
  SURVIVED  tools/watch.py:204 in main() -- the `if` is always taken
  SURVIVED  tools/watch.py:204 in main() -- `0` becomes `-1`
  SURVIVED  tools/watch.py:206 in main() -- the call to `time.sleep(...)` never happens
```

The final run:

```
1 file(s), 210 changed lines -> 68 mutants
3 lane(s) at 2679 MiB each, from 8037 MiB of usable memory -- see tools.mutate._share.
...
1 survived. A test that cannot see the fix removed is decoration:
  - tools/watch.py:129 in Watch.__init__() -- `1` becomes `2` (tests.test_watch)
Suspect the fixture before the mutation -- see CLAUDE.md rule 3.
```

67 of 68 caught. The survivor is `self.last = -1` becoming `-2`: `rows` is never
negative, so every negative sentinel is the same program. Equivalent, left alone.

Four of the ten were interesting enough to write down:

- **`os.kill(pid, 1)` is SIGHUP**, whose default action is to terminate. A
  watcher that reached for it would have killed the sweep it was hired to report
  on, and then correctly reported it dead — the worst available outcome. Nothing
  saw that. Now driven against a real child, `wait` timing out being the proof it
  survived.

  The fixture for it was wrong twice. A `SIG_IGN` disposition is inherited across
  fork **and** exec, so a suite launched under `nohup` — which is how a detached
  sweep gets started, and how this one was — hands every child an ignored SIGHUP;
  the test proved nothing on the machine that most needed to know. Resetting the
  disposition in the child was still not enough, because the signal arrived while
  the child was still importing. It now blocks on a byte from the child before
  signalling. The sweep caught both.

- **`step` returning `None` — the ordinary quiet poll — had no coverage at all**,
  because every other test stopped at the first event. So the code that has to
  *survive* a `None`, and the `--interval` argument, and the return-on-event
  condition, were all unguarded. One end-to-end test at 50ms now covers them:
  twenty polls, one line, still running when terminated.

- **The `time.sleep` was removable with no change to any output** — same lines,
  same order, a spin instead of a watch. Caught by measuring `RUSAGE_CHILDREN`
  CPU across that second. A loaded machine can only give the watcher *less* CPU,
  so the threshold has no false failure in it.

- **`// 60` becoming `* 60` was invisible** because every assertion read "0m".
  Back-dating `began` by an hour pins it without spending an hour.

The `--interval` and quiet-poll mutants also exposed a defect in my own tests:
the CLI invocations used `subprocess.run` with no `timeout`, so the mutants that
make `main` never return **hung** rather than failing. A sweep spent ten minutes
on its last ten rows and would have spent two hours. Bounded now, and the sweep
went from stalling indefinitely to 1 minute.

## Two things found on the way (rule 4)

**Filed as a P1 — `mutate.py`'s confirmation pass reports false `caught` on a
suite that is not green.** Issue to follow. `confirm()` calls
`run(widened, baseline=False, …)` with `failfast=True`, so unlike the selection
pass the whole-suite re-run never checks the suite is green first. On this
container three tests are red for environmental reasons, and both real survivors
of the second sweep came back "caught" naming
`test_an_unwritable_runtime_dir_falls_back_instead_of_giving_up` — a shell-hook
test that has never heard of `tools/watch.py`. That is the exact false `caught`
the module was rewritten to make impossible, one level up. Every sweep in this PR
that carries a survivor count was therefore run with `--no-confirm`.

**Said and let go:** `--interval 0` spins, and nothing rejects it. It is the
operator's own flag on a dev tool, and I would close the issue.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`). Local
`shellcheck` is 0.9.0 here against the `shellcheck-py>=0.11` CI pins, and reports
SC2120/SC2119 on `woswoar.bash` identically on `main`; this change touches no
shell.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_