### PR TITLE
fix: the confirmation pass takes a baseline (#268)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,12 @@ and the run says so; the narrow pass's own verdicts still stand. `--no-baseline`
 turns that off along with every other untouched-suite check, which is what it is
 for, and what it costs.
 
+Either way the `--json` report says which happened: `widened` is true only when
+every survivor in the file really was re-run against the whole suite. It is
+false after `--no-confirm`, after a suppressed confirmation, and in a
+part-written file from an interrupted sweep — the cases where the paragraph
+above promises something the file cannot deliver.
+
 Fifteen operators, and `--skip-operator NAME` drops one — the escape hatch for
 an equivalent mutant a whole operator keeps producing, where `# pragma: no
 mutate` only suppresses a line. Twelve rewrite an expression (`<` to `<=`, `and`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,14 @@ the file, and **every survivor is then re-run against the whole suite** before i
 is reported, so a narrow selection can cost time but cannot produce a false
 `SURVIVED`. On the change that became #216 that pass corrected nine of eleven.
 
+That pass takes its own baseline, and needs it: correcting a survivor is the
+claim *a test the selection had not run noticed this*, and on a suite that is
+already failing the claim is free — the re-run stops at the first red test,
+whatever it was about. So if the whole suite is not green, nothing is corrected
+and the run says so; the narrow pass's own verdicts still stand. `--no-baseline`
+turns that off along with every other untouched-suite check, which is what it is
+for, and what it costs.
+
 Fifteen operators, and `--skip-operator NAME` drops one — the escape hatch for
 an equivalent mutant a whole operator keeps producing, where `# pragma: no
 mutate` only suppresses a line. Twelve rewrite an expression (`<` to `<=`, `and`

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -864,6 +864,44 @@ class TestConfirmingNeedsAGreenSuiteToo(TwoRowsSharingALabel):
             ["survived", "survived"],
         )
 
+    def test_a_clean_report_is_neither_announced_nor_re_run(self) -> None:
+        """No survivor, so nothing to widen -- and nothing to say about it.
+
+        The promise holds vacuously, which is why `widened` is true here; a
+        clean sweep marked "not confirmed" would be the one report this tool
+        exists to produce, carrying a warning about work it correctly skipped.
+        Silence is asserted too, because falling through announces "confirming
+        0 survivor(s) against the whole suite" about a pass that runs nothing.
+        """
+        self.package(guarded=True)
+        report = run(
+            [Mutation("the clamp is gone", "mod.py", "if value < 0:", "if False:", "test_mod")],
+            baseline=False,
+        )
+        self.assertEqual([result.verdict.outcome for result in report.results], ["caught"])
+        with contextlib.redirect_stdout(io.StringIO()) as said:
+            confirmed = confirm(report, workers=None, timeout=60.0, memory=MEMORY)
+        self.assertEqual(said.getvalue(), "")
+        self.assertTrue(confirmed.widened)
+
+    def test_a_survivor_the_whole_suite_cannot_see_either_is_still_widened(self) -> None:
+        """The healthy-repo case, and the one the other tests skip past.
+
+        A real survivor on a green tree: the pass runs, corrects nothing, and
+        must still report that it happened -- otherwise `widened` is false
+        exactly when the news is "your test is genuinely weak", which is when a
+        reader most needs to trust the row.
+
+        Only the second row, because the first is corrected by the wide suite
+        and a non-empty `corrected` takes a different return.
+        """
+        report = run(self.two_rows_with_one_label(), baseline=False, strict=False)
+        genuine = Report(report.results[1:], report.baseline_red)
+        with contextlib.redirect_stdout(io.StringIO()):
+            confirmed = confirm(genuine, workers=None, timeout=60.0, memory=MEMORY)
+        self.assertEqual([result.verdict.outcome for result in confirmed.results], ["survived"])
+        self.assertTrue(confirmed.widened)
+
     def test_no_baseline_still_means_no_baseline(self) -> None:
         """The escape hatch keeps working, and the reader gets to see its price.
 

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -2186,6 +2186,52 @@ class TestTheGeneratedEntryPoint(MutateTestCase):
         self.assertIn("were not re-run against the whole suite", finished.stdout)
         self.assertEqual(finished.returncode, 1)
 
+    def red_for_its_own_reasons(self) -> None:
+        """A failing test the mutation has nothing to do with.
+
+        Untracked and outside `woswoar/`, so it changes no diff -- `mutable`
+        only generates for `woswoar/` and `tools/`, and `changed_lines` treats an
+        untracked *mutable* file as wholly changed. It is invisible to the narrow
+        pass (which runs `test_mod`) and unavoidable to the wide one.
+        """
+        self.write(
+            "tests/test_broken.py",
+            """
+            import unittest
+
+
+            class Broken(unittest.TestCase):
+                def test_something_else_entirely(self) -> None:
+                    self.fail("red for its own reasons")
+            """,
+        )
+
+    def test_a_red_suite_stops_the_confirmation_correcting(self) -> None:
+        """#268 through the command line, which is where it was wired.
+
+        The two mutants that survived this change's own sweep were both at this
+        call site -- `if not args.no_confirm` never taken, and the `not` dropped
+        from `baseline=not args.no_baseline`. Neither is visible to a test that
+        calls `confirm` directly, so the fix could have been wired to the wrong
+        flag, or to nothing, with every unit test still green.
+        """
+        self.repo(guarded=False)
+        self.red_for_its_own_reasons()
+        finished = cli(self.root, "--base", "HEAD", "--operator", "branch")
+        self.assertIn("of the confirmation rows only", finished.stdout, finished.stderr)
+        self.assertNotIn("caught by a test the selection had not run", finished.stdout)
+        self.assertEqual(finished.returncode, 1, finished.stdout + finished.stderr)
+
+    def test_no_baseline_reaches_the_confirmation_pass(self) -> None:
+        """The other direction, without which the test above passes on a call
+        site wired to `baseline=args.no_baseline` -- inverted, and asserting the
+        inversion. Same red tree, flag on: the check is skipped, so the run
+        corrects as it did before #268 and says nothing about a baseline."""
+        self.repo(guarded=False)
+        self.red_for_its_own_reasons()
+        finished = cli(self.root, "--base", "HEAD", "--operator", "branch", "--no-baseline")
+        self.assertNotIn("of the confirmation rows only", finished.stdout, finished.stderr)
+
     def test_the_two_ways_of_asking_for_nothing_are_refused(self) -> None:
         for args, said in (
             (("--all", "--base", "HEAD"), "Not both"),

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -624,13 +624,14 @@ class TestASpanThatNoLongerHoldsItsText(MutateTestCase):
         self.assertEqual((self.root / "mod.py").read_text(encoding="utf-8"), before)
 
 
-class TestConfirmingSurvivorsAgainstTheWholeSuite(MutateTestCase):
-    """The pass that makes narrow test selection a speed decision, not a wrong one.
+class TwoRowsSharingALabel(MutateTestCase):
+    """The fixture both confirmation suites below need, held in one place.
 
-    A row run against too few tests survives for the wrong reason, and that error
-    points the expensive way: it sends the author to rewrite a test that was
-    never weak. So every survivor is re-run against everything before it is
-    printed.
+    No tests of its own. It is a class rather than a function because it wants
+    `write`, and the two suites derive from it rather than copying it because a
+    fixture this fiddly -- two rows that must *both* survive the narrow pass,
+    one of which the wider suite catches -- drifts the moment there are two of
+    it, and a drifted copy is how a confirmation test stops confirming anything.
     """
 
     def two_rows_with_one_label(self) -> list[Mutation]:
@@ -684,6 +685,16 @@ class TestConfirmingSurvivorsAgainstTheWholeSuite(MutateTestCase):
             Mutation(shared, "mod.py", "2", "9", "test_narrow", span=(at_two, at_two + 1)),
         ]
 
+
+class TestConfirmingSurvivorsAgainstTheWholeSuite(TwoRowsSharingALabel):
+    """The pass that makes narrow test selection a speed decision, not a wrong one.
+
+    A row run against too few tests survives for the wrong reason, and that error
+    points the expensive way: it sends the author to rewrite a test that was
+    never weak. So every survivor is re-run against everything before it is
+    printed.
+    """
+
     def test_a_shared_label_does_not_spread_one_rows_answer_to_another(self) -> None:
         """Keying the corrections by label wrote the caught row's verdict onto the
         other, so a genuine survivor was reported as `caught` -- naming a test
@@ -704,6 +715,130 @@ class TestConfirmingSurvivorsAgainstTheWholeSuite(MutateTestCase):
             "one row's confirmation was written onto the other",
         )
         self.assertFalse(confirmed.clean)
+
+
+class TestConfirmingNeedsAGreenSuiteToo(TwoRowsSharingALabel):
+    """#268: the one pass that had no baseline, and what it cost.
+
+    `confirm` re-runs each survivor against everything with `failfast`, so the
+    first red test settles the row. On a suite that is already failing for its
+    own reasons that test is always reached, and every survivor comes back
+    "caught by a test the selection had not run" -- naming a test that has never
+    heard of the file under mutation. A false clean sweep, in the report a pull
+    request quotes as evidence.
+
+    Found for real: two genuine survivors of a `tools/watch.py` sweep were both
+    credited to a shell-hook test, on a container where three tests are red for
+    environmental reasons.
+    """
+
+    def with_an_unrelated_failure(self) -> Report:
+        """The narrow pass over two survivors, in a tree whose wider suite is red.
+
+        Built on `two_rows_with_one_label`'s fixture because it already has what
+        this needs and is hard to get: two rows that *survive* the narrow pass,
+        so there is something for `confirm` to widen, one of which the wide
+        suite legitimately catches and one of which it does not.
+
+        The failure is deliberately about nothing -- it does not import `mod`,
+        let alone call it -- because the point is that being red is enough. A
+        broken test that touched the mutated module would leave the reader
+        unable to tell a false correction from a true one.
+        """
+        rows = self.two_rows_with_one_label()
+        self.write(
+            "test_broken.py",
+            """
+            import unittest
+
+
+            class Broken(unittest.TestCase):
+                def test_something_else_entirely(self) -> None:
+                    self.fail("red for its own reasons")
+            """,
+        )
+        report = run(rows, baseline=False, strict=False)
+        self.assertEqual(
+            [result.verdict.outcome for result in report.results],
+            ["survived", "survived"],
+            "precondition: both rows must survive, or nothing is widened",
+        )
+        return report
+
+    def test_a_red_suite_corrects_nothing(self) -> None:
+        """Both rows stand as the narrow pass reported them.
+
+        Including the first, which the wide suite really does catch. Suppressing
+        a correction that happens to be true is the price of not publishing the
+        one that is false: with the suite red there is no way to tell them apart
+        from in here, and a report that is right by luck is the thing this
+        module refuses to produce.
+        """
+        report = self.with_an_unrelated_failure()
+        with contextlib.redirect_stdout(io.StringIO()):
+            confirmed = confirm(report, workers=None, timeout=60.0, memory=MEMORY)
+        self.assertEqual(
+            [result.verdict.outcome for result in confirmed.results],
+            ["survived", "survived"],
+            "a red suite was allowed to correct a survivor",
+        )
+
+    def test_it_says_the_suite_is_why(self) -> None:
+        """A silently unwidened survivor is a different bug report.
+
+        The reader is deciding whether to go and strengthen a test. "This row
+        survived" and "this row survived and nothing could widen it" send them
+        to different places, and only one of them is true here.
+        """
+        report = self.with_an_unrelated_failure()
+        with contextlib.redirect_stdout(io.StringIO()) as said:
+            confirm(report, workers=None, timeout=60.0, memory=MEMORY)
+        spoken = said.getvalue()
+        self.assertIn("BASELINE NOT GREEN", spoken)
+        # Not "stand as reported": the unanswerable-row line further down says
+        # that too, so a mutation removing this one would have been caught by
+        # the wrong print. `run`'s own "nothing above means anything" needs the
+        # scoping this line gives it, and that is what is asserted.
+        self.assertIn("of the confirmation rows only", spoken)
+        self.assertIn("No survivor was corrected", spoken)
+        self.assertNotIn("caught by a test the selection had not run", spoken)
+
+    def test_no_baseline_still_means_no_baseline(self) -> None:
+        """The escape hatch keeps working, and the reader gets to see its price.
+
+        `--no-baseline` exists for a tree the author knows is red and wants
+        mutation answers about anyway. If the check it turns off ran here
+        regardless, the flag would silently stop correcting anything on exactly
+        the tree it was reached for -- a worse failure than the one #268 fixed,
+        because at least that one printed a reason.
+
+        So with it off this is the old behaviour, false correction and all: the
+        second row is a real survivor and the broken test "catches" it.
+        """
+        report = self.with_an_unrelated_failure()
+        with contextlib.redirect_stdout(io.StringIO()):
+            confirmed = confirm(report, workers=None, timeout=60.0, memory=MEMORY, baseline=False)
+        self.assertEqual(
+            [result.verdict.outcome for result in confirmed.results],
+            ["caught", "caught"],
+            "--no-baseline no longer reaches the confirmation pass",
+        )
+
+    def test_a_green_suite_still_corrects(self) -> None:
+        """The other half, without which everything above passes on a `confirm`
+        that has stopped correcting anything at all.
+
+        Same fixture minus the broken test: the first row is caught by the wide
+        suite, the second is a real survivor and stays one.
+        """
+        rows = self.two_rows_with_one_label()
+        report = run(rows, baseline=False, strict=False)
+        with contextlib.redirect_stdout(io.StringIO()):
+            confirmed = confirm(report, workers=None, timeout=60.0, memory=MEMORY)
+        self.assertEqual(
+            [result.verdict.outcome for result in confirmed.results],
+            ["caught", "survived"],
+        )
 
 
 class TestASubTestIsARealAnswer(MutateTestCase):

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -66,6 +66,35 @@ class MutateTestCase(unittest.TestCase):
         path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
         return path
 
+    def red_for_its_own_reasons(self, at: str) -> None:
+        """A failing test the mutation has nothing to do with.
+
+        Deliberately about nothing -- it does not import the mutated module, let
+        alone call it -- because what the callers need is that *being red is
+        enough*. One that touched the module under mutation would leave a reader
+        unable to tell a false correction from a true one.
+
+        The path is the caller's, and under a git fixture it matters: it must be
+        untracked and outside `woswoar/`, or `changed_lines` treats it as wholly
+        changed and puts it in the diff.
+
+        Here rather than in the two suites that want it, for the reason `CLAMP`
+        gives above: written out separately, two copies stay self-consistent
+        while drifting into being red for different reasons, and both suites go
+        on looking green.
+        """
+        self.write(
+            at,
+            """
+            import unittest
+
+
+            class Broken(unittest.TestCase):
+                def test_something_else_entirely(self) -> None:
+                    self.fail("red for its own reasons")
+            """,
+        )
+
     def package(self, guarded: bool, inside: str = "", both: bool = False) -> None:
         """A module with one behaviour, and a test that may or may not see it.
 
@@ -730,6 +759,13 @@ class TestConfirmingNeedsAGreenSuiteToo(TwoRowsSharingALabel):
     Found for real: two genuine survivors of a `tools/watch.py` sweep were both
     credited to a shell-hook test, on a container where three tests are red for
     environmental reasons.
+
+    The other half -- that a *green* suite still corrects, without which all of
+    this passes on a `confirm` that has stopped correcting anything at all -- is
+    `TestConfirmingSurvivorsAgainstTheWholeSuite`'s own test, on this same
+    fixture, one class up. It is not repeated here: it asserts strictly more,
+    and a second copy is another whole-suite run for an answer already in the
+    same file and the same run.
     """
 
     def with_an_unrelated_failure(self) -> Report:
@@ -746,17 +782,7 @@ class TestConfirmingNeedsAGreenSuiteToo(TwoRowsSharingALabel):
         unable to tell a false correction from a true one.
         """
         rows = self.two_rows_with_one_label()
-        self.write(
-            "test_broken.py",
-            """
-            import unittest
-
-
-            class Broken(unittest.TestCase):
-                def test_something_else_entirely(self) -> None:
-                    self.fail("red for its own reasons")
-            """,
-        )
+        self.red_for_its_own_reasons("test_broken.py")
         report = run(rows, baseline=False, strict=False)
         self.assertEqual(
             [result.verdict.outcome for result in report.results],
@@ -795,13 +821,48 @@ class TestConfirmingNeedsAGreenSuiteToo(TwoRowsSharingALabel):
             confirm(report, workers=None, timeout=60.0, memory=MEMORY)
         spoken = said.getvalue()
         self.assertIn("BASELINE NOT GREEN", spoken)
-        # Not "stand as reported": the unanswerable-row line further down says
-        # that too, so a mutation removing this one would have been caught by
-        # the wrong print. `run`'s own "nothing above means anything" needs the
-        # scoping this line gives it, and that is what is asserted.
-        self.assertIn("of the confirmation rows only", spoken)
+        # The two halves, each from the function that owns it. `run` must scope
+        # its warning -- unscoped it reads as voiding the narrow pass too --
+        # and `confirm` must say what it decided. Not "stand as reported" on its
+        # own: the unanswerable-row line further down says that too, so a
+        # mutation removing this print would have been caught by the wrong one.
+        self.assertIn("nothing among the confirmation rows", spoken)
         self.assertIn("No survivor was corrected", spoken)
         self.assertNotIn("caught by a test the selection had not run", spoken)
+
+    def test_the_report_says_the_survivors_were_never_widened(self) -> None:
+        """The stdout line is gone the moment the terminal scrolls; the flag is
+        what `--json` writes and `tools/reached.py` will read.
+
+        `widened` is false until `confirm` earns it, so this asserts the earning
+        did not happen -- and the sibling below asserts it does on a green tree,
+        without which a flag hard-coded to false would pass here.
+        """
+        report = self.with_an_unrelated_failure()
+        with contextlib.redirect_stdout(io.StringIO()):
+            confirmed = confirm(report, workers=None, timeout=60.0, memory=MEMORY)
+        self.assertFalse(confirmed.widened)
+
+    def test_a_completed_pass_says_so(self) -> None:
+        report = run(self.two_rows_with_one_label(), baseline=False, strict=False)
+        with contextlib.redirect_stdout(io.StringIO()):
+            confirmed = confirm(report, workers=None, timeout=60.0, memory=MEMORY)
+        self.assertTrue(confirmed.widened)
+
+    def test_an_already_red_report_runs_nothing(self) -> None:
+        """The narrow pass's shard is a module inside the whole suite, so a red
+        one guarantees a red confirmation -- after paying a whole-suite run per
+        survivor to find out. Nothing should run, and the pass should not
+        announce itself either."""
+        report = self.with_an_unrelated_failure()._replace(baseline_red=True)
+        with contextlib.redirect_stdout(io.StringIO()) as said:
+            confirmed = confirm(report, workers=None, timeout=60.0, memory=MEMORY)
+        self.assertEqual(said.getvalue(), "")
+        self.assertFalse(confirmed.widened)
+        self.assertEqual(
+            [result.verdict.outcome for result in confirmed.results],
+            ["survived", "survived"],
+        )
 
     def test_no_baseline_still_means_no_baseline(self) -> None:
         """The escape hatch keeps working, and the reader gets to see its price.
@@ -822,22 +883,6 @@ class TestConfirmingNeedsAGreenSuiteToo(TwoRowsSharingALabel):
             [result.verdict.outcome for result in confirmed.results],
             ["caught", "caught"],
             "--no-baseline no longer reaches the confirmation pass",
-        )
-
-    def test_a_green_suite_still_corrects(self) -> None:
-        """The other half, without which everything above passes on a `confirm`
-        that has stopped correcting anything at all.
-
-        Same fixture minus the broken test: the first row is caught by the wide
-        suite, the second is a real survivor and stays one.
-        """
-        rows = self.two_rows_with_one_label()
-        report = run(rows, baseline=False, strict=False)
-        with contextlib.redirect_stdout(io.StringIO()):
-            confirmed = confirm(report, workers=None, timeout=60.0, memory=MEMORY)
-        self.assertEqual(
-            [result.verdict.outcome for result in confirmed.results],
-            ["caught", "survived"],
         )
 
 
@@ -2169,6 +2214,9 @@ class TestTheGeneratedEntryPoint(MutateTestCase):
         self.assertEqual(finished.returncode, 0, finished.stdout + finished.stderr)
         written = json.loads(report.read_text(encoding="utf-8"))
         self.assertFalse(written["baseline_red"])
+        # The claim the file makes about itself, and the only place it survives
+        # the terminal: every survivor here was re-run against the whole suite.
+        self.assertTrue(written["widened"])
         # As many rows as were printed, and about the file the diff touched.
         # What each row must *hold* is `TestTheJsonReport`'s question, asked
         # once there rather than again here.
@@ -2186,26 +2234,6 @@ class TestTheGeneratedEntryPoint(MutateTestCase):
         self.assertIn("were not re-run against the whole suite", finished.stdout)
         self.assertEqual(finished.returncode, 1)
 
-    def red_for_its_own_reasons(self) -> None:
-        """A failing test the mutation has nothing to do with.
-
-        Untracked and outside `woswoar/`, so it changes no diff -- `mutable`
-        only generates for `woswoar/` and `tools/`, and `changed_lines` treats an
-        untracked *mutable* file as wholly changed. It is invisible to the narrow
-        pass (which runs `test_mod`) and unavoidable to the wide one.
-        """
-        self.write(
-            "tests/test_broken.py",
-            """
-            import unittest
-
-
-            class Broken(unittest.TestCase):
-                def test_something_else_entirely(self) -> None:
-                    self.fail("red for its own reasons")
-            """,
-        )
-
     def test_a_red_suite_stops_the_confirmation_correcting(self) -> None:
         """#268 through the command line, which is where it was wired.
 
@@ -2216,9 +2244,9 @@ class TestTheGeneratedEntryPoint(MutateTestCase):
         flag, or to nothing, with every unit test still green.
         """
         self.repo(guarded=False)
-        self.red_for_its_own_reasons()
+        self.red_for_its_own_reasons("tests/test_broken.py")
         finished = cli(self.root, "--base", "HEAD", "--operator", "branch")
-        self.assertIn("of the confirmation rows only", finished.stdout, finished.stderr)
+        self.assertIn("No survivor was corrected", finished.stdout, finished.stderr)
         self.assertNotIn("caught by a test the selection had not run", finished.stdout)
         self.assertEqual(finished.returncode, 1, finished.stdout + finished.stderr)
 
@@ -2228,9 +2256,9 @@ class TestTheGeneratedEntryPoint(MutateTestCase):
         inversion. Same red tree, flag on: the check is skipped, so the run
         corrects as it did before #268 and says nothing about a baseline."""
         self.repo(guarded=False)
-        self.red_for_its_own_reasons()
+        self.red_for_its_own_reasons("tests/test_broken.py")
         finished = cli(self.root, "--base", "HEAD", "--operator", "branch", "--no-baseline")
-        self.assertNotIn("of the confirmation rows only", finished.stdout, finished.stderr)
+        self.assertNotIn("No survivor was corrected", finished.stdout, finished.stderr)
 
     def test_the_two_ways_of_asking_for_nothing_are_refused(self) -> None:
         for args, said in (

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -221,6 +221,20 @@ class Report(NamedTuple):
     #: Nothing in `results` means anything when this is set: a suite that already
     #: fails catches every mutation, including the ones no test can see.
     baseline_red: bool = False
+    #: Whether every survivor here was re-run against the whole suite, which is
+    #: what `CONTRIBUTING.md` promises about a survivor before it is reported.
+    #:
+    #: False by default and set only by `confirm`, rather than true by default
+    #: and cleared where the promise fails. The ways to *not* widen keep being
+    #: added -- `--no-confirm`, a red confirmation baseline, a crash mid-sweep --
+    #: and each one that forgot to clear the flag would claim a guarantee it had
+    #: not met. There is exactly one way to earn it, so that is what sets it.
+    #:
+    #: It is on the report at all because the failure is durable: `_persist`
+    #: writes these rows, `tools/reached.py` reads them back and explains each
+    #: survivor, and until #269 the only record that the promise had not been
+    #: kept was a line of prose in a terminal nobody scrolls back to.
+    widened: bool = False
 
     @property
     def clean(self) -> bool:
@@ -920,6 +934,7 @@ def run(
     timeout: float = TIMEOUT,
     memory: int = MEMORY,
     summarise: bool = True,
+    scope: str = "nothing above",
 ) -> Report:
     """Apply each mutation in its own copy of the tree; report what each answered.
 
@@ -932,6 +947,14 @@ def run(
     everything. Its targets are sharded and queued alongside the mutations rather
     than run as one serial pass, because a single pass over the union of every
     target was measured at two thirds of the wall clock.
+
+    ``scope`` names what a red baseline voids, because this function does not
+    always own the whole of "above". A nested pass -- `confirm`, or one batch of
+    a `sweep` -- prints its rows inside a larger run whose earlier verdicts are
+    still good, and "nothing above means anything" reads there as voiding those
+    too. The alternative was a second `print` in the caller correcting this one,
+    which is two sites that must stay adjacent, in order, and in agreement about
+    wording, with nothing enforcing any of the three.
 
     ``strict`` decides what an unanswerable row does. For a hand-written table it
     should stop the run: a row that breaks collection is a mistake in the table,
@@ -1016,7 +1039,7 @@ def run(
                 # happened.
                 print(
                     f"  BASELINE NOT GREEN ({baseline_verdict.outcome}) -- the suite does not "
-                    f"pass untouched, so nothing above means anything: {baseline_verdict.detail}"
+                    f"pass untouched, so {scope} means anything: {baseline_verdict.detail}"
                 )
                 red = True
                 break
@@ -1115,18 +1138,32 @@ def confirm(
     # had never seen it. On this branch's own diff, 23 labels are duplicated.
     #
     # `run` appends in table order, and with `strict=False` there is no early
-    # exit, so `again.results` is positionally aligned with `widened`.
+    # exit, so `again.results` is positionally aligned with `rerun`.
+    if report.baseline_red:
+        # The narrow pass already found the tree red, and its shard is a module
+        # *inside* the whole suite, so this pass would come back red too -- after
+        # paying one whole-suite run per survivor plus a baseline to learn it.
+        # `clean` is already False and nothing here could change that.
+        #
+        # It also drops a "confirming N survivor(s)..." line about a pass that
+        # was never going to correct one.
+        return report
     survivors = [
         (where, result)
         for where, result in enumerate(report.results)
         if result.verdict.outcome == "survived"
     ]
     if not survivors:
-        return report
+        # Vacuously widened: there was no survivor to re-run, so the promise
+        # holds. Leaving it false here would mark every clean sweep as
+        # unconfirmed, which is the one report this tool exists to produce.
+        return report._replace(widened=True)
     print(f"\nconfirming {len(survivors)} survivor(s) against the whole suite...")
-    widened = [result.mutation._replace(tests=WHOLE_SUITE) for _, result in survivors]
+    # `rerun` rather than `widened`: `Report.widened` is a different thing three
+    # lines down, and one word for two meanings in one function is a re-read.
+    rerun = [result.mutation._replace(tests=WHOLE_SUITE) for _, result in survivors]
     again = run(
-        widened,
+        rerun,
         baseline=baseline,
         workers=workers,
         strict=False,
@@ -1137,21 +1174,18 @@ def confirm(
         timeout=timeout,
         memory=memory,
         summarise=False,
+        # These rows are not the run's answer -- the narrow pass's are, and they
+        # are still good. See `run`'s ``scope``.
+        scope="nothing among the confirmation rows",
     )
 
     if again.baseline_red:
-        # Suppressed, not voided, and the wording has to carry that. `run` has
-        # just printed "nothing above means anything", which is true of the
-        # confirmation rows and false of the sweep -- the narrow pass had its
-        # own green baseline and its verdicts are worth exactly what they were.
-        # Left to stand alone, that line reads as voiding the whole run, which
-        # is the difference between "fix your suite and ask again" and "throw
-        # away the answers you have already paid for".
-        print(
-            "-- of the confirmation rows only. No survivor was corrected: on a "
-            "red suite, being noticed says nothing about the mutation. Every "
-            "verdict from the narrow pass stands as reported."
-        )
+        # Suppressed, not voided: the narrow pass had its own green baseline and
+        # its verdicts are worth exactly what they were. Only this line's own
+        # decision is printed here -- `run` has already scoped its warning to the
+        # confirmation rows, which is why that scoping is a parameter there
+        # rather than a correcting sentence here.
+        print("No survivor was corrected; the narrow pass's verdicts stand as reported.")
         return report
 
     # Only `caught` corrects a survivor. A confirmation that broke or timed out
@@ -1168,7 +1202,7 @@ def confirm(
     if unsure:
         print(f"{unsure} confirmation(s) could not be answered; those rows stand as reported.")
     if not corrected:
-        return report
+        return report._replace(widened=True)
     print(f"{len(corrected)} of them were caught by a test the selection had not run.")
     return Report(
         [
@@ -1176,6 +1210,7 @@ def confirm(
             for where, result in enumerate(report.results)
         ],
         report.baseline_red,
+        True,
     )
 
 
@@ -1287,7 +1322,10 @@ def _persist(report: Report, where: Path) -> None:
             }
         )
     where.write_text(
-        json.dumps({"baseline_red": report.baseline_red, "results": rows}, indent=1),
+        json.dumps(
+            {"baseline_red": report.baseline_red, "widened": report.widened, "results": rows},
+            indent=1,
+        ),
         encoding="utf-8",
     )
     print(f"\nwrote {len(rows)} row(s) to {where}")
@@ -1490,6 +1528,8 @@ def main(argv: list[str] | None = None) -> int:
                 baseline=not args.no_baseline,
             )
         else:
+            # Nothing to clear: `widened` is false until `confirm` earns it, so
+            # this branch reaches `_persist` saying so without a line here.
             print("\n--no-confirm: survivors below were not re-run against the whole suite,")
             print("so one may simply have been run against tests that cannot see it.")
         _summarise(report.results)

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -1068,7 +1068,14 @@ def verify(mutations: Iterable[Mutation], baseline: bool = True, workers: int | 
 WHOLE_SUITE = ""
 
 
-def confirm(report: Report, workers: int | None, timeout: float, memory: int) -> Report:
+def confirm(
+    report: Report,
+    workers: int | None,
+    timeout: float,
+    memory: int,
+    *,
+    baseline: bool = True,
+) -> Report:
     """Re-run every survivor against the whole suite, and correct the ones caught.
 
     This is what makes per-file test selection a *speed* decision rather than a
@@ -1080,6 +1087,25 @@ def confirm(report: Report, workers: int | None, timeout: float, memory: int) ->
     Only survivors, because they are the minority and the only ones whose answer
     can be wrong in that direction -- a `caught` row was caught by a real test,
     and no wider suite makes that less true.
+
+    **With a baseline, like every other pass, and this is the whole of #268.**
+    A correction here is the claim "a test the selection had not run noticed
+    this", and on a suite that is already failing the claim is free: `failfast`
+    stops at the first red test, whatever it was about. Both real survivors of
+    one sweep came back credited to a shell-hook test that had never heard of
+    the file under mutation. That is the false `caught` this module exists to
+    make impossible, arriving in the one pass that had no baseline.
+
+    The cost is one whole-suite run, not one per survivor: `run` shards its
+    baseline by `Mutation.tests`, and every row here carries `WHOLE_SUITE`, so
+    the set is a single shard queued alongside the survivors in the same lanes.
+
+    ``baseline`` is `--no-baseline` arriving here, and it has to arrive: that
+    flag means "skip the untouched-suite check", and a check it cannot turn off
+    would make it *worse* than useless on the tree it exists for -- a knowingly
+    red one -- by silently suppressing every correction instead of skipping a
+    check. Turned off, this is the pre-#268 behaviour, false `caught` included,
+    which is what the flag has always been an opt-in to.
     """
     # Positions, not labels. Two generated rows share a label whenever they touch
     # the same line with the same operator -- `generate` dedupes on `(span, new)`,
@@ -1101,7 +1127,7 @@ def confirm(report: Report, workers: int | None, timeout: float, memory: int) ->
     widened = [result.mutation._replace(tests=WHOLE_SUITE) for _, result in survivors]
     again = run(
         widened,
-        baseline=False,
+        baseline=baseline,
         workers=workers,
         strict=False,
         # As the narrow pass does, and for the same reason: the first test that
@@ -1112,6 +1138,21 @@ def confirm(report: Report, workers: int | None, timeout: float, memory: int) ->
         memory=memory,
         summarise=False,
     )
+
+    if again.baseline_red:
+        # Suppressed, not voided, and the wording has to carry that. `run` has
+        # just printed "nothing above means anything", which is true of the
+        # confirmation rows and false of the sweep -- the narrow pass had its
+        # own green baseline and its verdicts are worth exactly what they were.
+        # Left to stand alone, that line reads as voiding the whole run, which
+        # is the difference between "fix your suite and ask again" and "throw
+        # away the answers you have already paid for".
+        print(
+            "-- of the confirmation rows only. No survivor was corrected: on a "
+            "red suite, being noticed says nothing about the mutation. Every "
+            "verdict from the narrow pass stands as reported."
+        )
+        return report
 
     # Only `caught` corrects a survivor. A confirmation that broke or timed out
     # answered nothing, and folding it in would print "caught by a test the
@@ -1441,7 +1482,13 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         report = sweep(table, args) if args.all or args.batch else _run_generated(table, args)
         if not args.no_confirm:
-            report = confirm(report, args.workers, args.timeout, args.memory)
+            report = confirm(
+                report,
+                args.workers,
+                args.timeout,
+                args.memory,
+                baseline=not args.no_baseline,
+            )
         else:
             print("\n--no-confirm: survivors below were not re-run against the whole suite,")
             print("so one may simply have been run against tests that cannot see it.")


### PR DESCRIPTION
Closes #268.

## The bug

`confirm()` re-runs each survivor against the whole suite with `failfast=True`,
and called `run(..., baseline=False)`. Correcting a survivor is the claim *a test
the selection had not run noticed this* — and on a suite that is already failing,
that claim is free: the re-run stops at the first red test, whatever it was
about, and every survivor comes back caught. It was the one pass with no
baseline, which is the check that makes `caught` mean anything.

Now it takes one, and when that comes back red it corrects nothing and says so.

**Suppressed, not voided.** The narrow pass had its own green baseline, so its
verdicts still stand — only the *widening* is unbelievable. That distinction is
the difference between "fix your suite and ask again" and "throw away the answers
you already paid for", so it is in the output rather than left to the reader.

## It caught itself

An earlier revision of this branch, swept on a container where three tests are
red for environmental reasons:

```
  SURVIVED  tools/mutate.py:1484 in main() -- the `if` is never taken
  SURVIVED  tools/mutate.py:1490 in main() -- the `not` is dropped

confirming 2 survivor(s) against the whole suite...
  caught    tools/mutate.py:1484 in main() -- the `if` is never taken
  caught    tools/mutate.py:1490 in main() -- the `not` is dropped
  BASELINE NOT GREEN (caught) ... test_an_unwritable_runtime_dir_falls_back_instead_of_giving_up
No survivor was corrected; the narrow pass's verdicts stand as reported.
```

Both confirmation rows read `caught`, and both are false — credited to a
shell-hook test that has never heard of `tools/mutate.py`. Before this change
they would have been applied and the sweep would have exited zero. Those two
survivors were real, and are fixed below.

## What the report now records

A suppressed confirmation used to exist only as a line of prose in a terminal.
`_persist` still wrote `{"baseline_red": false, "results": [… "survived" …]}`,
and `tools/reached.py` reads exactly that file back to explain each survivor — so
a row that the whole suite *would* have caught gets filed as "a test reaches this
and asserts nothing", which is `confirm`'s own stated failure mode arriving
through the artifact instead of the table.

So `Report` carries **`widened`**, written to `--json`: whether every survivor in
the file really was re-run against the whole suite. It is false by default and
set only by `confirm`, rather than true by default and cleared where the promise
fails — the ways to not widen keep being added (`--no-confirm`, a red
confirmation baseline, a part-written file from an interrupted sweep) and each
one that forgot to clear it would claim a guarantee it had not met. There is one
way to earn it, so that is what sets it.

`reached.py` does not read it yet — it does not read `baseline_red` either, which
is a pre-existing hole this change makes reachable a second way. Filed rather
than widened into here.

## Cost

One extra whole-suite run per confirmation pass, not one per survivor: `run`
shards its baseline by `Mutation.tests` and every widened row carries
`WHOLE_SUITE`, so the set is a single shard queued alongside the survivors in the
same lanes. It consumes no extra lane either — `wanted` already counted
`len(table) + len(shards)`, so this puts a sandbox that was previously copied and
never borrowed to work. Zero added wall clock on a clean sweep (the pass returns
before running anything), and up to one suite run when every survivor is
corrected. That is arithmetic from the sharding, not a measurement: I did not
resolve a wall-clock difference on this four-core container, where sweep-to-sweep
variance is larger than the term.

Against it, `confirm` now returns immediately when the narrow pass **already**
reported a red baseline. Its shard is a module inside the whole suite, so the
answer was known before the pass started; that path used to pay S whole-suite
runs to arrive at the same `return`.

## `--no-baseline` still means no baseline

Threaded through to `confirm`, and this is not tidiness. That flag exists for a
tree the author *knows* is red and wants mutation answers about anyway. A check
it could not turn off would make the flag worse than useless on exactly the tree
it is reached for — silently suppressing every correction instead of skipping a
check. With it on, this is the pre-#268 behaviour, false `caught` included, which
is what the flag has always been an opt-in to.

## Tests (rule 3)

Eight unit tests on `confirm` and two through the command line. The fixture the
unit tests need — two rows that both survive the narrow pass, one of which the
wider suite legitimately catches — already existed for
`TestConfirmingSurvivorsAgainstTheWholeSuite`, so it is lifted into a shared base
class rather than copied; a fixture that fiddly drifts the moment there are two
of it. The unrelated failure is deliberately about nothing and does not import
the mutated module, because the point is that *being red is enough*.

**The hand table**, since the fix is a deletion and no generated operator re-adds
an argument:

```
3 lane(s) at 2679 MiB each, from 8037 MiB of usable memory -- see tools.mutate._share.
  caught    the confirmation pass runs without a baseline again
  caught    a red confirmation baseline stops suppressing corrections
```

**The generated sweep**, final state — 25 of 28 caught:

```
1 file(s), 97 changed lines -> 25 mutants
3 lane(s) at 2679 MiB each, from 8037 MiB of usable memory -- see tools.mutate._share.
...
3 survived. A test that cannot see the fix removed is decoration:
  - tools/mutate.py:1204 in confirm() -- the `if` is never taken (tests.test_mutate)
  - tools/mutate.py:1327 in _persist() -- `1` becomes `2` (tests.test_mutate)
  - tools/mutate.py:1327 in _persist() -- `1` becomes `0` (tests.test_mutate)
```

All three are equivalent, and I would rather argue that than leave it implied:

- `if not corrected:` never taken falls through to rebuild the `Report`, and with
  `corrected` empty `corrected.get(where, result.verdict)` returns each row's
  original verdict and `widened` is `True` on both paths. Same program.
- the two `_persist` rows are `json.dumps(indent=1)` becoming `indent=2` or `0`.
  Whitespace in a file every consumer reads with `json.loads`.

Earlier rounds were not equivalent. The first sweep's two survivors were **both
at the call site**, which no test calling `confirm()` directly can see — the fix
could have been wired to the wrong flag, or to nothing, with every unit test
green. They are now driven through `python -m tools.mutate` in a real git
fixture, in both directions: with the flag off the run must say it corrected
nothing, and with `--no-baseline` it must not. The `/simplify` round then left
five, of which two were real: a clean report announcing a confirmation pass it
does not run, and the `widened`-but-nothing-corrected return — which is the
*healthy repo* case, where the flag would have read false exactly when the news
is "your test is genuinely weak".

## Review

Rule 1's middle row, done as a careful read before the PR opened, then a full
`/simplify` on request. The read found two things, both applied: the new message
contradicted the "nothing above means anything" line it printed under, and
`--no-baseline` was not reaching the pass.

`/simplify` found five more, all applied:

- **The `widened` field**, above — the durable half of the bug.
- **`run()` now takes the noun for what a red baseline voids.** The first fix for
  the contradiction was a second `print` in `confirm` that grammatically
  continued `run`'s. Two prints in two functions that must stay adjacent, in
  order, and in agreement about wording, with nothing enforcing any of the three.
  `run` scopes its own warning now, and `confirm` prints only its own decision.
- **The early return** on an already-red report, above.
- **One spelling of the deliberately-failing module**, for the reason the `CLAMP`
  constant already gives in that file: two copies stay self-consistent while
  drifting into being red for different reasons, and both suites go on looking
  green.
- **Dropped a green-suite control** whose assertions are a strict subset of the
  sibling test on the same fixture, one class up. The class docstring names the
  sibling instead.

Two things named and skipped:

- `_borrow` never passes `failfast`, so the confirmation baseline runs the whole
  of a red suite to print the first failure `failfast` would have reached
  immediately — the longest task in a pass whose other rows are all failfast.
  Pre-existing, and a fix changes the narrow pass's baseline too.
- Under `sweep`, `_run_generated`'s per-batch "nothing above means anything" has
  the same over-claim `run`'s new `scope` parameter now fixes for `confirm`, with
  no corrector at all. It would be a one-argument fix, but it is a different bug
  in a different pass. Filed.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`). Which is, as
it happens, why this bug was visible here at all.