### PR TITLE
tools: a job that stops without ending is now an event too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,7 +275,9 @@ opens its PR and waits for a person regardless of what CI says.
   matches the asking shell's own command line, and it reported a dead sweep
   alive twice in one session, to somebody who had asked twice. Record the pid at
   launch and watch that — a death then arrives as a line and an exit status
-  rather than as more silence.
+  rather than as more silence, and so does a *stall*, which is the case that
+  actually bit: a run alive and wedged looks exactly like one that is slow, and
+  waiting longer is what both of them look like.
 
   **The generated sweep goes last.** Implement, write the hand table, preflight,
   run `/simplify` *and apply it*, and only then `--base main`. The table is

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -38,8 +38,23 @@ class Fixture(unittest.TestCase):
         self.log = self.root / "run.log"
         self.done = self.root / "report.json"
 
-    def watching(self, pid: int, match: str = ".") -> watch.Watch:
-        return watch.Watch(pid, self.log, self.done, re.compile(match))
+    def watching(self, pid: int, match: str = ".", stale: float = watch.STALE) -> watch.Watch:
+        return watch.Watch(pid, self.log, self.done, re.compile(match), stale)
+
+    def stuck_for(self, seconds: float, stale: float = 60.0) -> watch.Watch:
+        """A live watch whose count has not moved for ``seconds``.
+
+        Back-dated rather than waited out, as the elapsed-time tests here are:
+        the arithmetic is the same and the suite does not spend five minutes
+        proving a five-minute threshold. The first `step` is taken first, so the
+        clock this rewinds is the one a real run would be looking at -- rewinding
+        a freshly built `Watch` would test a state no job reaches, since the
+        opening poll always counts as movement.
+        """
+        watching = self.watching(os.getpid(), stale=stale)
+        watching.step()
+        watching.moved -= seconds
+        return watching
 
     def reaped(self) -> int:
         """A pid that has certainly exited *and been waited for*.
@@ -294,6 +309,90 @@ class TestWhatCountsAsProgress(Fixture):
         self.assertEqual(watch.counted(self.root / "not-yet", ANY), 0)
 
 
+class TestAJobCanStopWithoutEnding(Fixture):
+    """The third ending, and the one the first two versions of this tool missed.
+
+    `DIED` and `FINISHED` were events; being alive and wedged was silence -- the
+    same silence a job that is merely slow produces. So the reader was back to
+    guessing from the other side, which is the failure this whole tool is about.
+    It happened here: a mutation sweep went quiet at 58 of 68 rows and was called
+    dead, and it was still running.
+    """
+
+    def test_a_long_enough_silence_is_reported(self) -> None:
+        line, status = self.stuck_for(120.0).step() or ("", 0)
+        self.assertIn("STALLED", line)
+        self.assertEqual(status, -1)
+
+    def test_it_says_the_process_is_still_there(self) -> None:
+        """The half that separates this from `DIED`, and the half no amount of
+        waiting gives the reader. "Nothing is happening" and "nothing is
+        happening and the job is gone" call for different actions."""
+        line, _ = self.stuck_for(120.0).step() or ("", 0)
+        self.assertIn("alive and not working", line)
+
+    def test_it_says_how_long_and_how_far(self) -> None:
+        line, _ = self.stuck_for(120.0).step() or ("", 0)
+        self.assertIn("120s", line)
+        self.assertIn("0 rows", line)
+
+    def test_a_short_silence_is_not(self) -> None:
+        """The threshold is the whole value of the line. One that fires on an
+        ordinary gap trains the reader to skip it, and the next real one goes
+        with it."""
+        self.assertIsNone(self.stuck_for(30.0).step())
+
+    def test_it_does_not_repeat_itself_every_poll(self) -> None:
+        """A stall line every twenty seconds is the per-poll noise this tool was
+        built to avoid, arriving through the feature meant to fix it."""
+        watching = self.stuck_for(120.0)
+        self.assertIsNotNone(watching.step())
+        self.assertIsNone(watching.step())
+
+    def test_it_speaks_again_when_the_stall_doubles(self) -> None:
+        """One line at minute two is undatable by a reader arriving at minute
+        forty. A stall twice as long as the last report is new information."""
+        watching = self.stuck_for(120.0)
+        watching.step()
+        watching.moved -= 130.0
+        line, _ = watching.step() or ("", 0)
+        self.assertIn("250s", line)
+
+    def test_progress_starts_the_clock_again(self) -> None:
+        """Otherwise a job that recovers stays branded stalled for as long as it
+        runs, which is a lie that gets louder the longer it works."""
+        watching = self.stuck_for(120.0)
+        watching.step()
+        self.log.write_text("row\n", encoding="utf-8")
+        line, _ = watching.step() or ("", 0)
+        self.assertIn("working", line)
+        self.assertIsNone(watching.step())
+
+    def test_zero_turns_it_off(self) -> None:
+        """For a job whose work genuinely arrives in one lump at the end, where
+        every poll before it is a true stall and none of them is news."""
+        self.assertIsNone(self.stuck_for(9999.0, stale=0.0).step())
+
+    def test_a_finish_outranks_a_stall(self) -> None:
+        """`done` is checked first, and a stalled job that has since written its
+        report is a finished one. Reporting the stall would send the reader to
+        look at a run that is over."""
+        watching = self.stuck_for(9999.0)
+        self.done.write_text("{}", encoding="utf-8")
+        line, status = watching.step() or ("", -1)
+        self.assertIn("FINISHED", line)
+        self.assertEqual(status, 0)
+
+    def test_a_death_outranks_a_stall(self) -> None:
+        """Both are true of a dead job -- it has certainly stopped progressing --
+        and only one of them tells the reader to stop waiting."""
+        watching = self.watching(self.reaped(), stale=60.0)
+        watching.moved -= 9999.0
+        line, status = watching.step() or ("", 0)
+        self.assertIn("DIED", line)
+        self.assertEqual(status, 1)
+
+
 class TestItForksNothing(Fixture):
     """The property that keeps the original bug from coming back.
 
@@ -424,6 +523,33 @@ class TestTheCommandLine(Fixture):
         # failure in it.
         burned = resource.getrusage(resource.RUSAGE_CHILDREN).ru_utime - before
         self.assertLess(burned, 0.5, f"a second of watching cost {burned:.2f}s of CPU")
+
+    def test_the_stall_threshold_reaches_the_watch(self) -> None:
+        """End to end, because a flag wired to nothing is invisible to every
+        test that builds a `Watch` itself -- which is how both survivors of this
+        tool's first sweep got in.
+
+        Also the only place the doubling is driven by a real clock. A tenth of a
+        second against twenty polls: on a per-poll report that is nineteen stall
+        lines, on a doubling one it is a handful, and on a flag that never
+        arrived it is none. The three are far enough apart that a loaded machine
+        cannot turn one into another.
+        """
+        watcher = subprocess.Popen(
+            self.command(str(self.running().pid), "--interval", "0.05", "--stale", "0.1"),
+            cwd=self.repo,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self.addCleanup(watcher.kill)
+        time.sleep(1.0)
+        watcher.terminate()
+        out = watcher.communicate(timeout=10)[0]
+        self.assertNotIn("Traceback", out)
+        said = out.count("STALLED")
+        self.assertGreaterEqual(said, 1, out)
+        self.assertLess(said, 10, out)
 
     def test_a_pid_that_is_a_group_is_a_usage_error(self) -> None:
         ran = self.ran("0")

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -368,6 +368,25 @@ class TestAJobCanStopWithoutEnding(Fixture):
         self.assertIn("working", line)
         self.assertIsNone(watching.step())
 
+    def test_a_recovered_job_stalls_again_on_its_own_terms(self) -> None:
+        """Progress resets what was *said*, not only when work last moved.
+
+        The doubling is measured from the last report, so a job that stalled for
+        ten minutes and then recovered would need twenty minutes of silence
+        before anyone heard about its next stall -- the interval getting longer
+        exactly because the job had already been in trouble once.
+
+        The sibling above pins the clock; this pins the counter. Both are reset
+        in the same line, and the sweep found that only one of them was tested.
+        """
+        watching = self.stuck_for(600.0)
+        watching.step()
+        self.log.write_text("row\n", encoding="utf-8")
+        watching.step()
+        watching.moved -= 120.0
+        line, _ = watching.step() or ("", 0)
+        self.assertIn("STALLED", line)
+
     def test_zero_turns_it_off(self) -> None:
         """For a job whose work genuinely arrives in one lump at the end, where
         every poll before it is a true stall and none of them is news."""

--- a/tools/watch.py
+++ b/tools/watch.py
@@ -172,7 +172,9 @@ class Watch:
         #: latter; it was not there.
         self.moved = self.began
         #: The stall this last spoke about, which is what makes the next report a
-        #: doubling rather than a repeat. Zero means nothing said yet.
+        #: doubling rather than a repeat. Zero means nothing said yet -- and, as
+        #: with `moved`, the opening poll overwrites it before `stalling` can
+        #: read it, so this value is the declaration rather than the behaviour.
         self.told = 0.0
 
     def minutes(self) -> int:

--- a/tools/watch.py
+++ b/tools/watch.py
@@ -24,6 +24,23 @@ of finished work changes, one line when it ends, nothing in between. Emitting
 per poll instead would be a line every twenty seconds for forty minutes, which
 is the same as no signal at all by a different route.
 
+**A job can also stop without ending, and that was the gap the first two
+versions left.** Death and completion are events here; *stalling* was not, so a
+sweep that was alive and wedged printed one line and then nothing -- which is
+exactly what a sweep that is alive and slow prints. The reader is back to
+guessing, from the other side of the same silence. Measured on this repository:
+a nine-minute mutation run emitted a row every thirty seconds or so, and the run
+that hung went quiet for ten minutes and more. So a stall long enough to be
+abnormal is now its own line, and it says the job is still alive -- which is the
+half that distinguishes it from `DIED`, and the half a reader cannot get by
+waiting.
+
+Reported on a doubling interval rather than every poll or once. Every poll is
+the noise this tool exists to avoid; once is a line at minute five that a reader
+arriving at minute forty cannot date. Doubling gives four lines in forty minutes,
+each of which is real news -- a stall twice as long as the last report is worth
+saying, one ten per cent longer is not.
+
 **It watches rather than wraps.** The obvious shape is to run the job itself and
 report as it goes, and that is wrong here: these jobs are already started
 detached, precisely so that a foreground call timing out does not take them
@@ -50,6 +67,17 @@ from pathlib import Path
 #: minutes apart, and the point of the tool is to be cheap enough to leave
 #: running beside a job that is already using the machine.
 INTERVAL = 20.0
+
+#: Seconds without new work before a job is called stalled. Five minutes is a
+#: judgement, and it is this one: the longest gap between rows in a healthy
+#: mutation sweep here was about a minute, and the wedged one was silent for ten
+#: and counting. Anything in between is arbitrary, so the value is generous --
+#: a threshold that cries wolf is worse than none, because the next real one is
+#: read as noise too.
+#:
+#: No job's own rhythm is knowable from here, which is why this is a flag. Zero
+#: turns it off, for a job whose work genuinely arrives in one lump at the end.
+STALE = 300.0
 
 
 def alive(pid: int) -> bool:
@@ -117,16 +145,35 @@ class Watch:
     without a clock or a subprocess. `main` is the part that sleeps.
     """
 
-    def __init__(self, pid: int, log: Path, done: Path, pattern: re.Pattern[str]) -> None:
+    def __init__(
+        self,
+        pid: int,
+        log: Path,
+        done: Path,
+        pattern: re.Pattern[str],
+        stale: float = STALE,
+    ) -> None:
         self.pid = pid
         self.log = log
         self.done = done
         self.pattern = pattern
+        self.stale = stale
         self.began = time.monotonic()
         #: -1 rather than 0, so a job that is already at zero rows still gets its
         #: first "working" line. Starting at 0 would make the opening silence
         #: indistinguishable from a job that never starts.
         self.last = -1
+        #: When the count last moved. `began` rather than 0, because nothing has
+        #: moved yet and "since we started watching" is what that means. In
+        #: practice the first `step` overwrites it before anything reads it --
+        #: `last` starts at -1, so the opening poll is always a change -- which
+        #: is why a job stuck at zero rows stalls a `stale` after the watcher
+        #: starts rather than after the job did. The watcher cannot know the
+        #: latter; it was not there.
+        self.moved = self.began
+        #: The stall this last spoke about, which is what makes the next report a
+        #: doubling rather than a repeat. Zero means nothing said yet.
+        self.told = 0.0
 
     def minutes(self) -> int:
         return int((time.monotonic() - self.began) // 60)
@@ -152,8 +199,36 @@ class Watch:
             )
         if rows != self.last:
             self.last = rows
+            self.moved = time.monotonic()
+            self.told = 0.0
             return f"working: {rows} rows after {self.minutes()}m", -1
-        return None
+        return self.stalling(rows)
+
+    def stalling(self, rows: int) -> tuple[str, int] | None:
+        """The line for a job that is alive and getting nothing done.
+
+        Status -1, like `working`: a stall is not a verdict. The job may still
+        finish, and quite often does -- what the reader gains is the chance to
+        go and look rather than to keep waiting on a guess.
+
+        In seconds, where the rest of this speaks in minutes, and deliberately:
+        this is the one figure a reader compares against `--stale`, which is a
+        number of seconds they typed. Rendering it in a different unit from the
+        flag that controls it is how a threshold gets read as not working.
+        """
+        if not self.stale:
+            return None
+        idle = time.monotonic() - self.moved
+        # `told * 2` is the doubling. Below `stale` nothing is said at all, and
+        # `told` is 0 until the first report, so that term cannot suppress it.
+        if idle < self.stale or idle < self.told * 2:
+            return None
+        self.told = idle
+        return (
+            f"STALLED: no new rows for {int(idle)}s at {rows} rows, "
+            f"{self.minutes()}m in -- the process is alive and not working",
+            -1,
+        )
 
 
 def a_pid(text: str) -> int:
@@ -190,9 +265,15 @@ def main(argv: list[str] | None = None) -> int:
         "--match", default=".", help="count lines of --log matching this regex (default: all)"
     )
     parser.add_argument("--interval", type=float, default=INTERVAL, help="seconds between polls")
+    parser.add_argument(
+        "--stale",
+        type=float,
+        default=STALE,
+        help="say so when --log has not grown for this long; 0 to never (default: %(default)s)",
+    )
     args = parser.parse_args(argv)
 
-    watch = Watch(args.pid, args.log, args.done, re.compile(args.match))
+    watch = Watch(args.pid, args.log, args.done, re.compile(args.match), args.stale)
     while True:
         event = watch.step()
         if event is not None:


### PR DESCRIPTION
## The gap

`tools/watch.py` turned two endings into events — `DIED` and `FINISHED` — and
left the third as silence. A job that is **alive and wedged** printed one line
and then nothing, which is exactly what a job that is **alive and slow** prints.
The reader is back to guessing, from the other side of the same silence the tool
was built to remove.

It happened on this tool's own first outing: a mutation sweep went quiet at 58 of
68 rows, I called it dead, and it was still running — the original bug with the
sign flipped, made by the same reasoning.

So a stall long enough to be abnormal is now its own line, and it says the job is
still there:

```
STALLED: no new rows for 312s at 58 rows, 9m in -- the process is alive and not working
```

"Still alive" is the half that separates this from `DIED`, and the half no amount
of waiting gives the reader. *Nothing is happening* and *nothing is happening and
the job is gone* call for different actions.

## Three decisions worth arguing

**The threshold is a flag, not a guess about your job.** `--stale`, default 300s,
`0` disables. Five minutes is a judgement and it is this one: the longest gap
between rows in a healthy sweep here was about a minute, and the wedged one was
silent for ten and counting. Anything in between is arbitrary, so the default is
generous — a threshold that cries wolf is worse than none, because the next real
one gets read as noise too. No job's own rhythm is knowable from inside the
watcher, which is why it is a flag at all.

**Reported on a doubling interval**, not per poll and not once. Per poll is the
noise this tool exists to avoid, arriving through the feature meant to fix it.
Once is a line at minute five that a reader arriving at minute forty cannot date.
Doubling gives four lines in forty minutes, each of which is real news — a stall
twice as long as the last report is worth saying; one ten per cent longer is not.

**Status `-1`, like `working`.** A stall is not a verdict. The job may still
finish, and often does. What the reader gains is the chance to go and look
instead of continuing to wait on a guess.

One deliberate inconsistency: the stall figure is in **seconds** where the rest
of the tool speaks in minutes. It is the one number a reader compares against
`--stale`, which is a count of seconds they typed, and rendering it in a
different unit from the flag that controls it is how a threshold gets read as not
working.

## Mutation testing (rule 3)

`python -m tools.mutate --base main`, verbatim:

```
1 file(s), 86 changed lines -> 25 mutants
3 lane(s) at 2679 MiB each, from 8037 MiB of usable memory -- see tools.mutate._share.
...
3 survived. A test that cannot see the fix removed is decoration:
  - tools/watch.py:178 in Watch.__init__() -- `self.told` is never assigned (tests.test_watch)
  - tools/watch.py:226 in Watch.stalling() -- `<` becomes `<=` (tests.test_watch)
  - tools/watch.py:226 in Watch.stalling() -- `<` becomes `<=` (tests.test_watch)
Suspect the fixture before the mutation -- see CLAUDE.md rule 3.
```

25 of 28. All three survivors are equivalent, and I would rather argue that than
leave it implied:

- **`self.told` never assigned in `__init__`.** `stalling()` is reachable only
  once `rows == self.last`, which needs a prior `step`, and that same `step`
  assigns `told`. The constructor's value is a declaration that nothing ever
  reads. The same is true of `moved`, and both now carry a comment saying so —
  the first draft's comment claimed `moved`'s initial value handled a job that
  produces nothing at all, which is wrong, because the opening poll always counts
  as movement and overwrites it.
- **`<` becoming `<=`** on `idle < self.stale or idle < self.told * 2`, twice.
  Differs only when two floats are exactly equal, and `idle` comes from
  `time.monotonic()`. Not reachable with a wall clock.

**The round before was not clean, and the survivor mattered.** Progress resets
`moved`, and the test checked that — but nothing checked it also resets `told`.
Without that reset, a job that stalled for ten minutes and then recovered would
need *twenty* minutes of silence before anyone heard about its next stall: the
reporting interval growing precisely because the job had already been in trouble
once. Both fields are reset on the same line, and the sweep found that only one
of them was tested.

Ten new tests, driven against real processes and a real clock where it matters.
Elapsed time is back-dated rather than waited out — the arithmetic is identical
and the suite does not spend five minutes proving a five-minute threshold — but
the back-dating happens *after* the first `step`, because rewinding a freshly
built `Watch` would test a state no job ever reaches.

The CLI test is the one that uses a real clock: a tenth of a second against
twenty polls, where a per-poll report is nineteen lines, a doubling one is a
handful, and a flag wired to nothing is none. The three are far enough apart that
a loaded machine cannot turn one into another. It is there because both survivors
of this tool's first sweep were at a call site, invisible to any test that builds
its subject directly.

## Review

Rule 1's middle row: a careful read of the diff, aimed at the specific hazard,
which here is a stall report that is wrong in either direction. False positives
train the reader to skip the line and take the next real one with it; false
negatives are the gap we started from. Two things checked closely, both sound:
the doubling cannot suppress its own first report (`told` is 0 until then, so
`idle < told * 2` is vacuously false), and `FINISHED` and `DIED` both return
before `stalling` is reached — asserted, because a stalled job that has since
written its report is a finished one, and a dead job has certainly stopped
progressing.

`--stale` accepts a negative, which behaves like a very small positive: it
reports early, still with doubling, and is self-evidently wrong within one poll.
Left alone rather than guarded, unlike `a_pid`'s rejection of `0` — that one was
*silently* wrong, reporting a process group alive for ever, which is the failure
class this tool exists for. Noise is not that.

## Not in this PR

The step that feeds the tool still does not work in this environment.
`echo $! > pidfile` at launch — the documented way to record the pid — failed
silently here, and I recovered the pid from `ps` with a filter excluding its own
command line on all eight runs today. That is a launcher problem rather than a
`watch.py` one, and a different subject.

Also worth saying plainly: `DIED` has still never fired outside its tests. The
path that matters most is the one least exercised in anger, and this change does
not alter that.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_