### PR TITLE
mutants: sign and divisor, the two operators #272 measured us missing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,13 +90,23 @@ false after `--no-confirm`, after a suppressed confirmation, and in a
 part-written file from an interrupted sweep — the cases where the paragraph
 above promises something the file cannot deliver.
 
-Fifteen operators, and `--skip-operator NAME` drops one — the escape hatch for
+Seventeen operators, and `--skip-operator NAME` drops one — the escape hatch for
 an equivalent mutant a whole operator keeps producing, where `# pragma: no
-mutate` only suppresses a line. Twelve rewrite an expression (`<` to `<=`, `and`
-to `or`, `sorted(x)` to `sorted(x, reverse=True)`, `.endswith(...)` to `True`, an
-`if` forced both ways, `+` to `-`, a slice's bounds dropped, a small integer
-moved by one, `return X` to `return None`); two delete a statement, and one
-drops a keyword argument.
+mutate` only suppresses a line. Fourteen rewrite an expression (`<` to `<=`,
+`and` to `or`, `sorted(x)` to `sorted(x, reverse=True)`, `.endswith(...)` to
+`True`, an `if` forced both ways, `+` to `-`, a slice's bounds dropped, a small
+integer moved by one, a *divisor* moved by one, a negative literal made
+positive, `return X` to `return None`); two delete a statement, and one drops a
+keyword argument.
+
+The last two arrived from #274, after #272 measured us against mutmut on a
+revision whose answer was already known. `divisor` is separate from `off-by-one`
+rather than a widening of it: that operator caps at literals of two or less, and
+should — moving every integer in the codebase by one is thousands of rows, nearly
+all equivalent. A divisor is a *unit*, so its magnitude says nothing about how
+interesting it is to be wrong by one. `sign` exists because `-1` parses as a
+minus applied to `1`, so `off-by-one` moves the `1` and never the minus, and a
+sentinel chosen for being negative survives every row it produces.
 
 Deletion is deliberately narrow. `drop-call` removes a call whose value is
 discarded — `path.mkdir()`, `store.flush()` — which is the "the write never

--- a/tests/test_mutants.py
+++ b/tests/test_mutants.py
@@ -205,10 +205,23 @@ _QUIET: dict[str, str] = {
     # A variable divisor has no literal to move, and a multiplication is not a
     # division however constant its right side -- the second line is why this
     # is a separate operator from `arith` rather than a case inside it.
-    "divisor": "x = total // count\nx = total * 60\n",
+    #
+    # Then the three the guard rejects one clause at a time, because with only
+    # the two above, *dropping the whole guard* left this fixture quiet and the
+    # mutant survived: `True` is an `int` in Python and would otherwise divide
+    # into `2`, `0` is the division that raises rather than answers, and a float
+    # divisor moved by one is a change of a different order.
+    "divisor": (
+        "x = total // count\nx = total * 60\nw = total // True\ny = total // 0\nz = total // 1.5\n"
+    ),
     # `-0` is `0`, so the row would be an equivalent mutant by construction; and
     # a negated *name* has no literal whose sign there is to flip.
-    "sign": "x = -0\ny = -value\n",
+    #
+    # `-True` and `-"a"` are the two the guard rejects, and they are here for the
+    # same reason as above -- the first is an `int` by inheritance, the second is
+    # not a number at all, and without them the guard could be deleted whole with
+    # this fixture still silent.
+    "sign": 'x = -0\ny = -value\nz = -True\nw = -"a"\n',
     # `return None` is already what the mutation would produce -- and `return
     # True` is left to `return-constant`, which swaps it. `None` is falsy, so
     # asking both would be very nearly the same question at twice the price.

--- a/tests/test_mutants.py
+++ b/tests/test_mutants.py
@@ -158,6 +158,14 @@ _FIRES: dict[str, tuple[str, list[str]]] = {
     "drop-assign": ("self.total = 1\n", ["`self.total` is never assigned"]),
     "drop-kwarg": ("path.mkdir(mode=0o700)\n", ["`mode=448` is dropped"]),
     "off-by-one": ("x = items[1]\n", ["`1` becomes `2`", "`1` becomes `0`"]),
+    # Two statements: the second pins that a divisor of 1 yields the `2`
+    # direction only. `// 0` is a `ZeroDivisionError`, which is BROKE rather
+    # than an answer and costs a whole suite run to establish nothing.
+    "divisor": (
+        "x = total // 60\ny = total // 1\n",
+        ["`60` becomes `61`", "`60` becomes `59`", "`1` becomes `2`"],
+    ),
+    "sign": ("x = -1\n", ["`-1` becomes `1`"]),
     "return-value": (
         "def f():\n    return compute(x)\n",
         ["returns `None` instead of `compute(x)`"],
@@ -194,6 +202,13 @@ _QUIET: dict[str, str] = {
     "drop-kwarg": 'Check(label="x", ok=True)\n',
     # Big enough that +-1 is arbitrary rather than a boundary.
     "off-by-one": "x = items[97]\n",
+    # A variable divisor has no literal to move, and a multiplication is not a
+    # division however constant its right side -- the second line is why this
+    # is a separate operator from `arith` rather than a case inside it.
+    "divisor": "x = total // count\nx = total * 60\n",
+    # `-0` is `0`, so the row would be an equivalent mutant by construction; and
+    # a negated *name* has no literal whose sign there is to flip.
+    "sign": "x = -0\ny = -value\n",
     # `return None` is already what the mutation would produce -- and `return
     # True` is left to `return-constant`, which swaps it. `None` is falsy, so
     # asking both would be very nearly the same question at twice the price.

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -284,6 +284,22 @@ class TestWhatCountsAsProgress(Fixture):
         line, status = self.watching(os.getpid()).step() or ("", 0)
         self.assertEqual((line, status), ("working: 0 rows after 0m", -1))
 
+    def test_a_log_that_already_has_rows_still_gets_an_opening_line(self) -> None:
+        """The sentinel's *sign*, which its magnitude was standing in for.
+
+        `last` starts negative so the opening poll is always a change. Any
+        non-negative start silently swallows the first line for a log that
+        already holds exactly that many rows -- and attaching a watcher to a job
+        already under way is the ordinary case, not a corner.
+
+        Found by #274's `sign` operator: `-1` becoming `1` survived every test
+        in this file, because none of them started the watcher against a log
+        with anything in it.
+        """
+        self.log.write_text("row\n", encoding="utf-8")
+        line, status = self.watching(os.getpid()).step() or ("", 0)
+        self.assertEqual((line, status), ("working: 1 rows after 0m", -1))
+
     def test_an_unchanged_count_is_not_an_event(self) -> None:
         """One line per twenty seconds for forty minutes is the same as no
         signal, by a different route."""
@@ -302,6 +318,24 @@ class TestWhatCountsAsProgress(Fixture):
         self.log.write_text("caught one\nnoise\ncaught two\n", encoding="utf-8")
         line, _ = self.watching(os.getpid(), match="^caught").step() or ("", 0)
         self.assertIn("2 rows", line)
+
+    def test_a_log_holding_bytes_that_are_not_utf8_is_still_counted(self) -> None:
+        """`errors="replace"` rather than strict decoding, and why it matters.
+
+        The log belongs to the job, not to the watcher, and a job killed
+        mid-write leaves a partial multi-byte sequence at the end of it. Strict
+        decoding raises `UnicodeDecodeError` there -- a `ValueError`, so the
+        `except OSError` above does *not* catch it, and it propagates out of
+        `main` as a traceback. The watcher would die of the thing it was hired
+        to report on, at exactly the moment it was about to report it.
+
+        From #272: mutmut mutates string literals and found this unguarded. We
+        do not generate that mutant and #274 argues we should not, so this test
+        guards a property no sweep of ours will check -- which is the reason to
+        say all of that here rather than leave it to the next reader.
+        """
+        self.log.write_bytes(b"caught one\ncaught \xff\xfe two\n")
+        self.assertEqual(watch.counted(self.log, re.compile("^caught")), 2)
 
     def test_a_log_that_does_not_exist_yet_is_zero_rather_than_an_error(self) -> None:
         """A job that has not opened its log is at zero rows. Treating absence as

--- a/tools/mutants.py
+++ b/tools/mutants.py
@@ -499,6 +499,75 @@ def off_by_one(node: ast.AST) -> Iterator[Edit]:
         yield Edit(node, repr(now), f"`{node.value}` becomes `{now}`")
 
 
+def sign(node: ast.AST) -> Iterator[Edit]:
+    """A negative numeric literal, made positive. `-1` -> `1`.
+
+    `off-by-one` cannot reach this. `-1` parses as `UnaryOp(USub, Constant(1))`,
+    so that operator sees the `1` and moves it to `0` or `2`, which the minus
+    then turns into `0` and `-2` -- both still negative-or-zero, and a sentinel
+    chosen for being negative survives all of them. Nothing here touched the
+    minus itself until #274.
+
+    Found by comparing against mutmut on #272: `tools/watch.py` sets
+    `self.last = -1` so that a job already at zero rows still gets its opening
+    line, and `+1` breaks that for a log holding exactly one matching row --
+    silently, which is the failure the sentinel exists to prevent.
+
+    Only negative to positive, never the reverse. Flipping every positive
+    literal would fire on nearly every integer in the codebase, and a negative
+    one is rare enough to be deliberate: a sentinel, a reverse index, an offset
+    backwards. The asymmetry is the precision.
+    """
+    if not isinstance(node, ast.UnaryOp) or not isinstance(node.op, ast.USub):
+        return
+    if not isinstance(node.operand, ast.Constant):
+        return
+    value = node.operand.value
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return
+    # `0` and `-0` are the same number, so the row would be an equivalent mutant
+    # by construction and cost a suite run to say so.
+    if not value:
+        return
+    yield Edit(node, repr(value), f"`-{value}` becomes `{value}`")
+
+
+#: Division and modulo, where an off-by-one on the right operand changes the
+#: *unit* rather than an index -- `// 60` reading a count of seconds as minutes.
+_DIVIDES = (ast.Div, ast.FloorDiv, ast.Mod)
+
+
+def divisor(node: ast.AST) -> Iterator[Edit]:
+    """The right operand of `/`, `//` or `%`, moved by one.
+
+    Deliberately not a widening of `off-by-one`, which caps at `abs(value) > 2`
+    and should keep that cap: moving every integer in the codebase by one would
+    be thousands of rows, nearly all equivalent. The cap is why `// 60` was
+    never a candidate, and the answer is not a bigger cap but a narrower
+    position -- a divisor is a *unit*, and its magnitude says nothing about how
+    interesting it is to be wrong by one.
+
+    From #272: `Watch.minutes()` computes `// 60`, and at the revision compared
+    there nothing could tell `// 61` from it, because every assertion in the
+    file read "0m".
+
+    A divisor of `1` yields no row for the `0` direction: dividing by zero is a
+    `ZeroDivisionError`, which reports `BROKE` rather than an answer and costs a
+    whole suite run to establish nothing.
+    """
+    if not isinstance(node, ast.BinOp) or not isinstance(node.op, _DIVIDES):
+        return
+    if not isinstance(node.right, ast.Constant):
+        return
+    value = node.right.value
+    if isinstance(value, bool) or not isinstance(value, int) or not value:
+        return
+    for now in (value + 1, value - 1):
+        if not now:
+            continue
+        yield Edit(node.right, repr(now), f"`{value}` becomes `{now}`")
+
+
 def return_value(node: ast.AST) -> Iterator[Edit]:
     """`return X` -> `return None`: the function that silently returns nothing.
 
@@ -615,6 +684,8 @@ OPERATORS: tuple[Operator, ...] = (
     Operator("drop-assign", drop_assign),
     Operator("drop-kwarg", drop_kwarg),
     Operator("off-by-one", off_by_one),
+    Operator("sign", sign),
+    Operator("divisor", divisor),
     Operator("return-value", return_value),
     Operator("arith", arith),
     Operator("slice", slice_widened),


### PR DESCRIPTION
Closes #274.

Two operators, ported because #272 measured them finding things we could not,
not because a generic tool has them.

## `sign` — a negative literal made positive

`-1` parses as `UnaryOp(USub, Constant(1))`. `off-by-one` sees the `1` and moves
it to `0` or `2`, which the minus turns back into `0` and `-2` — both still
negative-or-zero. **A sentinel chosen for being negative survives every row that
operator produces**, and nothing touched the minus itself.

Only negative to positive, never the reverse: flipping every positive literal
would fire on nearly every integer in the codebase, while a negative one is rare
enough to be deliberate — a sentinel, a reverse index, an offset backwards. The
asymmetry is the precision. `-0` yields nothing, since it is `0` and the row
would be an equivalent mutant by construction.

**Its acceptance test was open on `main`**, exactly as #274 predicted:

```
1 file(s), 293 lines -> 3 mutants
  SURVIVED  tools/watch.py:165 in Watch.__init__() -- `-1` becomes `1`
  caught    tools/watch.py:206 in Watch.step() -- `-1` becomes `1`
  caught    tools/watch.py:232 in Watch.stalling() -- `-1` becomes `1`
```

`self.last = -1` exists so a job already at zero rows still gets its opening
line. `1` breaks that for a log holding exactly one matching row — silently,
which is the failure the sentinel exists to prevent — and no test in
`tests/test_watch.py` had ever started the watcher against a log with anything
in it. Now one does, and the mutant is caught.

## `divisor` — the right operand of `/`, `//` or `%`, moved by one

Deliberately **not** a widening of `off-by-one`. That operator caps at
`abs(value) > 2` and should keep the cap: moving every integer in the codebase by
one is thousands of rows, nearly all equivalent. The cap is why `// 60` was never
a candidate, and the answer is a narrower *position* rather than a bigger cap — a
divisor is a **unit**, so its magnitude says nothing about how interesting it is
to be wrong by one.

A divisor of `1` yields only the `2` direction: `// 0` is a `ZeroDivisionError`,
which reports `BROKE` rather than an answer and costs a whole suite run to
establish nothing.

Where it lands across the tree is the argument for it:

```
  divisor   woswoar/search.py:130 in relative_time() -- `60` becomes `61`
  divisor   woswoar/search.py:133 in relative_time() -- `3600` becomes `3601`
  divisor   woswoar/search.py:138 in relative_time() -- `86400` becomes `86401`
  divisor   woswoar/search.py:147 in relative_time() -- `30` becomes `31`
  divisor   woswoar/search.py:746 in _duration_label() -- `1000` becomes `1001`
  divisor   woswoar/report.py:83 in centred() -- `2` becomes `3`
  divisor   tools/bench.py:172 in _importtime() -- `1000` becomes `1001`
```

Seconds to minutes to hours to days, milliseconds, and a centring halve. It is
hitting unit conversions, which is what it was shaped for.

**Correction to #274 on this one:** the issue claims its acceptance test is open
on `main`. It is not — both directions are **caught** today, by
`test_it_says_how_long_the_job_had_been_running`, which #267 added for an
unrelated reason (`// 60` becoming `* 60`) and which back-dates `began` by an
hour. The gap was real at `a6b50d1` and has since closed by accident. The
operator still earns its place — it reaches a class of mutant we could not — but
its "fails without the fix" demonstration is the `_FIRES`/`_QUIET` fixture in
`tests/test_mutants.py`, not `watch.py`.

## Cost

| | mutants |
|---|---|
| full sweep before | 4,962 |
| full sweep after | **5,000** |
| `sign` alone | 20 |
| `divisor` alone | 22 |

**+38, or 0.77%.** Note 20 + 22 = 42, not 38: four `divisor` rows land on
divisors small enough that `off-by-one` already generates them, at the same span
with the same replacement text, and `generate`'s existing `(span, new)` dedupe
removes them. No new machinery for the overlap.

I have not swept `search.py`, so I cannot tell you how many of the twelve
`relative_time` rows are real. `--skip-operator divisor` is the escape hatch if
that concentration turns out to be noise, and CONTRIBUTING already describes it
as being for exactly that.

## The third item in #274, not done

The issue also proposes **string-literal mutation**, off by default. I have not
implemented it, and would rather argue that here than drop it silently:

- The measured ratio is bad. On one function it produced seven survivors where we
  had none: two pointed at one genuine gap, five were `"UTF-8"`, `"REPLACE"`,
  `"XXreplaceXX"` and two duplicate argument-drops.
- "Off by default" is new CLI surface we do not have. `--operator` selects one and
  `--skip-operator` drops one; there is no notion of an operator that exists but
  does not run, so it would mean a `default` field on `Operator` and a third flag.
- **The one real gap it found is closed in this PR by a test instead.**
  `counted()` reads the log with `errors="replace"`, and nothing fed it a byte
  that was not valid UTF-8. It matters: the log belongs to the job, a job killed
  mid-write leaves a partial multi-byte sequence, and `UnicodeDecodeError` is a
  `ValueError` — so the `except OSError` does not catch it and it propagates out
  of `main` as a traceback. The watcher would die of the thing it was hired to
  report on.

Since no operator of ours generates that mutation, rule 3's loop was run by hand:

```
$ sed -i 's/, errors="replace"//' tools/watch.py && python -m unittest tests.test_watch
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 18: invalid start byte
FAILED (errors=1, skipped=1)
$ # restored
OK (skipped=1)
```

## Mutation testing (rule 3)

`python -m tools.mutate --base main`, verbatim:

```
1 file(s), 71 changed lines -> 37 mutants
37 caught, 0 survived
```

The round before was not clean, and the survivors were worth having — four of
them, the same two shapes in each new operator:

```
  - tools/mutants.py:526 in sign() -- the `if` is never taken
  - tools/mutants.py:526 in sign() -- `or` becomes `and`
  - tools/mutants.py:563 in divisor() -- the `if` is never taken
  - tools/mutants.py:563 in divisor() -- `or` becomes `and`
```

Both operators' guards could be **deleted whole** with their `_QUIET` fixtures
still silent, because those fixtures only exercised one clause each. They now
reject a clause at a time: `-True` (an `int` by inheritance, which would
otherwise flip to `True`), `-"a"` (not a number at all), `// True`, `// 0` (the
division that raises rather than answers), and `// 1.5` (a float divisor moved by
one is a change of a different order).

That is the file's own completeness guard doing its job, incidentally —
`test_every_operator_has_a_test_here` requires both a fires-fixture and a
must-not-fire fixture for every operator, so neither could ship untested.

## Review

Rule 1's middle row, a careful read of the diff. The hazard for a new operator is
a mutant that is *wrong* rather than merely useless — a span spliced badly enough
to still parse. Checked: both operators yield a bare replacement for a whole node
the way `off-by-one` does rather than going through `_rewritten`, which is safe
here because the replaced span is a complete literal in both cases and `check()`
validates the span still holds the quoted text. Negative divisors (`x // -60`)
parse as a `UnaryOp` on the right, so `divisor` does not fire and `sign` does,
which is the right split. Annotations are not descended into, so
`x: Literal[-1]` is untouched.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_