### PR TITLE
reached: read what the report says about its own worth (#270)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,13 @@ silently unmatches them. `coverage` is not a dependency and is not imported —
 the map, because a caught mutation proves its line ran and in-process coverage
 cannot see the lines this suite reaches by running a real `bash`.
 
+It reads the two fields above before any of that. A report with `baseline_red`
+is refused outright — there is nothing in it to partition — and one without
+`widened` is partitioned under a printed caveat, because its survivors may be a
+narrow selection rather than a weak fixture. The asymmetry is the point: a red
+baseline makes every row meaningless, an unwidened one only makes the survivors
+provisional, and `--no-confirm` has to stay usable with this tool.
+
 Running out of memory is reported `BROKE`, never `caught`. It arrives as a
 `MemoryError` inside whichever test was running, which by protocol looks exactly
 like that test noticing — and crediting a test with a guard it does not have is

--- a/tests/test_reached.py
+++ b/tests/test_reached.py
@@ -31,6 +31,10 @@ def results(*rows: tuple[str, int, str]) -> dict[str, Any]:
     """A `--json` report holding `(path, line, outcome)` rows."""
     return {
         "baseline_red": False,
+        # A trustworthy report by default, so the partition tests below are
+        # about the partition. The two fields' own behaviour is
+        # `TestAReportThatCannotBeBelieved`'s subject, and it overrides them.
+        "widened": True,
         "results": [
             {
                 "label": f"{path}:{line} in f() -- something",
@@ -139,6 +143,39 @@ class TestReadingTheInputs(unittest.TestCase):
         self.assertEqual(reached.executed_lines({"files": {"a.py": {}}}), {"a.py": set()})
 
 
+class TestAReportThatCannotBeBelieved(unittest.TestCase):
+    """#270: this module explains survivors, and some reports have none to explain.
+
+    Both fields are about attribution, and they fail differently: a red baseline
+    makes every row meaningless, an unwidened one makes the survivors
+    provisional. Treating them the same would either refuse a `--no-confirm`
+    report that is perfectly usable with a caveat, or partition a void one.
+    """
+
+    def test_a_red_baseline_is_void(self) -> None:
+        self.assertTrue(reached.voided({"baseline_red": True}))
+
+    def test_a_green_one_is_not(self) -> None:
+        self.assertFalse(reached.voided({"baseline_red": False}))
+
+    def test_a_report_that_says_nothing_about_its_baseline_is_read_as_green(self) -> None:
+        """The opposite default from `confirmed`, and for the opposite reason:
+        every report since the flag existed writes it, so absence here means a
+        hand-built or ancient file rather than a claim being withheld -- and
+        refusing to read those would be a regression for no gain."""
+        self.assertFalse(reached.voided({}))
+
+    def test_a_report_that_says_nothing_about_widening_is_read_as_unwidened(self) -> None:
+        """A file written before `Report.widened` existed knows nothing either
+        way, which is precisely what the caveat says -- so the caveat is true of
+        it. Defaulting the other way would make old silence read as a claim."""
+        self.assertFalse(reached.confirmed({}))
+
+    def test_an_explicit_claim_is_believed(self) -> None:
+        self.assertTrue(reached.confirmed({"widened": True}))
+        self.assertFalse(reached.confirmed({"widened": False}))
+
+
 class TestTheCommandLine(unittest.TestCase):
     """Driven as a subprocess, because the exit status and the printed
     partition are what a person actually uses."""
@@ -188,6 +225,34 @@ class TestTheCommandLine(unittest.TestCase):
         self.assertEqual(got["SURVIVED"], 2, done.stdout)
         self.assertEqual(got["on a line NO test executes  (missing test)"], 1, done.stdout)
         self.assertEqual(got["on a line tests DO execute  (weak/equiv)"], 1, done.stdout)
+
+    def test_a_void_report_is_refused_rather_than_partitioned(self) -> None:
+        """Non-zero and nothing printed to stdout: a caller reading only the
+        status must not be told the run succeeded, and one reading stdout must
+        not find a partition drawn from rows that mean nothing."""
+        report = results(("a/b.py", 10, "survived"))
+        report["baseline_red"] = True
+        done = self.run_it(report, coverage(a__b=[]))
+        self.assertEqual(done.returncode, 1)
+        self.assertIn("not green", done.stderr)
+        self.assertNotIn("missing test", done.stdout)
+
+    def test_an_unwidened_report_is_explained_with_a_caveat(self) -> None:
+        """Still partitioned -- `--no-confirm` exists so a long sweep can skip
+        the expensive pass, and refusing here would make the two unusable
+        together -- but the reader is told before they act on it."""
+        report = results(("a/b.py", 10, "survived"))
+        report["widened"] = False
+        done = self.run_it(report, coverage(a__b=[]))
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertIn("not re-run against the whole suite", done.stdout)
+        self.assertEqual(self.counts(done.stdout)["SURVIVED"], 1, done.stdout)
+
+    def test_a_widened_report_gets_no_caveat(self) -> None:
+        """Without this the note could be printed unconditionally and every test
+        above would still pass."""
+        done = self.run_it(results(("a/b.py", 10, "survived")), coverage(a__b=[]))
+        self.assertNotIn("not re-run against the whole suite", done.stdout)
 
     def test_rows_that_asked_nothing_are_counted_apart(self) -> None:
         """`broke` and `timeout` are neither caught nor survived, and folding

--- a/tools/reached.py
+++ b/tools/reached.py
@@ -66,6 +66,30 @@ class Row(NamedTuple):
         return self.outcome in ("caught", "survived")
 
 
+def voided(report: dict[str, Any]) -> bool:
+    """Whether the run that produced ``report`` answered anything at all.
+
+    A suite that is already failing catches whatever it is shown, so on a red
+    baseline every `caught` is unattributable and every `survived` is whatever
+    happened to be left. There is no partition to draw from that, and drawing
+    one anyway is how a reader is sent to strengthen a test that was never weak.
+    """
+    return bool(report.get("baseline_red"))
+
+
+def confirmed(report: dict[str, Any]) -> bool:
+    """Whether every survivor in ``report`` was re-run against the whole suite.
+
+    Absent means **no**, and the default is the whole point. A report written
+    before `Report.widened` existed records nothing either way, and "nothing
+    knows whether these were widened" is exactly what the caveat says -- so the
+    caveat is *true* of those files. Defaulting to yes would make an old file's
+    silence indistinguishable from a claim, which is the class of error this
+    module exists to remove rather than add.
+    """
+    return bool(report.get("widened", False))
+
+
 def rows_from(results: dict[str, Any]) -> list[Row]:
     """The rows of a `--json` report, ignoring anything without a position."""
     out = []
@@ -175,12 +199,34 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        rows = rows_from(json.loads(args.results.read_text(encoding="utf-8")))
+        report = json.loads(args.results.read_text(encoding="utf-8"))
+        rows = rows_from(report)
         raw = executed_lines(json.loads(args.coverage.read_text(encoding="utf-8")))
     except (OSError, ValueError) as exc:
         raise SystemExit(f"cannot read the inputs: {exc}") from None
+    # Before the empty check, because "this report is void" is the more useful
+    # of the two things a caller can be told about a file with nothing in it.
+    if voided(report):
+        raise SystemExit(
+            f"{args.results} was produced against a suite that was not green, so no row "
+            f"in it is attributable: a failing test catches whatever it is shown. There "
+            f"is nothing here to partition. Fix the suite and sweep again."
+        )
     if not rows:
         raise SystemExit(f"{args.results} holds no positioned rows to classify.")
+
+    if not confirmed(report):
+        # A note rather than a refusal, and the asymmetry with `voided` above is
+        # deliberate. A red baseline makes every row meaningless; an unwidened
+        # one makes the survivors *provisional* -- the narrow pass's verdicts are
+        # sound and only the widening is missing. Refusing here would make
+        # `--no-confirm` unusable with this tool, and `--no-confirm` exists
+        # precisely so a long sweep can skip the expensive pass.
+        print(
+            "NOTE: this report's survivors were not re-run against the whole suite, so "
+            "some\nmay be a narrow test selection rather than a weak fixture. Confirm on "
+            "a green\ntree before rewriting a test on this evidence.\n"
+        )
 
     fixed = repair(raw, rows)
     corrected = sum(len(fixed[p] - raw.get(p, set())) for p in fixed)


### PR DESCRIPTION
Closes #270.

`tools/reached.py` explains why each survivor survived, and read the rows without
ever asking whether the report they came from was worth reading. Two fields say
so and both were ignored.

## Two failures, treated differently on purpose

**`baseline_red` → refused.** A suite that is already failing catches whatever it
is shown, so every `caught` is unattributable and every `survived` is whatever
happened to be left. There is no partition to draw. Exits non-zero and prints
nothing to stdout, so a caller reading only the status is not told the run
succeeded and one reading stdout does not find a partition drawn from noise.

**`widened` false → explained, with a caveat printed first.** Only the survivors
are provisional here: the narrow pass's verdicts are sound and the widening is
what is missing, so some rows may be a narrow selection rather than a weak
fixture. Refusing would make `--no-confirm` unusable with this tool, which is the
opposite of what that flag is for — it exists so a long sweep can skip the
expensive pass.

The asymmetry is the whole design. Collapsing them either refuses a perfectly
usable `--no-confirm` report or partitions a void one.

## The default that matters

`widened` absent reads as **no**. A report written before the field existed
records nothing either way, and *"nothing knows whether these were widened"* is
exactly what the caveat says — so the caveat is true of those files. Defaulting
the other way would make an old file's silence indistinguishable from a claim,
which is the class of error this module exists to remove rather than add.

`baseline_red` absent reads as green, which is the opposite default for the
opposite reason: every report since that flag existed writes it, so absence means
a hand-built or ancient file rather than a claim being withheld, and refusing
those would be a regression for no gain. Both defaults are tested, because a
reader will otherwise assume they match.

## Why this was worth a P2

The consequence is `confirm`'s own stated failure mode arriving through the
artifact instead of the table. A survivor the whole suite *would* have caught
gets filed as "a test reaches it and asserts nothing" — about a test that does in
fact assert — which "points the expensive way: it sends the author to rewrite a
test that was never weak."

It is not hypothetical. The sweep run after #276 merged came back
`baseline_red: true`, `widened: false`, and I read `caught` rows out of it
without noticing which batch they belonged to — reporting twelve `relative_time`
rows as caught when their batch was red. That is the mistake this refusal
prevents, made by hand, an hour before the code to prevent it.

## Mutation testing (rule 3)

`python -m tools.mutate --base main`, verbatim:

```
1 file(s), 47 changed lines -> 8 mutants
8 caught, 0 survived
```

Clean first time. The tests that earned it are the two-sided ones: a widened
report must get **no** caveat, or the note could be printed unconditionally and
every other test would still pass; and both absence defaults are asserted
separately, or the two `.get()` calls could be made to agree.

## Review

Rule 1's middle row, a careful read. The hazard is the refusal firing on a report
that is fine, which would make the tool useless on the reports people actually
have. Checked the ordering: `voided` is tested before the "no positioned rows"
exit, because *"this report is void"* is the more useful of the two things to
tell a caller about a file with nothing in it. Checked that the caveat prints
before `_summarise` rather than after, since it changes how the numbers below it
should be read.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_