### PR TITLE
mutate: a sweep's batch says which file it is voiding (#271)

### DIFF
--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -1188,6 +1188,75 @@ class TestResumingASweep(unittest.TestCase):
             report = mutate.sweep([], args)
         self.assertFalse(report.clean, "a recorded survivor still counts against the run")
 
+    def batch_args(self, where: Path) -> argparse.Namespace:
+        return argparse.Namespace(
+            json=where,
+            no_baseline=True,
+            workers=1,
+            timeout=30.0,
+            memory=mutate.MEMORY,
+            all=True,
+            batch=True,
+        )
+
+    def swept(self, table: list[Mutation], answer: Report) -> tuple[str, mock.Mock]:
+        """One sweep with `run` stubbed, returning what was printed and the stub.
+
+        Stubbed for the reason the resume test gives: `sweep`'s job is the
+        bookkeeping around `run`, and running a real mutation would test `run`,
+        which has its own tests.
+        """
+        box = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, box, True)
+        args = self.batch_args(Path(box) / "out.json")
+        with (
+            contextlib.redirect_stdout(io.StringIO()) as said,
+            mock.patch.object(mutate, "run", return_value=answer) as ran,
+        ):
+            mutate.sweep(table, args)
+        return said.getvalue(), ran
+
+    def test_each_batch_scopes_its_warning_to_its_own_file(self) -> None:
+        """#271. A sweep runs `run` once per file, and eleven batches' worth of
+        verdicts can be scrolled above the twelfth -- so an unscoped "nothing
+        above means anything" is false about all of them.
+
+        Asserted on the argument rather than the printed line, because the line
+        is `run`'s and is stubbed out here; that `run` honours `scope` is
+        `TestConfirmingNeedsAGreenSuiteToo`'s subject.
+        """
+        table = [Mutation("a.py:1 -- one", "a.py", "a", "b", "test_mod")]
+        _, ran = self.swept(table, Report([Result(table[0], Verdict("caught"))]))
+        self.assertEqual(ran.call_args.kwargs["scope"], "nothing above about a.py")
+
+    def test_a_whole_table_keeps_the_unscoped_wording(self) -> None:
+        """`main`'s single-table path really does own everything above it, so
+        the default must not drift to the per-file phrasing."""
+        rows = [Mutation("a.py:1 -- one", "a.py", "a", "b", "test_mod")]
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            mock.patch.object(mutate, "run", return_value=Report([])) as ran,
+        ):
+            mutate._run_generated(rows, self.batch_args(Path("unused.json")))
+        self.assertEqual(ran.call_args.kwargs["scope"], "nothing above")
+
+    def test_rows_from_a_red_batch_are_counted_at_the_end(self) -> None:
+        """The number nothing printed. A reader was told "nothing above means
+        anything" once per red file and never told how much of the run that
+        came to -- so a `caught` row could be lifted out of a void batch and
+        believed. That happened."""
+        table = [Mutation("a.py:1 -- one", "a.py", "a", "b", "test_mod")]
+        answer = Report([Result(table[0], Verdict("caught"))], baseline_red=True)
+        said, _ = self.swept(table, answer)
+        self.assertIn("1 of 1 row(s) came from a batch whose baseline was red", said)
+
+    def test_a_green_sweep_says_nothing_about_it(self) -> None:
+        """Without this the count could be printed unconditionally, saying
+        `0 of N` on every clean run."""
+        table = [Mutation("a.py:1 -- one", "a.py", "a", "b", "test_mod")]
+        said, _ = self.swept(table, Report([Result(table[0], Verdict("caught"))]))
+        self.assertNotIn("came from a batch whose baseline was red", said)
+
     def test_a_missing_file_is_not_an_error(self) -> None:
         """The first run of a sweep has nothing to resume from."""
         with tempfile.TemporaryDirectory() as box:

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -1248,7 +1248,13 @@ class TestResumingASweep(unittest.TestCase):
         table = [Mutation("a.py:1 -- one", "a.py", "a", "b", "test_mod")]
         answer = Report([Result(table[0], Verdict("caught"))], baseline_red=True)
         said, _ = self.swept(table, answer)
-        self.assertIn("1 of 1 row(s) came from a batch whose baseline was red", said)
+        # The line, then `startswith`, rather than `assertIn` on the whole of
+        # stdout. "-1 of 1 row(s)..." *contains* "1 of 1 row(s)...", so the
+        # obvious assertion passes on a counter that subtracts -- which is
+        # exactly the mutant that survived the first version of this test.
+        counted = next(line for line in said.splitlines() if "came from a batch" in line)
+        self.assertTrue(counted.startswith("1 of 1 row(s)"), counted)
+        self.assertIn("so they have no verdict", counted)
 
     def test_a_green_sweep_says_nothing_about_it(self) -> None:
         """Without this the count could be printed unconditionally, saying

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -1331,7 +1331,9 @@ def _persist(report: Report, where: Path) -> None:
     print(f"\nwrote {len(rows)} row(s) to {where}")
 
 
-def _run_generated(rows: Sequence[Mutation], args: argparse.Namespace) -> Report:
+def _run_generated(
+    rows: Sequence[Mutation], args: argparse.Namespace, scope: str = "nothing above"
+) -> Report:
     """One batch of generated rows. Both the whole table and `sweep` use this.
 
     `strict=False`: a generated row that breaks collection is not a mistake
@@ -1343,6 +1345,13 @@ def _run_generated(rows: Sequence[Mutation], args: argparse.Namespace) -> Report
     without it each one runs the rest of its target after the answer is known.
     An average, not a bound -- `unittest` runs classes alphabetically, so a
     mutant caught only by the last of them still pays for nearly all.
+
+    ``scope`` is passed through to `run`, and defaults to the whole-table
+    wording because that is what `main`'s single-table path is. `sweep` calls
+    this once per *file* and must say so: eleven batches' worth of verdicts can
+    be scrolled above the twelfth, and telling the reader that all of it means
+    nothing is both false and the reason a real sweep's numbers were misread --
+    see #271.
     """
     return run(
         rows,
@@ -1353,6 +1362,7 @@ def _run_generated(rows: Sequence[Mutation], args: argparse.Namespace) -> Report
         failfast=True,
         timeout=args.timeout,
         memory=args.memory,
+        scope=scope,
     )
 
 
@@ -1421,6 +1431,13 @@ def sweep(table: Sequence[Mutation], args: argparse.Namespace) -> Report:
         by_file.setdefault(row.path, []).append(row)
 
     red = False
+    #: Rows from a batch whose baseline was red. They are kept -- dropping them
+    #: would make a resumed sweep re-run work it has already paid for -- but
+    #: they have no verdict, and until #271 nothing said how many there were.
+    #: The per-batch line said "nothing above means anything" about one file of
+    #: twelve, and the summary said nothing at all, so a reader could take a
+    #: `caught` row out of a void batch and believe it. One did.
+    unanswered = 0
     order = sorted(by_file, key=lambda path: len(by_file[path]))
     for at, path in enumerate(order, start=1):
         if path in done:
@@ -1428,11 +1445,18 @@ def sweep(table: Sequence[Mutation], args: argparse.Namespace) -> Report:
             continue
         rows = by_file[path]
         print(f"\n[{at}/{len(order)}] {path}: {len(rows)} mutant(s)")
-        batch = _run_generated(rows, args)
+        batch = _run_generated(rows, args, scope=f"nothing above about {path}")
         red |= batch.baseline_red
+        if batch.baseline_red:
+            unanswered += len(batch.results)
         collected.extend(batch.results)
         if args.json:
             _persist(Report(collected, red), args.json)
+    if unanswered:
+        print(
+            f"\n{unanswered} of {len(collected)} row(s) came from a batch whose baseline "
+            f"was red, so they have no verdict -- the rest stand."
+        )
     return Report(collected, red)
 
 


### PR DESCRIPTION
Closes #271.

## What was wrong

`run` prints `BASELINE NOT GREEN … so nothing above means anything` when its
baseline fails. That is true when `run` owns the whole output. Under `sweep` it
does not: `_run_generated` is called once per file, so a red baseline in the
twelfth batch printed a line claiming to void the eleven batches scrolled above
it — which were fine, and which the final `Report` keeps.

#269 already added `run`'s `scope` parameter for exactly this, because `confirm`
had the same problem. `_run_generated` passed nothing and so kept printing the
unscoped wording. It now says `nothing above about woswoar/search.py`.

## The number nothing printed

Fixing the wording is half of it. A reader was told "nothing above means
anything" once per red file and **never told how much of the run that came to**.
So a `caught` row could be lifted out of a void batch and believed.

That is not hypothetical — I did it, on the sweep run after #276 merged. Five of
twelve batches were red, and I reported the twelve `divisor` rows in
`search.py`'s `relative_time()` as all caught, treating that operator's noise
question as resolved. Batch 12 was red. Those verdicts mean nothing and the
question is still open.

So `sweep` now counts them and says so at the end:

```
7 of 42 row(s) came from a batch whose baseline was red, so they have no
verdict -- the rest stand.
```

The rows are kept rather than dropped: discarding them would make a resumed
sweep re-run work it has already paid for, and `_recorded`'s docstring is
explicit that a resume must not shorten the report.

## Mutation testing (rule 3)

`python -m tools.mutate --base main`, verbatim:

```
1 file(s), 26 changed lines -> 9 mutants
9 caught, 0 survived
```

The round before had one survivor, and it was **my assertion, not the code**:

```
  - tools/mutate.py:1451 in sweep() -- `+=` becomes `-=` (tests.test_mutate)
```

`assertIn("1 of 1 row(s) came from a batch whose baseline was red", said)` passes
against `-1 of 1 row(s) came from …`, because the expected string is a substring
of the mutated output. A counter that subtracts instead of adding survived a test
written to catch exactly that. It now pulls the line out and uses `startswith`,
so the leading `-` has nowhere to hide.

Textbook CONTRIBUTING: *suspect the fixture before the mutation.*

## Tests

Four, and two of them are the negative halves that keep the others honest:

- each batch scopes its warning to its own file — asserted on the argument, since
  the line belongs to `run`, which is stubbed here; that `run` honours `scope` is
  `TestConfirmingNeedsAGreenSuiteToo`'s subject;
- **a whole table keeps the unscoped wording**, because `main`'s single-table
  path really does own everything above it and the default must not drift;
- red-batch rows are counted at the end;
- **a green sweep says nothing about it**, or the count could be printed
  unconditionally as `0 of N` on every clean run.

`run` is stubbed for the reason the neighbouring resume test gives: `sweep`'s job
is the bookkeeping around `run` — which files to skip, what to keep, what to
write — and running a real mutation would test `run`, which has its own tests.

## Review

Rule 1's middle row, a careful read. The hazard is a message that is *still*
wrong after being changed, so I checked the two directions separately: the
per-batch line must name a file, and the whole-table line must not gain one.
Both are tested. Also checked that the count uses `len(batch.results)` rather
than `len(rows)` — a batch that dies partway returns fewer results than it was
given, and the honest number is what came back.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_