### PR TITLE
mutate: a completion marker, because --json is not one (#275)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ opens its PR and waits for a person regardless of what CI says.
   python -m tools.reached r.json c.json     # which survivors are missing tests
   python -m tools.compare --base main --show .bashrc install doctor status
   python -m tools.bench --importtime woswoar.__main__ --base main
-  python -m tools.watch $PID --log sweep.log --done r.json --match 'caught|SURVIVED'
+  python -m tools.watch $PID --log sweep.log --done r.json.done --match 'caught|SURVIVED'
   ```
 
   The last one is not about the code, it is about *reporting on* a job that
@@ -278,6 +278,12 @@ opens its PR and waits for a person regardless of what CI says.
   rather than as more silence, and so does a *stall*, which is the case that
   actually bit: a run alive and wedged looks exactly like one that is slow, and
   waiting longer is what both of them look like.
+
+  Point `--done` at `<json>.done`, never at the `--json` report itself. Under
+  `--batch` and `--all` the report is written after every file, so it exists
+  long before the run ends — a watcher pointed at it announced a finish nine
+  minutes early, with eleven files still to sweep. The `.done` file is written
+  last, after the confirmation pass, and means only that.
 
   **The generated sweep goes last.** Implement, write the hand table, preflight,
   run `/simplify` *and apply it*, and only then `--base main`. The table is

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -2263,6 +2263,65 @@ class TestTheGeneratedEntryPoint(MutateTestCase):
         )
         self.assertEqual({row["path"] for row in written["results"]}, {"woswoar/mod.py"})
 
+    def test_a_finished_run_leaves_a_marker(self) -> None:
+        """#275. `--json` says a batch landed; this says the run is over.
+
+        `tools/watch.py --done` needs a file whose only meaning is "finished",
+        because under `--batch` the report is written after every file and a
+        watcher pointed at it announced a finish nine minutes early.
+        """
+        self.repo(guarded=True)
+        report = self.root / "rows.json"
+        finished = cli(self.root, "--base", "HEAD", "--operator", "branch", "--json", str(report))
+        self.assertEqual(finished.returncode, 0, finished.stdout + finished.stderr)
+        self.assertTrue(mutate._marker(report).exists(), finished.stdout)
+
+    def test_the_marker_is_written_even_when_the_news_is_bad(self) -> None:
+        """It means *over*, not *clean*. A watcher that kept waiting on a run
+        that found survivors would be the same silence, from a third side."""
+        self.repo(guarded=False)
+        report = self.root / "rows.json"
+        finished = cli(self.root, "--base", "HEAD", "--operator", "branch", "--json", str(report))
+        self.assertEqual(finished.returncode, 1)
+        self.assertTrue(mutate._marker(report).exists())
+
+    def test_listing_a_table_does_not_retract_an_earlier_marker(self) -> None:
+        """`--list` runs nothing, so it has no finish to report and no earlier
+        one to withdraw. The clear sits after that return for this reason."""
+        self.repo(guarded=True)
+        report = self.root / "rows.json"
+        mutate._marker(report).write_text("", encoding="utf-8")
+        cli(self.root, "--base", "HEAD", "--operator", "branch", "--json", str(report), "--list")
+        self.assertTrue(mutate._marker(report).exists())
+
+    def test_a_stale_marker_is_gone_while_the_run_is_still_going(self) -> None:
+        """The half that makes the marker worth anything.
+
+        A resumed sweep points `--json` at a part-written report from the run
+        that was interrupted -- and at the marker that run never removed. Written
+        only at the end, a watcher would read the *previous* run's marker and
+        call this one finished before it started.
+
+        Observed from inside the run rather than after it, because by the time
+        `main` returns the marker is back and the two cases look identical.
+        """
+        self.repo(guarded=True)
+        report = self.root / "rows.json"
+        mutate._marker(report).write_text("", encoding="utf-8")
+        seen: list[bool] = []
+
+        def watching(rows: Sequence[Mutation], args: Any, **kw: Any) -> Report:
+            seen.append(mutate._marker(report).exists())
+            return Report([])
+
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            mock.patch.object(mutate, "_run_generated", watching),
+        ):
+            mutate.main(["--base", "HEAD", "--operator", "branch", "--json", str(report)])
+        self.assertEqual(seen, [False], "the previous run's marker outlived its report")
+        self.assertTrue(mutate._marker(report).exists(), "and the new one was never written")
+
     def test_no_confirm_says_what_it_did_not_do(self) -> None:
         """A survivor that was never re-run against the whole suite may simply
         have been run against tests that cannot see it, and that is the
@@ -2307,6 +2366,16 @@ class TestTheGeneratedEntryPoint(MutateTestCase):
                 finished = cli(self.root, *args)
                 self.assertEqual(finished.returncode, 2, finished.stderr)
                 self.assertIn(said, finished.stderr)
+
+
+class TestTheCompletionMarker(unittest.TestCase):
+    def test_it_sits_beside_the_report(self) -> None:
+        """A sibling name rather than a suffix swap, so a reader sorting a
+        directory finds the two together and `.json` keeps its meaning."""
+        self.assertEqual(mutate._marker(Path("/tmp/r.json")), Path("/tmp/r.json.done"))
+
+    def test_a_report_without_a_suffix_still_gets_one(self) -> None:
+        self.assertEqual(mutate._marker(Path("/tmp/rows")), Path("/tmp/rows.done"))
 
 
 class TestTheScriptEntryPoint(MutateTestCase):

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -1287,6 +1287,23 @@ def _bytes(said: str) -> int:
     return value
 
 
+def _marker(where: Path) -> Path:
+    """The file whose only meaning is that the run is over.
+
+    ``--json`` cannot carry that meaning. Under `--batch` and `--all`, `_persist`
+    writes after every file, so the report exists long before the run ends and
+    the confirmation pass has not started -- `tools/watch.py --done` read its
+    arrival as a finish and announced one **nine minutes** early, exiting 0 while
+    the sweep still had eleven files to go. That is this repository's own
+    watchdog being told the wrong thing by this module, which is #275.
+
+    A sibling name rather than a suffix swap: `Path("r.json").with_suffix(...)`
+    has to reason about which suffix it is replacing, and `r.json.done` beside
+    `r.json` is what a reader sorting a directory expects to see.
+    """
+    return where.parent / (where.name + ".done")
+
+
 def _persist(report: Report, where: Path) -> None:
     """The run's answers, as `tools/reached.py` reads them.
 
@@ -1518,6 +1535,14 @@ def main(argv: list[str] | None = None) -> int:
             for row in table:
                 print(f"  {row.operator:16} {row.label}")
             return 0
+        if args.json:
+            # Cleared before the first row, not merely written after the last.
+            # A resumed sweep points `--json` at a part-written report, and a
+            # marker left by the run that was interrupted would tell a watcher
+            # that *this* one had finished before it began. After the `--list`
+            # return on purpose: listing a table is not a run, and must not
+            # retract a marker an earlier complete run earned.
+            _marker(args.json).unlink(missing_ok=True)
         report = sweep(table, args) if args.all or args.batch else _run_generated(table, args)
         if not args.no_confirm:
             report = confirm(
@@ -1535,6 +1560,9 @@ def main(argv: list[str] | None = None) -> int:
         _summarise(report.results)
         if args.json:
             _persist(report, args.json)
+            # Last, and after `confirm`: the marker means the whole run is over,
+            # including the pass that can still change a verdict.
+            _marker(args.json).touch()
         return 0 if report.clean else 1
 
     already = len(_RUNS)

--- a/tools/watch.py
+++ b/tools/watch.py
@@ -258,10 +258,15 @@ def main(argv: list[str] | None = None) -> int:
         "--done",
         type=Path,
         required=True,
-        # A report left by an earlier run reads as an instant finish, because
-        # this asks whether the file is there and not who wrote it. Cheaper to
-        # say so than to date-stamp it and be wrong about clock skew.
-        help="the file it writes when it finishes; remove a previous run's first",
+        # A file left by an earlier run reads as an instant finish, because this
+        # asks whether it is there and not who wrote it. Cheaper to say so than
+        # to date-stamp it and be wrong about clock skew -- and `tools.mutate`
+        # now clears its own marker before it starts, for that reason.
+        #
+        # It must be a file that means *finished*. A report written
+        # incrementally does not: pointed at one, this announced a finish nine
+        # minutes early. `tools.mutate --json r.json` writes `r.json.done` last.
+        help="the file it writes when it finishes; not one it appends to as it goes",
     )
     parser.add_argument(
         "--match", default=".", help="count lines of --log matching this regex (default: all)"


### PR DESCRIPTION
Closes #275.

## What was wrong

`tools/watch.py --done <file>` treats the file appearing as the job being over.
That holds for a plain `--base main --json r.json`, which writes the report last.
Under `--batch` and `--all` it does not: `sweep` calls `_persist` after **every
file**, and the confirmation pass runs after all of them.

Measured, on a real sweep in this repository:

```
working: 58 rows after 0m
working: 60 rows after 4m
FINISHED after 9m: 63 rows, report written
```

The process ran for a further nine minutes after that line, confirming eleven
survivors — and `FINISHED` exits 0, so a caller reading only the status was told
the run succeeded before its most expensive pass had begun.

This repository's own watchdog, told the wrong thing by this module. The tool
exists because silence was mistaken for progress; here a completion marker was
mistaken for completion.

## The fix

`--json r.json` now writes `r.json.done` **last**, after `confirm`. A sibling
name rather than a suffix swap: `with_suffix` has to reason about which suffix it
is replacing, and `r.json.done` beside `r.json` is what a reader sorting a
directory expects.

**It is also cleared before the first row runs**, and that half is what makes it
worth anything. A resumed sweep points `--json` at a part-written report from the
run that was interrupted — and at the marker that run never removed. Written only
at the end, a watcher would read the previous run's marker and call this one
finished before it started.

The clear sits *after* the `--list` early return, deliberately: listing a table
is not a run, so it has no finish to report and no earlier one to withdraw.

## Dogfooded

This PR's own sweep was watched through the new marker:

```
working: 0 rows after 0m
...
working: 9 rows after 2m
FINISHED after 2m: 11 rows, report written
```

`FINISHED` at the true end rather than at the first `_persist`.

## Mutation testing (rule 3)

`python -m tools.mutate --base main`, verbatim:

```
2 file(s), 37 changed lines -> 11 mutants
11 caught, 0 survived
```

Clean first time.

## Tests

Six, and the two that carry the weight are the ones that cannot be observed from
outside the run:

- **the stale marker is gone while the run is still going.** Checked from
  *inside*, with `_run_generated` patched to record whether the marker existed
  when it was called — by the time `main` returns the marker is back, and the
  fixed and unfixed cases look identical from there.
- **`--list` does not retract an earlier marker**, which is the reason the clear
  sits where it does rather than at the top of the branch.

Plus: a finished run leaves one; **a run that found survivors also leaves one**,
because the marker means *over*, not *clean* — a watcher that kept waiting on a
red run would be the same silence from a third side; and two naming tests,
including a report path with no suffix at all.

## Also updated

`CLAUDE.md`'s worked example now points `--done` at `r.json.done`, with the
reason beside it, and `watch.py`'s own `--done` help says "not one it appends to
as it goes" rather than the previous wording, which invited exactly this mistake.

## Review

Rule 1's middle row, a careful read. The hazard is a marker that lies in either
direction, so both were checked: written too early (the bug), and left behind
from a previous run (the resume case, which is why the clear exists). One thing I
looked for and did not find a problem with: `touch()` on a path whose parent does
not exist would raise, but `_persist` has already written the report to that same
directory one line above, so the parent is known to exist by then.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_