### PR TITLE
test: the importer's unknown sentinels are negative, and now say so (#277)

### DIFF
--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -42,6 +42,24 @@ class TestParseBash(unittest.TestCase):
     def test_blank_lines_ignored(self) -> None:
         self.assertEqual(len(importer.parse_bash("a\n\n\nb\n", MTIME)), 2)
 
+    def test_bash_records_no_timing_so_the_duration_is_unknown(self) -> None:
+        """The sentinel's *sign*, which is the whole of what it claims.
+
+        `.bash_history` carries no durations at all, so every imported row says
+        "not recorded". Flip the sign and each one claims it took a millisecond
+        -- a number, written into `logs/`, which rule 8 calls the primary copy
+        and which an import is the one operation that fills from outside.
+
+        `< 0` rather than `== -1`: the claim is "this means unknown", and an
+        assertion on the exact number would fail on a deliberate change to `-2`
+        that meant the same thing. Found by #276's `sign` operator, which no
+        test in this file could see.
+        """
+        parsed = importer.parse_bash("#1753000000\ngit status\nbare\n", MTIME)
+        self.assertEqual(len(parsed), 2)
+        for row in parsed:
+            self.assertLess(row.duration_ms, 0, row)
+
     def test_a_comment_is_not_mistaken_for_a_timestamp(self) -> None:
         parsed = importer.parse_bash("#!/bin/sh\n#not-a-number\n", MTIME)
         self.assertEqual([p.cmd for p in parsed], ["#!/bin/sh", "#not-a-number"])
@@ -65,6 +83,16 @@ class TestParseZsh(unittest.TestCase):
     def test_plain_history_without_headers(self) -> None:
         parsed = importer.parse_zsh("git status\nls -la\n", MTIME)
         self.assertEqual([p.cmd for p in parsed], ["git status", "ls -la"])
+
+    def test_a_plain_history_line_has_an_unknown_duration(self) -> None:
+        """The *untimed* branch, which is a separate literal from the one
+        `test_extended_format` pins. That test covers `: ts:0;cmd` -- a header
+        whose elapsed field is zero -- and a zsh history with no headers at all
+        takes the other path and was unguarded."""
+        parsed = importer.parse_zsh("git status\nls -la\n", MTIME)
+        self.assertEqual(len(parsed), 2)
+        for row in parsed:
+            self.assertLess(row.duration_ms, 0, row)
 
     def test_output_is_sorted_by_time(self) -> None:
         text = ": 1753000100:0;later\n: 1753000000:0;earlier\n"
@@ -97,6 +125,24 @@ class TestImportRun(ImportTestCase):
         result = importer.run("bash", source)
         self.assertEqual(result.imported, 2)
         self.assertEqual(self._commands(), {"git status", "ls"})
+
+    def test_an_imported_command_has_an_unknown_exit_code(self) -> None:
+        """The third sentinel, and the one whose flip is worst.
+
+        A shell history records what was *run*, never how it ended, so an
+        imported row cannot know. `1` is not a missing value: it is the code for
+        a command that failed, so every line a user ever imported would read as
+        having failed -- in the history they search, from the primary copy.
+
+        Asserted on what reaches the store rather than on `Parsed`, because
+        `run` builds the `Entry` itself and this literal is nowhere near the two
+        the parsers carry.
+        """
+        importer.run("bash", self._source("hist", "#1753000000\ngit status\n"))
+        codes = [entry.exit_code for entry in cache.load_entries()]
+        self.assertEqual(len(codes), 1)
+        for code in codes:
+            self.assertLess(code, 0, codes)
 
     def test_rerun_imports_nothing_new(self) -> None:
         source = self._source("hist", "#1753000000\ngit status\n")


### PR DESCRIPTION
Closes #277.

Tests only — the code is correct and stays as it is. What was missing is anything
that pins the **sign** of three sentinels meaning *not recorded*.

## What the mutant does

`-1` → `1` in `woswoar/importer.py`, at three sites, all surviving:

| site | flipped, it claims |
|---|---|
| `parse_bash()` `duration_ms=-1` | every bash command took **1 ms** |
| `parse_zsh()` `duration_ms=-1` (untimed) | the same for a header-less zsh history |
| `run()` `exit_code=-1` | every imported command **exited 1 — failed** |

The last is the worst. A shell history records what was *run*, never how it
ended, so an imported row cannot know — and `1` is not a missing value, it is the
code for a command that failed. Every line a user ever imported would read as
having failed, in the history they search, written into `logs/`, which rule 8
calls the primary copy and which an import is the one operation that fills from
outside.

## Rule 3, by the operator that found them

`--base main` correctly generates nothing here — a tests-only diff has no mutants
— and says so:

```
nothing mutable changed against main. Only woswoar/**.py and tools/**.py are
generated from; a change to tests/ is not a fix to test.
```

So the demonstration is the operator run, before and after. Before, from the
whole-tree sweep after #276 merged:

```
  SURVIVED  woswoar/importer.py:106 in parse_bash() -- `-1` becomes `1`
  SURVIVED  woswoar/importer.py:158 in parse_zsh() -- `-1` becomes `1`
  SURVIVED  woswoar/importer.py:533 in run() -- `-1` becomes `1`
```

After, on this branch:

```
[1/1] woswoar/importer.py: 5 mutant(s)
  caught    woswoar/importer.py:106 in parse_bash() -- `-1` becomes `1`
  caught    woswoar/importer.py:153 in parse_zsh() -- `-1` becomes `1`
  caught    woswoar/importer.py:158 in parse_zsh() -- `-1` becomes `1`
  caught    woswoar/importer.py:234 in _atuin_rows() -- `-1` becomes `1`
  caught    woswoar/importer.py:533 in run() -- `-1` becomes `1`
```

Five of five, from two of five.

## Three decisions in the tests

**`< 0`, not `== -1`.** The claim being made is *this means unknown*. An
assertion on the exact number would fail on a deliberate change to `-2` that
meant exactly the same thing, which would make the test an obstacle rather than
a guard.

**`parse_zsh` needed a second test, not an extended one.** `test_extended_format`
already pins `duration_ms == -1` — but for `: ts:0;cmd`, a header whose elapsed
field is zero, which is line 153's conditional `else -1`. A zsh history with no
headers at all takes a different branch through a different literal, and that one
was unguarded. Two literals, two tests.

**`run()` is asserted on what reaches the store**, via `cache.load_entries()`,
rather than on `Parsed`. `run` builds the `Entry` itself and its `exit_code=-1`
is nowhere near the two the parsers carry — the issue flagged this as the
constraint that makes the obvious single-test fix wrong, and it was right.

## Evidence caveat, now resolved

#277 noted the survivors came from a run whose confirmation pass never executed
(five of twelve batches had a red baseline, so `sweep` reported `baseline_red` and
#269's early return declined to widen), and said to confirm before concluding the
tests were weak rather than the selection narrow.

Resolved the other way round: the targeted re-run above is against
`woswoar/importer.py` alone with its own green baseline, and the three rows moved
from `SURVIVED` to `caught` on the strength of three new assertions. They were
weak fixtures, not narrow selection.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_