### PR TITLE
release: 0.12.0

### DIFF
--- a/woswoar/__init__.py
+++ b/woswoar/__init__.py
@@ -1,3 +1,3 @@
 """woswoar - distributed shell history over git, searched with fzf."""
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"


### PR DESCRIPTION
Step 1 of CONTRIBUTING's release procedure: bump `__version__`, merge, then tag
the merged commit.

One line. The version lives in `woswoar/__init__.py` and nowhere else —
`pyproject.toml` reads it from there, so the two cannot disagree. Verified
through both paths that could:

```
$ python -c "import woswoar; print(woswoar.__version__)"
0.12.0
$ python -m woswoar --version
woswoar 0.12.0
```

## What 0.12.0 contains

Twenty commits since `v0.11.0`, of which these are the ones a user meets —
about 1,021 lines in `woswoar/`:

- **`woswoar forget`** (#262) — removes recorded commands from this machine, out
  of `logs/`, Ctrl-R and `stats`, and remembers their digests so a later sync or
  import cannot write them back. Dry run by default.
- **a dir scope spanning several directories** (#265) — one project, several
  checkouts, one scope.
- **the session scope's prompt says how far back the shell goes** (#264).
- **the fleet table in `doctor`'s marks**, with a key under it (#259).
- **fix: export checks the watermark is on a line boundary** (#266).
- **fix: the bytecode check is about `sandbox_env`**, not about who ran the suite
  (#261).

The other eight commits are `tools/` and `tests/` — the mutation harness, the
watchdog, `reached.py`. `packages = ["woswoar"]`, so none of it is in the wheel.

## Rule 8

Nothing here needs an upgrade path, and both candidates were checked rather than
assumed:

- **`forget`'s digest file is new and additive.** `load_digests()` returns
  `set()` on `OSError`, so an installation that has never run the command is
  unaffected — no migration, nothing to delete.
- **#266 self-heals.** `export` now passes the watermark through
  `store.line_start()` before reading, so an install carrying a mid-line
  `state.exported` is corrected on its next run rather than needing a hand.

## Mutation testing (rule 3)

```
1 file(s), 1 changed lines -> 0 mutants
```

Correct rather than lazy: the diff is a version string, and no operator mutates
string literals — which is the deliberate omission argued in #276, where mutmut's
string operator scored two real findings against five pieces of noise.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

`python -m build` is not available in this container, so the artifacts were not
built locally. `release.yml` builds, attests and re-runs the whole suite at the
tagged commit, and this release changes no packaging — `publish-testpypi.yml` is
the rehearsal for when it does.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_