### PR TITLE
fix: a zsh re-import no longer drops out-of-order records (#289)

### DIFF
--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -42,6 +42,24 @@ class TestParseBash(unittest.TestCase):
     def test_blank_lines_ignored(self) -> None:
         self.assertEqual(len(importer.parse_bash("a\n\n\nb\n", MTIME)), 2)
 
+    def test_the_record_list_only_grows_at_the_end(self) -> None:
+        """The same requirement `parse_zsh` now carries, mirrored here.
+
+        `parse_bash` has always been file-ordered and assigns synthetic stamps
+        in place, so it never had #289's defect -- but until now that was prose
+        in a comment while zsh had an executable version of it. A future "sort
+        both for consistency" would reintroduce the bug on this path, silently,
+        and this is what stops it.
+        """
+        # Real epochs: `#100` is not a plausible timestamp and `parse_bash`
+        # reads it as a command, which made the first version of this fixture
+        # assert about seven untimed lines rather than the property.
+        before = "#1753000000\nalpha\nbare\n#1753000200\ngamma\n"
+        first = importer.parse_bash(before, MTIME)
+        grown = importer.parse_bash(before + "#1753000100\ndelta\n", MTIME)
+        self.assertEqual([r.cmd for r in grown[: len(first)]], [r.cmd for r in first])
+        self.assertEqual([r.cmd for r in grown[len(first) :]], ["delta"])
+
     def test_bash_records_no_timing_so_the_duration_is_unknown(self) -> None:
         """The sentinel's *sign*, which is the whole of what it claims.
 
@@ -97,27 +115,28 @@ class TestParseZsh(unittest.TestCase):
     def test_the_record_list_only_grows_at_the_end(self) -> None:
         """The property `run`'s watermark rests on, asserted directly.
 
-        `parse_zsh` sorts and is what every other caller wants; `_zsh_records`
-        is the file-order list, and appending to the history must leave every
-        earlier position exactly where it was.
+        Appending to the history must leave every earlier position exactly where
+        it was -- that is what makes a count of records a usable mark, and both
+        parsers now owe it.
         """
         before = ": 100:0;alpha\nbare\n: 200:0;gamma\n"
-        first = importer._zsh_records(before, 9999)
-        grown = importer._zsh_records(before + ": 150:0;delta\n", 9999)
+        first = importer.parse_zsh(before, MTIME)
+        grown = importer.parse_zsh(before + ": 150:0;delta\n", MTIME)
         self.assertEqual([r.cmd for r in grown[: len(first)]], [r.cmd for r in first])
         self.assertEqual([r.cmd for r in grown[len(first) :]], ["delta"])
 
-    def test_sorting_is_unchanged_by_the_file_order_split(self) -> None:
-        """`parse_zsh`'s own contract, which #289 must not have moved: untimed
-        records carry a synthetic stamp at or after the file's mtime, so they
-        still land last however the list was built."""
-        rows = importer.parse_zsh(": 200:0;gamma\nbare\n: 100:0;alpha\n", 9999)
-        self.assertEqual([r.cmd for r in rows], ["alpha", "gamma", "bare"])
+    def test_it_does_not_sort(self) -> None:
+        """File order, not timestamp order, and this is the executable form of
+        that requirement.
 
-    def test_output_is_sorted_by_time(self) -> None:
-        text = ": 1753000100:0;later\n: 1753000000:0;earlier\n"
-        parsed = importer.parse_zsh(text, MTIME)
-        self.assertEqual([p.cmd for p in parsed], ["earlier", "later"])
+        `parse_zsh` used to sort and return that, which is what #289 was: `run`
+        sliced a positional count into a re-sorted list. Nothing outside tests
+        ever wanted the sorted view, so the sort is gone rather than hidden
+        behind a second name -- a public parser handing back timestamp order is
+        the footgun, whatever it is called.
+        """
+        rows = importer.parse_zsh(": 200:0;gamma\n: 100:0;alpha\n", MTIME)
+        self.assertEqual([r.cmd for r in rows], ["gamma", "alpha"])
 
 
 class ImportTestCase(WoswoarTestCase):

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -94,6 +94,26 @@ class TestParseZsh(unittest.TestCase):
         for row in parsed:
             self.assertLess(row.duration_ms, 0, row)
 
+    def test_the_record_list_only_grows_at_the_end(self) -> None:
+        """The property `run`'s watermark rests on, asserted directly.
+
+        `parse_zsh` sorts and is what every other caller wants; `_zsh_records`
+        is the file-order list, and appending to the history must leave every
+        earlier position exactly where it was.
+        """
+        before = ": 100:0;alpha\nbare\n: 200:0;gamma\n"
+        first = importer._zsh_records(before, 9999)
+        grown = importer._zsh_records(before + ": 150:0;delta\n", 9999)
+        self.assertEqual([r.cmd for r in grown[: len(first)]], [r.cmd for r in first])
+        self.assertEqual([r.cmd for r in grown[len(first) :]], ["delta"])
+
+    def test_sorting_is_unchanged_by_the_file_order_split(self) -> None:
+        """`parse_zsh`'s own contract, which #289 must not have moved: untimed
+        records carry a synthetic stamp at or after the file's mtime, so they
+        still land last however the list was built."""
+        rows = importer.parse_zsh(": 200:0;gamma\nbare\n: 100:0;alpha\n", 9999)
+        self.assertEqual([r.cmd for r in rows], ["alpha", "gamma", "bare"])
+
     def test_output_is_sorted_by_time(self) -> None:
         text = ": 1753000100:0;later\n: 1753000000:0;earlier\n"
         parsed = importer.parse_zsh(text, MTIME)
@@ -143,6 +163,38 @@ class TestImportRun(ImportTestCase):
         self.assertEqual(len(codes), 1)
         for code in codes:
             self.assertLess(code, 0, codes)
+
+    def test_a_zsh_record_with_an_earlier_timestamp_is_still_imported(self) -> None:
+        """#289. The watermark counts records, so the list it counts into must
+        only ever grow at the end -- and timestamp order does not.
+
+        A shell writes its history when it exits, so two zsh sessions closed in
+        the other order interleave. The appended command sorted below the
+        watermark and was skipped on this run and on every run afterwards, with
+        a successful import reported each time.
+        """
+        source = self._source("hist", ": 100:0;alpha\n: 200:0;gamma\n")
+        importer.run("zsh", source)
+        self._rewrite(source, ": 100:0;alpha\n: 200:0;gamma\n: 150:0;delta\n")
+        result = importer.run("zsh", source)
+        self.assertEqual(result.imported, 1)
+        self.assertIn("delta", self._commands())
+
+    def test_an_untimed_neighbour_does_not_push_a_new_record_under_the_mark(self) -> None:
+        """The second way the order moved, and the one a timestamp fixture
+        misses entirely.
+
+        Untimed records used to be collected and appended *after* the timed
+        ones, so a newly timed record pushed every untimed one down a slot --
+        enough to drop a command with no out-of-order timestamp anywhere. Here
+        `delta`'s stamp is the highest of the three real ones, so a test that
+        only varied timestamps would pass against the old code.
+        """
+        source = self._source("hist", ": 100:0;alpha\nbare\n: 200:0;gamma\n")
+        importer.run("zsh", source)
+        self._rewrite(source, ": 100:0;alpha\nbare\n: 200:0;gamma\n: 300:0;delta\n")
+        importer.run("zsh", source)
+        self.assertIn("delta", self._commands())
 
     def test_rerun_imports_nothing_new(self) -> None:
         source = self._source("hist", "#1753000000\ngit status\n")

--- a/woswoar/importer.py
+++ b/woswoar/importer.py
@@ -108,7 +108,7 @@ def parse_bash(text: str, mtime: int) -> list[Parsed]:
     ]
 
 
-def _zsh_records(text: str, mtime: int) -> list[Parsed]:
+def parse_zsh(text: str, mtime: int) -> list[Parsed]:
     """Parse ``.zsh_history``, **in the order the records appear in the file**.
 
     Extended history looks like ``: <start>:<elapsed>;<command>``. A command
@@ -126,6 +126,12 @@ def _zsh_records(text: str, mtime: int) -> list[Parsed]:
     rather than two. Untimed records were collected and appended after the timed
     ones, so a newly timed record pushed every untimed one down a slot -- enough
     on its own to drop a command even without the sort.
+
+    It sorted, too, and returned that. Nothing wanted it: `run` was the only
+    caller in shipped code. A public parser handing back timestamp order is the
+    footgun that made #289 -- the next caller reaches for the obvious name and
+    inherits the ordering the watermark cannot survive -- so both parsers now
+    return file order, and a caller that wants time order sorts and says so.
     """
     records: list[str] = []
     current: list[str] = []
@@ -169,11 +175,6 @@ def _zsh_records(text: str, mtime: int) -> list[Parsed]:
             )
         )
     return rows
-
-
-def parse_zsh(text: str, mtime: int) -> list[Parsed]:
-    """`_zsh_records`, in timestamp order. What every caller but `run` wants."""
-    return sorted(_zsh_records(text, mtime), key=lambda row: row.ts)
 
 
 # ---------------------------------------------------------------------------
@@ -493,10 +494,9 @@ def run(
 
     mtime = int(source.stat().st_mtime)
     text = _read(source)
-    # `_zsh_records` rather than `parse_zsh`: the watermark below counts
-    # positions, so it has to count them in a list that only grows at the end.
-    # `parse_bash` is already in file order and never sorts. See #289.
-    parsed = parse_bash(text, mtime) if kind == "bash" else _zsh_records(text, mtime)
+    # Both parsers return file order and neither sorts, which is not a
+    # coincidence but the contract the watermark below rests on. See #289.
+    parsed = parse_bash(text, mtime) if kind == "bash" else parse_zsh(text, mtime)
 
     state = _load_state()
     key = str(source)

--- a/woswoar/importer.py
+++ b/woswoar/importer.py
@@ -108,12 +108,24 @@ def parse_bash(text: str, mtime: int) -> list[Parsed]:
     ]
 
 
-def parse_zsh(text: str, mtime: int) -> list[Parsed]:
-    """Parse ``.zsh_history``.
+def _zsh_records(text: str, mtime: int) -> list[Parsed]:
+    """Parse ``.zsh_history``, **in the order the records appear in the file**.
 
     Extended history looks like ``: <start>:<elapsed>;<command>``. A command
     continues onto the next line when the current one ends in a backslash.
     Plain (non-extended) history has no header and is handled like untimed bash.
+
+    File order is not a detail here, it is the whole of #289. `run` remembers how
+    far it got as a **count of records**, and slices that count off the front on
+    the next import -- so the order this returns has to be one that only ever
+    *grows at the end*. Timestamp order is not: a shell writes its history when
+    it exits, so two shells closed in the other order interleave, and a record
+    that sorts below the watermark is skipped on that run and on every run after.
+
+    The previous shape had a second way to reorder, which is why this is one loop
+    rather than two. Untimed records were collected and appended after the timed
+    ones, so a newly timed record pushed every untimed one down a slot -- enough
+    on its own to drop a command even without the sort.
     """
     records: list[str] = []
     current: list[str] = []
@@ -132,33 +144,36 @@ def parse_zsh(text: str, mtime: int) -> list[Parsed]:
     if current:
         records.append("\n".join(current))
 
-    parsed: list[Parsed] = []
-    untimed: list[str] = []
+    kept = [record for record in records if record.strip()]
+    # Counted in a pass of its own because `_synthetic` is told up front how
+    # many stamps to mint. The generator is then consumed in encounter order,
+    # so every untimed record gets the same stamp it did before #289 -- what
+    # changed is where it sits in the list, not what it holds.
+    synthetic = _synthetic(mtime, sum(1 for r in kept if _ZSH_HEADER.match(r) is None))
 
-    for record in records:
-        if not record.strip():
-            continue
+    rows: list[Parsed] = []
+    for record in kept:
         match = _ZSH_HEADER.match(record)
         if match is None:
-            untimed.append(record)
+            rows.append(Parsed(ts=next(synthetic), cmd=record, duration_ms=-1))
             continue
         elapsed = int(match.group(2))
         # Continuation backslashes are zsh's line-wrapping, not part of the
         # command.
         cmd = match.group(3).replace("\\\n", "\n")
-        parsed.append(
+        rows.append(
             Parsed(
                 ts=int(match.group(1)),
                 cmd=cmd,
                 duration_ms=elapsed * 1000 if elapsed > 0 else -1,
             )
         )
+    return rows
 
-    synthetic = _synthetic(mtime, len(untimed))
-    parsed.extend(Parsed(ts=next(synthetic), cmd=cmd, duration_ms=-1) for cmd in untimed)
 
-    parsed.sort(key=lambda p: p.ts)
-    return parsed
+def parse_zsh(text: str, mtime: int) -> list[Parsed]:
+    """`_zsh_records`, in timestamp order. What every caller but `run` wants."""
+    return sorted(_zsh_records(text, mtime), key=lambda row: row.ts)
 
 
 # ---------------------------------------------------------------------------
@@ -478,7 +493,10 @@ def run(
 
     mtime = int(source.stat().st_mtime)
     text = _read(source)
-    parsed = parse_bash(text, mtime) if kind == "bash" else parse_zsh(text, mtime)
+    # `_zsh_records` rather than `parse_zsh`: the watermark below counts
+    # positions, so it has to count them in a list that only grows at the end.
+    # `parse_bash` is already in file order and never sorts. See #289.
+    parsed = parse_bash(text, mtime) if kind == "bash" else _zsh_records(text, mtime)
 
     state = _load_state()
     key = str(source)


### PR DESCRIPTION
Closes #289.

**Rule 1's top row** — this changes what reaches `logs/`, the primary copy — so
it got the full review pass, and that pass changed the shape of the fix twice.

## The defect, and the half the issue missed

`run` remembers how far it got as a **count of records** and slices that count off
the front next time. `parse_zsh` returned **timestamp order**. zsh writes a
session's history when the shell exits, so two shells closed in the other order
interleave — and a record that sorts below the mark is skipped on that run and on
every run after, with a successful import reported each time.

Investigating turned up a **second reordering the issue did not describe**.
Untimed records were collected in their own list and appended after the timed
ones, so a newly *timed* record pushed every untimed one down a slot. Traced:

```
before: alpha(100), gamma(200), bare-one(9999)          watermark = 3
after:  alpha(100), delta(150), gamma(200), bare-one    [3:] = [bare-one]
```

`delta` is dropped — and it is dropped in the pre-sort order too, so slicing
before the sort (the issue's suggested fix) would not have been enough. Both
parsers now build one list in record order, so the list only ever grows at the
end.

## What the review changed

Two agents, reuse/simplification and efficiency/altitude, and they independently
found the same thing: the fix as first written left `parse_zsh` as a **sorted
wrapper with no caller in shipped code**. `run` had been its only one. So it
would have shipped a public name that hands back the exact ordering this issue is
about, for the next caller to reach for and inherit.

The sort is gone rather than hidden behind a second name. `parse_bash` and
`parse_zsh` now have the same contract — file order, no sorting — and the
asymmetry between them, which is what made the watermark wrong in the first
place, is closed. Nothing needed timestamp order; a caller that wants it can sort
and say so.

`test_output_is_sorted_by_time` is deleted rather than rewritten: it pinned a
property no path has any more. It is the only deletion in the diff.

**Also from the review:** `parse_bash` has always been file-ordered and assigned
synthetic stamps in place, so it never had this defect — but that requirement
lived only in a comment while zsh now has an executable version of it. It gets a
three-line mirror, so a future "sort both for consistency" cannot reintroduce
#289 on the bash path.

## Measured, and deliberately not chased

The new shape matches `_ZSH_HEADER` twice per record — once to count the untimed
ones (`_synthetic` is told its count up front), once in the build loop. Measured
on 100k records, min of 5 runs:

| history | before | after |
|---|---|---|
| all extended | 164 ms | **176 ms** |
| all plain | 96 ms | **97 ms** |

~12 ms per 100k timed records, ~7% of parse. Two alternatives were measured and
neither wins: caching the match objects costs the same 175 ms (17 MB of live
match objects eats the saving), and a one-loop-plus-index-fixup shape trades 12 ms
on extended histories for **58 ms** on plain ones. For scale, the per-row work
`run` does after parsing — `_dedup_key` plus `looks_like_credential` — is 728 ms
per 100k, four times the whole parse.

CLAUDE.md's "a millisecond of fifteen" case: stated, not chased.

## Mutation testing (rule 3)

```
1 file(s), 32 changed lines -> 11 mutants
11 caught
2 survived:
  - woswoar/importer.py:158 in parse_zsh() -- `1` becomes `2`
  - woswoar/importer.py:164 in parse_zsh() -- `1` becomes `2`
```

Both equivalent, and the second is equivalent *by a decision made in #281*:

- `:158` is `sum(1 for ...)` → `sum(2 ...)`, which mints twice as many synthetic
  stamps. Only as many as there are untimed records are ever consumed, so no
  output differs.
- `:164` is `duration_ms=-1` → `-2`. #281's test asserts `< 0` rather than
  `== -1` **on purpose** — the claim is "this means unknown", and pinning the
  number would fail on a deliberate change to `-2` that meant the same thing. So
  this row is the cost of that choice, knowingly paid.

The rule 3 loop was also run by hand twice, because the fix changed shape
mid-review: putting the sort back fails **4** of the new tests, and restoring it
passes all 38.

## Filed, not fixed here

**#294 (P1) — a `SAVEHIST` trim makes the watermark start too late.** The review
found that making the *parse* order stable is not enough, because the *file* is
not: zsh rewrites `.zsh_history` wholesale when trimming, dropping records from
the front. The `already > len(parsed)` guard only fires when the file gets
shorter, so a trim plus a larger append slips through and skips records
permanently — the same symptom as this issue, from a different direction. It
needs a validated watermark and an additive `state.json` field, which is a second
subject.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_