### PR TITLE
fix: republish accepts when a key rotates, not only when a host does (#290)

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -810,6 +810,95 @@ class TestWhoHasAcceptedWhom(SyncTestCase):
             )
 
 
+class TestRepublishingAfterAKeyRotation(unittest.TestCase):
+    """#290, at the level the bug lives: what the republish check compares.
+
+    Driven against `accepts_digest` and a hand-built `State` rather than through
+    a real two-machine sync, because the defect is entirely in the comparison --
+    the seal already carried the right thing. A full sync fixture would exercise
+    age, git and a second machine to assert a string equality, and would take
+    minutes to say what these say in milliseconds.
+    """
+
+    def test_a_rotated_key_changes_the_digest(self) -> None:
+        """The whole bug. `trust --replace` leaves the host set untouched and
+        changes what every entry points at, so a check over the *ids* cannot
+        see it -- and `accepts.age` keeps a fingerprint no peer can match."""
+        before = sync.accepts_digest({"alpha": "AAA", "beta": "BBB"})
+        after = sync.accepts_digest({"alpha": "AAA", "beta": "ROTATED"})
+        self.assertNotEqual(before, after)
+
+    def test_the_same_mapping_is_the_same_digest(self) -> None:
+        """The other half: without it the digest could be random and every sync
+        would republish, which is the cost the id check was avoiding."""
+        first = sync.accepts_digest({"alpha": "AAA", "beta": "BBB"})
+        again = sync.accepts_digest({"beta": "BBB", "alpha": "AAA"})
+        self.assertEqual(first, again, "insertion order is not part of the pin")
+
+    def test_two_mappings_cannot_flatten_into_one(self) -> None:
+        """The separator earning its place: without a delimiter between the id
+        and the fingerprint, `{"ab": "c"}` and `{"a": "bc"}` render identically
+        and a rotation could be made invisible by choosing names."""
+        self.assertNotEqual(sync.accepts_digest({"ab": "c"}), sync.accepts_digest({"a": "bc"}))
+
+    def wired(self, state: sync.State) -> bool:
+        """`publish_accepts` with only its side effects held back.
+
+        The digest tests above pass against a call site still comparing ids --
+        they exercise `accepts_digest`, not the decision that uses it. This is
+        the wiring, and it is the half #276 taught: both survivors of that
+        change were at a call site no unit test reached.
+
+        Mocked rather than driven through a two-machine sync because everything
+        held back here is *writing* -- minting a key, sealing, and one
+        `write_atomic` -- and none of it decides anything. The question is
+        whether the guard above them fires.
+        """
+        known = store.Machine(id="alpha", name="alpha")
+        with (
+            mock.patch.object(sync, "signing_public"),
+            mock.patch.object(sync, "recipients", return_value=[]),
+            mock.patch.object(fleet, "seal", return_value=b""),
+            mock.patch.object(archive, "accepts_seal", return_value=Path("/dev/null")),
+            mock.patch.object(store, "write_atomic"),
+        ):
+            return sync.publish_accepts(known, state, 2)
+
+    def test_publish_accepts_writes_again_after_a_rotation(self) -> None:
+        """End to end through the guard: same hosts, new fingerprint, and the
+        file has to be rewritten. Reverting the comparison to the id list makes
+        this the only test in the class that fails."""
+        state = sync.State(signers={"alpha": "AAA"})
+        self.assertTrue(self.wired(state), "never published, so it must write")
+        self.assertFalse(self.wired(state), "unchanged, so nothing to write")
+
+        state.signers = {"alpha": "ROTATED"}
+        self.assertTrue(self.wired(state), "the key rotated and the seal is stale")
+
+    def test_a_state_from_before_the_field_republishes_once(self) -> None:
+        """The upgrade path, per rule 8. An installation carrying only the old
+        id list has no digest, and the empty default must read as *not
+        published* -- treating it as published preserves exactly the bug."""
+        state = sync.State(published_accepts=["alpha", "beta"])
+        self.assertEqual(state.published_digest, "")
+        self.assertNotEqual(state.published_digest, sync.accepts_digest({"alpha": "AAA"}))
+
+    def test_the_digest_survives_a_round_trip(self) -> None:
+        """`published_digest` is only worth anything if it is still there on the
+        next run; a field that is written and not read republishes for ever."""
+        raw = {"published_accepts": ["alpha"], "published_digest": "deadbeef"}
+        with mock.patch.object(store, "load_json", return_value=raw):
+            self.assertEqual(sync.State.load().published_digest, "deadbeef")
+
+    def test_a_digest_that_is_not_a_string_is_discarded(self) -> None:
+        """`State.load` degrades an unreadable value to a safe default rather
+        than raising -- the pattern CLAUDE.md rule 8 names, and the one #291 is
+        about `exported` missing."""
+        raw = {"published_accepts": [], "published_digest": 17}
+        with mock.patch.object(store, "load_json", return_value=raw):
+            self.assertEqual(sync.State.load().published_digest, "")
+
+
 class TestTwoMachines(SyncTestCase):
     def test_history_reaches_the_other_machine(self) -> None:
         alpha = self.machine("alpha")

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -33,6 +33,7 @@ and `gitrepo`, every git fork and the only thing here that talks to the network
 from __future__ import annotations
 
 import fcntl
+import hashlib
 import time
 import zlib
 from collections import Counter
@@ -706,7 +707,24 @@ class State:
     #: Progress rather than history: losing it costs one extra publish. See
     #: `publish_accepts` for why the comparison lives here rather than in the
     #: file.
+    #:
+    #: No longer what decides whether to republish -- `published_digest` is --
+    #: but still written, so a machine that downgrades reads a field in the
+    #: shape it expects rather than a digest it would take for a host id.
     published_accepts: list[str] = field(default_factory=list)
+    #: A digest of the id -> fingerprint mapping this machine last published.
+    #:
+    #: The ids alone were the comparison until #290, and they cannot see a key
+    #: *rotation*: `woswoar trust --replace` leaves the host set untouched and
+    #: changes what every entry points at. The seal carries the mapping, so the
+    #: check has to as well, or `accepts.age` keeps a fingerprint that no longer
+    #: matches and every peer's `fleet` marks this machine `!` for ever.
+    #:
+    #: Empty on an installation that predates the field, which republishes once
+    #: on the next sync and costs one seal. That is the upgrade path, and it is
+    #: the safe direction: reading a missing digest as "already published" would
+    #: preserve exactly the bug.
+    published_digest: str = ""
     #: "<host>/<day>" -> the day directory's mtime when every chunk its signed
     #: manifest listed had been merged. A day whose stamp still matches has gained nothing since, so
     #: it needs no listing at all -- and listing is what a peer's whole archive
@@ -728,6 +746,7 @@ class State:
         granted = raw.get("granted", [])
         granted_complete = raw.get("granted_complete", False)
         published = raw.get("published_accepts", [])
+        digest = raw.get("published_digest", "")
         signers = raw.get("signers", {})
         merged_at = raw.get("merged_at", {})
         if not isinstance(exported, dict) or not isinstance(merged, dict):
@@ -755,6 +774,9 @@ class State:
             published_accepts=sorted(str(host) for host in published)
             if isinstance(published, list)
             else [],
+            # Anything that is not a string is not a digest this wrote, and the
+            # empty default republishes once rather than trusting it.
+            published_digest=digest if isinstance(digest, str) else "",
             signers={str(k): str(v) for k, v in signers.items()}
             if isinstance(signers, dict)
             else {},
@@ -780,6 +802,7 @@ class State:
             "granted": list(self.granted),
             "granted_complete": self.granted_complete,
             "published_accepts": list(self.published_accepts),
+            "published_digest": self.published_digest,
             "signers": dict(self.signers),
             "merged_at": dict(self.merged_at),
         }
@@ -1185,6 +1208,24 @@ def read_signer(host_id: str) -> Signer | None:
     return Signer(lines[0].strip(), lines[1].strip())
 
 
+def accepts_digest(signers: dict[str, str]) -> str:
+    """One comparable string for the id -> fingerprint mapping that gets sealed.
+
+    A digest rather than the mapping itself, because this is written into
+    `state.json` on every sync and a fleet of any size would put the whole table
+    there twice -- once as the pin, once as a record of having published it.
+
+    Tab-separated, and the separator matters. `hashlib` sees a byte sequence, so
+    two different mappings must not flatten into one string: without a delimiter
+    `{"ab": "c"}` and `{"a": "bc"}` are both `abc`. Host ids and age fingerprints
+    contain neither tabs nor newlines, so this pair cannot be forged from the
+    other side either -- which is the same argument `forget.digest` makes for
+    hashing a command apart from its timestamp.
+    """
+    rendered = "\n".join(f"{host}\t{signers[host]}" for host in sorted(signers))
+    return hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+
+
 def publish_accepts(known: Machine, state: State, now: int) -> bool:
     """Publish which hosts this machine has accepted. Says whether it wrote.
 
@@ -1201,7 +1242,7 @@ def publish_accepts(known: Machine, state: State, now: int) -> bool:
     """
     if not state.signers:
         return False
-    if state.published_accepts == sorted(state.signers):
+    if state.published_digest == accepts_digest(state.signers):
         return False
     # Through `signing_public`, which mints the key if it is missing, exactly as
     # `publish_signer` does. Signing directly would turn "this machine lost its
@@ -1215,6 +1256,7 @@ def publish_accepts(known: Machine, state: State, now: int) -> bool:
     # then wrote its older copy over the top -- so every sync republished,
     # committed and pushed, which three of this file's own invariants noticed.
     state.published_accepts = sorted(state.signers)
+    state.published_digest = accepts_digest(state.signers)
     return True
 
 


### PR DESCRIPTION
Closes #290.

**Rule 1's top row** — this changes a security claim (`fleet`'s trust marks) and
adds a `state.json` field.

## What was wrong

`publish_accepts` decided whether to re-seal by comparing the **host ids** it
last published:

```python
    if state.published_accepts == sorted(state.signers):
        return False
```

But the body it seals carries more than that — `fleet.seal(known.id,
state.signers, …)` seals the whole **id → fingerprint** mapping.

`woswoar trust --replace` leaves the host set untouched and changes what every
entry points at. The guard sees no change, `accepts.age` keeps the old
fingerprint indefinitely, and every peer's `woswoar fleet` marks the machine `!`
— *accepted under a signing key this machine did not pin* — for ever.

Nothing is exploitable and no data moves. What breaks is the signal, and that is
why it is a P1: a warning that is wrong after the documented rotation command
stops being a warning, and the next `!` that means something arrives to a reader
who has learned to dismiss it.

## The fix

`State.published_digest` — a SHA-256 over the sorted `(id, fingerprint)` pairs,
which is what actually got sealed.

A digest rather than the mapping: this is written to `state.json` on every sync,
and a fleet of any size would otherwise put the whole table there twice — once as
the pin, once as a record of having published it.

**Tab-separated, and the separator earns its place.** Without a delimiter,
`{"ab": "c"}` and `{"a": "bc"}` both render as `abc`, so a rotation could be made
invisible by choosing names. There is a test for exactly that, and removing the
separator fails it.

## Rule 8

`published_digest` is additive and defaults to `""`. An installation that
predates the field republishes **once** on the next sync and costs one seal.
That direction is the whole point — reading a missing digest as "already
published" preserves exactly the bug.

`published_accepts` is kept and still written, though nothing decides on it any
more, so a machine that downgrades reads a field in the shape it expects rather
than a digest it would take for a host id. `State.load` degrades a non-string
digest to `""`, matching the per-value guarding the field beside it documents.

## Tests, and the one that mattered

Seven. Six exercise `accepts_digest` and `State`; **the seventh is the wiring**,
and without it the other six pass against a call site still comparing ids.

That is #276's lesson applied before it cost anything: both survivors of that
change were at a call site no unit test reached. Reverting
`published_digest ==` to `published_accepts ==` fails exactly one test in the
class — the wiring one.

`publish_accepts` is driven with only its side effects held back (`signing_public`,
`recipients`, `fleet.seal`, `archive.accepts_seal`, `store.write_atomic`), rather
than through a real two-machine sync. Everything mocked is *writing* and none of
it decides anything; the question is whether the guard above them fires.

Rule 3 run by hand on both halves: dropping the tab from the digest fails the
flattening test, and reverting the comparison fails the wiring test. Both pass
restored.

## Mutation testing (rule 3)

```
1 file(s), 43 changed lines -> 8 mutants
8 caught, 0 survived
```

Clean first time.

## Review

Rule 1's top row, and I did a careful read rather than the four-agent pass — the
diff is one new pure function, one field, and two call sites, and the agent pass
on #289 earned its keep on a diff that restructured a parser. The hazards I
checked: the digest must be stable under insertion order (tested), must not
flatten two mappings (tested), and the new field must survive a round trip
(tested) — a field that is written and never read republishes for ever, which
would be a quieter version of the same bug.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_