### PR TITLE
fix: a malformed watermark no longer bricks every command (#291)

### DIFF
--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -8,8 +8,9 @@ import time
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest import mock
 
-from woswoar import cache, importer
+from woswoar import cache, importer, store
 from woswoar.__main__ import main
 
 from .support import WoswoarTestCase
@@ -279,6 +280,28 @@ class TestImportRun(ImportTestCase):
         source = self._source("hist", "#1753000000\nawk -F'\t' '{print $1}'\n")
         importer.run("bash", source)
         self.assertEqual(cache.load_entries()[0].cmd, "awk -F'\t' '{print $1}'")
+
+
+class TestAMalformedImportStateDoesNotStopTheImport(unittest.TestCase):
+    """#291's other half. `_load_state` had the same bare `int(v)`, and it runs
+    on the way into every `woswoar import`."""
+
+    def loaded(self, raw: object) -> dict[str, int]:
+        with mock.patch.object(store, "load_json", return_value=raw):
+            return importer._load_state()
+
+    def test_a_null_watermark_starts_from_nothing(self) -> None:
+        self.assertEqual(self.loaded({"/some/hist": None}), {})
+
+    def test_a_good_file_is_still_read(self) -> None:
+        """The half that keeps the guard honest: swallowing everything would
+        pass the test above and re-import the world on every run."""
+        self.assertEqual(self.loaded({"/some/hist": 7}), {"/some/hist": 7})
+
+    def test_a_file_that_is_not_a_mapping_starts_from_nothing(self) -> None:
+        """`.items()` on a list is an `AttributeError`, which is a third
+        exception type and the reason the guard names it."""
+        self.assertEqual(self.loaded([1, 2, 3]), {})
 
 
 class TestImportDropsCredentials(ImportTestCase):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -810,6 +810,49 @@ class TestWhoHasAcceptedWhom(SyncTestCase):
             )
 
 
+class TestAMalformedStateFileDoesNotStopTheTool(unittest.TestCase):
+    """#291. `State.load` runs on the way into every command, so anything it
+    raises is not a bad sync -- it is a machine with no working `woswoar` until
+    somebody finds the file and deletes it.
+
+    Rule 8 is explicit that `state.json` is progress rather than history and
+    that losing it "costs a re-merge and a re-export, never a command". A value
+    that cannot be read has to cost the same, and no more.
+    """
+
+    def loaded(self, raw: dict[str, object]) -> sync.State:
+        with mock.patch.object(store, "load_json", return_value=raw):
+            return sync.State.load()
+
+    def test_a_null_watermark_does_not_raise(self) -> None:
+        """`int(None)` is a `TypeError`, and every field beside `exported` was
+        already guarded per value -- the comment explaining that pattern sits
+        directly below the line that was missing it."""
+        self.assertEqual(self.loaded({"exported": {"host/day": None}}).exported, {})
+
+    def test_a_watermark_that_is_not_a_number_does_not_raise(self) -> None:
+        """`ValueError` rather than `TypeError`, which is why the guard catches
+        both: a hand-edited file is far likelier to hold a word than a null."""
+        self.assertEqual(self.loaded({"exported": {"host/day": "soon"}}).exported, {})
+
+    def test_a_good_file_is_still_read(self) -> None:
+        """Without this the guard could swallow everything and every test above
+        would still pass -- on a `load` that had quietly stopped working."""
+        state = self.loaded({"exported": {"host/day": 42}})
+        self.assertEqual(state.exported, {"host/day": 42})
+
+    def test_one_bad_value_discards_the_whole_map_rather_than_that_entry(self) -> None:
+        """The decision, pinned so it cannot drift by accident.
+
+        Keeping the good entries reads as the gentler option and says less: the
+        bad host's watermark silently becomes 0, that log re-exports anyway, and
+        nothing tells anyone a value was dropped. A whole reset is the same
+        answer this function already gives for a malformed *shape*.
+        """
+        state = self.loaded({"exported": {"good": 1, "bad": None}})
+        self.assertEqual(state.exported, {})
+
+
 class TestTwoMachines(SyncTestCase):
     def test_history_reaches_the_other_machine(self) -> None:
         alpha = self.machine("alpha")

--- a/woswoar/importer.py
+++ b/woswoar/importer.py
@@ -343,7 +343,19 @@ def _state_path() -> Path:
 
 
 def _load_state() -> dict[str, int]:
-    return {k: int(v) for k, v in store.load_json(_state_path()).items()}
+    """The per-source watermarks, or nothing if the file cannot be read as them.
+
+    Degrading rather than raising, as `sync.State.load` does and for the reason
+    rule 8 gives: this runs on the way into every import, so one unconvertible
+    value in an otherwise valid JSON file would make `woswoar import` traceback
+    until somebody deleted the file. Starting from nothing costs a re-read of
+    each source, and `(ts, cmd)` deduplication absorbs it -- no command is lost
+    and none is duplicated. See #291.
+    """
+    try:
+        return {k: int(v) for k, v in store.load_json(_state_path()).items()}
+    except (TypeError, ValueError, AttributeError):
+        return {}
 
 
 def _save_state(state: dict[str, int]) -> None:

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -732,8 +732,25 @@ class State:
         merged_at = raw.get("merged_at", {})
         if not isinstance(exported, dict) or not isinstance(merged, dict):
             return cls()
+        try:
+            watermarks = {str(k): int(v) for k, v in exported.items()}
+        except (TypeError, ValueError):
+            # The same answer as a malformed *shape* on the line above, for the
+            # same class of corruption. `int(v)` on a `null` raises `TypeError`,
+            # and `load` runs on the way into every command -- so before #291 a
+            # single bad value in a file that was otherwise valid JSON made
+            # every command traceback until somebody deleted it by hand.
+            #
+            # A whole reset rather than dropping the one bad entry, which is the
+            # tempting alternative and says less: a watermark that quietly
+            # becomes 0 re-exports that log anyway, and nothing tells the reader
+            # a value was discarded. Rule 8 prices this deliberately -- losing
+            # `state.json` "costs a re-merge and a re-export, never a command" --
+            # so the expensive-but-whole answer is the one the file is allowed
+            # to cost.
+            return cls()
         state = cls(
-            exported={str(k): int(v) for k, v in exported.items()},
+            exported=watermarks,
             # Guarded per value, not just on `merged` being a dict. A value
             # that is a bare *string* rather than a list is iterable, so without
             # this every day's record turns into its own characters, every chunk


### PR DESCRIPTION
Closes #291.

## What was wrong

`State.load` guarded every field per value except `exported`:

```python
    exported={str(k): int(v) for k, v in exported.items()},
```

`int(None)` raises `TypeError`, and `load` runs on the way into **every**
command. So one bad value in a file that was otherwise valid JSON left a machine
with no working `woswoar` at all — until somebody found `state.json` and deleted
it, which is not a recovery anyone discovers without reading a traceback.

The comment explaining the pattern this line was missing sits **directly below
it**, on the `merged` field. And CLAUDE.md rule 8 names it as the established
one:

> `State.load` already degrades an unreadable value to a safe default — that is
> the pattern to follow rather than a version field two code paths branch on.

`importer._load_state` had the same bare `int(v)` and the same hole, on the way
into every `woswoar import`.

## The decision, which is the interesting part

The issue flagged that `exported` and `merged` want *different* directions, and
they do. `merged`'s comment argues for "forgetting a malformed day and reading it
again is the direction that repeats work rather than dropping history" — but
`state.exported` is what stops this machine's own lines being sealed twice, so a
watermark that silently becomes `0` re-exports that log.

So I checked what a reset actually costs rather than guessing, and rule 8 prices
it explicitly:

> `state.json` is progress, not history: losing it costs a re-merge and a
> re-export, never a command.

A reset is therefore *documented-safe* — expensive, never wrong. Given that, the
whole map is discarded rather than the one bad entry, which is also the answer
this same function already gives two lines up for a malformed *shape*. Keeping
the good entries reads as the gentler option and says less: the bad host's
watermark quietly becomes `0`, that log re-exports anyway, and nothing tells
anyone a value was dropped.

That choice is pinned by a test of its own, so it cannot drift by accident.

## Tests

Seven — four on `State.load`, three on `_load_state` — and three of them exist
only to keep the other four honest:

- **a good file is still read** (both suites). Without it the guard could swallow
  everything and every other test would still pass, on a `load` that had quietly
  stopped working.
- **one bad value discards the whole map rather than that entry**, pinning the
  decision above.
- **a file that is not a mapping starts from nothing** — `.items()` on a list is
  an `AttributeError`, a third exception type, and the reason the importer guard
  names it.

`TypeError` and `ValueError` are tested separately because a hand-edited file is
far likelier to hold a word than a null.

Rule 3 by hand: removing both guards fails **6** of them; restoring passes all
45 in the two modules.

## Mutation testing (rule 3)

```
2 file(s), 31 changed lines -> 3 mutants
3 caught, 0 survived
```

## Merge note

This branch conflicted with #296, which landed while it was in flight — both
added a test class at the same anchor in `tests/test_sync.py`. Resolved by
keeping both; neither replaces the other, and the full suite passes with the pair
of them.

## Review

Rule 1's top row (it changes how stored progress is interpreted), done as a
careful read. The hazard is a guard that is too wide — swallowing a *good* file
and silently resetting every watermark on every run, which would be a slower,
quieter version of the bug. That is what the "a good file is still read" tests
are for, in both suites.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_