### PR TITLE
fix: the hook path is no longer read as a regex replacement (#292)

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -234,6 +234,36 @@ class TestInstall(WoswoarTestCase):
         self.assertIn('source "$HOME/.local/share/woswoar/woswoar.bash"', text)
         self.assertNotIn(str(self.home), text)
 
+    def test_a_backslash_in_the_path_survives_a_reinstall(self) -> None:
+        """#292. The second argument to `re.sub` is a replacement *template*,
+        and the block being substituted holds a path the user controls.
+
+        Two installs, because one never reaches `sub` -- the first appends the
+        block through the other branch, so this worked once and then broke. A
+        fixture with a single install cannot tell the two implementations apart,
+        which is why the existing reinstall test above did not catch it.
+
+        `\\i` is `bad escape` and raises; the quieter half is `\\1`, which
+        substitutes a group from the pattern and writes a `source` line pointing
+        somewhere else while reporting success.
+        """
+        weird = self.home / "back\\slash"
+        os.environ["WOSWOAR_DIR"] = str(weird)
+        first = self.install()
+        self.assertIn("woswoar.bash", first)
+
+        text = self.install()
+        self.assertIn("woswoar.bash", text)
+        self.assertEqual(text.count("# >>> woswoar >>>"), 1, "the block was duplicated")
+
+    def test_a_group_reference_in_the_path_is_not_expanded(self) -> None:
+        """The silent half on its own. `\\1` does not raise -- it substitutes,
+        so the rc file still looks plausible and the hook simply never loads."""
+        os.environ["WOSWOAR_DIR"] = str(self.home / "g\\1roup")
+        self.install()
+        text = self.install()
+        self.assertIn("g\\1roup", text, "the group reference was expanded away")
+
     def test_reinstalling_rewrites_an_older_absolute_block(self) -> None:
         """The upgrade path. Both of the reporting machines have one of these."""
         os.environ["WOSWOAR_DIR"] = str(self.home / ".local/share/woswoar")

--- a/woswoar/install.py
+++ b/woswoar/install.py
@@ -195,7 +195,21 @@ def write_block(rcfile: Path, target: Path) -> str:
     block = f'{BEGIN}\nsource "{portable_hook_path(target)}"\n{_END}\n'
     existing = rcfile.read_text(encoding="utf-8") if rcfile.is_file() else ""
     if _BLOCK.search(existing):
-        updated = _BLOCK.sub(block, existing)
+        # A *function* replacement, because the second argument to `sub` is a
+        # template and `block` holds a filesystem path the user controls through
+        # `WOSWOAR_DIR` or `XDG_DATA_HOME`. A backslash in it is read as an
+        # escape: `\i` raises `re.error` and `\1` substitutes a group from the
+        # pattern, writing a `source` line that points somewhere else and
+        # reporting success. Only the *second* install reaches this, since the
+        # first appends through the branch below -- so it worked once and then
+        # broke, or worked once and then lied.
+        #
+        # A lambda rather than `block.replace("\\", "\\\\")`: escaping is
+        # correct and is one refactor away from being lost, while a callable
+        # cannot be template-parsed at all. `re.escape` is the reflex and is the
+        # wrong tool -- it escapes for a *pattern*, and would put literal
+        # backslashes into the rc file.
+        updated = _BLOCK.sub(lambda _: block, existing)
         action = "updated"
     else:
         separator = "" if not existing or existing.endswith("\n") else "\n"


### PR DESCRIPTION
Closes #292.

## What was wrong

```python
    updated = _BLOCK.sub(block, existing)
```

The second argument to `re.sub` is a **replacement template**, not a literal —
and `block` holds a filesystem path the user controls through `WOSWOAR_DIR` or
`XDG_DATA_HOME`. Backslash sequences in it are interpreted.

Two failures, and the quiet one is worse:

- `\i`, `\d`, most letters → `re.error: bad escape` and `woswoar install` dies.
- `\1`, `\g<name>` → substituted with a group **from the pattern**, silently
  writing a `source` line that points somewhere else. The rc file still looks
  plausible and the hook never loads.

Only the **second** install reaches `sub` — the first appends the block through
the other branch — so it worked once and then broke, or worked once and then
lied.

## The fix

`_BLOCK.sub(lambda _: block, existing)`. A callable replacement bypasses template
parsing entirely.

A lambda rather than `block.replace("\\", "\\\\")`: escaping is correct and is
one refactor away from being lost, while a callable cannot be template-parsed at
all. `re.escape` is the reflex here and is the wrong tool — it escapes for a
*pattern*, and would put literal backslashes into the rc file.

## Tests

Two, and **both need two installs**, which is why the existing reinstall test
did not catch this: one install never reaches `sub`. A single-install fixture
cannot tell the two implementations apart.

- a backslash in the path survives a reinstall, and does not duplicate the block;
- **a group reference is not expanded** — the silent half on its own. `\1` does
  not raise, it substitutes, so the rc file still parses and the hook simply
  never loads. Without this test the loud failure alone could be fixed by
  escaping only the letters.

Rule 3 by hand: reverting to `sub(block, …)` errors both; restoring passes all 43.

## Mutation testing (rule 3)

```
1 file(s), 15 changed lines -> 2 mutants
2 caught, 0 survived
```

## Review

Rule 1's middle row — it changes what gets written into a user's shell rc file,
but not stored history or a security claim — so a careful read rather than the
agent pass. The hazard I looked for is the fix being incomplete in the other
direction: `block` is also interpolated into an f-string above, but that is a
plain format and takes no escapes, and `portable_hook_path` already rewrites
`$HOME`, so the path in the block is the only user-controlled text on that line.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_