### PR TITLE
fix: doctor no longer tracebacks when it races the background sync (#293)

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -555,6 +555,40 @@ class TestAFinderVisitDoesNotDisturbTheLogs(WoswoarTestCase):
         self.assertEqual(store.readable_by_others(), [])
         self.assertNotIn("[FAIL] private", support.run_cli("doctor").out)
 
+    def test_a_file_that_vanishes_mid_walk_is_skipped(self) -> None:
+        """#293. `_private_paths` walks, then this stats, and `write_atomic`
+        makes the gap between them routine: it creates a temp file and
+        `os.replace`s it, and sync runs on a timer once a minute.
+
+        `doctor` racing that used to exit with a `FileNotFoundError` traceback
+        instead of a report -- a crash in the command you run *to check your
+        setup is sound*, which reads as "my install is broken" rather than "try
+        again".
+
+        The vanished path is injected rather than raced for: a real race would
+        be a flaky test that passes for the wrong reason most of the time.
+        """
+        ghost = store.host_dir(MACHINE_ID) / "gone-between-the-walk-and-the-stat.tsv"
+        real = list(store._private_paths())
+        with mock.patch.object(store, "_private_paths", return_value=[*real, (ghost, False)]):
+            self.assertEqual(store.readable_by_others(), [])
+
+    def test_a_path_it_cannot_stat_at_all_is_not_called_safe(self) -> None:
+        """The half that keeps the guard narrow.
+
+        Widening it to `OSError` is the reflex, and it is wrong here: this
+        answers "can another account read my history?", so "could not look" and
+        "safe" are different answers. `harden`'s blanket suppress is right for
+        best-effort tightening and would be a silent pass here.
+        """
+        real = list(store._private_paths())
+        with (
+            mock.patch.object(store, "_private_paths", return_value=real[:1]),
+            mock.patch.object(Path, "stat", side_effect=PermissionError("no")),
+            self.assertRaises(PermissionError),
+        ):
+            store.readable_by_others()
+
     def test_a_real_log_left_loose_is_still_reported(self) -> None:
         """Otherwise the test above passes against a `doctor` that stopped
         looking at `logs/` at all."""

--- a/woswoar/store.py
+++ b/woswoar/store.py
@@ -360,8 +360,31 @@ def readable_by_others() -> list[Path]:
 
     Named for the check it performs -- the mask is group *and* other, which
     ``world_readable`` would have misdescribed for anyone adding a caller.
+
+    A path that vanishes between the walk and the stat is skipped, and that is
+    the true answer rather than a convenience: a file that no longer exists
+    cannot be read by anybody. `write_atomic` makes this routine rather than
+    rare -- it creates a temp file and `os.replace`s it, and sync runs on a timer
+    once a minute, so `doctor` racing it used to exit with a traceback instead of
+    a report (#293).
+
+    **Only `FileNotFoundError`, not `OSError`.** This is a security check, so
+    "could not look" and "safe" are different answers and collapsing them is the
+    failure the function exists to prevent. `harden`'s blanket suppress two
+    definitions up is right for what it does -- best-effort tightening, where
+    failing to chmod one file costs nothing it claimed -- and would be wrong
+    here. Anything that is not a missing file still propagates, loudly, because
+    a check that cannot see is not a check that passed.
     """
-    return [p for p, _ in _private_paths() if p.stat().st_mode & OTHER_BITS]
+    found = []
+    for path, _ in _private_paths():
+        try:
+            mode = path.stat().st_mode
+        except FileNotFoundError:
+            continue
+        if mode & OTHER_BITS:
+            found.append(path)
+    return found
 
 
 def write_atomic(path: Path, data: bytes) -> None:


### PR DESCRIPTION
Closes #293.

## What was wrong

```python
    return [p for p, _ in _private_paths() if p.stat().st_mode & OTHER_BITS]
```

`_private_paths()` walks, then this stats, and between the two the path can be
gone. `write_atomic` — ten lines below in the same file — creates a temp file and
`os.replace`s it, so every file woswoar rewrites appears and vanishes under the
walk: the parse cache, the import watermarks, `state.json`.

Sync runs in the background about once a minute, so `woswoar doctor` racing it
exited with a `FileNotFoundError` traceback instead of a report. A crash in the
command you run **to check your setup is sound** reads as "my install is broken"
rather than "try again".

## The interesting part: how wide to catch

`harden()`, two definitions up, does the same walk under
`contextlib.suppress(OSError)`. Copying that here would be wrong, and the
difference is the whole design:

- `harden` is **best-effort tightening**. Failing to chmod one file costs nothing
  it claimed.
- this is **the check that says whether the tightening worked**. It answers "can
  another account on this machine read my history?", so *could not look* and
  *safe* are different answers, and collapsing them is the failure the function
  exists to prevent.

So only `FileNotFoundError` is caught. A file that no longer exists cannot be
read by anybody, which makes skipping it the true answer rather than a
convenience. Anything else still propagates, loudly.

## Tests

Two, and they pin **both** edges:

- a file that vanishes mid-walk is skipped. Injected rather than raced for — a
  real race would be a flaky test that passes for the wrong reason most of the
  time.
- **a path it cannot stat at all is not called safe**, which is what stops the
  guard being widened to `OSError` by a later reader who sees `harden` and
  assumes they should match.

Rule 3 by hand, in both directions: removing the guard **errors** one test,
widening it to `OSError` **fails** the other, and the restored version passes all
43.

## Mutation testing (rule 3)

```
1 file(s), 24 changed lines -> 4 mutants
4 caught, 0 survived
```

## Review

Rule 1's top row — it changes a security claim — done as a careful read. The
hazard is a guard that turns a security check into a silent pass, which is
exactly what the second test exists to prevent, and it is the reason the catch is
narrow rather than convenient. I also checked the caller: `doctor.py:224` treats
the returned list as "these are exposed", so a path that could not be stat'd must
not silently leave it, and with this shape it cannot — it raises instead.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_