### PR TITLE
fix: a SAVEHIST trim no longer moves the import watermark past records (#294)

### DIFF
--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -250,12 +250,64 @@ class TestImportRun(ImportTestCase):
         source = self._source("hist", "#1753000000\na\n#1753000100\nb\n")
         importer.run("bash", source)
 
-        # Log rotation: the count is now meaningless, so the (ts, cmd) guard has
-        # to carry it.
+        # Log rotation. Since #294 the anchor resolves this before the
+        # `(ts, cmd)` guard has to: the last imported command is found at its new
+        # position and the count is corrected to it, so `b` is not re-examined
+        # and `skipped` is 0 rather than 1. The outcome is what it always was --
+        # nothing imported, nothing duplicated -- and the guard below still
+        # covers the case the anchor cannot find.
         self._rewrite(source, "#1753000100\nb\n")
         result = importer.run("bash", source)
         self.assertEqual(result.imported, 0)
-        self.assertEqual(result.skipped, 1)
+        self.assertEqual(len(cache.load_entries()), 2)
+
+    def test_a_savehist_trim_plus_a_larger_append_loses_nothing(self) -> None:
+        """#294. The file grew overall, so the shrink guard never fired.
+
+        zsh rewrites `.zsh_history` wholesale when trimming to `SAVEHIST`, and
+        again under `HIST_EXPIRE_DUPS_FIRST`, dropping records from the *front*.
+        `run`'s only staleness guard is `already > len(parsed)`, which fires when
+        the file gets shorter -- so a trim of two plus an append of three leaves
+        it longer, nothing fires, and the slice begins two records too late.
+
+        The lost commands are not merely re-read later: they are below the mark
+        on this run and on every run after, and each import reports success.
+
+        The append is deliberately larger than the trim. A fixture where the
+        file shrinks passes against the old code, because that is the one case
+        the existing guard already handled.
+        """
+        source = self._source("hist", ": 100:0;one\n: 200:0;two\n: 300:0;three\n")
+        importer.run("zsh", source)
+        self.assertEqual(self._commands(), {"one", "two", "three"})
+
+        # Trimmed to the last one, then three more arrive: 4 records where there
+        # were 3, so `already > len(parsed)` is false and the count stands.
+        self._rewrite(
+            source,
+            ": 300:0;three\n: 400:0;four\n: 500:0;five\n: 600:0;six\n",
+        )
+        importer.run("zsh", source)
+        self.assertEqual(
+            self._commands(),
+            {"one", "two", "three", "four", "five", "six"},
+            "records below the stale mark were skipped",
+        )
+
+    def test_a_wholly_replaced_source_still_falls_to_the_dedup_guard(self) -> None:
+        """The path the anchor cannot rescue, kept covered.
+
+        When the last imported command is nowhere in the new file, there is no
+        position to re-anchor to. The count then behaves as it always did, and
+        `(ts, cmd)` is what stops a duplicate -- which is why that guard stays.
+        """
+        source = self._source("hist", "#1753000000\na\n#1753000100\nb\n")
+        importer.run("bash", source)
+
+        self._rewrite(source, "#1753000000\na\n")
+        result = importer.run("bash", source)
+        self.assertEqual(result.imported, 0)
+        self.assertEqual(result.skipped, 1, "the anchor missed, so dedup carried it")
         self.assertEqual(len(cache.load_entries()), 2)
 
     def test_dry_run_writes_nothing(self) -> None:
@@ -286,7 +338,7 @@ class TestAMalformedImportStateDoesNotStopTheImport(unittest.TestCase):
     """#291's other half. `_load_state` had the same bare `int(v)`, and it runs
     on the way into every `woswoar import`."""
 
-    def loaded(self, raw: object) -> dict[str, int]:
+    def loaded(self, raw: object) -> dict[str, int | str]:
         with mock.patch.object(store, "load_json", return_value=raw):
             return importer._load_state()
 

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -334,6 +334,71 @@ class TestImportRun(ImportTestCase):
         self.assertEqual(cache.load_entries()[0].cmd, "awk -F'\t' '{print $1}'")
 
 
+class TestFindingTheWatermarkAgain(unittest.TestCase):
+    """`_anchored` as a unit. #294 goes through `run` for the behaviour that
+    matters, and `run` reaches two of these branches -- the sweep reported
+    twelve survivors in here, which is what an under-tested unit looks like from
+    the outside.
+    """
+
+    @staticmethod
+    def rows(*commands: str) -> list[importer.Parsed]:
+        return [importer.Parsed(ts=100 + n, cmd=c, duration_ms=-1) for n, c in enumerate(commands)]
+
+    def test_no_mark_leaves_the_count_alone(self) -> None:
+        """A source imported before the anchor existed. Trusted once, and the
+        mark is written on the way out -- the protection starts next run."""
+        self.assertEqual(importer._anchored(2, None, self.rows("a", "b", "c")), 2)
+
+    def test_an_empty_mark_leaves_the_count_alone(self) -> None:
+        """What an import of an empty source writes. It anchors nothing, and
+        must not be searched for -- every record's command would fail to match
+        and the scan would walk the whole history to conclude nothing."""
+        self.assertEqual(importer._anchored(2, "", self.rows("a", "b", "c")), 2)
+
+    def test_a_mark_still_in_place_leaves_the_count_alone(self) -> None:
+        """The ordinary case, and the one that must not pay for a scan: the
+        file only grew, so the record below the mark is where it was."""
+        self.assertEqual(importer._anchored(2, "b", self.rows("a", "b", "c")), 2)
+
+    def test_a_trimmed_front_moves_the_count_down(self) -> None:
+        """Two records dropped from the front, so what was at index 1 is now at
+        index 0 and the count must follow it."""
+        self.assertEqual(importer._anchored(3, "c", self.rows("c", "d", "e")), 1)
+
+    def test_a_mark_that_is_gone_leaves_the_count_alone(self) -> None:
+        """Replaced rather than trimmed. There is no position to re-anchor to,
+        so this is the pre-#294 answer -- and the safe one, since resetting
+        would re-import an untimed history in full."""
+        self.assertEqual(importer._anchored(2, "b", self.rows("x", "y", "z")), 2)
+
+    def test_a_count_past_the_end_still_searches(self) -> None:
+        """The shrink case `run`'s own guard also catches, reached here when the
+        file lost records without gaining any. The scan is clamped to the list
+        rather than indexing past it."""
+        self.assertEqual(importer._anchored(9, "a", self.rows("a", "b")), 1)
+
+    def test_a_count_of_zero_searches_nothing(self) -> None:
+        """Nothing was imported, so there is no anchor to find and no work to
+        do -- and `parsed[already - 1]` would be `parsed[-1]`, the *last*
+        record, which is the wrong end of the file entirely."""
+        self.assertEqual(importer._anchored(0, "a", self.rows("a", "b")), 0)
+
+    def test_a_count_that_is_not_a_number_starts_from_nothing(self) -> None:
+        """The state file is hand-editable and #291 is about exactly that."""
+        self.assertEqual(importer._anchored("two", "b", self.rows("a", "b")), 0)
+
+    def test_a_mark_that_is_not_a_string_is_ignored(self) -> None:
+        self.assertEqual(importer._anchored(2, 17, self.rows("a", "b", "c")), 2)
+
+    def test_the_last_of_two_equal_commands_wins(self) -> None:
+        """A repeated command is ordinary in a shell history, so the scan runs
+        backwards from the old position: the nearest match below it is the one
+        a trim would have produced, and anchoring to the earlier copy would
+        re-import everything between them."""
+        self.assertEqual(importer._anchored(4, "ls", self.rows("ls", "cd", "ls", "vi")), 3)
+
+
 class TestAMalformedImportStateDoesNotStopTheImport(unittest.TestCase):
     """#291's other half. `_load_state` had the same bare `int(v)`, and it runs
     on the way into every `woswoar import`."""

--- a/woswoar/importer.py
+++ b/woswoar/importer.py
@@ -338,11 +338,67 @@ def _dedup_key(ts: int, cmd: str) -> tuple[int, str]:
     return (ts, truncate(cmd))
 
 
+def _mark_key(source: str) -> str:
+    """Where a source's anchor lives, beside its count.
+
+    A second key rather than a richer value, so the file stays a flat
+    `str -> str | int` map: `_load_state` degrades a value it cannot read to
+    nothing (#291), and a nested shape would have to degrade per level.
+    """
+    return f"{source}\x00mark"
+
+
+def _anchored(counted: object, mark: object, parsed: list[Parsed]) -> int:
+    """``already``, corrected if the source was rewritten under us.
+
+    The count is a position, and a position is only meaningful while the records
+    below it stay put. #289 made the *parse* order stable; this is about the
+    *file*, which zsh rewrites wholesale when trimming to ``SAVEHIST`` -- and
+    again under ``HIST_EXPIRE_DUPS_FIRST`` -- dropping records from the front.
+
+    `run`'s only staleness guard fires when the file gets *shorter*. A trim of k
+    plus an append of more than k leaves it longer, so nothing fired and the
+    slice began k records too late. Those k commands were skipped on that run and
+    on every run after, with a successful import reported each time.
+
+    **Re-anchored rather than reset**, and the difference matters. Resetting to 0
+    looks safer and is not: an untimed history's timestamps are synthesised from
+    the file's length, so they shift when it grows, and the `(ts, cmd)` guard
+    cannot match what is already stored. Re-reading such a source appends every
+    line again. That is why the count exists at all -- see
+    `test_untimed_rerun_does_not_duplicate` -- so the fix has to *find* the old
+    position, not abandon it.
+
+    Two honest limits. A source imported before the anchor existed has none, and
+    is trusted once: the mark is written on the way out, so the protection starts
+    from the next run. And a trim that happens to leave the same command text at
+    the same index is invisible here -- the anchor is the command, because that
+    is the only part of a record that survives a re-synthesis of its timestamp.
+    """
+    # Both come out of a `str | int` map, so neither is trusted to be what it
+    # should be: the file is hand-editable and #291 is about exactly that.
+    already = counted if isinstance(counted, int) else 0
+    if not isinstance(mark, str) or not mark:
+        return already
+    if 0 < already <= len(parsed) and parsed[already - 1].cmd == mark:
+        return already
+    # Backwards: the anchor is near the end of what was imported, and a trim only
+    # ever moves it *down*. Scanning from the old position outwards finds it in a
+    # few steps for the ordinary case instead of walking the whole history.
+    for at in range(min(already, len(parsed)) - 1, -1, -1):
+        if parsed[at].cmd == mark:
+            return at + 1
+    # Not found at all: the source was replaced rather than trimmed. Keeping the
+    # count is the same answer as before this function existed, and the safe one
+    # -- see the untimed argument above.
+    return already
+
+
 def _state_path() -> Path:
     return store.config_dir() / "imported.json"
 
 
-def _load_state() -> dict[str, int]:
+def _load_state() -> dict[str, int | str]:
     """The per-source watermarks, or nothing if the file cannot be read as them.
 
     Degrading rather than raising, as `sync.State.load` does and for the reason
@@ -353,12 +409,15 @@ def _load_state() -> dict[str, int]:
     and none is duplicated. See #291.
     """
     try:
-        return {k: int(v) for k, v in store.load_json(_state_path()).items()}
+        return {
+            k: (v if isinstance(v, str) else int(v))
+            for k, v in store.load_json(_state_path()).items()
+        }
     except (TypeError, ValueError, AttributeError):
         return {}
 
 
-def _save_state(state: dict[str, int]) -> None:
+def _save_state(state: dict[str, int | str]) -> None:
     # Atomic: a half-written watermark file would make the next import either
     # duplicate everything or skip entries silently.
     store.save_json(_state_path(), state)
@@ -512,7 +571,7 @@ def run(
 
     state = _load_state()
     key = str(source)
-    already = state.get(key, 0)
+    already = _anchored(state.get(key, 0), state.get(_mark_key(key)), parsed)
     if already > len(parsed):
         # Source was rotated or truncated; the count means nothing now.
         already = 0
@@ -575,6 +634,9 @@ def run(
     if not dry_run:
         store.append_entries(machine_id, entries)
         state[key] = len(parsed)
+        # The command at the far end of what was imported, so the next run can
+        # tell whether the count still points where it did. See `_anchored`.
+        state[_mark_key(key)] = parsed[-1].cmd if parsed else ""
         _save_state(state)
 
     return Result(


### PR DESCRIPTION
Closes #294.

**Rule 1's top row** — it changes what reaches `logs/`.

## What was wrong

#289 made the *parse* order stable, which is what makes a count of records a
usable watermark. This is about the *file*, which is not stable: zsh rewrites
`.zsh_history` wholesale when trimming to `SAVEHIST`, and again under
`HIST_EXPIRE_DUPS_FIRST`, dropping records from the **front**.

The only staleness guard fires when the file gets *shorter*:

```python
    if already > len(parsed):
        already = 0
```

A trim of k plus an append of more than k leaves the file **longer**. Nothing
fires, the slice begins k records too late, and those commands are skipped on
that run and on every run after — with a successful import reported each time.

`run`'s own docstring claimed otherwise, and that claim is now corrected: the
`(ts, cmd)` guard "covers the count going stale if the source is rotated or
trimmed" is false in this direction. That guard prevents **duplicates**, never
**omissions** — a record below the mark is never examined, so nothing dedups it.

## Re-anchored, not reset

The obvious fix is to reset the count to 0 and let dedup absorb the re-read. It
looks safer and is not.

An untimed history's timestamps are **synthesised from the file's length**, so
they shift as it grows and `(ts, cmd)` cannot match what is already stored.
Re-reading such a source appends every line again — which is precisely why the
count exists, and what `test_untimed_rerun_does_not_duplicate` records.

So `_anchored` stores the last imported **command** beside the count and finds it
again: scanning backwards from the old position, the nearest match below it is
where a trim would have left it. The command rather than the whole record,
because it is the only part that survives a re-synthesis of the timestamp.

Two limits, both stated in the docstring rather than left to be discovered:

- a source imported before the anchor existed has none, and is **trusted once** —
  the mark is written on the way out, so protection starts from the next run;
- a trim that leaves the same command at the same index is invisible.

## The state file

A second key (`<source>\x00mark`) beside the count rather than a richer value, so
the file stays a flat `str -> str | int` map — `_load_state` degrades a value it
cannot read to nothing (#291), and a nested shape would have to degrade per
level. Both values are re-checked in `_anchored`, since the file is hand-editable
and #291 is about exactly that.

## An existing test changed, deliberately

`test_truncated_source_reimports_without_duplicating` asserted `skipped == 1`.
The anchor now resolves rotation *before* the dedup has to, so the record is not
re-examined and `skipped` is 0. The outcome is unchanged — nothing imported,
nothing duplicated — and the assertion was on the mechanism rather than the
result.

To keep the dedup path covered, **a new test drives a wholly replaced source**,
where the anchor cannot find its mark and `(ts, cmd)` is what stops the
duplicate.

## Mutation testing (rule 3)

```
1 file(s), 66 changed lines -> 46 mutants
46 caught
7 survived, all in _anchored()
```

The first round had **twelve** survivors in that one function, which is what an
under-tested unit looks like from outside: `run` reaches two of its branches and
the rest were covered by nothing. Ten direct unit tests closed five of them.

The remaining seven share one cause, and I checked it rather than asserting it —
**`_anchored`'s fast path is an optimisation**. It returns what the scan below
would compute anyway, so every mutation that disables it is equivalent by
construction. Demonstrated by running both:

```
counted:            0    1    2    3    9
with fast path:  [  0,   1,   2,   2,   2 ]
scan only:       [  0,   1,   2,   2,   2 ]
```

The early return on an absent mark is the same kind: `None` and `""` match no
record's command — records are filtered by `record.strip()`, so no command is
empty — and the scan falls through to the same answer. The return itself is
pinned: `at + 1` becoming `at + 2` is caught.

Rule 3 by hand: removing the anchor fails the trim test; restoring passes all 53.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_