### PR TITLE
fix: drop the one bad watermark, not the whole map (#285)

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -930,16 +930,27 @@ class TestAMalformedStateFileDoesNotStopTheTool(unittest.TestCase):
         state = self.loaded({"exported": {"host/day": 42}})
         self.assertEqual(state.exported, {"host/day": 42})
 
-    def test_one_bad_value_discards_the_whole_map_rather_than_that_entry(self) -> None:
-        """The decision, pinned so it cannot drift by accident.
+    def test_one_bad_value_costs_that_entry_and_no_other(self) -> None:
+        """The decision, corrected. #291 discarded the whole map and argued that
+        was the careful answer; #285 pointed out it is the opposite.
 
-        Keeping the good entries reads as the gentler option and says less: the
-        bad host's watermark silently becomes 0, that log re-exports anyway, and
-        nothing tells anyone a value was dropped. A whole reset is the same
-        answer this function already gives for a malformed *shape*.
+        What a dropped watermark costs is a re-export, and what a re-export
+        costs is duplicate rows in the archive. Dropping one entry duplicates
+        one log. Discarding the map duplicates *every* log -- so the reset
+        multiplied precisely the thing that made it look safe.
+
+        `merged_at`, two lines below in the same expression, has always filtered
+        per value. This is that, and `merged`'s comment gives the reason:
+        repeating work beats dropping history.
         """
         state = self.loaded({"exported": {"good": 1, "bad": None}})
-        self.assertEqual(state.exported, {})
+        self.assertEqual(state.exported, {"good": 1})
+
+    def test_a_watermark_that_is_a_bare_string_of_digits_is_still_dropped(self) -> None:
+        """`isinstance(v, int)` rather than `int(v)` in a `try`, matching
+        `merged_at`. `"7"` converts and is still not what this file writes, so
+        taking it would be trusting a shape nothing here produces."""
+        self.assertEqual(self.loaded({"exported": {"a": "7"}}).exported, {})
 
 
 class TestTwoMachines(SyncTestCase):

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -751,25 +751,17 @@ class State:
         merged_at = raw.get("merged_at", {})
         if not isinstance(exported, dict) or not isinstance(merged, dict):
             return cls()
-        try:
-            watermarks = {str(k): int(v) for k, v in exported.items()}
-        except (TypeError, ValueError):
-            # The same answer as a malformed *shape* on the line above, for the
-            # same class of corruption. `int(v)` on a `null` raises `TypeError`,
-            # and `load` runs on the way into every command -- so before #291 a
-            # single bad value in a file that was otherwise valid JSON made
-            # every command traceback until somebody deleted it by hand.
-            #
-            # A whole reset rather than dropping the one bad entry, which is the
-            # tempting alternative and says less: a watermark that quietly
-            # becomes 0 re-exports that log anyway, and nothing tells the reader
-            # a value was discarded. Rule 8 prices this deliberately -- losing
-            # `state.json` "costs a re-merge and a re-export, never a command" --
-            # so the expensive-but-whole answer is the one the file is allowed
-            # to cost.
-            return cls()
         state = cls(
-            exported=watermarks,
+            # Per value, matching `merged_at` below rather than the whole-file
+            # reset this first carried. Both keep `load` from raising, and the
+            # difference is what they cost: dropping one watermark re-exports
+            # one log, where discarding the map re-exports *every* log -- and
+            # what a re-export costs is duplicate rows in the archive, so the
+            # reset multiplies exactly the thing that made it look careful.
+            #
+            # Same direction as `merged`'s comment below, for the same reason:
+            # repeating work beats dropping history. #285 over #291.
+            exported={str(k): int(v) for k, v in exported.items() if isinstance(v, int)},
             # Guarded per value, not just on `merged` being a dict. A value
             # that is a bare *string* rather than a list is iterable, so without
             # this every day's record turns into its own characters, every chunk


### PR DESCRIPTION
Closes #285. **This corrects #297, which I merged earlier today.**

## What I got wrong

#291 and #285 are the same defect — `State.load`'s `exported` field crashing on
a value it cannot convert — found independently. I fixed it by discarding the
whole map:

```python
        except (TypeError, ValueError):
            return cls()
```

and argued in #297 that the "expensive-but-whole answer is the one the file is
allowed to cost", citing rule 8's *losing `state.json` costs a re-merge and a
re-export, never a command*.

#285 had already named the better fix, and it is right where I was not. **What a
dropped watermark costs is a re-export, and what a re-export costs is duplicate
rows in the archive.** So:

| | re-exports | duplicates |
|---|---|---|
| drop the one bad entry | one log | one log's rows |
| **discard the map (what I shipped)** | **every log** | **every log's rows** |

I framed the reset as the careful option without noticing it multiplies exactly
the thing that made it look careful. The rule 8 quote is about losing the file
entirely, which is a real event with a known cost — it is not a licence to cause
that event on purpose from one bad key.

I also cited the wrong precedent. I pointed at the `return cls()` two lines *up*,
which is for a malformed **shape**. The nearer one is `merged_at`, two lines
**down** in the same expression, which has always filtered per value:

```python
    merged_at={str(k): int(v) for k, v in merged_at.items() if isinstance(v, int)}
```

This change is that, for `exported`.

## Behaviour, on every case #285 lists

```
{'exported': {'a': 'x'}}             -> {}
{'exported': 'nope'}                 -> {}
{'exported': {'a': None}}            -> {}
{'exported': {'good': 1, 'bad': None}} -> {'good': 1}
```

The last line is the whole point: the good watermark survives, so that log is not
re-exported and its rows are not duplicated.

`isinstance(v, int)` rather than `int(v)` in a `try`, matching `merged_at`: `"7"`
converts and is still not a shape this file ever writes, so accepting it would be
trusting something nothing here produces. Tested.

## Tests

The test that pinned my wrong decision —
`test_one_bad_value_discards_the_whole_map_rather_than_that_entry` — is replaced
by one asserting the opposite, with the reasoning in its docstring so the next
reader sees why it changed. Plus one for the digit-string case.

The other four from #297 stand unaltered: a null does not raise, a non-number
does not raise, and **a good file is still read** — which remains the test that
keeps the guard from swallowing everything.

## Note on #291

#291 and #285 are duplicates; #291 is closed by #297 and this supersedes its
implementation. I filed #291 without seeing #285 — my `list_issues` call returned
an empty list at the time, though #283–#288 already existed. Worth knowing that
happened, since the cost was a wrong fix shipped and then reverted rather than
just a duplicate issue.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_