### PR TITLE
fix: re-enrolling after a revoke updates the owner line (#283)

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5401,6 +5401,51 @@ class TestSyncDoesNotForkGitMoreThanItNeedsTo(SyncTestCase):
             self.assertIn("commit -q", calls)
             self.assertIn("push --quiet", calls)
 
+    def test_a_new_identity_moves_the_owner_line(self) -> None:
+        """#283. `signer.pub` has two lines and only the first was compared.
+
+        The second names the age recipient that owns this host, and it is why
+        the file exists at all: revocation names a *recipient* while chunks live
+        under a *host id*, and nothing else joins the two.
+
+        `woswoar init --new-identity` -- the remedy the program prints after a
+        revoke -- changes the identity and nothing else. The host id and the
+        signing key both stay, so the verify key still matched, `publish_signer`
+        returned False, and the owner line went on naming the tombstoned
+        recipient for the life of the machine: unpinned on every peer's sync for
+        ever, and never offered for trust again.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+            before = sync.read_signer(alpha.id)
+            assert before is not None
+
+            # The identity alone, exactly as `--new-identity` does it. The
+            # signing key is deliberately left in place: with it changed the old
+            # guard rewrites anyway and the test proves nothing.
+            identity = sync.identity_path(store.machine())
+            # The `.pub` sibling goes too: `recipient_for` prefers it, so a
+            # stale one would report the old recipient for the new identity and
+            # the test would pass against an unfixed guard.
+            crypto.public_half(identity).unlink(missing_ok=True)
+            identity.write_text(crypto.generate_identity().secret, encoding="utf-8")
+
+            self.assertTrue(sync.publish_signer(store.machine()), "nothing was rewritten")
+            after = sync.read_signer(alpha.id)
+            assert after is not None
+            self.assertEqual(after.verify_key, before.verify_key, "the signing key did not move")
+            self.assertNotEqual(after.owner, before.owner, "the owner line is still the old one")
+
+    def test_an_unchanged_identity_rewrites_nothing(self) -> None:
+        """The other direction, and without it the fix could be "always
+        rewrite" -- which passes the test above and puts a write plus a commit
+        on a timer that fires every minute."""
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+            self.assertFalse(sync.publish_signer(store.machine()))
+
     def test_a_republished_signer_is_committed_even_with_nothing_to_export(self) -> None:
         """The other writer on this path, and the one with no chunk beside it.
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -1281,13 +1281,38 @@ def publish_signer(known: Machine) -> bool:
     """Make sure this host's published signer file says what is true.
 
     Guarded, and the guard is not only tidiness: working out the owning
-    recipient means reading an identity, which for a dedicated age key is an
+    recipient means reading an identity, which for a dedicated age key can be an
     `age-keygen` subprocess. This runs on a one-minute timer, and the file
     changes about once in a machine's life. Returns whether it wrote.
+
+    **Both lines are compared, not just the key (#283).** The file's second line
+    names the age recipient that owns this host, and `archive.signer_public`'s
+    docstring says that line is why the file exists: revocation names a
+    *recipient* while chunks live under a *host id*, and nothing else joins the
+    two.
+
+    `woswoar init --new-identity` changes the identity and nothing else -- the
+    host id comes from `config/machine` and the signing key from
+    `config/signing_key`, and neither moves. So the verify key still matched,
+    this returned `False`, and the owner line went on naming the tombstoned
+    recipient for the life of the machine. That is the remedy the program itself
+    prints after a revoke, and following it left the machine unpinned on every
+    peer's sync for ever and never offered for trust again.
+
+    The owner is read *after* the key comparison rather than before it, and the
+    `and` chain is what keeps that true: a machine whose key has changed is being
+    rewritten anyway, so the read costs nothing there, and one that has not is
+    the only case where this is on the idle path.
     """
     verify_key = signing_public()
     current = read_signer(known.id)
-    if current is not None and current.verify_key == verify_key:
+    if (
+        current is not None
+        and current.verify_key == verify_key
+        # Last, and `and` short-circuits: reached only once the cheap
+        # comparisons have failed to settle it. See the docstring.
+        and current.owner == _own_recipient(known)
+    ):
         return False
     store.write_atomic(
         archive.signer_public(known.id),


### PR DESCRIPTION
Closes #283.

**Rule 1's top row** — a security claim: which recipient owns a host directory.

## What was wrong

`publish_signer` decided whether `hosts/<id>/signer.pub` needed rewriting by
comparing the verify key alone. That file has **two** lines, and the second is
why it exists — `archive.signer_public`'s docstring says so: revocation names an
*age recipient*, chunks live under a *host id*, and nothing else joins the two.

`woswoar init --new-identity` changes the identity and nothing else. The host id
comes from `config/machine`, the signing key from `config/signing_key`, and
neither moves. So the verify key still matched, `publish_signer` returned
`False`, and the owner line went on naming the **tombstoned** recipient for the
life of the machine.

That is the remedy the program itself prints after a revoke, in three places.
Following it left the machine, on every peer:

- **unpinned on every sync, for ever** — `withdrawn_hosts` matches
  `signer.owner in revoked_keys()`;
- **never offered again** — `_trust_candidates` skips a host whose owner is not
  live, and a tombstoned key never is.

`revoke`'s "a revocation is permanent, deliberately" was meant for a *key*. This
made it permanent for the *host directory*.

## The fix, and the constraint

Compare both lines. The owner is read **last** in an `and` chain, so
`_own_recipient` is reached only once the cheap comparisons have failed to settle
it — the issue is right that this runs on a one-minute timer and
`TestSyncDoesNotForkGitMoreThanItNeedsTo` exists to keep work off that path.

One correction to the issue's framing, checked rather than assumed: reading the
recipient is **not** normally a fork. `crypto.recipient_for` returns the `.pub`
sibling's contents for an SSH key, and for an age identity `public_of` parses the
`# public key:` comment that `age-keygen` always emits — the subprocess is the
fallback for a hand-written identity without one. So the idle cost here is a file
read or a string scan, not an `age-keygen`. The short-circuit is still right;
the reason is smaller than stated.

## Tests, in both directions

The issue asks for exactly this, and it matters:

- **a new identity moves the owner line** — the signing key is deliberately left
  in place, because with it changed the old guard rewrites anyway and the test
  would prove nothing. Asserts the verify key did *not* move and the owner did.
- **an unchanged identity rewrites nothing** — without it the fix could be
  "always rewrite", which passes the first test and puts a write plus a commit on
  a timer that fires every minute.

The fixture also removes the `.pub` sibling when replacing the identity:
`recipient_for` prefers it, so a stale one would report the old recipient for the
new identity and the test would pass against an unfixed guard.

Rule 3 by hand: dropping the owner clause fails one of the eleven tests in that
class; restoring passes all of them.

## Mutation testing (rule 3)

```
1 file(s), 27 changed lines -> 6 mutants
6 caught, 0 survived
```

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons — the `chmod 000` test (running as root) and
two `test_sync` marker tests (git 2.43 not writing `origin/HEAD`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_