### PR TITLE
fix: init reports the peers it accepted, not itself (#287)

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -969,12 +969,14 @@ class TestInitDoesNotPinItself(SyncTestCase):
         alpha = self.machine("alpha", enrol=False)
         with alpha.active():
             known, _identity, pinned = sync.initialise(remote=str(self.origin), new_identity=True)
-            self.assertEqual(pinned, [], "it pinned something on an empty repo")
-            # `state.signers`, not just `pinned`: the first is what is rendered
-            # and the second is what is believed and then published in
-            # `accepts.age`. A fix that only trimmed the display would pass an
-            # assertion on `pinned` alone while leaving the self-pin on the wire.
-            self.assertNotIn(known.id, sync.State.load().signers)
+            self.assertEqual(pinned, [], "it reported accepting somebody on an empty repo")
+            # And the pin itself *stays*. `state.signers` answers "whose
+            # manifests can I verify", which legitimately includes this machine:
+            # `unlisted_chunks` skips a host it has not pinned, so dropping the
+            # self-entry stops `doctor` noticing this machine's own crash debris
+            # -- #66's whole subject. The two facts were conflated, and only the
+            # reported one was wrong.
+            self.assertIn(known.id, sync.State.load().signers)
 
     def test_a_peer_is_still_pinned(self) -> None:
         """The fixture the issue asks for, and the reason: with no peer in the
@@ -992,9 +994,9 @@ class TestInitDoesNotPinItself(SyncTestCase):
         with beta.active():
             known, _identity, pinned = sync.initialise(remote=str(self.origin), new_identity=True)
             signers = sync.State.load().signers
-            self.assertEqual(len(pinned), 1, "alpha was not pinned")
+            self.assertEqual(pinned, [signers[alpha.id]], "beta reported the wrong set")
             self.assertIn(alpha.id, signers)
-            self.assertNotIn(known.id, signers, "beta pinned itself as well")
+            self.assertIn(known.id, signers, "beta must still verify its own manifests")
 
 
 class TestTwoMachines(SyncTestCase):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -953,6 +953,50 @@ class TestAMalformedStateFileDoesNotStopTheTool(unittest.TestCase):
         self.assertEqual(self.loaded({"exported": {"a": "7"}}).exported, {})
 
 
+class TestInitDoesNotPinItself(SyncTestCase):
+    """#287. Trust on first use is the one moment a machine accepts others
+    without a human comparing anything, and `init` prints the keys so there is
+    something to compare against afterwards.
+
+    It was printing its own among them. On a solo repo -- the README's install
+    path -- that list was *entirely* this machine's own key, under a sentence
+    telling the reader to check it against the machines themselves. A list that
+    contains rows which are not decisions is one people learn to skim, which is
+    the same argument `grant` makes for only prompting about additions.
+    """
+
+    def test_a_solo_init_pins_nobody(self) -> None:
+        alpha = self.machine("alpha", enrol=False)
+        with alpha.active():
+            known, _identity, pinned = sync.initialise(remote=str(self.origin), new_identity=True)
+            self.assertEqual(pinned, [], "it pinned something on an empty repo")
+            # `state.signers`, not just `pinned`: the first is what is rendered
+            # and the second is what is believed and then published in
+            # `accepts.age`. A fix that only trimmed the display would pass an
+            # assertion on `pinned` alone while leaving the self-pin on the wire.
+            self.assertNotIn(known.id, sync.State.load().signers)
+
+    def test_a_peer_is_still_pinned(self) -> None:
+        """The fixture the issue asks for, and the reason: with no peer in the
+        repo, "nobody was pinned" and "it skipped itself" are the same
+        observation -- exactly the too-weak fixture rule 3 warns about.
+
+        Here alpha is already publishing, so beta's init has a real decision to
+        make. It must pin alpha and only alpha.
+        """
+        alpha = self.machine("alpha")
+        with alpha.active():
+            sync.run()
+
+        beta = self.machine("beta", enrol=False)
+        with beta.active():
+            known, _identity, pinned = sync.initialise(remote=str(self.origin), new_identity=True)
+            signers = sync.State.load().signers
+            self.assertEqual(len(pinned), 1, "alpha was not pinned")
+            self.assertIn(alpha.id, signers)
+            self.assertNotIn(known.id, signers, "beta pinned itself as well")
+
+
 class TestTwoMachines(SyncTestCase):
     def test_history_reaches_the_other_machine(self) -> None:
         alpha = self.machine("alpha")

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -2360,6 +2360,21 @@ def initialise(
     state = State.load()
     pinned: list[str] = []
     for host_id in archive.repo_hosts():
+        # Not ourselves. `_write_repo_metadata` ran a few lines up and called
+        # `publish_signer`, so this machine's own `signer.pub` is already there
+        # and it was pinning itself -- then printing its own key under "check
+        # these against the machines themselves", which on a solo repo is the
+        # whole of that list and cannot be checked against anything (#287).
+        #
+        # The skip is here rather than in the printing, and that matters:
+        # `pinned` is what `_init` renders but `state.signers` is what is
+        # believed, and `publish_accepts` puts it in `accepts.age`. Trimming the
+        # display alone would leave the self-pin in `state.json` and on the wire
+        # while the screen said otherwise -- a report that no longer describes
+        # the state. `merge`, `_trust_candidates` and `trust_status` all skip
+        # this id already.
+        if host_id == known.id:
+            continue
         signer = read_signer(host_id)
         if signer is not None and host_id not in state.signers:
             state.signers[host_id] = signer.verify_key

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -2398,12 +2398,22 @@ def initialise(
         # while the screen said otherwise -- a report that no longer describes
         # the state. `merge`, `_trust_candidates` and `trust_status` all skip
         # this id already.
-        if host_id == known.id:
-            continue
         signer = read_signer(host_id)
         if signer is not None and host_id not in state.signers:
             state.signers[host_id] = signer.verify_key
-            pinned.append(signer.verify_key)
+            # Reported only for somebody else. `state.signers` is "keys I can
+            # verify a manifest against" and legitimately holds this machine --
+            # `unlisted_chunks` skips a host it has not pinned, so without the
+            # self-entry `doctor` stops noticing this machine's *own* crash
+            # debris, which is the whole of #66.
+            #
+            # `pinned` is a different fact: who this machine accepted on trust
+            # on first use. It never accepted itself, and printing its own key
+            # under "check these against the machines themselves" put a row in
+            # that list which is not a decision and cannot be checked -- on a
+            # solo repo, the only row. See #287.
+            if host_id != known.id:
+                pinned.append(signer.verify_key)
 
     # Here, with the pins that were just made, rather than on the first sync.
     # Publishing is a write, a commit and a push, and doing it on the first sync


### PR DESCRIPTION
Closes #287. **The fix is not the one the issue proposes**, because its premise
turned out to be wrong — details below, since that is the part worth reading.

## What is wrong

`init`'s trust-on-first-use block is the one security-relevant message the
command has:

> Accepted the 1 machine(s) already publishing here:
>   SHA256:pgBoNGz...
> Check these against the machines themselves if the repository is shared.

`_write_repo_metadata` runs a few lines earlier and calls `publish_signer`, so
this machine's own `signer.pub` is already there when the loop runs — and it was
listing its own key. On a solo repo, the README's install path, that list is
**entirely** your own key, under a sentence telling you to go and check it
against the machines themselves.

## Why not the suggested fix

The issue says to `continue` past our own id in the loop, on the grounds that
*"the pin itself is inert as far as I can find"*. It is not. I tried it, and it
broke six tests.

**`unlisted_chunks` skips a host this machine has not pinned** — its own docstring
says so, and gives the reason: without a key there is nothing to check manifests
against. The self-pin is what makes this machine check its **own** chunks. Drop
it and `doctor` stops noticing this machine's own crash debris, which is the
whole of #66. `test_doctor_lists_it` catches it.

**`publish_accepts` opens with `if not state.signers: return False`**, so a
machine that has pinned nobody publishes no `accepts.age` at all — and every
peer's `fleet` shows it as `?` rather than as having accepted nothing. Five
`TestWhoHasAcceptedWhom` tests catch that.

## The fix

Two facts were conflated in one line:

| | |
|---|---|
| `state.signers` | *whose manifests can I verify* — legitimately includes this machine |
| `pinned`, returned and printed | *who did I accept on trust-on-first-use* — never this machine |

So the pin stays and only the report changes. `init` now prints the block when
there is genuinely somebody to check, which is when the sentence under it is
true.

**This is not the "filter the display" fix the issue rejects.** That objection is
that `pinned` is rendered while `state.signers` is believed, so trimming the
screen alone would leave the state contradicting it. But the screen does not
claim to show `state.signers` — it claims to show who was *accepted*, and this
machine never was. The two differing is the point.

Result: **no existing test needed changing.** The full suite is at its baseline.

## Tests

- **a solo init reports nobody** — and asserts the self-pin *is* in
  `state.signers`, which is the half that stops this being re-"fixed" by removing
  it later.
- **a peer is still pinned and reported** — the fixture the issue asks for, and
  its reasoning is right: with no peer in the repo, "nobody was reported" and "it
  skipped itself" are the same observation, exactly the too-weak fixture rule 3
  warns about.

Rule 3 by hand: dropping the `host_id != known.id` guard fails both.

## Mutation testing (rule 3)

```
1 file(s), 26 changed lines -> 6 mutants
6 caught, 0 survived
```

## Worth its own issue

`publish_accepts` currently makes *"I have accepted nobody"* indistinguishable
from *"I cannot be read"*, and `fleet` has different symbols for those. Removing
the emptiness guard fixes it and costs one publish per machine ever — the digest
guard from #296 makes it idempotent, since an empty set has a stable digest. I
tried it and it works, but it changes what goes on the wire in service of a
display, so it is a separate subject rather than part of this.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean.
`python -m tools.run_tests` fails only the three that are red on `main` in this
container for environmental reasons.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_