### PR TITLE
fix: a hung git is a message, not a traceback (#286)

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -953,6 +953,72 @@ class TestAMalformedStateFileDoesNotStopTheTool(unittest.TestCase):
         self.assertEqual(self.loaded({"exported": {"a": "7"}}).exported, {})
 
 
+class TestAHungGitIsAMessageNotATraceback(unittest.TestCase):
+    """#286. `gitrepo.git` is the seam that talks to the network, so a hang is
+    ordinary here rather than exotic -- and it was the one seam of the three
+    that let `TimeoutExpired` through.
+
+    `WoswoarError`'s docstring names the contract: sync runs unattended from a
+    timer, "where nobody ever reads one". A remote that accepts and then stalls
+    ended the run in a stack trace, and `cmd_sync` recorded the class name
+    `TimeoutExpired` into `sync-failure.json` as the reason -- which is then what
+    every later bare `woswoar` showed the user.
+
+    Mocked at `subprocess.run`, because the seam is the whole of it: producing a
+    real 300-second hang would be a test that takes five minutes to assert one
+    conversion.
+    """
+
+    def hung(self, **kwargs: object) -> subprocess.TimeoutExpired:
+        return subprocess.TimeoutExpired("git", gitrepo.GIT_TIMEOUT)
+
+    def test_a_timeout_becomes_a_sync_error(self) -> None:
+        with (
+            mock.patch("subprocess.run", side_effect=self.hung()),
+            self.assertRaises(errors.SyncError) as raised,
+        ):
+            gitrepo.git("fetch", "origin")
+        self.assertIn("timed out", str(raised.exception))
+
+    def test_the_message_names_the_command_and_the_limit(self) -> None:
+        """A sentence a person can act on. "TimeoutExpired" alone is the class
+        name, which is what `sync-failure.json` was recording."""
+        with (
+            mock.patch("subprocess.run", side_effect=self.hung()),
+            self.assertRaises(errors.SyncError) as raised,
+        ):
+            gitrepo.git("fetch", "origin")
+        said = str(raised.exception)
+        self.assertIn("fetch origin", said)
+        self.assertIn(str(gitrepo.GIT_TIMEOUT), said)
+
+    def test_check_false_does_not_swallow_it(self) -> None:
+        """The constraint, and the reason the guard is on the `try` rather than
+        inside the `if`.
+
+        `check=False` means "a non-zero exit is an answer" -- `read_repo`,
+        `remote_summary` and `resolve` rely on it. A timeout is an answer in
+        none of them: `resolve` would hand back empty strings and
+        `fetch_and_rebase` would read that as "no upstream" and skip the rebase
+        without a word.
+        """
+        with (
+            mock.patch("subprocess.run", side_effect=self.hung()),
+            self.assertRaises(errors.SyncError),
+        ):
+            gitrepo.git("rev-parse", "HEAD", check=False)
+
+    def test_a_missing_git_is_left_alone(self) -> None:
+        """Deliberately not widened. git absent from `PATH` is a different
+        failure with a different remedy, and `deps` owns that message -- so it
+        must still arrive as an `OSError` rather than as a sync problem."""
+        with (
+            mock.patch("subprocess.run", side_effect=FileNotFoundError("git")),
+            self.assertRaises(FileNotFoundError),
+        ):
+            gitrepo.git("status")
+
+
 class TestTwoMachines(SyncTestCase):
     def test_history_reaches_the_other_machine(self) -> None:
         alpha = self.machine("alpha")

--- a/woswoar/gitrepo.py
+++ b/woswoar/gitrepo.py
@@ -56,15 +56,39 @@ def is_repo() -> bool:
 
 
 def git(*args: str, cwd: Path | None = None, check: bool = True) -> str:
+    """One git fork, with a timeout that is an error rather than a traceback.
+
+    `crypto._run` and `_run_signer` both convert `TimeoutExpired`; this seam did
+    not, and it is the one that talks to the **network** -- so a hang here is
+    ordinary rather than exotic. A remote that accepts the connection and then
+    stalls (a sleeping NAS, a dead ssh host, an https remote behind a captive
+    portal) gives `git fetch` no reason to exit, and after `GIT_TIMEOUT` the
+    unattended sync ended in a stack trace nobody reads. `WoswoarError`'s
+    docstring is explicit that this is the contract: sync runs from a timer,
+    "where nobody ever reads one". See #286.
+
+    **Raised regardless of `check`, which is why it is on the `try` and not
+    inside the `if`.** `check=False` means "a non-zero exit is an answer" --
+    `read_repo`, `remote_summary` and `resolve` all rely on that -- and a
+    timeout is an answer in none of them: `resolve` would hand back empty
+    strings and `fetch_and_rebase` would read that as "no upstream" and skip
+    the rebase without a word.
+
+    `OSError` is deliberately left alone: git missing from `PATH` is a different
+    failure with a different remedy, and `deps` already owns that message.
+    """
     repo = cwd or store.history_dir()
-    result = subprocess.run(
-        ["git", *args],
-        cwd=repo,
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=GIT_TIMEOUT,
-    )
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=GIT_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SyncError(f"git {' '.join(args)} timed out after {GIT_TIMEOUT}s") from exc
     if check and result.returncode != 0:
         raise SyncError(f"git {' '.join(args)} failed:\n{result.stderr.strip()}")
     return result.stdout.strip()


### PR DESCRIPTION
Closes #286.

## What was wrong

`gitrepo.git` set a timeout and converted only the non-zero exit, so
`subprocess.TimeoutExpired` went straight past. Both of the package's other
subprocess seams convert it — `crypto._run` and `_run_signer` — and this is the
one that talks to the **network**, where a hang is ordinary rather than exotic.

`WoswoarError`'s docstring names the contract it breaks:

> Sync in particular runs unattended from a timer, where nobody ever reads one.

A remote that accepts the connection and then stalls — a sleeping NAS, a dead
ssh host, an https remote behind a captive portal — gives `git fetch` no reason
to exit. After `GIT_TIMEOUT` the run ended in a stack trace, and `cmd_sync`
recorded the *class name* `TimeoutExpired` into `sync-failure.json`, which is
then what every later bare `woswoar` showed as the reason syncing had been
failing. `init` is worse: it clones from a remote the user has just typed, so a
mistyped host is the first thing a new user can hit and it answers with a
traceback.

## The fix, and where the guard sits

Three lines, the same ones the other two seams carry — **on the `try`, not inside
the `if`**, which is the constraint the issue names and the reason it matters:

`check=False` means *a non-zero exit is an answer*, and `read_repo`,
`remote_summary` and `resolve` all rely on that. A timeout is an answer in none
of them — `resolve` would hand back empty strings and `fetch_and_rebase` would
read that as "no upstream" and skip the rebase without a word. So it raises
regardless of `check`, and there is a test for exactly that.

`OSError` is deliberately left alone: git missing from `PATH` is a different
failure with a different remedy, and `deps` already owns that message. Also
tested, so a later widening of the `except` fails rather than passing quietly.

## Tests

Four, mocked at `subprocess.run` because the seam is the whole of it — producing
a real 300-second hang would be a test that takes five minutes to assert one
conversion:

- a timeout becomes a `SyncError`;
- the message names the command and the limit, since `TimeoutExpired` alone is
  the class name and that is what was reaching `sync-failure.json`;
- **`check=False` does not swallow it**;
- **a missing git is still an `OSError`**.

Rule 3 by hand: removing the conversion fails three of the four — the fourth is
the `OSError` guard, correctly unaffected.

## Mutation testing (rule 3)

```
1 file(s), 32 changed lines -> 0 mutants
```

Correct rather than lazy, and worth saying why: the change is a `try`, an
`except`, and a `raise` of an f-string. No operator generates for any of them —
`JoinedStr` is in `_SKIP_SUBTREE` because on 3.10/3.11 the nodes inside an
f-string carry the enclosing string's position, so a span computed from them
splices the wrong bytes. The by-hand revert above is the whole of the rule 3
evidence here.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean, full suite
green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_