### PR TITLE
tools: the sweep records its own pid, so the watcher stops guessing

### DIFF
--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -2338,6 +2338,36 @@ class TestTheGeneratedEntryPoint(MutateTestCase):
         )
         self.assertEqual({row["path"] for row in written["results"]}, {"woswoar/mod.py"})
 
+    def test_a_finished_run_takes_its_pidfile_away(self) -> None:
+        """The run writes its own pid because the caller could not.
+
+        Removed at the end, because by then it names a process that is gone --
+        and a stale pid read as live is the exact false answer `tools/watch.py`
+        exists to refuse.
+        """
+        self.repo(guarded=True)
+        report = self.root / "rows.json"
+        cli(self.root, "--base", "HEAD", "--operator", "branch", "--json", str(report))
+        self.assertFalse(mutate._pidfile(report).exists())
+
+    def test_the_pid_is_there_while_the_run_is_going(self) -> None:
+        """Observed from inside, because it is gone by the time `main` returns
+        -- which is the same reason the stale-marker test looks from in here."""
+        self.repo(guarded=True)
+        report = self.root / "rows.json"
+        seen: list[str] = []
+
+        def watching(rows: Sequence[Mutation], args: Any, **kw: Any) -> Report:
+            seen.append(mutate._pidfile(report).read_text(encoding="utf-8").strip())
+            return Report([])
+
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            mock.patch.object(mutate, "_run_generated", watching),
+        ):
+            mutate.main(["--base", "HEAD", "--operator", "branch", "--json", str(report)])
+        self.assertEqual(seen, [str(os.getpid())], "the run did not name itself")
+
     def test_a_finished_run_leaves_a_marker(self) -> None:
         """#275. `--json` says a batch landed; this says the run is over.
 
@@ -2444,6 +2474,9 @@ class TestTheGeneratedEntryPoint(MutateTestCase):
 
 
 class TestTheCompletionMarker(unittest.TestCase):
+    def test_the_pidfile_sits_beside_the_report_too(self) -> None:
+        self.assertEqual(mutate._pidfile(Path("/tmp/r.json")), Path("/tmp/r.json.pid"))
+
     def test_it_sits_beside_the_report(self) -> None:
         """A sibling name rather than a suffix swap, so a reader sorting a
         directory finds the two together and `.json` keeps its meaning."""

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -604,6 +604,64 @@ class TestTheCommandLine(Fixture):
         self.assertGreaterEqual(said, 1, out)
         self.assertLess(said, 10, out)
 
+    def test_it_reads_the_pid_the_job_wrote(self) -> None:
+        """The step that feeds this tool, which never worked by hand.
+
+        `... & echo $! > sweep.pid` looks equivalent to the job writing it and
+        is not -- in one session it produced no file, and the pid was recovered
+        from the process table fifteen runs running, by a *pattern*, which is
+        exactly the `pgrep -f` hole this tool exists to close.
+        """
+        self.done.write_text("{}", encoding="utf-8")
+        pidfile = self.root / "sweep.pid"
+        pidfile.write_text(f"{self.reaped()}\n", encoding="utf-8")
+        ran = self.ran("--pidfile", str(pidfile))
+        self.assertEqual(ran.returncode, 0, ran.stderr)
+        self.assertIn("FINISHED", ran.stdout)
+
+    def test_it_waits_for_a_pidfile_that_is_not_there_yet(self) -> None:
+        """The watcher is started in the same breath as the job and can win the
+        race. Waiting is the difference between that being fine and being a
+        usage error the caller has to sleep around."""
+        self.done.write_text("{}", encoding="utf-8")
+        pidfile = self.root / "late.pid"
+        writer = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                f"import time,pathlib\ntime.sleep(0.4)\n"
+                f"pathlib.Path({str(pidfile)!r}).write_text('{os.getpid()}')\n",
+            ]
+        )
+        self.addCleanup(writer.wait)
+        self.addCleanup(writer.kill)
+        ran = self.ran("--pidfile", str(pidfile))
+        self.assertEqual(ran.returncode, 0, ran.stderr)
+
+    def test_a_pidfile_that_never_arrives_is_an_error_not_a_wait(self) -> None:
+        """A watcher that settled into watching nothing would be reporting the
+        silence it was built to break. Bounded, and it says which file."""
+        ran = subprocess.run(
+            self.command("--pidfile", str(self.root / "never"), "--interval", "0.05"),
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env={**os.environ, "PYTHONPATH": str(self.repo)},
+        )
+        self.assertEqual(ran.returncode, 1)
+        self.assertIn("no usable pid", ran.stderr)
+
+    def test_a_pid_and_a_pidfile_together_are_refused(self) -> None:
+        """Two answers to one question, and no way to tell which the caller
+        meant. argparse says so before anything runs."""
+        ran = self.ran("123", "--pidfile", str(self.root / "p"))
+        self.assertEqual(ran.returncode, 2)
+
+    def test_neither_a_pid_nor_a_pidfile_is_refused(self) -> None:
+        ran = self.ran()
+        self.assertEqual(ran.returncode, 2)
+
     def test_a_pid_that_is_a_group_is_a_usage_error(self) -> None:
         ran = self.ran("0")
         self.assertEqual(ran.returncode, 2)

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -638,6 +638,53 @@ class TestTheCommandLine(Fixture):
         ran = self.ran("--pidfile", str(pidfile))
         self.assertEqual(ran.returncode, 0, ran.stderr)
 
+    def test_a_long_poll_interval_does_not_stall_the_wait(self) -> None:
+        """The poll step is the *shorter* of `--interval` and a tenth of a
+        second, and this is why.
+
+        `--interval` is tuned for the work being watched -- twenty seconds, so a
+        sweep is not polled to death. Reusing it here would check for the pidfile
+        every twenty seconds against a ten-second deadline, so a job that wrote
+        its pid promptly would be declared missing. The two waits measure
+        different things and only one of them is minutes long.
+
+        Timed, not just completed: with the longer step this still finishes, it
+        just takes twenty seconds to do it.
+        """
+        self.done.write_text("{}", encoding="utf-8")
+        pidfile = self.root / "slow.pid"
+        writer = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                f"import time,pathlib\ntime.sleep(0.3)\n"
+                f"pathlib.Path({str(pidfile)!r}).write_text('{os.getpid()}')\n",
+            ]
+        )
+        self.addCleanup(writer.wait)
+        self.addCleanup(writer.kill)
+        began = time.monotonic()
+        ran = self.ran("--pidfile", str(pidfile), "--interval", "20")
+        self.assertEqual(ran.returncode, 0, ran.stderr)
+        self.assertLess(time.monotonic() - began, 5.0, "it waited a whole poll interval")
+
+    def test_waiting_for_a_pidfile_is_not_a_spin(self) -> None:
+        """Ten seconds of busy loop is ten seconds of a core, on a machine about
+        to be busy with the job being waited for. Measured rather than read,
+        the same way the main loop's sleep is."""
+        before = resource.getrusage(resource.RUSAGE_CHILDREN).ru_utime
+        ran = subprocess.run(
+            self.command("--pidfile", str(self.root / "never"), "--interval", "0.05"),
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env={**os.environ, "PYTHONPATH": str(self.repo)},
+        )
+        self.assertEqual(ran.returncode, 1)
+        burned = resource.getrusage(resource.RUSAGE_CHILDREN).ru_utime - before
+        self.assertLess(burned, 2.0, f"waiting cost {burned:.2f}s of CPU")
+
     def test_a_pidfile_that_never_arrives_is_an_error_not_a_wait(self) -> None:
         """A watcher that settled into watching nothing would be reporting the
         silence it was built to break. Bounded, and it says which file."""

--- a/tools/mutate.py
+++ b/tools/mutate.py
@@ -1304,6 +1304,23 @@ def _marker(where: Path) -> Path:
     return where.parent / (where.name + ".done")
 
 
+def _pidfile(where: Path) -> Path:
+    """Where a run records its own process id, beside its report.
+
+    Written because the caller could not reliably record it. A sweep is started
+    detached -- that is the whole reason `tools/watch.py` exists -- and the
+    obvious `python -m tools.mutate ... & echo $! > sweep.pid` does not survive
+    every shell: in one session it produced no file at all, and the pid had to
+    be recovered from the process table on fifteen consecutive runs, with a
+    pattern filter carefully written not to match the filtering command. That is
+    the `pgrep -f` hole `watch.py` was built to close, reappearing in the step
+    that feeds it.
+
+    The run knows its own pid and cannot get it wrong, so it writes it.
+    """
+    return where.parent / (where.name + ".pid")
+
+
 def _persist(report: Report, where: Path) -> None:
     """The run's answers, as `tools/reached.py` reads them.
 
@@ -1560,6 +1577,9 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  {row.operator:16} {row.label}")
             return 0
         if args.json:
+            # Before the first row, so a watcher started alongside this one has
+            # something to read straight away. Its own pid, not a caller's guess.
+            _pidfile(args.json).write_text(f"{os.getpid()}\n", encoding="utf-8")
             # Cleared before the first row, not merely written after the last.
             # A resumed sweep points `--json` at a part-written report, and a
             # marker left by the run that was interrupted would tell a watcher
@@ -1587,6 +1607,9 @@ def main(argv: list[str] | None = None) -> int:
             # Last, and after `confirm`: the marker means the whole run is over,
             # including the pass that can still change a verdict.
             _marker(args.json).touch()
+            # The pid names a process that no longer exists, and a stale one is
+            # exactly the false-liveness `watch.py` refuses to answer with.
+            _pidfile(args.json).unlink(missing_ok=True)
         return 0 if report.clean else 1
 
     already = len(_RUNS)

--- a/tools/watch.py
+++ b/tools/watch.py
@@ -247,12 +247,60 @@ def a_pid(text: str) -> int:
     return pid
 
 
+#: How long `--pidfile` waits for the job to write one before giving up. Ten
+#: seconds because the file is written before the first row of work, so the only
+#: thing being waited on is an interpreter starting -- and a watcher that hung
+#: here for ever would be the silence this tool exists to break.
+PIDFILE_WAIT = 10.0
+
+
+def _await_pid(where: Path, interval: float) -> int:
+    """The pid in ``where``, once the job has written it.
+
+    Waited for rather than required up front, because the watcher is usually
+    started in the same breath as the job and may win the race. Polled at
+    `--interval` or a tenth of a second, whichever is shorter: this is the one
+    place a poll is cheap and the wait is measured in a startup rather than in
+    minutes.
+
+    A file that never appears, or holds something that is not a pid, is an
+    error and not a wait: the job it names is not running, and a watcher that
+    settled into watching nothing would be reporting the thing it was built to
+    refuse.
+    """
+    step = min(interval, 0.1)
+    deadline = time.monotonic() + PIDFILE_WAIT
+    while True:
+        try:
+            return a_pid(where.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError, argparse.ArgumentTypeError) as exc:
+            if time.monotonic() >= deadline:
+                raise SystemExit(
+                    f"no usable pid in {where} after {PIDFILE_WAIT:g}s: {exc}"
+                ) from None
+        time.sleep(step)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="python -m tools.watch",
         description="Report a long job's progress, and say plainly when it dies.",
     )
-    parser.add_argument("pid", type=a_pid, help="the job's process id, recorded when it started")
+    where = parser.add_mutually_exclusive_group(required=True)
+    where.add_argument(
+        "pid", type=a_pid, nargs="?", help="the job's process id, recorded when it started"
+    )
+    where.add_argument(
+        "--pidfile",
+        type=Path,
+        # The job writes its own, which is the only party that cannot get it
+        # wrong. `... & echo $! > sweep.pid` looks equivalent and is not: it
+        # produced no file at all in one shell, and the pid was recovered from
+        # the process table fifteen times running -- by pattern, which is the
+        # `pgrep -f` hole this tool exists to close, back in the step that feeds
+        # it. `tools.mutate --json r.json` writes `r.json.pid`.
+        help="read the pid from this file instead, waiting briefly for it to appear",
+    )
     parser.add_argument("--log", type=Path, required=True, help="the file it appends progress to")
     parser.add_argument(
         "--done",
@@ -280,7 +328,8 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    watch = Watch(args.pid, args.log, args.done, re.compile(args.match), args.stale)
+    pid = args.pid if args.pid is not None else _await_pid(args.pidfile, args.interval)
+    watch = Watch(pid, args.log, args.done, re.compile(args.match), args.stale)
     while True:
         event = watch.step()
         if event is not None:


### PR DESCRIPTION
## Why

`tools/watch.py` needs a pid recorded at launch — that is the whole of its
design, because matching on a command line answers about the asker. The step
that *records* it never worked:

```sh
python -m tools.mutate ... & echo $! > sweep.pid
```

produced no file at all in this shell, on every attempt. So the pid was recovered
from the process table instead, **fifteen consecutive runs**, with an `awk`
filter written carefully not to match the filtering command — which is the
`pgrep -f` hole `watch.py` exists to close, reappearing in the step that feeds
it. Once, that recovery went the other way and a live sweep was reported dead.

The run knows its own pid and cannot get it wrong, so it writes it.

- `mutate --json r.json` writes `r.json.pid` **before the first row** and removes
  it after the last — a stale pid read as live is the exact false answer
  `watch.py` refuses to give.
- `watch --pidfile r.json.pid` reads it, **waiting up to ten seconds** for it to
  appear, because the watcher is usually started in the same breath as the job
  and can win the race. A file that never arrives is an error, not a longer wait:
  a watcher settled into watching nothing is the silence this tool was built to
  break.

`pid` and `--pidfile` are mutually exclusive and one is required — two answers to
one question with no way to tell which was meant.

## Dogfooded, including the part I did not plan

The launch is now one line with nothing to recover, and it worked first time.
Then the harness killed my foreground call and took the sweep with it, and the
watcher said:

```
DIED after 0m: 22 rows done, no report written -- the job is gone, not slow
```

exit 1. That is the first time in this whole session the `DIED` path has fired
outside its own tests, and it was right. The stale `r.json.pid` left behind by
the killed run did **not** produce a false positive, because `alive()` asks the
kernel about a number rather than matching a name — which is the property the
tool was built around, demonstrated by accident.

## Mutation testing (rule 3)

```
2 file(s), 74 changed lines -> 20 mutants
19 caught
1 survived:
  - tools/watch.py:277 in _await_pid() -- `>=` becomes `>`
```

A float deadline compared with `time.monotonic()`; the two differ only when the
clock lands exactly on it. Equivalent.

The round before had **three**, and one was real: `min(interval, 0.1)` becoming
`max`. `--interval` is tuned for the work being watched — twenty seconds, so a
sweep is not polled to death — and reusing it here would check a **ten-second**
deadline every twenty seconds, declaring a promptly-written pid missing. The two
waits measure different things and only one is minutes long. Now timed, not
merely completed: with the longer step the test still passes, it just takes
twenty seconds, so the assertion is on elapsed time.

The third was the busy-loop — ten seconds of spin on a machine about to be busy
with the job being waited for — killed by measuring `RUSAGE_CHILDREN`, the same
way the main loop's sleep is.

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean; full suite
green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_