### PR TITLE
fix: a lost anchor starts over rather than skipping records

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,11 @@ jobs:
       # parallel runner can. No --no-skips here: strace is not installed in this
       # job, so the fork-scaling tests legitimately skip. The `hook` job is
       # where they are made fatal.
+      # `[test]` rather than `[dev]`: this job runs the suite and nothing else,
+      # and the property tests are the only part of it with a dependency. The
+      # `--only` jobs do not need it -- their filter runs before discovery
+      # imports the module.
+      - run: pip install -e .[test]
       - run: python -m tools.run_tests
       # The ranking tests are the one part of the suite whose subject is fzf's
       # behaviour rather than woswoar's, so they cannot be asserted against a
@@ -394,6 +399,11 @@ jobs:
       # 174 s to 96 s of CPU, on a runner with three cores to absorb it.
       # Nothing is lost; every exclusion here reappears under a strictly
       # stronger flag, `test_sync`'s on another machine.
+      # `[test]` rather than `[dev]`: this job runs the suite and nothing else,
+      # and the property tests are the only part of it with a dependency. The
+      # `--only` jobs do not need it -- their filter runs before discovery
+      # imports the module.
+      - run: pip install -e .[test]
       - run: |
           python -m tools.run_tests \
             --exclude tests.test_shell_hook_zsh \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = []
 # gate, and its output changes between versions, so a floor three years behind
 # lets a contributor pass locally and fail in CI for no reason they can see.
 # These are the versions the suite is actually run against.
-dev = ["ruff>=0.16", "mypy>=2.3", "shellcheck-py>=0.11"]
+dev = ["ruff>=0.16", "mypy>=2.3", "shellcheck-py>=0.11", "hypothesis>=6.100"]
 
 [project.scripts]
 woswoar = "woswoar.__main__:main"
@@ -81,3 +81,23 @@ select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
 python_version = "3.10"
 strict = true
 warn_unreachable = true
+
+# Hypothesis is the first third-party import the suite has ever had, and it
+# arrives with two frictions against `strict`. Both are narrowed to the one
+# module that uses it rather than relaxed for the tree: an exemption wide enough
+# to cover a file nobody remembers writing is the kind that stops being noticed.
+[[tool.mypy.overrides]]
+module = "hypothesis.*"
+ignore_missing_imports = true
+
+# `@rule` and `@invariant` are generic wrappers mypy reads as untyped, so
+# `disallow_untyped_decorators` rejects every rule in the state machine. The
+# alternative is a `type: ignore` on each one, which is the same exemption
+# written five times where a reader will stop seeing it.
+[[tool.mypy.overrides]]
+module = "tests.test_import_properties"
+disallow_untyped_decorators = false
+# And `RuleBasedStateMachine` reads as `Any` once its module is unresolved
+# above, so subclassing it trips `disallow_subclassing_any`. Same exemption,
+# same reason, same one file.
+disallow_subclassing_any = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,12 @@ dependencies = []
 # gate, and its output changes between versions, so a floor three years behind
 # lets a contributor pass locally and fail in CI for no reason they can see.
 # These are the versions the suite is actually run against.
-dev = ["ruff>=0.16", "mypy>=2.3", "shellcheck-py>=0.11", "hypothesis>=6.100"]
+# The suite had no third-party dependency until the property tests, and the CI
+# jobs reflected that: only `lint` installed anything. Kept as its own extra so
+# the two jobs that run full discovery can take hypothesis without also pulling
+# ruff, mypy and shellcheck into a job that runs none of them.
+test = ["hypothesis>=6.100"]
+dev = ["ruff>=0.16", "mypy>=2.3", "shellcheck-py>=0.11", "woswoar[test]"]
 
 [project.scripts]
 woswoar = "woswoar.__main__:main"

--- a/tests/test_import_properties.py
+++ b/tests/test_import_properties.py
@@ -1,0 +1,121 @@
+"""Import as a state machine, driven by generated sequences of edits.
+
+The example tests beside this one each pin one story: append, re-import, expect
+these commands. A property test states the *rule* those stories are instances of
+and lets the machine look for a sequence that breaks it:
+
+    every command in the history at the moment of an import ends up in `logs/`
+
+Then it searches. Where a hand-written fixture asks the two or three questions
+its author thought of, this asks a few hundred nobody did -- and when one fails
+it *shrinks*, cutting the failing sequence down to the shortest one that still
+breaks, which is usually small enough to read as a bug report.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from hypothesis import HealthCheck, settings
+from hypothesis import strategies as st
+from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
+
+from woswoar import cache, importer, store
+
+
+class ImportKeepsEverything(RuleBasedStateMachine):
+    """A zsh history that grows, gets trimmed, and is imported, in any order.
+
+    The three rules are the three things that happen to a real
+    `.zsh_history`: a shell appends when it exits, zsh rewrites the file from
+    the front when it trims to `SAVEHIST`, and `woswoar import` reads it.
+    Hypothesis picks the order and the sizes.
+
+    Commands are unique and numbered, which is the fixture doing one job well:
+    with repeated text, "is it in `logs/`" stops distinguishing *this* command
+    from an earlier identical one, and the invariant would pass for the wrong
+    reason.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._tmp = tempfile.TemporaryDirectory(prefix="woswoar-prop-")
+        self.root = Path(self._tmp.name).resolve()
+        (self.root / "home").mkdir()
+        self._env = mock.patch.dict(
+            os.environ, store.sandbox_environ(self.root, self.root / "home"), clear=True
+        )
+        self._env.start()
+
+        self.source = self.root / "hist"
+        self.source.write_text("", encoding="utf-8")
+        #: The records in the file, newest last.
+        self.lines: list[str] = []
+        #: Every command the file held at the moment of some import. This is
+        #: what `logs/` is owed, and it never shrinks -- trimming the source
+        #: after an import does not un-import anything.
+        self.owed: set[str] = set()
+        self.made = 0
+
+    def teardown(self) -> None:
+        self._env.stop()
+        self._tmp.cleanup()
+
+    def write(self) -> None:
+        self.source.write_text("".join(self.lines), encoding="utf-8")
+        os.utime(self.source, (1_700_000_000, 1_700_000_000))
+
+    @rule(count=st.integers(min_value=1, max_value=4))
+    def append(self, count: int) -> None:
+        """A shell exiting: new records on the end, timestamps of their own.
+
+        Deliberately not always increasing. Two shells opened together and
+        closed in the other order interleave, which is ordinary and is what
+        #289 was about.
+        """
+        for _ in range(count):
+            self.made += 1
+            stamp = 1_700_000_000 + (self.made * 7919) % 1000
+            self.lines.append(f": {stamp}:0;cmd-{self.made}\n")
+        self.write()
+
+    @rule(count=st.integers(min_value=1, max_value=3))
+    def trim(self, count: int) -> None:
+        """zsh rewriting the file to fit `SAVEHIST`: records leave the front."""
+        del self.lines[:count]
+        self.write()
+
+    @rule()
+    def do_import(self) -> None:
+        self.owed |= {line.split(";", 1)[1].strip() for line in self.lines}
+        importer.run("zsh", self.source)
+
+    @invariant()
+    def nothing_the_import_saw_is_missing(self) -> None:
+        if not self.owed:
+            return
+        have = {entry.cmd for entry in cache.load_entries()}
+        missing = self.owed - have
+        assert not missing, f"never imported: {sorted(missing)}"
+
+
+ImportKeepsEverything.TestCase.settings = settings(
+    max_examples=250,
+    stateful_step_count=15,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+TestImportKeepsEverything = ImportKeepsEverything.TestCase
+# Hypothesis names the generated case after the machine, so `tools/run_tests.py`
+# -- which records a class by name and loads it back by name to shard the run --
+# looked for `ImportKeepsEverything` and found the state machine, which is not a
+# `TestCase`. Renaming it is what makes the two agree.
+TestImportKeepsEverything.__name__ = "TestImportKeepsEverything"
+TestImportKeepsEverything.__qualname__ = "TestImportKeepsEverything"
+# `__module__` as well, and it is the one that actually bit: the generated class
+# is defined in `hypothesis.stateful`, so the runner built
+# `hypothesis.stateful.TestImportKeepsEverything` and could not load it back.
+TestImportKeepsEverything.__module__ = __name__

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -366,11 +366,21 @@ class TestFindingTheWatermarkAgain(unittest.TestCase):
         index 0 and the count must follow it."""
         self.assertEqual(importer._anchored(3, "c", self.rows("c", "d", "e")), 1)
 
-    def test_a_mark_that_is_gone_leaves_the_count_alone(self) -> None:
-        """Replaced rather than trimmed. There is no position to re-anchor to,
-        so this is the pre-#294 answer -- and the safe one, since resetting
-        would re-import an untimed history in full."""
-        self.assertEqual(importer._anchored(2, "b", self.rows("x", "y", "z")), 2)
+    def test_a_mark_that_is_gone_starts_over(self) -> None:
+        """The file was rewritten past the point the mark named, so the count
+        is a position into something that no longer exists.
+
+        #300 kept the count here and this test pinned that. Both were wrong, and
+        a property test found the four steps that show it: import one command,
+        append a second, trim the first away, import again -- the anchor is gone,
+        the count still says one, and the second command sits below it for ever.
+
+        Starting over re-reads, and `(ts, cmd)` absorbs it. That can duplicate
+        rows in a header-less history, whose stamps shift with the file's
+        length -- and rule 8 ranks the two: losing a command from `logs/` is
+        unrecoverable, a duplicate row can be forgotten.
+        """
+        self.assertEqual(importer._anchored(2, "b", self.rows("x", "y", "z")), 0)
 
     def test_a_count_past_the_end_still_searches(self) -> None:
         """The shrink case `run`'s own guard also catches, reached here when the

--- a/woswoar/importer.py
+++ b/woswoar/importer.py
@@ -388,10 +388,22 @@ def _anchored(counted: object, mark: object, parsed: list[Parsed]) -> int:
     for at in range(min(already, len(parsed)) - 1, -1, -1):
         if parsed[at].cmd == mark:
             return at + 1
-    # Not found at all: the source was replaced rather than trimmed. Keeping the
-    # count is the same answer as before this function existed, and the safe one
-    # -- see the untimed argument above.
-    return already
+    # Not found at all: the file was rewritten past the point this mark named.
+    # Start over, and let the `(ts, cmd)` guard absorb the re-read.
+    #
+    # #300 kept the count here and called it the safe answer. It is not, and a
+    # property test found the four steps that show it: import one command,
+    # append a second, trim the first away, import again -- the anchor is gone,
+    # the count still says one, and the second command is below it for ever.
+    # "Same as before this function existed" was true and beside the point: this
+    # function exists because that answer loses records.
+    #
+    # The untimed argument that reasoned the other way is real but smaller.
+    # Re-reading a header-less history can duplicate rows, because its stamps
+    # are synthesised from the file's length and shift as it grows. Rule 8 ranks
+    # these: `logs/` is the primary copy, losing a command is unrecoverable, and
+    # a duplicate row is ugly and can be forgotten. Losing is worse.
+    return 0
 
 
 def _state_path() -> Path:


### PR DESCRIPTION
This started as an experiment — would property-based testing find the two
watermark bugs I fixed by hand today? It found those, and then it found a third
that **I introduced this morning in #300**.

## What property testing is, for the record

An example test pins one story: *append these lines, import, expect these
commands*. A property test states the rule those stories are instances of —

> every command in the history at the moment of an import ends up in `logs/`

— and then generates sequences looking for one that breaks it. `tests/test_import_properties.py`
models the three things that actually happen to a `.zsh_history`: a shell
appends when it exits, zsh rewrites from the front when trimming to `SAVEHIST`,
and `woswoar import` reads it. Hypothesis picks the order and the sizes.

The part that makes it worth having is **shrinking**. It finds a failure in some
20-step sequence, then cuts it down to the shortest one that still fails — which
usually arrives small enough to read as a bug report.

## The experiment

**Against `8405f39` (before today's fixes):**

```
append(count=1)     # cmd-1
do_import()
append(count=1)     # cmd-2
do_import()
→ AssertionError: never imported: ['cmd-2']
```

Four steps. That is #289 exactly: `cmd-2`'s timestamp is lower than `cmd-1`'s, so
`parse_zsh` sorts it below the watermark and it is dropped for ever.

**Against `main` with both fixes in:**

```
append(count=1)     # cmd-1
do_import()
append(count=1)     # cmd-2
trim(count=1)       # cmd-1 leaves the front
do_import()
→ AssertionError: never imported: ['cmd-2']
```

Five steps, and a live bug. Confirmed directly:

```
_anchored(already=1, mark='cmd-1', parsed=[cmd-2]) -> 1
  so fresh = parsed[1:] = []   <- cmd-2 is never seen
```

## The bug I shipped

`_anchored` falls back to keeping the count when the anchor is not found, and
#300's comment called that **"the safe one"**:

> Not found at all: the source was replaced rather than trimmed. Keeping the
> count is the same answer as before this function existed, and the safe one.

It is not safe. It loses commands. "Same as before this function existed" was
true and beside the point — the function exists *because* that answer loses
records.

Starting over re-reads, and the `(ts, cmd)` guard absorbs it. That can duplicate
rows in a header-less history, whose stamps are synthesised from the file's
length and shift as it grows — the reasoning I used to justify the old fallback.
But rule 8 ranks the two and I had it backwards: **`logs/` is the primary copy,
losing a command is unrecoverable, and a duplicate row can be forgotten.**

`tests/test_importer.py`'s `test_a_mark_that_is_gone_leaves_the_count_alone`
pinned the wrong behaviour and is replaced.

## Why the existing machinery missed it

Neither the review nor the sweep caught this, and that is the general point.
Every line of `_anchored` is individually correct; the composition is wrong.
**Mutation testing verifies that tests notice changes — it cannot find code that
is wrong-but-consistent**, because no mutation makes a correct-looking program
more wrong. Today's eleven defects were all of that class.

## Cost

`max_examples=250, stateful_step_count=15` runs in about **2 seconds**. Pushed
to 1500 examples × 30 steps it takes 23 seconds and still passes, so the
committed budget is a deliberate floor rather than the limit of what it can do —
run it harder locally when touching the import path.

## Wiring

- `hypothesis>=6.100` joins the `dev` extra, the suite's first third-party
  import.
- Two **narrow** mypy overrides, scoped to the one module: `@rule`/`@invariant`
  are generic wrappers `strict` reads as untyped, and the state machine base is
  `Any`. Narrowed rather than relaxed for the tree — an exemption wide enough to
  cover a file nobody remembers writing is the kind that stops being noticed.
- `TestImportKeepsEverything.__module__` is set explicitly. Hypothesis defines
  the generated case in `hypothesis.stateful`, so `tools/run_tests.py` — which
  records a class by `f"{__module__}.{__qualname__}"` and loads it back to shard
  the run — built a name it could not resolve. That cost two rounds to find.

## Mutation testing (rule 3)

```
1 file(s), 16 changed lines -> 3 mutants
3 caught, 0 survived
```

## Preflight

`ruff check`, `ruff format --check`, `mypy woswoar tests tools` clean; full suite
green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_