### PR TITLE
test: property tests for the two paths that remove and publish records

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,9 +104,16 @@ ignore_missing_imports = true
 # `tests.test_*_properties` is rejected outright. Every `_properties` module
 # belongs here and needs the same pair -- the suffix is the convention that
 # earns them, and the list is what mypy will take.
-module = ["tests.test_import_properties", "tests.test_record_properties"]
+module = [
+    "tests.test_export_properties",
+    "tests.test_forget_properties",
+    "tests.test_import_properties",
+    "tests.test_record_properties",
+]
 disallow_untyped_decorators = false
 # And `RuleBasedStateMachine` reads as `Any` once its module is unresolved
 # above, so subclassing it trips `disallow_subclassing_any`. Same exemption,
-# same reason, same one file.
+# same reason -- and it applies to the whole list rather than to one file,
+# because only some of these define a machine and mypy takes the pair either
+# way.
 disallow_subclassing_any = false

--- a/tests/test_export_properties.py
+++ b/tests/test_export_properties.py
@@ -1,0 +1,333 @@
+"""The export watermark: what `read_tail` and `line_start` promise a log file.
+
+These two are the only things standing between a log file and an append-only
+encrypted repository. `export` seals from the watermark to the end of the file
+and commits it, so a watermark that is wrong by one byte publishes a record with
+its head missing -- to every peer, for ever, in a history that cannot be
+rewritten. #263 is that bug: `forget` shortens a log, a crash lands between the
+rewrite and the `state.save`, and the stale watermark now points into the middle
+of a record.
+
+Examples cover the shapes someone thought of. What this asks instead is the
+question the whole design is an answer to -- *can a fragment ever reach a
+chunk?* -- against sequences of appends, forgets and crashes nobody chose.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
+
+from woswoar import store
+
+settings.register_profile("woswoar-export", max_examples=300, deadline=None)
+settings.load_profile("woswoar-export")
+
+#: A record as it sits in a log. Bytes, not text: these two functions are the
+#: layer below the record format and never decode anything, and a text strategy
+#: encoded strictly cannot even generate the mis-decoded byte that
+#: `entry`'s ``surrogateescape`` exists to carry through here intact.
+RECORD = st.binary(min_size=1, max_size=30).map(lambda row: row.replace(b"\n", b"x"))
+
+
+def joined(records: list[bytes]) -> bytes:
+    return b"".join(row + b"\n" for row in records)
+
+
+#: What a log file can hold, and the reason it is not just `st.binary`.
+#:
+#: A newline is one byte in 256, so a random 80-byte string holds one about a
+#: third of the time and two almost never -- and every claim here is about where
+#: the newlines are. A mutation making `line_start` rewind to the *first*
+#: boundary in its window instead of the last survived a run against
+#: `st.binary` alone, not because the property was wrong but because nearly no
+#: generated body had two boundaries to tell apart.
+#:
+#: Both arms are kept: real logs are the first, and the second is where a file
+#: that is not one at all gets its answer.
+#: A record's contents, with no ``<``: the machine tags each record with one and
+#: leans on payloads never containing it. See `ExportPublishesWholeRecords.ever`.
+PAYLOAD = st.binary(max_size=24).map(lambda row: row.replace(b"\n", b"x").replace(b"<", b"y"))
+
+BODIES = st.one_of(
+    st.builds(
+        lambda rows, tail: joined(rows) + tail,
+        st.lists(RECORD, max_size=6),
+        st.binary(max_size=8).map(lambda row: row.replace(b"\n", b"x")),
+    ),
+    st.binary(max_size=80),
+)
+
+
+class Tempfiles:
+    """A directory of scratch log files, torn down with the test."""
+
+    def setUp(self) -> None:
+        box = tempfile.TemporaryDirectory(prefix="woswoar-export-prop-")
+        self.addCleanup(box.cleanup)  # type: ignore[attr-defined]
+        self.box = Path(box.name)
+        self.made = 0
+
+    def written(self, body: bytes) -> Path:
+        """A file holding ``body``.
+
+        A new name each time: Hypothesis reuses one fixture across every example
+        of a method, and a reused path would leave the previous example's bytes
+        behind whenever this one is shorter.
+        """
+        self.made += 1
+        path = self.box / f"log{self.made}"
+        path.write_bytes(body)
+        return path
+
+
+class TestReadingTheTail(Tempfiles, unittest.TestCase):
+    @given(BODIES, st.integers(0, 220))
+    def test_it_returns_whole_lines_or_nothing(self, body: bytes, offset: int) -> None:
+        """The single claim `export` rests on. Whatever is returned is sealed
+        into a chunk, and a chunk not ending on a record boundary is a record
+        published in halves.
+        """
+        path = self.written(body)
+        data, _ = store.read_tail(path, offset)
+        self.assertTrue(data == b"" or data.endswith(b"\n"))
+
+    @given(BODIES, st.integers(0, 220))
+    def test_the_new_watermark_is_where_the_data_ended(self, body: bytes, offset: int) -> None:
+        """The offset is saved and the data is committed; if they disagree the
+        next export either repeats bytes or skips them, and skipping loses a
+        command with nothing to notice."""
+        path = self.written(body)
+        data, mark = store.read_tail(path, offset)
+        self.assertEqual(mark, offset + len(data))
+
+    @given(BODIES, st.integers(0, 220))
+    def test_reading_past_the_end_consumes_nothing(self, body: bytes, offset: int) -> None:
+        """`export` leans on this: it stats first and skips the call when the
+        file cannot have grown, which is only sound if the call it skipped
+        would have been a no-op."""
+        path = self.written(body)
+        if offset < len(body):
+            return
+        self.assertEqual(store.read_tail(path, offset), (b"", offset))
+
+    @given(st.lists(RECORD, max_size=8))
+    def test_successive_reads_tile_the_file(self, records: list[bytes]) -> None:
+        """No byte read twice, none skipped. Reading to exhaustion from zero has
+        to reproduce the file's complete-line prefix exactly."""
+        body = joined(records)
+        path = self.written(body)
+        seen, mark = b"", 0
+        # Bounded, not ``while True``: a `read_tail` that ignored the watermark
+        # would return the whole file for ever, and an unbounded loop turns that
+        # into a hung test rather than a failing one. It did -- the mutation run
+        # for this file reported TIMEOUT on exactly that edit, which says
+        # nothing about whether the property noticed.
+        for _ in range(len(records) + 2):
+            data, mark = store.read_tail(path, mark)
+            if not data:
+                break
+            seen += data
+        else:
+            self.fail("read_tail never reached the end of the file")
+        self.assertEqual(seen, body)
+        self.assertEqual(mark, len(body))
+
+    @given(st.lists(RECORD, min_size=1, max_size=6), RECORD)
+    def test_a_half_written_record_waits(self, records: list[bytes], partial: bytes) -> None:
+        """A shell killed mid-append leaves a line with no newline. Sealing it
+        would publish a fragment, so it is left for the writer to finish."""
+        whole = joined(records)
+        path = self.written(whole + partial)
+        data, mark = store.read_tail(path, 0)
+        self.assertEqual(data, whole)
+        self.assertEqual(mark, len(whole))
+
+
+class TestRewindingAWatermark(Tempfiles, unittest.TestCase):
+    @given(BODIES, st.integers(0, 220))
+    def test_it_never_moves_forward(self, body: bytes, offset: int) -> None:
+        """Rewinding re-publishes, which a peer's dedup absorbs. Advancing
+        skips, which loses a record -- so the direction is not symmetric and
+        this is the half worth pinning."""
+        path = self.written(body)
+        self.assertLessEqual(store.line_start(path, offset), offset)
+
+    @given(BODIES, st.integers(0, 220))
+    def test_it_lands_on_a_boundary(self, body: bytes, offset: int) -> None:
+        """Zero, or immediately after a newline. Anything else is the #263
+        failure with extra steps."""
+        path = self.written(body)
+        mark = store.line_start(path, offset)
+        if mark > 0:
+            self.assertEqual(body[mark - 1 : mark], b"\n")
+
+    @given(BODIES, st.integers(0, 220))
+    def test_it_rewinds_to_the_nearest_boundary(self, body: bytes, offset: int) -> None:
+        """Not merely *a* boundary -- the closest one at or before the mark.
+
+        Rewinding further is still safe, which is why "lands on a boundary"
+        cannot see the difference: it re-publishes records that were already
+        sealed, and the peer's dedup absorbs them. It is a cost rather than a
+        bug, and the cost is paid in a chunk committed to an append-only
+        repository, so it is worth pinning exactly.
+
+        Exact only because these bodies are far shorter than `_LINE_WINDOW`; a
+        log with no newline in the last 64 KiB is defined to start over, and
+        this format cannot produce one.
+        """
+        path = self.written(body)
+        if offset <= 0:
+            return
+        self.assertEqual(store.line_start(path, offset), body.rfind(b"\n", 0, offset) + 1)
+
+    @given(BODIES, st.integers(0, 220))
+    def test_it_is_idempotent(self, body: bytes, offset: int) -> None:
+        """`export` calls it on every grown file on a one-minute timer, so a
+        watermark it already rewound must be left alone."""
+        path = self.written(body)
+        once = store.line_start(path, offset)
+        self.assertEqual(store.line_start(path, once), once)
+
+    @given(st.lists(RECORD, max_size=8))
+    def test_a_watermark_already_on_a_boundary_does_not_move(self, records: list[bytes]) -> None:
+        """The case that always happens, and the one the single-byte read
+        exists for: an ordinary sync must not pay to rediscover a boundary."""
+        body = joined(records)
+        path = self.written(body)
+        mark = 0
+        for line in records:
+            self.assertEqual(store.line_start(path, mark), mark)
+            mark += len(line) + 1
+
+
+class ExportPublishesWholeRecords(RuleBasedStateMachine):
+    """A log being appended to, forgotten from, and exported, in any order.
+
+    The machine models the three things that touch a log file and the one thing
+    that reads it, including the interleaving #263 is about: `forget` shortens
+    the file, the watermark is *not* updated -- the crash -- and the next
+    `export` runs against a mark that is now past the middle of a record.
+
+    Two claims, and only the second is absolute. A record may be published more
+    than once, because rewinding re-publishes and that is the direction chosen
+    to be wrong in. A record may never be published in pieces.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        box = tempfile.TemporaryDirectory(prefix="woswoar-export-machine-")
+        self.box = box
+        self.path = Path(box.name) / "log"
+        self.path.write_bytes(b"")
+        self.mark = 0
+        #: Every record the file has ever held, by its exact bytes. A fragment
+        #: is a byte string that is not one of these, which is how the invariant
+        #: recognises a half-published record without knowing where it was cut.
+        #:
+        #: That only works because a record's *tail* can never be another
+        #: record -- see `append` for the tag that guarantees it. Without one,
+        #: `b"\x00"` and `b"\x00\x00"` are both records Hypothesis will
+        #: generate, the second cut in half is the first, and the invariant
+        #: passes on a published fragment. That is a fixture that cannot tell
+        #: the two answers apart, which CLAUDE.md rule 3 says to suspect before
+        #: the code.
+        self.ever: set[bytes] = set()
+        self.made = 0
+        self.live: list[bytes] = []
+        #: Bytes on disk with no newline after them yet. Whatever is appended
+        #: next joins them into a single line, because that is what the file
+        #: physically holds -- see `append`.
+        self.pending = b""
+        self.published: list[bytes] = []
+
+    def teardown(self) -> None:
+        self.box.cleanup()
+
+    @rule(payloads=st.lists(PAYLOAD, min_size=1, max_size=3))
+    def append(self, payloads: list[bytes]) -> None:
+        # Each record is tagged with a number no other record carries, and no
+        # payload may contain the ``<`` that opens a tag. A proper suffix of a
+        # record therefore holds no tag but the one it was cut out of, so it can
+        # equal no other record -- which is what lets the invariant below say
+        # "not a record" and mean "a fragment".
+        records = []
+        for payload in payloads:
+            self.made += 1
+            records.append(b"<%d>%s" % (self.made, payload))
+        # The subtlety this machine got wrong first. A shell killed before its
+        # newline leaves bytes that the *next* append runs straight into, so the
+        # file holds one line made of both -- and exporting that whole line is
+        # correct, not a published fragment. woswoar's answer to the resulting
+        # torn record is `parse_line` returning None for it, one layer up.
+        rows = [self.pending + records[0], *records[1:]]
+        self.pending = b""
+        self.ever.update(rows)
+        self.live.extend(rows)
+        with self.path.open("ab") as out:
+            out.write(joined(records))
+
+    @rule(tail=PAYLOAD)
+    def half_write(self, tail: bytes) -> None:
+        """A shell killed between the write and its newline."""
+        # Tagless too, so a torn tail cannot forge a record boundary.
+        if not tail:
+            return
+        self.pending += tail
+        with self.path.open("ab") as out:
+            out.write(tail)
+
+    @rule(which=st.integers(0, 20))
+    def forget(self, which: int) -> None:
+        """Shorten the log without touching the watermark -- the crash in #263.
+
+        Whole records only, because that is what `forget.surviving` writes; the
+        damage is entirely in the watermark left behind.
+        """
+        if not self.live:
+            return
+        del self.live[which % len(self.live)]
+        # The rewrite emits whole records, so any torn tail goes with it.
+        self.pending = b""
+        self.path.write_bytes(joined(self.live))
+
+    @rule()
+    def export(self) -> None:
+        mark = store.line_start(self.path, self.mark)
+        data, self.mark = store.read_tail(self.path, mark)
+        if data:
+            self.published.extend(data.split(b"\n")[:-1])
+
+    @invariant()
+    def nothing_is_published_in_halves(self) -> None:
+        for row in self.published:
+            # A machine is not a TestCase, so this is a bare assert: `assertIn`
+            # would be an AttributeError reported as the property failing.
+            assert row in self.ever, f"a fragment reached a chunk: {row!r}"
+
+    @invariant()
+    def the_watermark_never_names_a_partial_record(self) -> None:
+        body = self.path.read_bytes()
+        mark = store.line_start(self.path, self.mark)
+        assert mark == 0 or body[mark - 1 : mark] == b"\n", "watermark inside a record"
+
+
+ExportPublishesWholeRecords.TestCase.settings = settings(
+    max_examples=200, stateful_step_count=20, deadline=None
+)
+TestExportPublishesWholeRecords = ExportPublishesWholeRecords.TestCase
+# `run_tests` loads a class by ``f"{__module__}.{__qualname__}"``, and Hypothesis
+# builds this one inside `hypothesis.stateful` -- so without these it looks for
+# it there and cannot find it.
+TestExportPublishesWholeRecords.__name__ = "TestExportPublishesWholeRecords"
+TestExportPublishesWholeRecords.__qualname__ = "TestExportPublishesWholeRecords"
+TestExportPublishesWholeRecords.__module__ = __name__
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_forget_properties.py
+++ b/tests/test_forget_properties.py
@@ -1,0 +1,311 @@
+"""What `forget` promises, as properties rather than as examples.
+
+`forget` is the one command that takes something *out* of `logs/`, and history
+is append-only: a chunk keeps a forgotten row for ever, so the only place it can
+be stopped is on its way back out, every time a peer's chunk is merged. That
+makes `surviving` a filter that runs on every line of every chunk, for the life
+of the installation, and gives it the shape a property test is for -- a small
+pure function whose failure is a command reappearing, or a command that was
+never forgotten disappearing.
+
+The second is the one worth the effort. A row that comes back is visible and can
+be forgotten again; a row that vanishes for nobody's reason is the failure the
+`digest` docstring calls "a line that vanishes from somebody's history for no
+reason they could ever find".
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from tests.test_record_properties import ENTRIES
+from woswoar import entry, forget, store
+
+settings.load_profile("woswoar")  # registered beside `ENTRIES`, which this imports.
+
+#: Lines as they sit in a log. Bytes rather than text, because that is what
+#: `surviving` is handed -- a decrypted chunk straight off a peer -- and because
+#: the module hashes with ``surrogateescape`` precisely so that a row no strict
+#: decoder would accept still gets a name. A strategy built on `st.text` and
+#: encoded strictly would refuse to generate exactly those rows.
+LINE = st.binary(max_size=24).map(lambda row: row.replace(b"\n", b"x"))
+
+#: A digest no generated row can carry. ``b"absent"`` was the first spelling
+#: and it is wrong: `LINE` is unrestricted binary, so it *can* produce those six
+#: bytes, and a property asserting "nothing here is suppressed" would then fail
+#: for a reason that has nothing to do with the code -- rarely, and only for
+#: whoever happened to run it. A newline cannot appear in a row, because it is
+#: what separates them.
+NO_ROW = forget._of(b"\n")
+
+#: A chunk's plaintext, with and without the trailing newline -- the shape
+#: `surviving`'s docstring promises to preserve.
+BLOCKS = st.builds(
+    lambda lines, final: b"\n".join(lines) + (b"\n" if final and lines else b""),
+    st.lists(LINE, max_size=8),
+    st.booleans(),
+)
+
+
+def lines_of(block: bytes) -> list[bytes]:
+    """The rows of a block, without their separators.
+
+    Not `bytes.splitlines`, which also splits on ``\r`` and on the Unicode
+    separators -- `surviving` splits on ``\n`` alone, and a helper that
+    disagreed with it would turn one row into two and read as a bug in the
+    function under test.
+    """
+    if not block:
+        return []
+    return block.split(b"\n")[:-1] if block.endswith(b"\n") else block.split(b"\n")
+
+
+def sandbox(case: unittest.TestCase) -> None:
+    """A fresh `WOSWOAR_HOME` for one test method.
+
+    `setUp` runs once per test *method*, not once per example, so without
+    `fresh` below the digest file accumulates across a method's examples and
+    whatever an earlier example forgot stays forgotten. That is not a
+    theoretical tidiness: it failed "drops the forgotten and only those" on the
+    second run, because an all-default `Entry` is a shape Hypothesis generates
+    often and one example had already forgotten the line another one expected
+    to keep.
+    """
+    box = tempfile.TemporaryDirectory(prefix="woswoar-forget-prop-")
+    case.addCleanup(box.cleanup)
+    root = Path(box.name).resolve()
+    (root / "home").mkdir()
+    patched = mock.patch.dict(os.environ, store.sandbox_environ(root, root / "home"), clear=True)
+    patched.start()
+    case.addCleanup(patched.stop)
+
+
+def fresh() -> None:
+    """Start an example with nothing forgotten.
+
+    Called first in every property that touches the file, so each example is
+    independent and its assertions can be exact. Unlinking rather than a new
+    `TemporaryDirectory` per example: `store.sandbox_environ` is read by every
+    caller through the environment, and re-patching it mid-method would race the
+    ``addCleanup`` stack rather than nest inside it.
+    """
+    store.forgotten_file().unlink(missing_ok=True)
+
+
+class TestSurvivingAChunk(unittest.TestCase):
+    @given(BLOCKS)
+    def test_suppressing_nothing_changes_nothing(self, block: bytes) -> None:
+        """And the docstring claims more than equality: the argument itself
+        comes back, so a machine that never ran `forget` pays one truth test
+        per chunk rather than a copy of it."""
+        self.assertIs(forget.surviving(block, frozenset()), block)
+
+    @given(BLOCKS)
+    def test_a_chunk_holding_none_of_them_comes_back_untouched(self, block: bytes) -> None:
+        """The second half of the same claim, and the half an equality
+        assertion cannot see. The docstring gives the identity return two
+        reasons, and this is the one that applies to a machine that *has* run
+        `forget`: almost every chunk it merges holds none of what it forgot, and
+        rebuilding one that lost nothing measured 4.4 ms and a second copy of a
+        4 MB block. ``assertEqual`` passes against a rebuild; only ``assertIs``
+        says the copy was not made.
+        """
+        self.assertIs(forget.surviving(block, {NO_ROW}), block)
+
+    @given(BLOCKS)
+    def test_forgetting_every_line_leaves_nothing(self, block: bytes) -> None:
+        every = {forget._of(line) for line in lines_of(block)}
+        self.assertEqual(forget.surviving(block, every), b"")
+
+    @given(BLOCKS)
+    def test_a_line_nobody_forgot_survives(self, block: bytes) -> None:
+        """The failure that cannot be undone. A row that comes back can be
+        forgotten again; a row that vanishes for no reason is gone from a
+        history whose owner has no way to find out why."""
+        rows = lines_of(block)
+        if not rows:
+            return
+        doomed = forget._of(rows[0])
+        kept = lines_of(forget.surviving(block, {doomed}))
+        for row in rows[1:]:
+            if forget._of(row) != doomed:
+                self.assertIn(row, kept)
+
+    @given(BLOCKS)
+    def test_it_invents_nothing(self, block: bytes) -> None:
+        """Every surviving row was an input row. A filter that can rewrite a
+        line is a filter that can put a command in somebody's history."""
+        rows = set(lines_of(block))
+        survivors = lines_of(forget.surviving(block, {NO_ROW}))
+        for row in survivors:
+            self.assertIn(row, rows)
+
+    @given(BLOCKS)
+    def test_it_keeps_the_order(self, block: bytes) -> None:
+        rows = lines_of(block)
+        if not rows:
+            return
+        doomed = {forget._of(rows[0])}
+        expected = [row for row in rows if forget._of(row) not in doomed]
+        self.assertEqual(lines_of(forget.surviving(block, doomed)), expected)
+
+    @given(BLOCKS)
+    def test_it_is_idempotent(self, block: bytes) -> None:
+        rows = lines_of(block)
+        doomed = {forget._of(rows[0])} if rows else {NO_ROW}
+        once = forget.surviving(block, doomed)
+        self.assertEqual(forget.surviving(once, doomed), once)
+
+    @given(BLOCKS)
+    def test_the_last_line_gets_no_newline_it_did_not_have(self, block: bytes) -> None:
+        """The docstring's third claim, and only as far as it goes: it is about
+        the *final* row. Stated any wider it is false for an honest reason --
+        drop the last row of ``b"a\\nb"`` and what is left is ``b"a\\n"``, which
+        ends in a newline because that newline was always ``a``'s. Nothing in
+        the bytes says whether a trailing newline terminates the last row or
+        merely separates it from a row that is no longer there.
+        """
+        rows = lines_of(block)
+        if not rows or block.endswith(b"\n"):
+            return
+        # Suppress something that is *not* the last row, so the last row is
+        # what decides the ending. A fixture where every row is forgotten
+        # cannot tell an invented newline from an absent one.
+        doomed = {forget._of(rows[0])}
+        if forget._of(rows[-1]) in doomed:
+            return
+        out = forget.surviving(block, doomed)
+        self.assertFalse(out.endswith(b"\n"), "a trailing newline was invented")
+
+    @given(BLOCKS, st.integers(0, 7))
+    def test_it_is_the_surviving_rows_and_nothing_else(self, block: bytes, which: int) -> None:
+        """The whole contract in one line, which the four properties above are
+        each a readable corner of: the result is the surviving rows, in order,
+        carrying exactly the bytes they carried in the input. Written on its own
+        it would pass while saying nothing about *which* rows survive; written
+        alongside them it pins the bytes.
+        """
+        rows = lines_of(block)
+        if not rows:
+            return
+        doomed = {forget._of(rows[which % len(rows)])}
+        last = len(rows) - 1
+        expected = b"".join(
+            row + (b"" if index == last and not block.endswith(b"\n") else b"\n")
+            for index, row in enumerate(rows)
+            if forget._of(row) not in doomed
+        )
+        self.assertEqual(forget.surviving(block, doomed), expected)
+
+
+class TestTheDigestFile(unittest.TestCase):
+    """`remember` and `load_digests` against a real file, since that is the pair
+    that has to survive a restart."""
+
+    def setUp(self) -> None:
+        sandbox(self)
+
+    @given(st.lists(st.text(max_size=20), max_size=6))
+    def test_what_was_remembered_comes_back(self, texts: list[str]) -> None:
+        fresh()
+        names = [forget.digest(text) for text in texts]
+        forget.remember(names)
+        self.assertEqual(forget.load_digests(), set(names))
+
+    @given(st.lists(st.text(max_size=20), min_size=1, max_size=6))
+    def test_remembering_twice_is_remembering_once(self, texts: list[str]) -> None:
+        """`remember` reads back before appending, so a repeated `forget` must
+        not grow the file with names it already holds."""
+        fresh()
+        names = [forget.digest(text) for text in texts]
+        forget.remember(names)
+        self.assertEqual(
+            # Append-only, so a duplicate is not cosmetic: it is a line this
+            # file carries for the life of the installation, and `remember`
+            # deduplicates within its own argument as well as against the file.
+            len(store.forgotten_file().read_text(encoding="utf-8").split()),
+            len(set(names)),
+        )
+        first = store.forgotten_file().read_text(encoding="utf-8")
+        forget.remember(names)
+        self.assertEqual(store.forgotten_file().read_text(encoding="utf-8"), first)
+
+    @given(st.lists(st.text(max_size=20), min_size=1, max_size=4))
+    def test_a_malformed_line_costs_only_itself(self, texts: list[str]) -> None:
+        """Skipping is deliberate: one row coming back on a re-merge is
+        visible and fixable, where raising stops `sync` on every machine that
+        ever ran this command."""
+        fresh()
+        names = [forget.digest(text) for text in texts]
+        forget.remember(names)
+        with store.private_append(store.forgotten_file()) as out:
+            out.write("not-a-digest\n\n  \n")
+        # Exact, not ``<=``: a subset assertion passes just as happily when
+        # `load_digests` has *also* loaded the malformed line, which is half of
+        # what this claims. It was written that way first and a mutation that
+        # dropped the `_DIGEST` guard survived it.
+        self.assertEqual(forget.load_digests(), set(names))
+
+
+class TestKeepingEntries(unittest.TestCase):
+    """`keep` is the other door. `surviving` stops a forgotten row arriving from
+    a peer; `keep` stops one arriving from a re-import of the same machine's own
+    shell history, which is the case its docstring is about -- once `forget` has
+    removed the row, `store.existing_keys` no longer recognises it as present.
+    """
+
+    def setUp(self) -> None:
+        sandbox(self)
+
+    @given(st.lists(ENTRIES, max_size=6))
+    def test_forgetting_nothing_keeps_everything(self, entries: list[entry.Entry]) -> None:
+        fresh()
+        self.assertIs(forget.keep(entries), entries)
+
+    @given(st.lists(ENTRIES, min_size=1, max_size=6), st.integers(0, 5))
+    def test_it_drops_the_forgotten_and_only_those(
+        self, entries: list[entry.Entry], which: int
+    ) -> None:
+        fresh()
+        doomed = entry.format_line(entries[which % len(entries)])
+        forget.remember([forget.digest(doomed)])
+        expected = [item for item in entries if entry.format_line(item) != doomed]
+        self.assertEqual(forget.keep(entries), expected)
+
+    @given(st.lists(ENTRIES, min_size=1, max_size=6))
+    def test_it_is_idempotent(self, entries: list[entry.Entry]) -> None:
+        fresh()
+        forget.remember([forget.digest(entry.format_line(entries[0]))])
+        once = forget.keep(entries)
+        self.assertEqual(forget.keep(once), once)
+
+    @given(ENTRIES)
+    def test_a_forgotten_command_does_not_come_back_through_a_re_import(
+        self, item: entry.Entry
+    ) -> None:
+        """The headline claim, and the one that spans two modules. A digest
+        names a *stored line*, so the row only stays forgotten while the record
+        round trip is exact. #309 found a `session` field that came back
+        unescaped: under that bug this entry re-imports to a line with a
+        different digest, and a command the user deleted reappears -- which is
+        the failure `forget` exists to prevent and no test inside `entry` would
+        have called by that name.
+        """
+        fresh()
+        forget.remember([forget.digest(entry.format_line(item))])
+        # The host is the directory the file sits in, not a field of the line.
+        again = entry.parse_line(entry.format_line(item), item.host)
+        self.assertIsNotNone(again)
+        assert again is not None
+        self.assertEqual(forget.keep([again]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`forget` is the only thing that takes a row out of `logs/`; the export watermark is the only thing that decides which bytes leave it. Both were covered by examples. Neither had been asked the question its design is an answer to.

Two new files, 27 properties, no production code changed.

## `tests/test_forget_properties.py` — 16 properties

Over `surviving`, `keep`, `remember` and `load_digests`. The ones worth naming:

- **A line nobody forgot survives.** The asymmetric failure: a row that comes back can be forgotten again, a row that vanishes is gone from a history whose owner has no way to find out why.
- **`surviving` returns its argument, not a copy** — twice, because the docstring gives that fast path two reasons and only one of them is the empty-suppressed case. The other (a chunk holding none of what this machine forgot) is the one an `assertEqual` cannot see, and I only wrote it after predicting the mutation that would survive without it.
- **A forgotten command does not come back through a re-import.** This spans two modules: a digest names a *stored line*, so the row stays forgotten only while the record round trip is exact. Under the `session` bug #309 fixed, this property fails.

## `tests/test_export_properties.py` — 11 properties

Over `read_tail` and `line_start`, plus `ExportPublishesWholeRecords`, a state machine that appends, half-writes (a shell killed before its newline), forgets *without saving the watermark* — the #263 crash — and exports, in any interleaving. It asserts the absolute claim: no record is ever published in halves.

`line_start` rewinding to the **nearest** boundary is pinned exactly, not just "a boundary". Rewinding further is safe — it re-publishes what the peer's dedup absorbs — so no boundary-only assertion can see the difference, and the cost is paid in a chunk committed to an append-only repo.

## Rule 3

Two hand tables rather than `--base main`: the diff is test files, so generated mutants would edit assertions, and a mutated assertion failing its own test says nothing. 20 rows against `woswoar/forget.py` and `woswoar/store.py`, verbatim:

```
  SURVIVED  surviving rebuilds a chunk it had nothing to drop from
  caught    surviving copies rather than returning the argument
  caught    a row is hashed with its newline
  caught    a surviving row loses its newline
  caught    a block that starts with a newline is read as one row
  caught    keep copies the list it had nothing to drop from
  caught    keep drops what it should keep
  caught    remember appends a name the file already holds
  caught    remember writes a repeated name twice
  caught    load_digests trusts a malformed line
```
```
  caught    read_tail cuts at the first newline rather than the last
  caught    read_tail drops the newline it cut at
  caught    read_tail publishes a half-written final record
  caught    read_tail ignores the watermark and reads from the start
  caught    read_tail reports a watermark one byte short
  caught    line_start lands one byte before the boundary
  caught    line_start keeps a mark it found no newline before
  caught    line_start rewinds to the first boundary in the window
  caught    line_start trusts a watermark that is not on a boundary
```

**The survivor is equivalent, and this is the argument.** The row replaces `if not suppressed: return plaintext` with `if False:`. The loop then runs over an empty `suppressed`, finds nothing to drop, leaves `dropped` false, and the closing ternary returns `plaintext` — *the same object*. Output-identical; the fast path is a cost optimisation and nothing else. The mutation surviving a file containing two `assertIs` properties is itself the evidence: had the bytes or the identity changed, they would have failed.

## Three fixtures that were too weak, and what they cost

Rule 3 says suspect the fixture before the mutation. All three of these passed while proving nothing, and each is now a comment where the strategy is defined:

1. **`load_digests` trusting a malformed line survived.** The assertion was `set(names) <= load_digests()`, which is just as happy when the malformed line was *also* loaded — half of what the test claimed. Now exact.
2. **`line_start` rewinding to the first boundary instead of the last survived** against `st.binary`. Not because the property was wrong but because a newline is one byte in 256, so almost no generated body had two boundaries to tell apart. The bodies now look like logs.
3. **The state machine's "not a record, therefore a fragment" could not tell the two apart.** `b"\x00"` and `b"\x00\x00"` are both records Hypothesis generates; the second cut in half is the first, and the invariant passes on a published fragment. Records now carry a tag no payload can contain.

Also fixed in review: a sentinel digest of `b"absent"`, which `LINE` can generate — a rare failure for whoever happened to run it. It is now the digest of `b"\n"`, which no row can contain because it is what separates them.

## One defect found, filed rather than fixed here: #310

The machine asserts no record is published in *halves*. The question it raised is the one it does not assert — whether every record is published *at all*. It is not.

A crash between `forget.apply`'s rewrite and `state.save` leaves the watermark above the shortened log. `line_start` fixes the half where the mark points inside a record. It does not fix the half where the mark is above the file's end: `export`'s stat guard skips the file while it is short, and once the user's new commands grow it back past the stale mark, everything in between is never read — and the watermark then advances past it.

```
published b'aaaa\nbbbb\ncccc\n', watermark 15
after the crash: file is 10 bytes, watermark still 15
next export publishes b'eeee\nffff\n', watermark 25
file now holds        b'aaaa\ncccc\ndddd\neeee\nffff\n'
never published, and never will be: [b'dddd']
```

Not fixed here because it is a second subject (rule 9), and because the obvious fix has a constraint worth checking first — `export` would be writing to `state.exported` on a path that produces nothing to commit, so it depends on whether `sync` saves state after an empty export. That is written up in #310 along with the reproduction. It is the export-side twin of #294 and the unfixed half of #263; P2 rather than #294's P1 because the trigger needs a crash in a narrow window rather than an ordinary `SAVEHIST` trim.

## Review (rule 1)

Bottom row: no production code changes, no stored data, no security claim. I re-read the diff myself rather than running agents; the sentinel bug and the dead `max(offset, 0)` came out of that pass, as did the third weak fixture above.

## Preflight

`ruff check`, `ruff format --check`, `mypy` (77 files) and `python -m tools.run_tests` → `OK (0 failures, 0 errors, 72 skipped)`.

`shellcheck` reports SC2120/SC2119 on `woswoar/shell/woswoar.bash` locally — that file is byte-identical to `main` on this branch, and local shellcheck is 0.9.0 against CI's pip-pinned version. Not this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_