### PR TITLE
fix: a credential flag is recognised before a shell metacharacter (#312)

### DIFF
--- a/tests/test_credential_properties.py
+++ b/tests/test_credential_properties.py
@@ -35,22 +35,7 @@ from woswoar import credentials
 settings.register_profile("woswoar-credentials", max_examples=400, deadline=None)
 settings.load_profile("woswoar-credentials")
 
-#: The one shape whose match does not survive a metacharacter, and the reason
-#: is #312: the option rule's boundary is ``(?:[=\s]|$)``, so a *bare* flag
-#: ending a word before ``;`` or ``|`` falls out of the rule.
-#:
-#: Pinned rather than quietly excluded, and pinned as a live assertion below
-#: rather than as a comment. `tests/credential_shapes.py` already argues why:
-#: an unbacked claim in a security document is worse than a known gap, because
-#: a later change falsifies it with CI green and nobody looks. The same holds
-#: for a property with an unexplained hole in it.
-ESCAPES_A_TRAILING_METACHARACTER = "gh auth login --with-token"
-
-#: Everything the embedding properties are allowed to assert about. When #312
-#: is fixed this list becomes `SECRET_SHAPES` again and the pin below goes red.
-EMBEDDABLE = [s for s in SECRET_SHAPES if s != ESCAPES_A_TRAILING_METACHARACTER]
-
-SECRET = st.sampled_from(EMBEDDABLE)
+SECRET = st.sampled_from(SECRET_SHAPES)
 INNOCENT = st.sampled_from(INNOCENT_SHAPES)
 
 #: What can stand before a command on one shell line. Every one of these ends in
@@ -119,34 +104,29 @@ class TestASecretStaysRecognised(unittest.TestCase):
         self.assertTrue(credentials.looks_like_credential(f"{innocent}; {secret}"))
         self.assertTrue(credentials.looks_like_credential(f"{secret}; {innocent}"))
 
+    @given(SECRET, st.sampled_from([";", "|tee log", "&", "(", ")", "<f", ">out", "&&x"]))
+    def test_a_bare_flag_before_a_shell_metacharacter_is_still_caught(
+        self, secret: str, tail: str
+    ) -> None:
+        """#312. The rule's boundary once admitted only `=`, whitespace or end
+        of string, so a bare credential flag was recognised when it ended the
+        line and not when a `;` followed it -- and a one-liner is one history
+        entry.
+
+        Written as its own property rather than left to the embedding one
+        above, because that one separates its contexts with a space: a space
+        satisfies the old boundary too, so it could never have found this.
+        """
+        self.assertTrue(
+            credentials.looks_like_credential(secret + tail),
+            f"a metacharacter hid a known shape: {secret + tail!r}",
+        )
+
     @given(SECRET, st.text(alphabet=" \t", max_size=4))
     def test_leading_whitespace_does_not_hide_it(self, secret: str, pad: str) -> None:
         """`HIST_IGNORE_SPACE` means a space-prefixed command is a shape users
         type on purpose, so the filter meets it often."""
         self.assertTrue(credentials.looks_like_credential(pad + secret))
-
-
-class TestTheKnownGap(unittest.TestCase):
-    """#312, held open so that closing it is noticed.
-
-    This asserts the bug, which is the only way a pin is worth having: fix the
-    boundary and this test fails, and whoever fixed it deletes this class and
-    puts the shape back in `EMBEDDABLE`. A comment saying "known gap" would
-    still be sitting here in a year.
-    """
-
-    def test_the_shape_is_dropped_when_it_ends_the_line(self) -> None:
-        """Guard the guard. If this ever stops being a recognised shape, the
-        pin below would pass for the wrong reason -- the rule not matching it
-        at all rather than the boundary being narrow."""
-        self.assertTrue(credentials.looks_like_credential(ESCAPES_A_TRAILING_METACHARACTER))
-
-    @given(st.sampled_from([";", "|tee log", "&", ")", '"', "'", ">out", "&&x", "\\"]))
-    def test_and_is_not_when_a_metacharacter_follows(self, tail: str) -> None:
-        self.assertFalse(
-            credentials.looks_like_credential(ESCAPES_A_TRAILING_METACHARACTER + tail),
-            "#312 looks fixed -- delete this class and restore the shape to EMBEDDABLE",
-        )
 
 
 class TestAnOrdinaryCommandStaysOrdinary(unittest.TestCase):

--- a/woswoar/credentials.py
+++ b/woswoar/credentials.py
@@ -44,9 +44,27 @@ _SHARED = (
     # after `_`, or MONKEY=, KEYS= and PASSAGE= would all be dropped.
     r"(?:TOKEN|SECRET|PASSW|CREDENTIAL|APIKEY|_KEY|_PASS|_AUTH)[A-Za-z0-9_]*=",
     # A long option that names one. The trailing boundary is what keeps
-    # `--auth-mode` (a real azure flag, not a secret) out of it.
+    # `--auth-mode` (a real azure flag, not a secret) out of it, and the
+    # character doing that work is the `-`: admitting one costs exactly that
+    # command. A letter is a different matter and admitting one would change
+    # almost nothing, because `[a-z-]*` above has already absorbed the letters
+    # before the boundary is consulted -- `--tokenizer` matches today. It stays
+    # out anyway, since the three branches with no `[a-z-]*` of their own
+    # (`api-?key`, `access-?key`, `auth`) are the ones it would loosen.
+    #
+    # It admits the characters that *end a word* in a shell, and #312 is why:
+    # with `[=\s]|$` alone the rule matched `--with-token` only when the flag
+    # ended the line, so `gh auth login --with-token; echo done` went
+    # unrecognised while the same command alone was dropped.
+    #
+    # Word terminators only. `"`, `'` and `\` are excluded deliberately even
+    # though they too can follow the flag: they *continue* the word rather than
+    # end it, so `--password'x'` is the single word `--passwordx` -- an
+    # attached value, which is not a spelling long options accept. Admitting
+    # them would also cost the hook's parity test two more shell-unescaping
+    # rules, since this pattern lives inside a double-quoted default assignment.
     r"--(?:[a-z]+-)*(?:(?:passw|token|secret|credential)[a-z-]*|api-?key|access-?key|auth)"
-    r"(?:[=\s]|$)",
+    r"(?:[=\s;|&()<>]|$)",
     r"--from-literal=",
     # Credentials inside a URL. Two shapes: a `user:pass@` prefix, and a token
     # that *is* a path component -- a webhook URL, where holding the address is

--- a/woswoar/shell/woswoar.bash
+++ b/woswoar/shell/woswoar.bash
@@ -181,7 +181,7 @@ export WOSWOAR_SESSION
 # the pattern's *length*, not how much of it can match. Measured here: 30us for
 # the four-keyword pattern this replaces, 54us for this one, against a 288us ->
 # 324us record path. Weigh anything added against that.
-: "${WOSWOAR_IGNORE=(TOKEN|SECRET|PASSW|CREDENTIAL|APIKEY|_KEY|_PASS|_AUTH)[A-Za-z0-9_]*=|--([a-z]+-)*((passw|token|secret|credential)[a-z-]*|api-?key|access-?key|auth)([=[:space:]]|\$)|--from-literal=|://[^/[:space:]]+:[^/@[:space:]]+@|://(hooks\.slack\.com|discord(app)?\.com/api/webhooks)/[^[:space:]]|[Aa]uthorization:[[:space:]]*[A-Za-z]|(sshpass|htpasswd|openssl passwd)[[:space:]]|curl[^|;&]*[[:space:]]-u[[:space:]]|mysql[a-z]*[^|;&]*[[:space:]]-p[^-[:space:]]|docker login[^|;&]*[[:space:]]-p|ssh-keygen[^|;&]*[[:space:]]-N[[:space:]]}"
+: "${WOSWOAR_IGNORE=(TOKEN|SECRET|PASSW|CREDENTIAL|APIKEY|_KEY|_PASS|_AUTH)[A-Za-z0-9_]*=|--([a-z]+-)*((passw|token|secret|credential)[a-z-]*|api-?key|access-?key|auth)([=[:space:];|&()<>]|\$)|--from-literal=|://[^/[:space:]]+:[^/@[:space:]]+@|://(hooks\.slack\.com|discord(app)?\.com/api/webhooks)/[^[:space:]]|[Aa]uthorization:[[:space:]]*[A-Za-z]|(sshpass|htpasswd|openssl passwd)[[:space:]]|curl[^|;&]*[[:space:]]-u[[:space:]]|mysql[a-z]*[^|;&]*[[:space:]]-p[^-[:space:]]|docker login[^|;&]*[[:space:]]-p|ssh-keygen[^|;&]*[[:space:]]-N[[:space:]]}"
 
 # The webhook alternative above measured +7.4us per command, 58.3us to 65.7us
 # for the test itself against a record path of ~306us. Paid because the URL *is*

--- a/woswoar/shell/woswoar.zsh
+++ b/woswoar/shell/woswoar.zsh
@@ -111,7 +111,7 @@ export WOSWOAR_SESSION
 # reasoning lives; `tests/test_credentials.py`'s `TestParityWithTheHook` holds
 # *every* hook against `credentials._SHARED`, so a rule can never be added to
 # one shell alone -- nor to both shells and not to the importer.
-: "${WOSWOAR_IGNORE=(TOKEN|SECRET|PASSW|CREDENTIAL|APIKEY|_KEY|_PASS|_AUTH)[A-Za-z0-9_]*=|--([a-z]+-)*((passw|token|secret|credential)[a-z-]*|api-?key|access-?key|auth)([=[:space:]]|\$)|--from-literal=|://[^/[:space:]]+:[^/@[:space:]]+@|://(hooks\.slack\.com|discord(app)?\.com/api/webhooks)/[^[:space:]]|[Aa]uthorization:[[:space:]]*[A-Za-z]|(sshpass|htpasswd|openssl passwd)[[:space:]]|curl[^|;&]*[[:space:]]-u[[:space:]]|mysql[a-z]*[^|;&]*[[:space:]]-p[^-[:space:]]|docker login[^|;&]*[[:space:]]-p|ssh-keygen[^|;&]*[[:space:]]-N[[:space:]]}"
+: "${WOSWOAR_IGNORE=(TOKEN|SECRET|PASSW|CREDENTIAL|APIKEY|_KEY|_PASS|_AUTH)[A-Za-z0-9_]*=|--([a-z]+-)*((passw|token|secret|credential)[a-z-]*|api-?key|access-?key|auth)([=[:space:];|&()<>]|\$)|--from-literal=|://[^/[:space:]]+:[^/@[:space:]]+@|://(hooks\.slack\.com|discord(app)?\.com/api/webhooks)/[^[:space:]]|[Aa]uthorization:[[:space:]]*[A-Za-z]|(sshpass|htpasswd|openssl passwd)[[:space:]]|curl[^|;&]*[[:space:]]-u[[:space:]]|mysql[a-z]*[^|;&]*[[:space:]]-p[^-[:space:]]|docker login[^|;&]*[[:space:]]-p|ssh-keygen[^|;&]*[[:space:]]-N[[:space:]]}"
 
 # Appended, not merged into the default above, so that adding one rule of your
 # own does not pin you to today's default forever.


### PR DESCRIPTION
Closes #312. First of three (#312 → #314 → #310).

The long-option rule ended in `(?:[=\s]|$)`, so a bare credential flag was recognised when it ended the line and not when a `;` followed it — and a one-liner is one history entry:

```python
>>> c.looks_like_credential("gh auth login --with-token")
True
>>> c.looks_like_credential("gh auth login --with-token; echo done")   # before
False
```

The boundary now admits the characters that **end a word** in a shell: `[=\s;|&()<>]`.

## Where this diverges from the issue, and why

The issue proposed `[=\s;|&)"'<>\\]`. Two changes, both from checking the premise rather than implementing it (rule 9):

**Dropped `"`, `'` and `\`.** They can follow a flag, but they *continue* the word rather than end it — `--password'x'` is the single word `--passwordx` after quote removal, an attached value that long options do not accept. Admitting them would also cost the hook's parity test two more shell-unescaping rules, because the pattern lives inside a double-quoted `: "${WOSWOAR_IGNORE=…}"` assignment and `hook_pattern` currently un-escapes only `\$`. Real complexity in a test whose whole value is being mechanical, for a shape that is not valid syntax.

**Added `(`.** The issue listed `)` and not `(`, which was arbitrary.

## All three copies move together

`_SHARED`, `woswoar.bash` and `woswoar.zsh`. The hook text was generated from the same `as_posix_ere` translation `TestParityWithTheHook` uses, rather than edited by hand — so the parity test is checking a translation it did not produce, not comparing my typing to itself.

## Rule 3

```
  caught    the boundary is back to what #312 reported
  caught    the boundary admits a '-', so --auth-mode matches again
  caught    the boundary loses the word terminators but keeps a letter out
  caught    the bash hook is left behind on the old boundary
  caught    the zsh hook is left behind on the old boundary
```

The new property is its own test rather than a widening of the existing embedding one, and the reason is in the docstring: the embedding property separates its contexts with a space, and **a space satisfied the old boundary too**, so it could never have found this.

**One row corrected a comment instead of the code.** I first wrote that the boundary "may never admit a letter or a `-`". The letter half is wrong: `[a-z-]*` has already absorbed the letters before the boundary is consulted, so `--tokenizer` matches today and admitting `a-z` produces no new false positive on the corpus. The `-` is the character doing the work — admitting one costs exactly `az storage blob list --auth-mode login`. The comment now says that, and the table row tests the claim that is actually load-bearing.

## Precision, measured

Against the corpus, with the new boundary:

```
false positives on INNOCENT_SHAPES: []
all SECRET_SHAPES still caught bare: True
--auth-mode still ignored: True
DOCUMENTED_GAPS caught: unchanged from before (4, all via the importer's token rules)
```

## Cost to the hook

The hook's own comment asks that anything added be weighed against the per-command budget, so: **below measurement.** Three blocks of 6000 `[[ =~ ]]` evaluations against the same command —

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| before | 93.07 µs | 96.16 µs | 99.11 µs |
| after | 94.51 µs | 93.86 µs | 97.12 µs |

The ranges overlap completely and the new median is *lower*, which is noise, not a speedup. The pattern grew 524 → 531 bytes (1.3%), and cost tracks length, so a small increase is expected and is smaller than this machine can resolve. Absolute numbers are this container, not the 54 µs in the comment.

## Docs

Nothing to change. `docs/shell-integration.md:282` and `docs/security.md:482` describe the rule by example (`--password`, `--token`, `--with-token`), not by boundary, and the change only broadens what is caught — `--password-stdin` at `shell-integration.md:317` still behaves as documented.

## Review (rule 1)

Top row — this changes a security claim. Reviewed by hand rather than with `/simplify` agents, which this session is configured against; the two findings above (the divergence from the proposed fix, and the wrong claim in my own comment) came out of that pass and out of the mutation table.

Residual risk worth naming: the zsh hook's copy is exercised by tests that **skip locally** (`zsh 5.0+ required`), so the bracket expression's behaviour under zsh's `=~` is verified by CI here and not by my preflight.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_