### PR TITLE
fix: a damaged number in the cache rebuilds it rather than raising (#314)

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -174,6 +174,80 @@ class TestCache(WoswoarTestCase):
         self.assertEqual(leftovers, [])
 
 
+class TestADamagedNumberRebuilds(WoswoarTestCase):
+    """#314: `loads` accepts a cache whose numbers are not numbers.
+
+    It does so on purpose -- converting them costs 25 ms of the 39 ms it takes
+    to read a real history's cache -- so the damage surfaces later, in
+    `entries`, outside the `try` in `load` that answers every other kind. The
+    answer for this kind is the same one: throw the cache away and re-parse.
+    """
+
+    def damage_a_timestamp(self, ts: int) -> None:
+        """Change one byte inside a stored timestamp, leaving the separators.
+
+        Not a hand-built `Cache`: this is the shape ordinary corruption takes,
+        because most of a cache row's bytes *are* digits in a numeric field.
+        Fuzzing a real dump at one to three byte positions put 294 of 4000
+        trials in exactly this state.
+        """
+        path = store.cache_file()
+        blob = path.read_bytes()
+        at = blob.index(str(ts).encode("utf-8"))
+        # The *second* digit, so the damage stays inside the number whatever
+        # its length. Writing past the last digit lands on the field separator
+        # instead, which breaks the record structure -- a different failure,
+        # caught by `loads` and already rebuilt by `load`, so a test damaging
+        # that byte passes with or without the fix under test.
+        path.write_bytes(blob[: at + 1] + b"?" + blob[at + 2 :])
+
+    def test_the_entries_come_back_rather_than_a_traceback(self) -> None:
+        self.write_log(MACHINE_ID, "2026-07-29", [line(100, "git status"), line(200, "ls")])
+        self.assertEqual([e.cmd for e in cache.load_entries()], ["git status", "ls"])
+
+        self.damage_a_timestamp(100)
+        # Reads the damaged file, notices in `entries`, re-parses from `logs/`.
+        self.assertEqual([e.cmd for e in cache.load_entries()], ["git status", "ls"])
+
+    def test_the_damaged_file_is_replaced_and_not_merely_bypassed(self) -> None:
+        """Otherwise every later run pays the rebuild again -- and Ctrl-R,
+        which converts nothing and so never notices, would go on displaying the
+        damaged timestamp for as long as that day's log stayed unchanged."""
+        self.write_log(MACHINE_ID, "2026-07-29", [line(100, "git status")])
+        cache.load_entries()
+        self.damage_a_timestamp(100)
+        cache.load_entries()
+
+        restored = cache.loads(store.cache_file().read_bytes())
+        self.assertEqual([e.ts for e in restored.entries()], [100])
+
+    def test_a_cache_that_is_merely_stale_is_still_updated_in_place(self) -> None:
+        """Guard the guard, and it has to be observable rather than merely
+        true. If `load_entries` rebuilt on *every* call the two tests above
+        would still pass -- a rebuilt cache holds the same entries -- so this
+        needs something only the incremental path does.
+
+        That thing is the deferred write. An ordinary load persists nothing
+        until `_SAVE_THRESHOLD` entries have accumulated, while the rebuild
+        saves unconditionally. So after a one-line append the returned entries
+        are current and the file on disk is deliberately still behind, and a
+        rebuild-every-time makes them agree.
+        """
+        path = self.write_log(MACHINE_ID, "2026-07-29", [line(100, "first")])
+        self.assertEqual([e.cmd for e in cache.load_entries()], ["first"])
+
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(line(200, "second") + "\n")
+
+        self.assertEqual([e.cmd for e in cache.load_entries()], ["first", "second"])
+        on_disk = cache.loads(store.cache_file().read_bytes())
+        self.assertEqual(
+            [e.cmd for e in on_disk.entries()],
+            ["first"],
+            "the cache was rewritten for one entry, so this was a rebuild",
+        )
+
+
 class TestNoFormatWeReadCanExecute(unittest.TestCase):
     """docs/security.md claims this of the whole codebase, so assert it there.
 

--- a/tests/test_cache_properties.py
+++ b/tests/test_cache_properties.py
@@ -42,12 +42,6 @@ FILES = st.lists(
 
 SEPARATORS = ("\x00", "\x01", "\x02")
 
-#: One ordinary entry, for the pin below. Fixed rather than generated: it needs
-#: a timestamp whose digits can be found in the dump by `bytes.index`.
-_SAMPLE = Entry(
-    ts=1700000000, host="h", session="s", cwd="/tmp", exit_code=0, duration_ms=5, cmd="echo hi"
-)
-
 
 def built(files: dict[str, tuple[str, list[Entry]]]) -> cache.Cache:
     """A `Cache` holding exactly ``files``, as `refresh` would leave it."""
@@ -164,46 +158,6 @@ class TestDamageBecomesARebuild(unittest.TestCase):
             except self.CAUGHT:
                 continue
             self.whole(loaded)
-
-
-class TestTheKnownGap(unittest.TestCase):
-    """#314, held open so that closing it is noticed.
-
-    `loads` leaves the numeric entry fields as strings and says a bad one
-    "surfaces as a rebuild rather than a traceback, which is what every other
-    kind of damage to this file already does". It does not: `loads` accepts the
-    cache, and the `int()` happens later in `entries()`, outside `load`'s
-    `try`. Fix #314 and this test fails, and whoever fixed it deletes the class.
-    """
-
-    def test_one_byte_of_ordinary_corruption_reaches_it(self) -> None:
-        """The route that matters, and the reason #314 is P2 rather than P3.
-
-        A cache row is a ten-digit timestamp, a session, a cwd, two more
-        numbers and the command -- so a large share of the file's bytes *are*
-        digits in a numeric field, and changing one is the most ordinary thing
-        corruption does. Fuzzing a real dump at one to three byte positions,
-        294 of 4000 trials were accepted by `loads` and then raised in
-        `entries()`. This is one of them, made deterministic.
-        """
-        original = built({"a/1.log": ("h", [_SAMPLE])})
-        blob = cache.dumps(original)
-        stamp = str(_SAMPLE.ts).encode("utf-8")
-        at = blob.index(stamp)
-        damaged = blob[: at + 3] + b"?" + blob[at + 4 :]
-
-        back = cache.loads(damaged)
-        with self.assertRaises(ValueError, msg="#314 looks fixed -- delete this class"):
-            back.entries()
-
-    def test_loads_accepts_a_field_that_is_not_a_number(self) -> None:
-        broken = cache.Cache()
-        broken.meta["a/1.log"] = cache.FileMeta(size=1, mtime_ns=1, offset=1, head=b"", host="h")
-        broken.files["a/1.log"] = ["not-a-number", "s", "/tmp", "0", "5", "echo hi"]
-        back = cache.loads(cache.dumps(broken))
-        self.assertEqual(back.files["a/1.log"][0], "not-a-number")
-        with self.assertRaises(ValueError, msg="#314 looks fixed -- delete this class"):
-            back.entries()
 
 
 if __name__ == "__main__":

--- a/woswoar/cache.py
+++ b/woswoar/cache.py
@@ -386,9 +386,14 @@ def loads(blob: bytes) -> Cache:
     not -- which is Ctrl-R, the reason this file exists.
 
     The numeric fields are left as strings too. They are validated on the way
-    *out*, by whichever accessor converts them; a field that is not a number
-    therefore surfaces as a rebuild rather than a traceback, which is what every
-    other kind of damage to this file already does.
+    *out*, by whichever accessor converts them -- so a field that is not a
+    number is not caught here, and the rebuild that answers it lives in
+    `load_entries` rather than in `load`. This docstring claimed the rebuild
+    outright for a while and there was none: the `int()` happens after
+    `load_columns` has returned, so `stats` and `doctor` ended in a traceback
+    (#314). `stamps_and_commands` still converts nothing, so Ctrl-R displays
+    such a field rather than crashing on it, and keeps doing so until some
+    command that wants whole entries triggers the rebuild.
     """
     chunks = blob.decode("utf-8").split(_FILE)
     if chunks[0] != _MAGIC:
@@ -499,4 +504,28 @@ def load_columns() -> Cache:
 
 def load_entries() -> list[Entry]:
     """Load, incrementally update, persist, and build every `Entry`."""
-    return load_columns().entries()
+    loaded = load_columns()
+    try:
+        return loaded.entries()
+    except ValueError:
+        # Where a damaged numeric field finally surfaces. `loads` leaves those
+        # as strings on purpose -- converting them costs 25 ms of the 39 ms it
+        # takes to read a real history's cache -- so `entries` is the first
+        # thing to look, and that is outside the `try` in `load` which turns
+        # every other kind of damage into a rebuild. Without this the answer
+        # was a traceback out of `stats` and `doctor` (#314).
+        #
+        # Rebuilt rather than repaired, for the reason `dumps` already gives
+        # about skipping a bad row: a warm cache and a cold one must not show
+        # different history.
+        #
+        # Built here rather than by unlinking and calling `load_columns` again:
+        # `save` replaces the file atomically, so the damaged one is gone
+        # either way, and this cannot loop. `refresh` fills these fields
+        # through `parse_line`, which has no way to produce a non-numeric
+        # timestamp, so a second failure would be a real defect and deserves
+        # the traceback this one no longer gets.
+        rebuilt = Cache()
+        refresh(rebuilt)
+        save(rebuilt)
+        return rebuilt.entries()


### PR DESCRIPTION
Closes #314. Second of three (#312 → #314 → #310).

`loads` leaves the numeric fields as strings on purpose — converting them costs 25 ms of the 39 ms it takes to read a real history's cache. So damage there surfaces in `entries()`, after `load_columns` has returned, outside the `try` in `load` that turns every other kind of damage into a rebuild. `__main__.py:1748` catches only `WoswoarError`, so `stats` and `doctor` ended in a traceback — on a file whose entire design is that throwing it away costs nothing, and on `doctor`, which is what a person runs *because* something already seems wrong.

`load_entries` now answers it the way `load` answers the rest: build a fresh `Cache` from `logs/`, save it, return its entries.

## Where this diverges from the issue

The issue proposed unlinking the cache file and calling `load_columns()` again, and warned that the unlink had to come first because `load_columns` may persist what it loaded. Building the fresh `Cache` inline is simpler and strictly better:

- `save` uses `write_atomic`, so the damaged file is replaced either way — no unlink needed, and no dependence on the unlink succeeding.
- It cannot loop. `refresh` fills these fields through `parse_line`, which has no way to produce a non-numeric timestamp, so a second failure would be a real defect and deserves the traceback this one no longer gets. Re-entering `load_columns` would have needed a recursion guard to say the same thing.

Rebuilt rather than repaired — skipping the bad rows would make a warm cache and a cold one show different history, which is the tradeoff `dumps` already considered and rejected at `cache.py:352-360`.

## The second constraint, decided rather than omitted

The issue flagged that `stamps_and_commands` converts nothing, so **Ctrl-R displays a corrupt timestamp rather than crashing on it**, and asked for that to be a decision.

It is: left alone. Validating on the keystroke path costs exactly the 25 ms the format exists to avoid, and a wrong-looking timestamp in the picker is visible and harmless next to a traceback. It is also self-limiting in a way the issue did not note — because the rebuild is *persisted*, the first `stats` or `doctor` run fixes it for every later reader, Ctrl-R included. The `loads` docstring now says all of this, including that it previously claimed a rebuild that did not exist.

## Rule 3

```
  caught    the damaged cache is not caught at all -- #314 restored
  caught    the rebuild is never persisted, so every later run pays for it
  caught    the rebuild does not read the logs, so the history is lost
  caught    every load rebuilds, so the incremental path is dead
```

**Two fixture problems, both found rather than assumed:**

1. My first damage helper wrote past the last digit of the timestamp and hit the **field separator** instead. That is a different failure — one `loads` already catches and `load` already rebuilds — so the test passed with or without the fix under test. It now changes the *second digit*, which stays inside the number whatever its length.

2. The guard-the-guard test ("the incremental path still works") first went through `load()` and `refresh()` directly, so it never exercised `load_entries` and the "every load rebuilds" mutation survived it. There is no way to see the difference in the *entries* — a rebuilt cache holds the same ones. What is observable is the **deferred write**: an ordinary load persists nothing until `_SAVE_THRESHOLD` (2000) entries accumulate, while the rebuild saves unconditionally. So after a one-line append the returned entries are current and the file on disk is deliberately still behind, and a rebuild-every-time makes them agree.

The pin in `tests/test_cache_properties.py` is deleted, as its own docstring instructed.

## Preflight

`ruff check`, `ruff format --check`, `mypy` (80 files), `python -m tools.run_tests` → `OK (0 failures, 0 errors, 72 skipped)`.

## Review (rule 1)

Top row — this changes what happens to a cached fact about the world. Reviewed by hand rather than with `/simplify` agents, which this session is configured against. The two fixture problems above came out of the mutation table; the simplification of the issue's proposed fix came out of reading `save`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_