### PR TITLE
fix: a watermark is not trusted once its file has been rewritten (#310)

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5388,6 +5388,112 @@ class TestWalkingAPeersChunks(SyncTestCase):
         self.assertEqual(used, [], "merge built Chunk objects for an idle sync")
 
 
+class TestAWatermarkThatOutlivedItsFile(SyncTestCase):
+    """#310: a `forget` that rewrote a log and died before saving.
+
+    `forget_rows` rewrites the files first and saves the corrected watermarks
+    second, and says why: the other order leaves a low watermark with the rows
+    still in `logs/`, which re-publishes the very rows somebody asked to be rid
+    of. The cost of that choice is this window -- a mark describing a shape the
+    file no longer has -- and until now the lines written after it were skipped
+    for good, because the mark then advances past them and no later sync looks
+    again.
+    """
+
+    DAY = "2023-11-14"
+
+    def crashed_forget(self, machine: Fake, drop: str) -> None:
+        """Rewrite a log without the rows naming ``drop``, saving no watermark.
+
+        Exactly what `forget.apply` leaves behind when the process dies before
+        `forget_rows` reaches `state.save()`. The rewrite is whole lines, which
+        is all `apply` ever writes.
+        """
+        path = store.log_file(machine.id, self.DAY)
+        kept = [
+            line for line in path.read_text(encoding="utf-8").splitlines(True) if drop not in line
+        ]
+        path.write_text("".join(kept), encoding="utf-8")
+
+    def peer_sees(self, alpha: Fake, beta: Fake) -> set[str]:
+        """What `beta` holds after fetching and merging `alpha`'s day.
+
+        Twice, with `settle` between: the first run is what puts alpha's chunk
+        directory in beta's checkout at all, and `settle` ages it past the racy
+        window that would otherwise make the day unstampable.
+        """
+        with beta.active():
+            sync.run()
+        self.settle(beta, alpha, self.DAY)
+        with beta.active():
+            sync.run()
+            return beta.commands()
+
+    def test_a_sync_that_saw_the_short_file_does_not_lose_what_came_next(self) -> None:
+        """The short-file signal, isolated -- and it took two attempts.
+
+        The first version of this test replaced the forgotten command with a
+        *longer* one and asserted the replacement arrived. It passed with the
+        fix removed, because the loss needs the stale watermark to land exactly
+        on a record boundary of the rewritten file: anywhere else, `line_start`
+        rewinds into the middle of a record and republishes the whole of it. A
+        replacement of the same length is what puts a boundary there.
+
+        So: a sync runs while the file is short -- which is what the one-minute
+        timer does after a crash -- and only then are two commands typed, the
+        first of them the same length as the one `forget` removed. Without the
+        reset the mark now names the boundary between them and the first is
+        skipped for good.
+        """
+        alpha, beta = self.machine("alpha"), self.machine("beta")
+        self.accept_everyone(beta)
+        with alpha.active():
+            alpha.record(self.DAY, 1_700_000_001, "before one")
+            alpha.record(self.DAY, 1_700_000_002, "the secret")
+            sync.run()
+
+            self.crashed_forget(alpha, "the secret")
+            sync.run()
+
+            alpha.record(self.DAY, 1_700_000_003, "the sekret")
+            alpha.record(self.DAY, 1_700_000_004, "and later")
+            sync.run()
+
+        self.assertIn("the sekret", self.peer_sees(alpha, beta))
+
+    def test_a_rewrite_that_kept_the_length_is_caught_too(self) -> None:
+        """The case a size comparison cannot see, and the reason the watermark
+        carries a modification time.
+
+        The replacement command is the same length as the one removed, so the
+        day grows back to exactly the length the watermark records and there is
+        nothing short about the file when the next sync looks at it. Built by
+        construction rather than by padding: a fixture that has to be measured
+        into shape is one that silently stops testing this case the day a field
+        width changes.
+        """
+        alpha, beta = self.machine("alpha"), self.machine("beta")
+        self.accept_everyone(beta)
+        with alpha.active():
+            alpha.record(self.DAY, 1_700_000_001, "before one")
+            alpha.record(self.DAY, 1_700_000_002, "the secret")
+            sync.run()
+            was = store.log_file(alpha.id, self.DAY).stat().st_size
+
+            self.crashed_forget(alpha, "the secret")
+            # Same width of timestamp and same length of command, so the record
+            # is byte-for-byte as long as the one that went.
+            alpha.record(self.DAY, 1_700_000_003, "the sekret")
+            self.assertEqual(
+                store.log_file(alpha.id, self.DAY).stat().st_size,
+                was,
+                "fixture no longer reproduces an equal-length rewrite",
+            )
+            sync.run()
+
+        self.assertIn("the sekret", self.peer_sees(alpha, beta))
+
+
 class TestExportDoesNotReadWhatCannotHaveChanged(SyncTestCase):
     """Issue #80: the early exit is the shape of every idle sync.
 

--- a/woswoar/sync.py
+++ b/woswoar/sync.py
@@ -669,6 +669,21 @@ class State:
 
     #: log relpath -> plaintext bytes already sealed into a chunk.
     exported: dict[str, int] = field(default_factory=dict)
+    #: log relpath -> the file's `st_mtime_ns` when that watermark was taken.
+    #:
+    #: A watermark is a byte count and means nothing once the file it counts
+    #: into has been *rewritten* rather than appended to. Only `forget` rewrites
+    #: a log, and it saves the corrected watermarks itself -- but a crash
+    #: between its rewrite and that save leaves a mark describing a file that no
+    #: longer exists in that shape, and `export` then skips real history for
+    #: good (#310). Comparing what the file says now against what it said when
+    #: the mark was taken is what makes that recoverable, and the stat it needs
+    #: is one `export` already does.
+    #:
+    #: Absent for a log means "not known", which is what every installation
+    #: written before this field looks like: the mark is trusted and the stamp
+    #: recorded, so an upgrade re-exports nothing.
+    stamped: dict[str, int] = field(default_factory=dict)
     #: "<host>/<day>" -> the chunk filenames of that day already merged into
     #: logs/. Pruned to the day's *signed manifest* once every name in it has
     #: been merged, so this shrinks when a peer compacts -- it is a record of
@@ -749,6 +764,7 @@ class State:
         digest = raw.get("published_digest", "")
         signers = raw.get("signers", {})
         merged_at = raw.get("merged_at", {})
+        stamped = raw.get("stamped", {})
         if not isinstance(exported, dict) or not isinstance(merged, dict):
             return cls()
         state = cls(
@@ -762,6 +778,15 @@ class State:
             # Same direction as `merged`'s comment below, for the same reason:
             # repeating work beats dropping history. #285 over #291.
             exported={str(k): int(v) for k, v in exported.items() if isinstance(v, int)},
+            # Per value like `exported` above. Dropping one stamp costs a
+            # single log its rewrite detection until the next export records a
+            # fresh one -- the same "repeat work rather than drop history"
+            # direction, and cheaper here, since a missing stamp means trust.
+            stamped=(
+                {str(k): int(v) for k, v in stamped.items() if isinstance(v, int)}
+                if isinstance(stamped, dict)
+                else {}
+            ),
             # Guarded per value, not just on `merged` being a dict. A value
             # that is a bare *string* rather than a list is iterable, so without
             # this every day's record turns into its own characters, every chunk
@@ -807,6 +832,7 @@ class State:
         """
         return {
             "exported": dict(self.exported),
+            "stamped": dict(self.stamped),
             "merged": {key: sorted(names) for key, names in self.merged.items()},
             "granted": list(self.granted),
             "granted_complete": self.granted_complete,
@@ -1532,6 +1558,11 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
     # that turned a no-op sync from 0.04 s into nearly 3 s and grew with the
     # archive forever.
     fresh: dict[str, list[tuple[str, bytes, int]]] = {}
+    #: relpath -> the `st_mtime_ns` the file had when its tail was taken. Kept
+    #: beside the tail rather than re-stat'ed at save time, so an append landing
+    #: during the read cannot be mistaken for the state the mark was taken
+    #: against. See the rewrite check above for what it is compared with.
+    stamp_of: dict[str, int] = {}
     # Only this machine's own logs: other hosts' arrived decrypted and are never
     # re-exported. Asked for by host rather than listed and then filtered, which
     # at three machines walked two thirds of a tree to throw it away.
@@ -1548,12 +1579,61 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
         # every idle sync -- goes from 5.50 ms to 1.85 ms at three years of
         # three machines, and stops growing with how many machines there are.
         try:
-            size = log.path.stat().st_size
+            stat = log.path.stat()
         except OSError:
             # As `read_tail` treats one: a file that went away between being
             # listed and being looked at has no tail to export.
             continue
+        size = stat.st_size
+
+        # A watermark counts bytes into a particular file, and `forget` is the
+        # one thing that rewrites a log rather than appending to it. It saves
+        # the corrected watermarks itself; a crash between its rewrite and that
+        # save leaves this mark describing a shape the file no longer has, and
+        # the lines written *after* the crash are then skipped for good -- the
+        # mark advances past them and no later sync looks again (#310).
+        #
+        # Two signals, both free, because this is the `stat` the fast path was
+        # already making:
+        #
+        # - shorter than the mark: nothing but a rewrite can do that.
+        # - exactly as long as the mark, but modified since the mark was taken:
+        #   a rewrite that happened to land on the same length. `forget` can do
+        #   that -- remove a line and let the day grow back -- and size alone
+        #   is blind to it, which is why the stamp exists.
+        #
+        # What neither sees is a rewrite the file has since grown *past*, since
+        # an append moves the modification time exactly as a rewrite does and
+        # the mark is then no longer above the end. Catching that needs the
+        # content below the mark hashed, which is a read of the whole prefix on
+        # a path tuned to one stat -- so the honest position is that this closes
+        # the window a sync can still see and narrows #310 rather than removing
+        # it. The sync timer is what bounds the rest: the run that follows the
+        # crash sees the short file, unless the machine out-types a one-minute
+        # timer first.
+        #
+        # Reset to zero rather than to the new size. The correct mark is the old
+        # one minus however much was removed *below* it, which is not knowable
+        # from here, and any guess too high skips exactly the history this is
+        # trying to save. Zero re-seals the day: duplicate rows on a peer, which
+        # dedup absorbs -- "recoverable, visible, and the direction to be wrong
+        # in", as `store.line_start` puts it. One log, not the map, which is
+        # #285's granularity and #291's mistake.
+        #
+        # Safe *here* and not one step earlier, which is the whole reason it
+        # lives in `export`: by the time a rewrite is visible the rows are gone
+        # from `logs/`, so re-sealing the day cannot re-publish them.
+        # `forget_rows` explains why saving a low watermark before the rewrite
+        # is worse, and it is right.
+        stamped = state.stamped.get(log.relpath)
+        if size < exported or (size == exported and stamped not in (None, stat.st_mtime_ns)):
+            exported = 0
+            state.exported[log.relpath] = 0
+
         if size <= exported:
+            # Stamped even on the idle path, so the first sync after this field
+            # arrives gives every log a stamp and re-exports nothing.
+            state.stamped[log.relpath] = stat.st_mtime_ns
             continue
 
         # The watermark has to name the start of a line, and until `forget`
@@ -1565,6 +1645,7 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
             fresh.setdefault(store.day_of_log(log.relpath), []).append(
                 (log.relpath, data, new_offset)
             )
+            stamp_of[log.relpath] = stat.st_mtime_ns
 
     # Whether anything reached the repo. What lets `run` skip the `git add` that
     # would otherwise stat the whole working tree to find that out.
@@ -1652,6 +1733,11 @@ def export(known: Machine, state: State, report: Report, now: int) -> bool:
             # that dies part way through persists no watermark at all. What it
             # does leave is chunks in no manifest, which is issue #66.
             state.exported[relpath] = new_offset
+            # Beside the watermark it describes, and from the same stat that
+            # decided this file had grown -- a fresh stat here could pick up an
+            # append that happened during the read, and then the next sync
+            # would believe the mark had been taken against it.
+            state.stamped[relpath] = stamp_of.get(relpath, 0)
 
         manifest.write(known, day, listed)
         wrote = True


### PR DESCRIPTION
Closes #310. Third of three (#312 → #314 → #310).

A watermark counts bytes into a particular file, and `forget` is the one thing that rewrites a log rather than appending to it. A crash between its rewrite and `forget_rows`' `state.save()` leaves a mark describing a shape the file no longer has — and the lines written after it were then skipped for good, because the mark advances past them and no later sync looks again.

**The issue's proposed fix is wrong, in two ways, and both took measuring.**

## 1. Lowering the mark to the new size does nothing when the length is unchanged

`forget` can remove a line and leave the day to grow back to exactly the length the mark records. Then there is nothing short about the file at all:

```
proposed fix applied=False: published b'eeee\n'  -> 'dddd' lost: True
proposed fix applied=True:  published b'eeee\n'  -> 'dddd' lost: True
```

Same harness as the issue's reproduction, with `state.exported[relpath] = size` added on shrinkage. It changes nothing, because `size <= exported` is never entered.

## 2. And where it does fire, `size` is a guess that can still skip

The correct mark is the old one less however much was removed *below* it, which is not knowable at export time. Any guess that is too high skips exactly the history this is trying to save. So the reset is to **zero** — re-seal the day, duplicate rows on a peer, which dedup absorbs. That is `store.line_start`'s own "recoverable, visible, and the direction to be wrong in", and it is one log rather than the map: #285's granularity, not #291's mistake.

## Why it cannot move to the write end

The natural fix is to save a conservative watermark *before* rewriting. `forget_rows` already considered exactly that and rejected it, in a docstring I would not have thought to check without rule 9:

> *"The other order is worse for this command specifically: a watermark saved low with the rows still in `logs/` re-seals and re-publishes them, and the row in question is the one somebody just asked to be rid of."*

That is right, and it is precisely what puts this check in `export` instead: by the time a rewrite is *visible*, the rows are already gone from `logs/`, so re-sealing the day cannot re-publish them.

## What landed

`State` gains `stamped` — the `st_mtime_ns` each watermark was taken against — and `export` resets a log's mark to zero when the file is **shorter than the mark**, or **exactly as long but modified since**. Both signals come from the `stat` the fast path was already making, so the idle sync costs nothing extra. `cache.refresh` decides the same question the same way, one field wider.

## Narrowed, not closed — stated in the code

A rewrite the file has since **grown past** is invisible here: an append moves the modification time exactly as a rewrite does, and the mark is no longer above the end. Catching that needs the content below the mark hashed, which is a read of the whole prefix on a path tuned to one stat. What bounds the rest is the sync timer — the run following the crash sees the short file unless the machine out-types a one-minute interval. The comment in `export` says this rather than implying the window is gone.

## Rule 8

`state.json` gains a field. `State.load` guards it per value like `exported`, and an **absent stamp means "trust the mark"** — so an existing installation upgrades silently and re-exports nothing. The corollary is worth naming: an installation whose crash happened *before* the upgrade is not repaired by it, because there is no stamp describing the pre-upgrade file.

## Rule 3

```
  caught    neither signal is checked -- #310 restored
  caught    only the short file is noticed, not the equal-length rewrite
  caught    only the stamp is consulted, so a short file is trusted
  caught    the mark is lowered to the new size rather than reset
  caught    the stamp is never recorded beside the watermark it describes
```

**The first regression test was decoration and the table said so.** It replaced the forgotten command with a *longer* one and asserted the replacement arrived — and it passed with the fix removed. The loss needs the stale mark to land exactly on a record boundary of the rewritten file; anywhere else `line_start` rewinds into the middle of a record and republishes the whole of it. A replacement of the **same length** is what puts a boundary there. Both tests are built that way now, by construction rather than by padding, and each was re-run alone against a disabled fix to confirm it fails without it.

Both are end-to-end: two machines, and the assertion is that the peer actually receives the command.

## Preflight

`ruff check`, `ruff format --check`, `mypy` (80 files), `python -m tools.run_tests` → `OK (0 failures, 0 errors, 72 skipped)`.

## Review (rule 1)

Top row — this changes what reaches an append-only archive. Reviewed by hand rather than with `/simplify` agents, which this session is configured against. The two corrections to the issue's own fix came out of that pass; the decoration test came out of the mutation table.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBbZ1pyWpvsUJNVsGdNmFF)_